### PR TITLE
Use SVG PWA icons

### DIFF
--- a/icons/icon-192.svg
+++ b/icons/icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="32" fill="#0f172a"/>
+  <text x="50%" y="50%" font-size="96" fill="#fff" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">MC</text>
+</svg>

--- a/icons/icon-512.svg
+++ b/icons/icon-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="64" fill="#0f172a"/>
+  <text x="50%" y="50%" font-size="256" fill="#fff" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">MC</text>
+</svg>

--- a/icons/maskable-192.svg
+++ b/icons/maskable-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" fill="#0f172a"/>
+  <text x="50%" y="50%" font-size="96" fill="#fff" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">MC</text>
+</svg>

--- a/icons/maskable-512.svg
+++ b/icons/maskable-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#0f172a"/>
+  <text x="50%" y="50%" font-size="256" fill="#fff" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">MC</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Memory Cue</title>
 
   <link rel="manifest" href="manifest.webmanifest" />
-  <link rel="icon" href="icons/icon-192.png" sizes="192x192" />
+  <link rel="icon" href="icons/icon-192.svg" type="image/svg+xml" sizes="any" />
   <link rel="stylesheet" href="./css/app.css" />
   <meta name="theme-color" content="#10b981" media="(prefers-color-scheme: light)">
   <meta name="theme-color" content="#0f172a" media="(prefers-color-scheme: dark)">

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -8,9 +8,9 @@
   "background_color": "#0f172a",
   "description": "Offline-friendly reminder app with local notifications, smart sort, voice quick-add, and optional Google Apps Script sync.",
   "icons": [
-    { "src": "icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
-    { "src": "icons/maskable-192.png", "sizes": "192x192", "type": "image/png", "purpose": "maskable any" },
-    { "src": "icons/maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable any" }
+    { "src": "icons/icon-192.svg", "sizes": "192x192", "type": "image/svg+xml" },
+    { "src": "icons/icon-512.svg", "sizes": "512x512", "type": "image/svg+xml" },
+    { "src": "icons/maskable-192.svg", "sizes": "192x192", "type": "image/svg+xml", "purpose": "maskable any" },
+    { "src": "icons/maskable-512.svg", "sizes": "512x512", "type": "image/svg+xml", "purpose": "maskable any" }
   ]
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -23,8 +23,8 @@ const SHELL_URLS = [
   `${APP_PATH}mobile.html`,
   `${APP_PATH}manifest.webmanifest`,
   // Add your real icons below if present; missing files are skipped.
-  `${APP_PATH}icons/icon-192.png`,
-  `${APP_PATH}icons/icon-512.png`,
+  `${APP_PATH}icons/icon-192.svg`,
+  `${APP_PATH}icons/icon-512.svg`,
 ];
 
 // File extensions treated as static assets for SWR caching


### PR DESCRIPTION
## Summary
- replace binary PWA icons with simple SVG placeholders
- update manifest, HTML, and service worker to reference SVG icons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c4899e43e88327bd3f880509734d69