### PR TITLE
Add Firebase authentication

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="css/teacher.css" />
   <script src="https://www.gstatic.com/firebasejs/12.2.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/12.2.1/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/12.2.1/firebase-auth-compat.js"></script>
   <style>
     /* Critical inline styles for immediate rendering */
     .app-layout { display: flex; height: 100vh; overflow: hidden; }
@@ -89,11 +90,12 @@
           <button id="notifBtn" class="topbar-btn" type="button" title="Enable notifications">
             🔔
           </button>
+          <button id="authBtn" class="topbar-btn" type="button" title="Sign in">Sign In</button>
           <div class="quick-add-container">
-            <input 
-              id="quickAddInput" 
-              class="quick-add-input" 
-              placeholder="Quick add reminder..." 
+            <input
+              id="quickAddInput"
+              class="quick-add-input"
+              placeholder="Quick add reminder..."
               style="display: none;"
             />
           </div>
@@ -450,6 +452,7 @@
     };
     firebase.initializeApp(firebaseConfig);
     const db = firebase.firestore();
+    const auth = firebase.auth();
     firebase.firestore().enablePersistence().catch(() => {});
 
     // App state
@@ -879,6 +882,7 @@
     const statusEl = $('#status');
     const voiceBtn = $('#voiceBtn');
     const notifBtn = $('#notifBtn');
+    const authBtn = $('#authBtn');
     const addQuickBtn = $('#addQuickBtn');
     const copyMtlBtn = $('#copyMtlBtn');
     const importFile = $('#importFile');
@@ -930,6 +934,29 @@
         syncStatus.textContent = 'Sync Error';
         syncStatus.className = 'sync-status error';
       });
+    }
+
+    function handleAuth() {
+      if (auth.currentUser) {
+        auth.signOut();
+      } else {
+        const provider = new firebase.auth.GoogleAuthProvider();
+        auth.signInWithPopup(provider).catch((err) => {
+          console.error('Auth error:', err);
+          toast('Sign in failed');
+        });
+      }
+    }
+
+    function updateAuthButton(user) {
+      if (!authBtn) return;
+      if (user) {
+        authBtn.textContent = 'Sign Out';
+        authBtn.title = 'Sign out';
+      } else {
+        authBtn.textContent = 'Sign In';
+        authBtn.title = 'Sign in';
+      }
     }
 
     function mergeWithLocal(remoteItems) {
@@ -1556,6 +1583,8 @@
       }
     } catch { }
 
+    authBtn.addEventListener('click', handleAuth);
+
     voiceBtn.addEventListener('click', () => {
       if (!recog) return;
       if (!listening) { 
@@ -1595,6 +1624,13 @@
     window.addEventListener('offline', () => {
       syncStatus.textContent = 'Offline';
       syncStatus.className = 'sync-status offline';
+    });
+
+    auth.onAuthStateChanged((user) => {
+      currentUser = user;
+      userId = user ? user.uid : null;
+      updateAuthButton(user);
+      setupFirestoreSync();
     });
 
     initializeTeacherApp();

--- a/mobile.html
+++ b/mobile.html
@@ -144,6 +144,7 @@ z-index:100;box-shadow:var(--shadow-sm)}
               <button id="syncAllBtn" class="menu-item" role="menuitem">Sync All Now</button>
               <div class="menu-sep"></div>
               <button id="openSettings" class="menu-item" role="menuitem">Settings</button>
+              <button id="authBtn" class="menu-item" role="menuitem">Sign In</button>
             </div>
           </div>
         </div>
@@ -272,6 +273,7 @@ z-index:100;box-shadow:var(--shadow-sm)}
   <script type="module">
     import { initializeApp } from 'https://www.gstatic.com/firebasejs/12.2.1/firebase-app.js';
     import { getFirestore, doc, setDoc, deleteDoc, onSnapshot, collection, query, orderBy, enableIndexedDbPersistence, serverTimestamp } from 'https://www.gstatic.com/firebasejs/12.2.1/firebase-firestore.js';
+    import { getAuth, signInWithPopup, GoogleAuthProvider, signOut, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/12.2.1/firebase-auth.js';
 
     // Firebase
     const firebaseConfig = {
@@ -285,6 +287,7 @@ z-index:100;box-shadow:var(--shadow-sm)}
     };
     const app = initializeApp(firebaseConfig);
     const db = getFirestore(app);
+    const auth = getAuth(app);
     enableIndexedDbPersistence(db).catch(err => { console.warn('Firestore persistence not enabled:', err?.code || err); });
 
     // State
@@ -336,7 +339,7 @@ z-index:100;box-shadow:var(--shadow-sm)}
     const sortSel = $('#sort'), openSettings = $('#openSettings'), settingsSection = $('#settingsSection');
     const syncAllBtn = document.getElementById('syncAllBtn');
     const syncUrlInput = $('#syncUrl'), saveSettings = $('#saveSettings'), testSync = $('#testSync');
-    const moreBtn = $('#moreBtn'), moreMenu = $('#moreMenu');
+    const moreBtn = $('#moreBtn'), moreMenu = $('#moreMenu'), authBtn = $('#authBtn');
     const inlineTodayCount = $('#inlineTodayCount'), inlineWeekCount = $('#inlineWeekCount');
     const notesEl = $('#notes');
     const saveNoteBtn = $('#saveNoteBtn'), newNoteBtn = $('#newNoteBtn');
@@ -378,6 +381,20 @@ z-index:100;box-shadow:var(--shadow-sm)}
         console.error('Firestore sync error:', error);
         syncStatus.textContent = 'Sync Error'; syncStatus.className = 'sync-status error';
       });
+    }
+
+    function handleAuth() {
+      if (auth.currentUser) {
+        signOut(auth);
+      } else {
+        const provider = new GoogleAuthProvider();
+        signInWithPopup(auth, provider).catch(() => toast('Sign in failed'));
+      }
+    }
+
+    function updateAuthButton(user) {
+      if (!authBtn) return;
+      authBtn.textContent = user ? 'Sign Out' : 'Sign In';
     }
 
     // Save/Delete
@@ -850,6 +867,11 @@ z-index:100;box-shadow:var(--shadow-sm)}
       closeMenu();
     });
 
+    authBtn.addEventListener('click', () => {
+      handleAuth();
+      closeMenu();
+    });
+
     // Sync All Now -> POST everything in batches
     syncAllBtn?.addEventListener('click', async () => {
       const url = (localStorage.getItem('syncUrl') || '').trim();
@@ -932,6 +954,12 @@ z-index:100;box-shadow:var(--shadow-sm)}
     })();
 
     // Initial render
+    onAuthStateChanged(auth, user => {
+      userId = user ? user.uid : null;
+      updateAuthButton(user);
+      setupFirestoreSync();
+    });
+
     render();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- integrate Firebase Auth for sign-in/out
- add auth buttons on desktop and mobile pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1838f7e5483249ce4f45e465a2530