### PR TITLE
Add manual save/load buttons for mobile notebook

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -277,6 +277,10 @@ z-index:100;box-shadow:var(--shadow-sm)}
       <section class="card section">
         <div class="card-content">
           <textarea id="notes" placeholder="Type notes..." style="width:100%;min-height:200px;"></textarea>
+          <div class="form-row" style="margin-top: var(--space-3);">
+            <button id="saveNotesBtn" class="btn-success flex-1" type="button">Save Notes</button>
+            <button id="loadNotesBtn" class="btn-ghost flex-1" type="button">Load Notes</button>
+          </div>
         </div>
       </section>
     </div>
@@ -354,7 +358,7 @@ z-index:100;box-shadow:var(--shadow-sm)}
     const googleSignInBtn = $('#googleSignInBtn'), googleSignOutBtn = $('#googleSignOutBtn'), googleAvatar = $('#googleAvatar'), googleUserName = $('#googleUserName');
     const moreBtn = $('#moreBtn'), moreMenu = $('#moreMenu');
     const inlineTodayCount = $('#inlineTodayCount'), inlineWeekCount = $('#inlineWeekCount');
-    const notesEl = $('#notes');
+    const notesEl = $('#notes'), saveNotesBtn = $('#saveNotesBtn'), loadNotesBtn = $('#loadNotesBtn');
     const tabs   = document.querySelectorAll('[role="tab"]');
     const panels = document.querySelectorAll('[role="tabpanel"]');
     const baseTab     = 'tab-btn';
@@ -363,6 +367,14 @@ z-index:100;box-shadow:var(--shadow-sm)}
 
     notesEl.value = localStorage.getItem('mobileNotes') || '';
     notesEl.addEventListener('input', () => localStorage.setItem('mobileNotes', notesEl.value));
+    saveNotesBtn?.addEventListener('click', () => {
+      localStorage.setItem('mobileNotes', notesEl.value);
+      toast('Notes saved');
+    });
+    loadNotesBtn?.addEventListener('click', () => {
+      notesEl.value = localStorage.getItem('mobileNotes') || '';
+      toast('Notes loaded');
+    });
 
     function setActive(current) {
       tabs.forEach((tab) => {


### PR DESCRIPTION
## Summary
- add Save Notes and Load Notes buttons in notebook tab
- persist notes to localStorage on save
- allow reloading notes from storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c403d9678c83279ee7832c81006255