### PR TITLE
feat: save notes

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -925,7 +925,8 @@ z-index:100;box-shadow:var(--shadow-sm)}
 
     // Notebook functionality
     saveNoteBtn.addEventListener('click', () => {
-      // Notes are already auto-saved to localStorage, so just show confirmation
+      // Persist current note to localStorage and show confirmation
+      localStorage.setItem('mobileNotes', notesEl.value);
       toast('Note saved');
     });
     


### PR DESCRIPTION
## Summary
- explicitly persist notebook content to localStorage on Save Note

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c18adf638c8324adf999159d76ce57