### PR TITLE
feat: redesign UI layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,9 @@
     }
     .wrap{max-width:980px;margin:0 auto;padding:16px;}
     header{position:sticky;top:0;background:rgba(10,15,28,.7);backdrop-filter:blur(8px);border-bottom:1px solid #1f2937;z-index:20}
-    h1{font-size:20px;margin:0;padding:12px 0;font-weight:700;letter-spacing:.2px}
+    .header-bar{display:flex;justify-content:space-between;align-items:center;padding:12px 0;}
+    h1{font-size:20px;margin:0;font-weight:700;letter-spacing:.2px;display:flex;align-items:center;gap:8px}
+    .chip{font-size:12px;padding:2px 8px;border-radius:999px;border:1px solid var(--border);background:#0f1a32}
     .row{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
     input,select,button,textarea{
       color:var(--text);background:#0f172a;border:1px solid var(--border);border-radius:12px;padding:10px 12px;font-size:14px
@@ -33,15 +35,17 @@
     button.good{background:var(--ok);border-color:#157a3a;color:#001108;font-weight:700}
     button.warn{background:var(--warn);border-color:#7a5a0f;color:#1b1200;font-weight:700}
     button.ghost{background:#0f172a;border-color:var(--border)}
-    .panel{background:var(--panel);border:1px solid var(--border);border-radius:16px;padding:12px}
+    .panel{background:var(--panel);border:1px solid var(--border);border-radius:16px;padding:12px;box-shadow:0 2px 4px rgba(0,0,0,.4)}
     .grid{display:grid;grid-template-columns:1fr;gap:12px}
     @media (min-width:980px){.grid{grid-template-columns:1.2fr .8fr}}
     .list{display:grid;gap:8px}
-    .item{display:grid;grid-template-columns:auto 1fr auto;gap:10px;align-items:center;padding:12px;border:1px solid #20314b;border-radius:16px;background:#0c1426}
+    .item{display:grid;grid-template-columns:auto 1fr auto;gap:12px;align-items:flex-start;padding:12px;border:1px solid var(--border);border-radius:16px;background:#0c1426;box-shadow:0 1px 2px rgba(0,0,0,.5)}
     .item.done .title{text-decoration:line-through;color:#93a3b8}
-    .title{font-weight:600}
-    .meta{font-size:12px;color:var(--muted)}
-    .badge{font-size:11px;padding:4px 8px;border-radius:999px;border:1px solid #2b3b58;background:#0f1a32}
+    .title{font-weight:600;display:flex;flex-wrap:wrap;gap:4px}
+    .title .due{font-weight:400;color:var(--muted)}
+    .meta{font-size:12px;color:var(--muted);margin-top:4px}
+    .meta .note{margin-left:4px}
+    .badge{font-size:11px;padding:4px 8px;border-radius:999px;border:1px solid var(--border);background:#0f1a32}
     .section-title{margin:8px 0 0;font-size:13px;color:#a8b2c2;text-transform:uppercase;letter-spacing:.12em}
     .footer{color:#8aa0b8;font-size:12px;text-align:center;margin:14px 0}
     .sr-only{position:absolute;height:1px;width:1px;clip:rect(1px,1px,1px,1px);overflow:hidden;white-space:nowrap}
@@ -54,8 +58,18 @@
       width:min(680px,92vw);background:#0f172a;border:1px solid var(--border);border-radius:16px;padding:12px}
     /* Floating add bar (mobile) */
     .fab-add{position:sticky;bottom:0;display:flex;gap:8px;padding:10px;background:linear-gradient(180deg,rgba(11,18,32,0),#0b1220 35%);z-index:5}
+    .fab-add input{flex:1;font-size:16px;padding:14px 12px}
+    .fab-add button{padding:14px 20px;font-size:16px}
     @media (min-width:980px){.fab-add{position:static;background:none;padding:0}}
-    .fab-add input{flex:1}
+    /* Collapsible add form */
+    .add-form{border:1px solid var(--border);border-radius:16px;overflow:hidden}
+    .add-form>summary{list-style:none;cursor:pointer;padding:12px;font-weight:600}
+    .add-form[open]>summary{border-bottom:1px solid var(--border)}
+    .form-fields{padding:12px}
+    @media (min-width:980px){.add-form{border:none} .add-form>summary{display:none} .form-fields{padding:0}}
+    /* Toast */
+    .toast{position:fixed;bottom:16px;left:50%;transform:translateX(-50%);background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:12px 16px;box-shadow:0 2px 6px rgba(0,0,0,.5);display:flex;align-items:center;gap:12px;z-index:2000}
+    .toast.hidden{display:none;}
     /* Focus visibility */
     :focus-visible{outline:3px solid var(--accent);outline-offset:2px;border-radius:12px}
     /* Reduced motion */
@@ -67,16 +81,15 @@
 <body>
   <header>
     <div class="wrap">
-      <div class="row" style="justify-content:space-between;align-items:center">
-        <h1>Memory Cue</h1>
+      <div class="header-bar">
+        <h1>Memory Cue <span id="syncChip" class="chip">Online</span></h1>
         <div class="row">
-          <span id="syncChip" class="badge">Online</span>
           <button id="notifBtn" class="ghost" type="button" title="Enable notifications">🔔</button>
           <button id="syncNow" class="ghost" type="button" title="Sync now">⟳</button>
           <button id="openSettings" class="ghost" type="button" title="Settings">⚙️</button>
         </div>
       </div>
-      <div class="row" style="padding:8px 0 12px">
+      <div class="row search-bar" style="padding:8px 0 12px">
         <input id="q" placeholder="Search reminders or #tags" style="flex:1"/>
         <button id="voiceBtn" class="ghost" type="button" title="Voice quick add">🎙️ Voice</button>
         <select id="sort">
@@ -91,21 +104,11 @@
   <main class="wrap grid">
     <!-- Left: Lists -->
     <section class="panel">
-      <div class="row" style="justify-content:space-between">
-        <div class="row" style="gap:8px">
-          <button class="ghost" data-filter="today" type="button">Today</button>
-          <button class="ghost" data-filter="overdue" type="button">Overdue</button>
-          <button class="ghost" data-filter="all" type="button">All</button>
-          <button class="ghost" data-filter="done" type="button">Completed</button>
-        </div>
-        <div class="row" style="gap:8px">
-          <label class="ghost" style="display:inline-flex;align-items:center;gap:8px;padding:8px 12px">
-            Import <input id="importFile" type="file" accept="application/json" style="display:none"/>
-          </label>
-          <button id="exportBtn" class="ghost" type="button">Export</button>
-          <button id="copyMtlBtn" class="ghost" type="button">Copy MTL</button>
-          <button id="shareMtl" class="ghost" type="button">Share</button>
-        </div>
+      <div class="row" style="gap:8px">
+        <button class="ghost" data-filter="today" type="button">Today</button>
+        <button class="ghost" data-filter="overdue" type="button">Overdue</button>
+        <button class="ghost" data-filter="all" type="button">All</button>
+        <button class="ghost" data-filter="done" type="button">Completed</button>
       </div>
 
       <div class="section-title">Reminders</div>
@@ -117,33 +120,48 @@
       <div class="fab-add">
         <input id="quickTitle" placeholder="Add a reminder… e.g., Pick up dog 6pm"/>
         <button id="quickAdd" class="primary" type="button">Add</button>
-        <span id="status" class="meta"></span>
       </div>
+      <span id="status" class="meta"></span>
     </section>
 
-    <!-- Right: Full Add -->
+    <!-- Right: Full Add & Settings -->
     <section class="panel">
-      <div class="row" style="gap:8px;align-items:flex-end">
-        <div style="flex:1">
-          <label class="sr-only" for="title">Reminder</label>
-          <input id="title" placeholder="Reminder title"/>
+      <details id="addForm" class="add-form">
+        <summary>+ New Reminder</summary>
+        <div class="form-fields">
+          <div class="row" style="gap:8px;align-items:flex-end">
+            <div style="flex:1">
+              <label class="sr-only" for="title">Reminder</label>
+              <input id="title" placeholder="Reminder title"/>
+            </div>
+            <div>
+              <label class="sr-only" for="date">Date</label>
+              <input id="date" type="date"/>
+            </div>
+            <div>
+              <label class="sr-only" for="time">Time</label>
+              <input id="time" type="time"/>
+            </div>
+            <div>
+              <select id="priority">
+                <option>High</option>
+                <option selected>Medium</option>
+                <option>Low</option>
+              </select>
+            </div>
+            <button id="saveBtn" class="good" type="button">Save</button>
+          </div>
         </div>
-        <div>
-          <label class="sr-only" for="date">Date</label>
-          <input id="date" type="date"/>
-        </div>
-        <div>
-          <label class="sr-only" for="time">Time</label>
-          <input id="time" type="time"/>
-        </div>
-        <div>
-          <select id="priority">
-            <option>High</option>
-            <option selected>Medium</option>
-            <option>Low</option>
-          </select>
-        </div>
-        <button id="saveBtn" class="good" type="button">Save</button>
+      </details>
+
+      <div class="section-title">Settings</div>
+      <div class="row" style="gap:8px">
+        <label class="ghost" style="display:inline-flex;align-items:center;gap:8px;padding:8px 12px">
+          Import <input id="importFile" type="file" accept="application/json" style="display:none"/>
+        </label>
+        <button id="exportBtn" class="ghost" type="button">Export</button>
+        <button id="copyMtlBtn" class="ghost" type="button">Copy MTL</button>
+        <button id="shareMtl" class="ghost" type="button">Share</button>
       </div>
     </section>
   </main>
@@ -169,12 +187,30 @@
     </div>
   </div>
 
+  <div id="updateToast" class="toast hidden" role="status" aria-live="polite">
+    <span>Update available</span>
+    <button class="primary" type="button" onclick="location.reload()">Reload</button>
+  </div>
+
+  <script>
+    const addForm=document.getElementById('addForm');
+    const mq=window.matchMedia('(min-width:980px)');
+    function syncAddForm(){ if(mq.matches) addForm.setAttribute('open',''); else addForm.removeAttribute('open'); }
+    syncAddForm();
+    mq.addEventListener('change', syncAddForm);
+  </script>
+
   <script>
   (async function(){
     // PWA SW
     let deferredPrompt=null;
     window.addEventListener('beforeinstallprompt',(e)=>{e.preventDefault();deferredPrompt=e;});
-    if('serviceWorker' in navigator){ navigator.serviceWorker.register('./service-worker.js').catch(console.error); }
+    if('serviceWorker' in navigator){
+      navigator.serviceWorker.register('./service-worker.js').catch(console.error);
+      navigator.serviceWorker.addEventListener('message', (e)=>{
+        if(e.data && e.data.type==='UPDATE_AVAILABLE') updateToast?.classList.remove('hidden');
+      });
+    }
 
     // ---- Constants & helpers
     const TZ='Australia/Adelaide';
@@ -219,7 +255,7 @@
     const saveBtn=$('#saveBtn'), list=$('#list'), statusEl=$('#status');
     const voiceBtn=$('#voiceBtn'), notifBtn=$('#notifBtn'), importFile=$('#importFile'), exportBtn=$('#exportBtn');
     const copyMtlBtn=$('#copyMtlBtn'), shareMtlBtn=$('#shareMtl'), sortSel=$('#sort');
-    const quickTitle=$('#quickTitle'), quickAdd=$('#quickAdd'), syncNow=$('#syncNow'), syncChip=$('#syncChip');
+    const quickTitle=$('#quickTitle'), quickAdd=$('#quickAdd'), syncNow=$('#syncNow'), syncChip=$('#syncChip'), updateToast=$('#updateToast');
     const settingsModal=$('#settingsModal'), openSettings=$('#openSettings'), syncUrlInput=$('#syncUrl');
     const saveSettings=$('#saveSettings'), testSync=$('#testSync');
 
@@ -360,22 +396,16 @@
         group.forEach(r=>{
           const div=document.createElement('div');
           div.className='item'+(r.done?' done':'');
-          const dueTxt=r.due
-            ? new Date(r.due).toLocaleString('en-AU', { timeZone: TZ, hour:'2-digit', minute:'2-digit'})+' • '+fmtDayDate(r.due.slice(0,10))
-            : '—';
       div.innerHTML = `
   <input type="checkbox" ${r.done?'checked':''} aria-label="Mark done"/>
   <div>
     <div class="title">
       ${escapeHtml(r.title)}
-      ${r.due
-        ? ` — ${new Date(r.due).toLocaleTimeString('en-AU',{hour:'2-digit',minute:'2-digit'})} ${fmtDayDate(r.due.slice(0,10))}`
-        : ''
-      }
+      ${r.due? `<span class=\"due\">${new Date(r.due).toLocaleTimeString('en-AU',{hour:'2-digit',minute:'2-digit'})} ${fmtDayDate(r.due.slice(0,10))}</span>` : ''}
     </div>
     <div class="meta">
       <span class="badge">${r.priority}</span>
-      ${r.notes ? '• ' + escapeHtml(r.notes) : ''}
+      ${r.notes ? `<span class=\"note\">• ${escapeHtml(r.notes)}</span>` : ''}
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
## Summary
- modern two-column layout with collapsible add form on mobile
- card-style reminders and sticky quick-add bar
- header status chip, settings block, and update toast container
- muted inline due times and service worker-triggered update toast

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc744179c832483b3254c8fbe13ed