### PR TITLE
Add tabbed navigation to mobile page

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -61,6 +61,13 @@
   </header>
 
   <main class="max-w-screen-sm mx-auto px-4">
+    <div role="tablist" class="flex gap-2 pt-6">
+      <button id="tab-reminders" role="tab" aria-controls="panel-reminders" aria-selected="true" class="flex-1 rounded-lg bg-slate-900 text-white px-3 py-1.5">Reminders</button>
+      <button id="tab-settings" role="tab" aria-controls="panel-settings" aria-selected="false" class="flex-1 rounded-lg text-slate-600 px-3 py-1.5 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white">Settings</button>
+      <button id="tab-notebook" role="tab" aria-controls="panel-notebook" aria-selected="false" class="flex-1 rounded-lg text-slate-600 px-3 py-1.5 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white">Notebook</button>
+    </div>
+
+    <div id="panel-reminders" role="tabpanel" tabindex="0">
     <!-- Quick stats / search -->
     <section class="py-6">
       <div class="rounded-2xl ring-1 ring-black/5 bg-white/80 p-4 dark:bg-slate-900/60 dark:ring-white/10">
@@ -174,9 +181,11 @@
       </ul>
       <div id="syncStatus" class="mt-3 text-sm text-slate-500"></div>
     </section>
+    </div>
 
+    <div id="panel-settings" role="tabpanel" tabindex="0" hidden>
     <!-- Settings / Sync -->
-    <section id="settingsSection" class="py-8 border-t border-slate-200/60 dark:border-slate-800">
+    <section id="settingsSection" class="py-8">
       <h2 class="text-2xl font-semibold tracking-tight mb-4">Sync Settings</h2>
 
       <div class="rounded-2xl ring-1 ring-black/5 bg-white/80 p-5 dark:bg-slate-900/60 dark:ring-white/10">
@@ -210,15 +219,17 @@
             <input id="emailAddress" type="email" class="block w-full rounded-xl border-slate-300/60 bg-white/80 px-3 py-2 focus:ring-2 focus:ring-slate-900/20 outline-none dark:bg-slate-900/60" placeholder="teacher@example.edu.au" />
           </label>
         </div>
-        <div class="mt-3 flex items-center gap-2">
+      <div class="mt-3 flex items-center gap-2">
           <button id="saveEmail" class="inline-flex items-center gap-2 rounded-xl bg-brand-600 text-white px-4 py-2 hover:bg-brand-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-700">Save Email</button>
           <button id="testEmail" class="inline-flex items-center gap-2 rounded-xl ring-1 ring-slate-300/60 bg-white px-4 py-2 hover:bg-slate-50 dark:bg-slate-900 dark:ring-white/10">Send Now</button>
         </div>
       </div>
     </section>
+    </div>
 
+    <div id="panel-notebook" role="tabpanel" tabindex="0" hidden>
     <!-- Notebook -->
-    <section class="py-8 border-t border-slate-200/60 dark:border-slate-800">
+    <section class="py-8">
       <h2 class="text-2xl font-semibold tracking-tight mb-4">Notebook</h2>
       <div class="rounded-2xl ring-1 ring-black/5 bg-white/80 p-5 dark:bg-slate-900/60 dark:ring-white/10">
         <label for="note" class="block text-sm font-medium text-slate-700 dark:text-slate-200 mb-2">Quick note</label>
@@ -229,6 +240,7 @@
         </div>
       </div>
     </section>
+    </div>
   </main>
 
   <footer class="border-t border-slate-200/60 dark:border-slate-800 py-6 mt-6">
@@ -241,6 +253,34 @@
   <!-- Small helpers (no app logic changed) -->
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
+
+    // Simple tabs
+    const tabs = document.querySelectorAll('[role="tab"]');
+    const panels = document.querySelectorAll('[role="tabpanel"]');
+    const baseTab = 'flex-1 rounded-lg px-3 py-1.5 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white';
+    const activeTab = 'bg-slate-900 text-white';
+    const inactiveTab = 'text-slate-600';
+
+    const setActive = (current) => {
+      tabs.forEach((tab) => {
+        const active = tab === current;
+        tab.setAttribute('aria-selected', active);
+        tab.className = `${baseTab} ${active ? activeTab : inactiveTab}`;
+      });
+      panels.forEach((panel) => {
+        panel.hidden = panel.id !== current.getAttribute('aria-controls');
+      });
+    };
+
+    tabs.forEach((tab) => {
+      tab.addEventListener('click', () => setActive(tab));
+    });
+
+    document.getElementById('openSettings')?.addEventListener('click', () => {
+      setActive(document.getElementById('tab-settings'));
+    });
+
+    setActive(document.getElementById('tab-reminders'));
   </script>
 
   <!-- =======================


### PR DESCRIPTION
## Summary
- add tabs to mobile page for Reminders, Settings and Notebook
- include simple JavaScript controller for tab switching

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3610f69808324bc4b4cc252bb19ba