### PR TITLE
style(pocket): Tailwind UI refresh (no logic changes)

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -6,13 +6,12 @@
   <title>Memory Cue (Mobile) — Inline + Edit + Sync All</title>
   <meta name="theme-color" content="#0f172a" />
   <link rel="manifest" href="#" id="manifestLink" />
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = {
-      theme: { extend: { colors: { brand: '#38bdf8' } } }
+  <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+  <style type="text/tailwindcss">
+    @theme {
+      --color-accent: var(--color-indigo-500);
     }
-  </script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@tailwindplus/elements@1"></script>
+  </style>
   <style>
     :root{
       --bg-primary:#0b1220; --bg-secondary:#0f172a; --bg-tertiary:#1e293b;
@@ -129,34 +128,32 @@ z-index:100;box-shadow:var(--shadow-sm)}
     }
   </style>
 </head>
-<body class="bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-  <header class="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
-    <div class="container">
-      <div class="header-content">
-        <div class="header-top">
-          <h1>Memory Cue</h1>
-          <div id="syncStatus" class="sync-status offline" aria-live="polite">Offline</div>
-        </div>
-        <div class="header-controls">
-          <input id="q" class="search-input" placeholder="Search reminders or #tags" aria-label="Search reminders" />
-          <button id="voiceBtn" class="btn-ghost btn-compact" type="button" title="Voice quick add" aria-label="Start voice input">
-            <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+<body class="leading-7 text-slate-600 dark:text-slate-300 bg-slate-50 dark:bg-slate-950">
+  <header class="sticky top-0 z-40 bg-white/70 dark:bg-slate-900/70 backdrop-blur border-b border-slate-200/60 dark:border-slate-800">
+    <div class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex items-center justify-between h-14">
+        <h1 class="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">Memory Cue</h1>
+        <div class="flex items-center gap-2">
+          <div id="syncStatus" class="sync-status offline text-xs" aria-live="polite">Offline</div>
+          <input id="q" class="block w-full rounded-xl border-slate-300/60 bg-white/80 dark:bg-slate-900/60 px-3 py-2 focus:ring-2 focus:ring-slate-900/20 outline-none" placeholder="Search reminders or #tags" aria-label="Search reminders" />
+          <button id="voiceBtn" class="inline-flex items-center gap-2 rounded-xl ring-1 ring-slate-300/60 bg-white px-4 py-2 hover:bg-slate-50 dark:bg-slate-800 dark:text-slate-200 dark:ring-white/10" type="button" title="Voice quick add" aria-label="Start voice input">
+            <svg class="size-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 1.5a3 3 0 00-3 3v6a3 3 0 006 0v-6a3 3 0 00-3-3z" />
               <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5v1a7.5 7.5 0 01-15 0v-1M12 21v-3" />
             </svg>
           </button>
-          <button id="notifBtn" class="btn-ghost btn-compact" type="button" title="Enable notifications" aria-label="Enable notifications">
-            <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+          <button id="notifBtn" class="inline-flex items-center gap-2 rounded-xl ring-1 ring-slate-300/60 bg-white px-4 py-2 hover:bg-slate-50 dark:bg-slate-800 dark:text-slate-200 dark:ring-white/10" type="button" title="Enable notifications" aria-label="Enable notifications">
+            <svg class="size-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M14.25 18.75a1.5 1.5 0 01-3 0M18.75 9a6.75 6.75 0 10-13.5 0c0 3.135-1.195 4.35-1.5 4.5h16.5c-.305-.15-1.5-1.365-1.5-4.5z" />
             </svg>
           </button>
-          <button id="addQuickBtn" class="btn-primary btn-compact flex items-center justify-center" type="button" title="Add quick reminder" aria-label="Add quick reminder">
-            <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+          <button id="addQuickBtn" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 text-white px-4 py-2 hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900" type="button" title="Add quick reminder" aria-label="Add quick reminder">
+            <svg class="size-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
             </svg>
           </button>
