### PR TITLE
fix: compile tailwind directives and load config before CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="icon" href="icons/icon-192.png" sizes="192x192" />
   <link rel="stylesheet" href="css/teacher.css" />
-  <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
       theme: {
@@ -18,7 +17,8 @@
       }
     }
   </script>
-  <style>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style type="text/tailwindcss">
     :root { --color-brand: #38bdf8; }
 
     @layer components {

--- a/mobile.html
+++ b/mobile.html
@@ -6,12 +6,12 @@
   <title>Memory Cue (Mobile) — Inline + Edit + Sync All</title>
   <meta name="theme-color" content="#0f172a" />
   <link rel="manifest" href="#" id="manifestLink" />
-  <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
       theme: { extend: { colors: { brand: '#38bdf8' } } }
     }
   </script>
+  <script src="https://cdn.tailwindcss.com"></script>
   <style type="text/tailwindcss">
     :root { --color-brand: #38bdf8; }
 


### PR DESCRIPTION
## Summary
- load Tailwind config before CDN so custom brand color renders on desktop and mobile
- mark desktop component styles with `type="text/tailwindcss"` so `@apply` utilities compile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c334ef209483249f8f476c188c940e