### PR TITLE
fix: guard settings button listener

### DIFF
--- a/index.html
+++ b/index.html
@@ -1516,7 +1516,7 @@
       URL.revokeObjectURL(url);
     });
 
-    openSettings.addEventListener('click', () => {
+    openSettings?.addEventListener('click', () => {
       if (settingsSection) {
         settingsSection.classList.remove('hidden');
         settingsSection.scrollIntoView({ behavior: 'smooth', block: 'start' });


### PR DESCRIPTION
## Summary
- Guard missing `#openSettings` element before binding click handler so app initialization continues

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c15e0548b8832491231d277300e4d1