-          <div class="menu-wrap">
-            <button id="moreBtn" class="btn-ghost btn-compact" aria-haspopup="true" aria-expanded="false" aria-controls="moreMenu" title="More actions" aria-label="More actions">⋯</button>
+          <div class="relative">
+            <button id="moreBtn" class="inline-flex items-center gap-2 rounded-xl ring-1 ring-slate-300/60 bg-white px-4 py-2 hover:bg-slate-50 dark:bg-slate-800 dark:text-slate-200 dark:ring-white/10" aria-haspopup="true" aria-expanded="false" aria-controls="moreMenu" title="More actions" aria-label="More actions">⋯</button>
             <el-menu id="moreMenu" class="menu hidden" role="menu" aria-label="More actions">
               <button id="copyMtlBtn" class="menu-item" role="menuitem">Copy MTL</button>
               <label class="menu-item" role="menuitem" for="importFile" style="display:flex; align-items:center; gap:8px; cursor:pointer;">Import<input id="importFile" type="file" accept="application/json" class="sr-only" /></label>
@@ -178,11 +175,12 @@ z-index:100;box-shadow:var(--shadow-sm)}
 
   <div id="tasksTab" class="tab-panel">
     <main class="main-content">
-    <div class="container">
+    <div class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
       <!-- Create Reminder Card -->
-      <section class="card section">
-        <div class="card-header"><h2 class="card-title">Create Reminder</h2></div>
-        <div class="card-content">
+      <section class="py-8 sm:py-10 lg:py-14">
+        <div class="rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-slate-900/60 dark:ring-white/10 p-5 sm:p-6">
+          <h2 class="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">Create Reminder</h2>
+          <div class="mt-5">
           <div class="form-stack">
             <div class="form-group">
               <label class="sr-only" for="title">Reminder</label>
@@ -212,11 +210,12 @@ z-index:100;box-shadow:var(--shadow-sm)}
           </div>
           <div id="status" class="status-message" aria-live="polite"></div>
         </div>
+      </div>
       </section>
 
       <!-- Reminders List with inline counters -->
-      <section class="card section">
-        <div class="card-header">
+      <section class="py-8 sm:py-10 lg:py-14">
+        <div class="rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-slate-900/60 dark:ring-white/10 p-5 sm:p-6">
           <div class="panel-header">
             <div class="summary-pills">
               <div class="pill" title="Tasks due today">
@@ -245,18 +244,19 @@ z-index:100;box-shadow:var(--shadow-sm)}
               </div>
             </div>
           </div>
-        </div>
-        <div class="card-content">
-          <div id="list" class="task-list" aria-live="polite">
-            <div class="text-muted">No reminders yet.</div>
+          <div class="mt-5">
+            <div id="list" class="task-list" aria-live="polite">
+              <div class="text-muted">No reminders yet.</div>
+            </div>
           </div>
         </div>
       </section>
 
       <!-- Settings (hidden by default) -->
-      <section class="card section hidden" id="settingsSection">
-        <div class="card-header"><h2 class="card-title">Sync Settings</h2></div>
-        <div class="card-content">
+      <section class="py-8 sm:py-10 lg:py-14 hidden" id="settingsSection">
+        <div class="rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-slate-900/60 dark:ring-white/10 p-5 sm:p-6">
+          <h2 class="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">Sync Settings</h2>
+          <div class="mt-5">
           <div class="form-stack">
             <div class="form-group"><input id="syncUrl" placeholder="https://script.google.com/macros/s/AKfycb.../exec" aria-label="Google Apps Script URL" /></div>
             <div class="form-row"><button id="saveSettings" class="btn-success flex-1" type="button">Save</button><button id="testSync" class="btn-ghost flex-1" type="button">Test</button></div>
@@ -267,6 +267,7 @@ z-index:100;box-shadow:var(--shadow-sm)}
             <strong>Tip:</strong> In Google Apps Script, click <strong>Deploy → New deployment → Web app</strong>,
             set <strong>Execute as: Me</strong>, <strong>Who has access: Anyone with the link</strong>, then copy the URL.
           </div>
+          </div>
         </div>
       </section>
     </div>
@@ -274,18 +275,18 @@ z-index:100;box-shadow:var(--shadow-sm)}
   </div>
 
   <div id="notebookTab" class="tab-panel hidden">
