### PR TITLE
style(memory-cue): Pocket UI refresh (no logic changes)

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,20 +8,11 @@
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="icon" href="icons/icon-192.png" sizes="192x192" />
   <link rel="stylesheet" href="css/teacher.css" />
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: { brand: '#38bdf8' }
-        }
-      }
-    }
-  </script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@tailwindplus/elements@1"></script>
-  <style>
-    :root { --color-brand: #38bdf8; }
+  <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+  <style type="text/tailwindcss">
+    @theme { --color-accent: var(--color-indigo-500); }
   </style>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@tailwindplus/elements@1"></script>
   <script src="https://www.gstatic.com/firebasejs/12.2.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/12.2.1/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/12.2.1/firebase-auth-compat.js"></script>
@@ -82,23 +73,24 @@
     <!-- Main Content Area -->
     <div class="main-area">
       <!-- Top Bar -->
-      <header class="topbar flex items-center justify-between p-4 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700" role="banner">
-        <div class="topbar-left flex items-center gap-4">
-          <h1 class="text-xl font-semibold text-gray-900 dark:text-gray-100">Memory Cue</h1>
-          <div class="search-container relative">
-            <input
-              id="q"
-              class="search-input pl-10"
-              placeholder="Search reminders, resources, notes..."
-              aria-label="Search"
-            />
+      <header class="sticky top-0 z-40 bg-white/70 backdrop-blur border-b border-slate-200/60" role="banner">
+        <div class="h-14 flex items-center justify-between max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div class="topbar-left flex items-center gap-4">
+            <h1 class="text-xl font-semibold text-gray-900 dark:text-gray-100">Memory Cue</h1>
+            <div class="search-container relative">
+              <input
+                id="q"
+                class="search-input pl-10 block w-full rounded-xl border-slate-300/60 bg-white/80 px-3 py-2 focus:ring-2 focus:ring-slate-900/20 outline-none"
+                placeholder="Search reminders, resources, notes..."
+                aria-label="Search"
+              />
             <svg class="pointer-events-none w-5 h-5 text-gray-400 absolute left-3 top-1/2 -translate-y-1/2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 103.75 9.75a7.5 7.5 0 0012.9 6.9z" />
             </svg>
-          </div>
         </div>
-        <div class="topbar-right flex items-center gap-2">
-          <button class="topbar-btn" id="themeToggle" title="Toggle theme" aria-label="Toggle theme">
+        </div>
+          <div class="topbar-right flex items-center gap-2">
+            <button class="topbar-btn" id="themeToggle" title="Toggle theme" aria-label="Toggle theme">
             <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1.5M16.95 7.05l1.06 1.06M21 12h-1.5M16.95 16.95l1.06-1.06M12 21v-1.5M7.05 16.95l-1.06-1.06M3 12h1.5M7.05 7.05L6 8.11M12 8.25a3.75 3.75 0 110 7.5 3.75 3.75 0 010-7.5z" />
             </svg>
@@ -115,7 +107,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" d="M14.25 18.75a1.5 1.5 0 01-3 0M18.75 9a6.75 6.75 0 10-13.5 0c0 3.135-1.195 4.35-1.5 4.5h16.5c-.305-.15-1.5-1.365-1.5-4.5z" />
             </svg>
           </button>
-          <button id="authBtn" class="topbar-btn" type="button" title="Sign in">Sign In</button>
+          <button id="authBtn" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 text-white px-4 py-2 hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900" type="button" title="Sign in">Sign In</button>
           <div class="quick-add-container">
             <input
               id="quickAddInput"
@@ -124,12 +116,13 @@
               style="display: none;"
             />
           </div>
-          <button id="addQuickBtn" class="topbar-btn primary flex items-center gap-1" type="button" title="Add quick reminder">
+          <button id="addQuickBtn" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 text-white px-4 py-2 hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900" type="button" title="Add quick reminder">
             <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
             </svg>
             Add
           </button>
+          </div>
         </div>
       </header>
 
@@ -137,10 +130,30 @@
       <main class="content-area" role="main">
         <!-- Dashboard Panel -->
         <div class="content-panel active" id="dashboardPanel">
-          <div class="panel-header">
+          <div class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-10 lg:py-14">
+          <div class="panel-header py-8 sm:py-10 lg:py-14">
             <div>
-              <h1 class="panel-title">Dashboard</h1>
-              <p class="panel-subtitle">Your daily overview and quick agenda</p>
+              <h1 class="panel-title text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900">Dashboard</h1>
+              <p class="panel-subtitle leading-7 text-slate-600">Your daily overview and quick agenda</p>
+            </div>
+          </div>
+
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5 mb-8">
+            <div class="rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 p-5 sm:p-6 text-center">
+              <div id="subjectCount" class="text-3xl font-semibold text-slate-900">0</div>
+              <div class="mt-1 text-sm text-slate-600">Subjects</div>
+            </div>
+            <div class="rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 p-5 sm:p-6 text-center">
+              <div id="reminderCount" class="text-3xl font-semibold text-slate-900">0</div>
+              <div class="mt-1 text-sm text-slate-600">Active Reminders</div>
+            </div>
+            <div class="rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 p-5 sm:p-6 text-center">
+              <div id="lessonCount" class="text-3xl font-semibold text-slate-900">0</div>
+              <div class="mt-1 text-sm text-slate-600">This Week's Lessons</div>
+            </div>
+            <div class="rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 p-5 sm:p-6 text-center">
+              <div id="templateCount" class="text-3xl font-semibold text-slate-900">0</div>
+              <div class="mt-1 text-sm text-slate-600">Templates</div>
             </div>
           </div>
 
@@ -160,33 +173,7 @@
                 </div>
               </div>
             </div>
-
-            <!-- Quick Stats -->
-            <div class="card">
-              <div class="card-header">
-                <h2 class="card-title">Quick Stats</h2>
-              </div>
-              <div class="card-content">
-                <div class="grid grid-2">
-                  <div class="stat-item">
-                    <div class="stat-number" id="subjectCount">0</div>
-                    <div class="stat-label">Subjects</div>
-                  </div>
-                  <div class="stat-item">
-                    <div class="stat-number" id="reminderCount">0</div>
-                    <div class="stat-label">Active Reminders</div>
-                  </div>
-                  <div class="stat-item">
-                    <div class="stat-number" id="lessonCount">0</div>
-                    <div class="stat-label">This Week's Lessons</div>
-                  </div>
-                  <div class="stat-item">
-                    <div class="stat-number" id="templateCount">0</div>
-                    <div class="stat-label">Templates</div>
-                  </div>
-                </div>
-              </div>
-            </div>
+          </div>
           </div>
         </div>
 

--- a/mobile.html
+++ b/mobile.html
@@ -130,8 +130,7 @@ z-index:100;box-shadow:var(--shadow-sm)}
 </head>
 <body class="leading-7 text-slate-600 dark:text-slate-300 bg-slate-50 dark:bg-slate-950">
   <header class="sticky top-0 z-40 bg-white/70 dark:bg-slate-900/70 backdrop-blur border-b border-slate-200/60 dark:border-slate-800">
-    <div class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="flex items-center justify-between h-14">
+    <div class="h-14 flex items-center justify-between max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
         <h1 class="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">Memory Cue</h1>
         <div class="flex items-center gap-2">
           <div id="syncStatus" class="sync-status offline text-xs" aria-live="polite">Offline</div>
@@ -165,7 +164,6 @@ z-index:100;box-shadow:var(--shadow-sm)}
             </el-menu>
           </div>
         </div>
-      </div>
     </div>
   </header>
   <el-tabs class="tabs">


### PR DESCRIPTION
## Summary
- upgrade to Tailwind v4 play CDN and define accent color
- introduce sticky translucent header and primary button styling
- display dashboard stats in responsive card grid
- simplify mobile header container

## Testing
- `npm test`

_No screenshots due to network restrictions._

------
https://chatgpt.com/codex/tasks/task_e_68c33e0d92808324b17a2223498585fd