### PR TITLE
Remove sign-in screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
   <link rel="icon" href="icons/icon-192.png" sizes="192x192" />
   <link rel="stylesheet" href="css/teacher.css" />
   <script src="https://www.gstatic.com/firebasejs/12.2.1/firebase-app-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/12.2.1/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/12.2.1/firebase-firestore-compat.js"></script>
   <style>
     /* Critical inline styles for immediate rendering */
@@ -17,20 +16,11 @@
     .content-panel { display: none; }
     .content-panel.active { display: block; }
     .hidden { display: none; }
-    .login-view { display:flex; align-items:center; justify-content:center; height:100vh; }
-    .login-box { max-width:320px; width:100%; display:flex; flex-direction:column; }
-    .login-box input { margin-bottom:0.5rem; padding:0.5rem; }
+    
   </style>
 </head>
 <body>
-  <div id="loginView" class="login-view">
-    <div class="login-box">
-      <h2>Login</h2>
-      <button id="googleSignInBtn" type="button">Sign in with Google</button>
-    </div>
-  </div>
-
-  <div id="app" class="app-layout hidden">
+  <div id="app" class="app-layout">
     <!-- Sidebar Navigation -->
     <aside class="sidebar" id="sidebar" role="navigation" aria-label="Main navigation">
       <div class="sidebar-header">
@@ -110,11 +100,6 @@
           <button id="addQuickBtn" class="topbar-btn primary" type="button" title="Add quick reminder">
             + Add
           </button>
-          <button id="googleSignOutBtn" class="topbar-btn hidden" type="button">
-            <img id="googleAvatar" class="user-avatar hidden" />
-            Sign out
-          </button>
-          <span id="googleUserName" class="text-muted"></span>
         </div>
       </header>
 
@@ -463,16 +448,6 @@
       appId: "1:458740047814:web:9a072d8f529af9c24df448"
     };
     firebase.initializeApp(firebaseConfig);
-    const auth = firebase.auth();
-    auth.setPersistence(firebase.auth.Auth.Persistence.LOCAL);
-    auth.onIdTokenChanged(async (user) => {
-      if (user) {
-        const token = await user.getIdToken();
-        localStorage.setItem('mcAuthToken', token);
-      } else {
-        localStorage.removeItem('mcAuthToken');
-      }
-    });
     const db = firebase.firestore();
     firebase.firestore().enablePersistence().catch(() => {});
 
@@ -914,10 +889,6 @@
     const saveSettings = $('#saveSettings');
     const testSync = $('#testSync');
     const settingsSection = $('#settingsSection');
-    const googleSignInBtn = $('#googleSignInBtn');
-    const googleSignOutBtn = $('#googleSignOutBtn');
-    const googleAvatar = $('#googleAvatar');
-    const googleUserName = $('#googleUserName');
 
     // Restore saved Sync URL
     const savedSyncUrl = localStorage.getItem('syncUrl') || '';
@@ -1597,64 +1568,7 @@
       syncStatus.className = 'sync-status offline';
     });
 
-    function setupLogin() {
-      const app = document.getElementById('app');
-      const loginView = document.getElementById('loginView');
-      const signInBtn = document.getElementById('googleSignInBtn');
-      const signOutBtn = document.getElementById('googleSignOutBtn');
-
-      auth.onAuthStateChanged((user) => {
-        if (user) {
-          userId = user.uid;
-          loginView.classList.add('hidden');
-          app.classList.remove('hidden');
-          signOutBtn.classList.remove('hidden');
-          googleUserName.textContent = user.displayName || user.email || '';
-          if (user.photoURL) {
-            googleAvatar.src = user.photoURL;
-            googleAvatar.classList.remove('hidden');
-          } else {
-            googleAvatar.src = '';
-            googleAvatar.classList.add('hidden');
-          }
-          initializeTeacherApp();
-        } else {
-          userId = null;
-          loginView.classList.remove('hidden');
-          app.classList.add('hidden');
-          signOutBtn.classList.add('hidden');
-          googleAvatar.classList.add('hidden');
-          googleAvatar.src = '';
-          googleUserName.textContent = '';
-          items = [];
-          render();
-        }
-      });
-
-      signInBtn.addEventListener('click', async () => {
-        const provider = new firebase.auth.GoogleAuthProvider();
-        try {
-          await auth.signInWithPopup(provider);
-        } catch (error) {
-          try {
-            await auth.signInWithRedirect(provider);
-          } catch (e) {
-            toast('Google sign-in failed');
-          }
-        }
-      });
-
-      signOutBtn.addEventListener('click', async () => {
-        try {
-          await auth.signOut();
-          toast('Signed out');
-        } catch {
-          toast('Sign-out failed');
-        }
-      });
-    }
-
-    setupLogin();
+    initializeTeacherApp();
 
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker

--- a/mobile.html
+++ b/mobile.html
@@ -79,8 +79,7 @@ z-index:100;box-shadow:var(--shadow-sm)}
     .sync-status.online{background:rgba(34,197,94,.1);color:var(--success);border-color:rgba(34,197,94,.2)}
     .sync-status.offline{background:rgba(245,158,11,.1);color:var(--warning);border-color:rgba(245,158,11,.2)}
     .sync-status.error{background:rgba(239,68,68,.1);color:var(--danger);border-color:rgba(239,68,68,.2)}
