### PR TITLE
Register service worker after login

### DIFF
--- a/index.html
+++ b/index.html
@@ -1613,6 +1613,19 @@
     }
 
     setupLogin();
+
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker
+        .register('service-worker.js')
+        .then(() => {
+          console.log('Service worker registered');
+          toast('App ready for offline use');
+        })
+        .catch((err) => {
+          console.error('Service worker registration failed:', err);
+          toast('Service worker registration failed');
+        });
+    }
   </script>
 
   <!-- Non-module scripts (same as before) -->


### PR DESCRIPTION
## Summary
- Register service worker after login setup to enable offline caching
- Provide toast and console feedback on registration success or failure

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check service-worker.js` *(fails: SyntaxError: Invalid regular expression)*

------
https://chatgpt.com/codex/tasks/task_e_68c172cd4fec8324857b39d53d0aa882