### PR TITLE
chore: configure Tailwind build and link generated CSS

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1,0 +1,1 @@
+/* Tailwind build output placeholder - build failed due to missing dependencies */

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="icon" href="icons/icon-192.png" sizes="192x192" />
+  <link rel="stylesheet" href="./css/app.css" />
   <meta name="theme-color" content="#10b981" media="(prefers-color-scheme: light)">
   <meta name="theme-color" content="#0f172a" media="(prefers-color-scheme: dark)">
 

--- a/mobile.html
+++ b/mobile.html
@@ -6,6 +6,7 @@
   <title>Memory Cue (Mobile) — Inline + Edit + Sync All</title>
   <meta name="theme-color" content="#065f46" />
   <link rel="manifest" href="#" id="manifestLink" />
+  <link rel="stylesheet" href="./css/app.css" />
   <style>
     :root{
       --bg-primary:#0b1220; --bg-secondary:#0f172a; --bg-tertiary:#1e293b;

--- a/package.json
+++ b/package.json
@@ -4,13 +4,18 @@
   "description": "",
   "main": "service-worker.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "build:css": "tailwindcss -i ./src/styles/input.css -o ./css/app.css --minify",
+    "watch:css": "tailwindcss -i ./src/styles/input.css -o ./css/app.css --watch"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.16"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -1,0 +1,5 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* If you used custom CSS variables or brand tokens, keep them here too */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./*.html",
+    "./**/*.html",
+    "./**/*.js"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- configure Tailwind and PostCSS, add build scripts
- add Tailwind input and placeholder build output
- reference compiled stylesheet from HTML pages

## Testing
- `npm run build:css` *(fails: tailwindcss: not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c40a520e9483278387ec81a1a6e465