### PR TITLE
Correct manifest and service worker paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Memory Cue</title>
 
-  <link rel="manifest" href="manifest.json" />
+  <link rel="manifest" href="manifest.webmanifest" />
   <link rel="icon" href="icons/icon-192.png" sizes="192x192" />
   <meta name="theme-color" content="#10b981" media="(prefers-color-scheme: light)">
   <meta name="theme-color" content="#0f172a" media="(prefers-color-scheme: dark)">
@@ -207,7 +207,7 @@
 
     // Service Worker registration
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('./sw.js').catch(console.error);
+      navigator.serviceWorker.register('./service-worker.js').catch(console.error);
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Point the app manifest link at the existing `manifest.webmanifest` file.
- Register the service worker using the proper `service-worker.js` path.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c3ffafbe20832783185443ec7f9735