-    .google-avatar{width:20px;height:20px;border-radius:50%;object-fit:cover;margin-right:var(--space-1)}
-    .auth-info{font-size:var(--text-xs);color:var(--text-muted);display:flex;align-items:center;gap:var(--space-1)}
+    
     .status-message{font-size:var(--text-xs);color:var(--text-muted);margin-top:var(--space-2)}
     .footer{text-align:center;padding:var(--space-6) 0;color:var(--text-muted);font-size:var(--text-xs);border-top:1px solid var(--border);margin-top:var(--space-8)}
 
@@ -147,14 +146,6 @@ z-index:100;box-shadow:var(--shadow-sm)}
               <button id="openSettings" class="menu-item" role="menuitem">Settings</button>
             </div>
           </div>
-        </div>
-        <div class="header-controls" style="margin-top: var(--space-2);">
-          <button id="googleSignInBtn" class="btn-ghost" type="button" aria-label="Sign in with Google">Sign in with Google</button>
-          <button id="googleSignOutBtn" class="btn-ghost hidden" type="button" aria-label="Sign out">
-            <img id="googleAvatar" class="google-avatar hidden" alt="Google avatar" />
-            Sign out
-          </button>
-          <div id="googleUserName" class="auth-info" aria-live="polite"></div>
         </div>
       </div>
     </div>
@@ -281,7 +272,6 @@ z-index:100;box-shadow:var(--shadow-sm)}
   <script type="module">
     import { initializeApp } from 'https://www.gstatic.com/firebasejs/12.2.1/firebase-app.js';
     import { getFirestore, doc, setDoc, deleteDoc, onSnapshot, collection, query, orderBy, enableIndexedDbPersistence, serverTimestamp } from 'https://www.gstatic.com/firebasejs/12.2.1/firebase-firestore.js';
-    import { getAuth, onAuthStateChanged, GoogleAuthProvider, signInWithPopup, signInWithRedirect, getRedirectResult, signOut } from 'https://www.gstatic.com/firebasejs/12.2.1/firebase-auth.js';
 
     // Firebase
     const firebaseConfig = {
@@ -296,7 +286,6 @@ z-index:100;box-shadow:var(--shadow-sm)}
     const app = initializeApp(firebaseConfig);
     const db = getFirestore(app);
     enableIndexedDbPersistence(db).catch(err => { console.warn('Firestore persistence not enabled:', err?.code || err); });
-    const auth = getAuth(app);
 
     // State
     let items = [];
@@ -347,7 +336,6 @@ z-index:100;box-shadow:var(--shadow-sm)}
     const sortSel = $('#sort'), openSettings = $('#openSettings'), settingsSection = $('#settingsSection');
     const syncAllBtn = document.getElementById('syncAllBtn');
     const syncUrlInput = $('#syncUrl'), saveSettings = $('#saveSettings'), testSync = $('#testSync');
-    const googleSignInBtn = $('#googleSignInBtn'), googleSignOutBtn = $('#googleSignOutBtn'), googleAvatar = $('#googleAvatar'), googleUserName = $('#googleUserName');
     const moreBtn = $('#moreBtn'), moreMenu = $('#moreMenu');
     const inlineTodayCount = $('#inlineTodayCount'), inlineWeekCount = $('#inlineWeekCount');
     const notesEl = $('#notes');
@@ -365,28 +353,6 @@ z-index:100;box-shadow:var(--shadow-sm)}
       const target = btn.getAttribute('data-target');
       document.getElementById(target).classList.remove('hidden');
     }));
-
-    // Auth
-    googleSignInBtn.addEventListener('click', async () => {
-      const provider = new GoogleAuthProvider();
-      try { await signInWithPopup(auth, provider); } catch (error) { try { await signInWithRedirect(auth, provider); } catch (e) { toast('Google sign-in failed'); } }
-    });
-    getRedirectResult(auth).catch(()=>{});
-    googleSignOutBtn.addEventListener('click', async () => { try { await signOut(auth); toast('Signed out'); items=[]; render(); } catch { toast('Sign-out failed'); } });
-    onAuthStateChanged(auth, (user) => {
-      if (user) {
-        userId = user.uid;
-        syncStatus.textContent = 'Online'; syncStatus.className = 'sync-status online';
-        googleSignInBtn.classList.add('hidden'); googleSignOutBtn.classList.remove('hidden');
-        if (user.photoURL) { googleAvatar.classList.remove('hidden'); googleAvatar.src = user.photoURL; } else { googleAvatar.classList.add('hidden'); googleAvatar.src = ''; }
-        googleUserName.textContent = user.displayName || user.email || '';
-        setupFirestoreSync();
-      } else {
-        googleSignInBtn.classList.remove('hidden'); googleSignOutBtn.classList.add('hidden');
-        googleAvatar.classList.add('hidden'); googleAvatar.src = ''; googleUserName.textContent = '';
-        items = []; render();
-      }
-    });
 
     // Firestore sync
     function setupFirestoreSync() {


### PR DESCRIPTION
## Summary
- Strip all Google sign-in/out UI and login flow from teacher web app.
- Remove Firebase Auth usage and show application directly without sign-in.
- Mirror changes in mobile interface, dropping auth imports and related markup.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c177f452448324acd7bab78fa71ed5