### PR TITLE
Fix manifest link in mobile view and specify start_url

### DIFF
--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "Memory Cue — Reminders",
   "short_name": "Memory Cue",
-  "start_url": "'",
+  "start_url": "/",
   "scope": ".",
   "display": "standalone",
   "theme_color": "#0f172a",

--- a/mobile.html
+++ b/mobile.html
@@ -7,7 +7,7 @@
   <meta name="color-scheme" content="light dark" />
 
   <!-- Manifest hook your script updates at runtime -->
-  <link id="manifestLink" rel="manifest" href="#" />
+  <link id="manifestLink" rel="manifest" href="manifest.webmanifest" />
 
   <!-- Tailwind v4 Play CDN -->
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>


### PR DESCRIPTION
## Summary
- Correct mobile manifest link to point to `manifest.webmanifest`
- Update web manifest `start_url` to root path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3644a0df4832498ab7457a719df98