-    <div class="container">
-      <section class="card section">
-        <div class="card-header">
-          <h2 class="card-title">Notebook</h2>
-        </div>
-        <div class="card-content">
+    <div class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
+      <section class="py-8 sm:py-10 lg:py-14">
+        <div class="rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-slate-900/60 dark:ring-white/10 p-5 sm:p-6">
+          <h2 class="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">Notebook</h2>
+          <div class="mt-5">
           <div class="form-stack">
             <textarea id="notes" placeholder="Type notes..." style="width:100%;min-height:200px;"></textarea>
             <div class="form-row">
               <button id="saveNoteBtn" class="btn-success flex-1" type="button">Save Note</button>
               <button id="newNoteBtn" class="btn-ghost flex-1" type="button">New Note</button>
             </div>
+          </div>
           </div>
         </div>
       </section>
@@ -799,23 +800,23 @@ z-index:100;box-shadow:var(--shadow-sm)}
       list.replaceChildren();
       rows.forEach(r => {
         const div = document.createElement('div');
-        div.className = 'task-item' + (r.done ? ' completed' : '');
+        div.className = 'rounded-2xl p-4 sm:p-5 ring-1 ring-transparent hover:ring-black/5 transition hover:shadow-sm grid grid-cols-[auto,1fr,auto] gap-3 items-start' + (r.done ? ' opacity-60' : '');
         const dueTxt = r.due ? `${fmtTime(new Date(r.due))} • ${fmtDayDate(r.due.slice(0,10))}` : 'No due date';
-        const priorityClass = `priority-${r.priority.toLowerCase()}`;
+        const priorityClass = r.priority === 'High' ? 'bg-rose-50 text-rose-900 ring-rose-200' : r.priority === 'Low' ? 'bg-emerald-50 text-emerald-900 ring-emerald-200' : 'bg-amber-50 text-amber-900 ring-amber-200';
         div.innerHTML = `
-          <input type="checkbox" ${r.done ? 'checked' : ''} aria-label="Mark complete" />
-          <div class="task-content">
-            <div class="task-title">${escapeHtml(r.title)}</div>
-            <div class="task-meta">
-              <div class="task-meta-row">
+          <input type="checkbox" ${r.done ? 'checked' : ''} aria-label="Mark complete" class="mt-1 w-4 h-4 rounded border-slate-300 text-slate-900 focus:ring-slate-900/20" />
+          <div class="min-w-0 pt-0">
+            <div class="font-medium text-slate-900 dark:text-slate-100 line-clamp-1">${escapeHtml(r.title)}</div>
+            <div class="text-sm text-slate-500 dark:text-slate-400">
+              <div class="flex gap-2 flex-wrap items-center">
                 <span>${dueTxt}</span>
-                <span class="priority-badge ${priorityClass}">${r.priority}</span>
+                <span class="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ring-1 ${priorityClass}">${r.priority}</span>
               </div>
             </div>
           </div>
-          <div class="task-actions">
-            <button class="btn-ghost" data-edit type="button">Edit</button>
-            <button class="btn-ghost" data-del type="button">Del</button>
+          <div class="flex gap-2">
+            <button class="inline-flex items-center gap-2 rounded-xl ring-1 ring-slate-300/60 bg-white px-4 py-2 hover:bg-slate-50 dark:bg-slate-800 dark:text-slate-200 dark:ring-white/10" data-edit type="button">Edit</button>
+            <button class="inline-flex items-center gap-2 rounded-xl ring-1 ring-slate-300/60 bg-white px-4 py-2 hover:bg-slate-50 dark:bg-slate-800 dark:text-slate-200 dark:ring-white/10" data-del type="button">Del</button>
           </div>`;
         div.querySelector('input').addEventListener('change', () => toggleDone(r.id));
         div.querySelector('[data-edit]').addEventListener('click', () => loadForEdit(r.id));
@@ -1041,5 +1042,6 @@ z-index:100;box-shadow:var(--shadow-sm)}
 
     render();
   </script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@tailwindplus/elements@1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- switch to Tailwind v4 Play CDN with accent theme
- modernize header and layout with Pocket-style utilities
- restyle task cards using Tailwind classes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c338f26234832498717bfa35ea74be