### PR TITLE
feat: expand color palette

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1,6 +1,13 @@
 /* Minimal Tailwind build (dependencies unavailable in this environment) */
+:root{--red:#ef4444;--orange:#f97316;--purple:#8b5cf6;--purple-hover:#7c3aed;--warning-hover:#ea580c;--danger-hover:#dc2626;--success-light:rgba(34,197,94,.1);--warning-light:rgba(249,115,22,.1);--danger-light:rgba(239,68,68,.1);--purple-light:rgba(139,92,246,.1)}
 .pt-safe-top{padding-top:env(safe-area-inset-top)}
 .hidden{display:none}
+.bg-red-500{--tw-bg-opacity:1;background-color:var(--red)}
+.text-red-500{--tw-text-opacity:1;color:var(--red)}
+.bg-orange-500{--tw-bg-opacity:1;background-color:var(--orange)}
+.text-orange-500{--tw-text-opacity:1;color:var(--orange)}
+.bg-purple-500{--tw-bg-opacity:1;background-color:var(--purple)}
+.text-purple-500{--tw-text-opacity:1;color:var(--purple)}
 .bg-brand-50{--tw-bg-opacity:1;background-color:#ecfdf5}
 .bg-brand-100{--tw-bg-opacity:1;background-color:#d1fae5}
 .bg-brand-200{--tw-bg-opacity:1;background-color:#a7f3d0}

--- a/css/teacher.css
+++ b/css/teacher.css
@@ -14,8 +14,16 @@
   --accent-light: rgba(56, 189, 248, 0.1);
   --success: #22c55e;
   --success-hover: #16a34a;
+  --success-light: rgba(34, 197, 94, 0.1);
   --warning: #f59e0b;
+  --warning-hover: #ea580c;
+  --warning-light: rgba(249, 115, 22, 0.1);
   --danger: #ef4444;
+  --danger-hover: #dc2626;
+  --danger-light: rgba(239, 68, 68, 0.1);
+  --purple: #8b5cf6;
+  --purple-hover: #7c3aed;
+  --purple-light: rgba(139, 92, 246, 0.1);
   --border: #334155;
   --border-light: #475569;
 
@@ -142,7 +150,7 @@ body {
 .sidebar-logo {
   font-size: var(--text-xl);
   font-weight: 700;
-  background: linear-gradient(135deg, var(--accent), var(--success));
+  background: linear-gradient(135deg, var(--accent), var(--purple));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -319,6 +327,39 @@ body {
   border-color: var(--accent-hover);
 }
 
+.topbar-btn.purple {
+  background: var(--purple);
+  color: var(--bg-primary);
+  border-color: var(--purple);
+}
+
+.topbar-btn.purple:hover {
+  background: var(--purple-hover);
+  border-color: var(--purple-hover);
+}
+
+.topbar-btn.warning {
+  background: var(--warning);
+  color: var(--bg-primary);
+  border-color: var(--warning);
+}
+
+.topbar-btn.warning:hover {
+  background: var(--warning-hover);
+  border-color: var(--warning-hover);
+}
+
+.topbar-btn.danger {
+  background: var(--danger);
+  color: var(--bg-primary);
+  border-color: var(--danger);
+}
+
+.topbar-btn.danger:hover {
+  background: var(--danger-hover);
+  border-color: var(--danger-hover);
+}
+
 /* Content Panels */
 .content-area {
   flex: 1;
@@ -481,6 +522,42 @@ input::placeholder, textarea::placeholder {
   background: var(--bg-quaternary);
   color: var(--text-primary);
   border-color: var(--border-light);
+}
+
+.btn-purple {
+  background: var(--purple);
+  color: var(--bg-primary);
+  border-color: var(--purple);
+  font-weight: 600;
+}
+
+.btn-purple:hover {
+  background: var(--purple-hover);
+  border-color: var(--purple-hover);
+}
+
+.btn-warning {
+  background: var(--warning);
+  color: var(--bg-primary);
+  border-color: var(--warning);
+  font-weight: 600;
+}
+
+.btn-warning:hover {
+  background: var(--warning-hover);
+  border-color: var(--warning-hover);
+}
+
+.btn-danger {
+  background: var(--danger);
+  color: var(--bg-primary);
+  border-color: var(--danger);
+  font-weight: 600;
+}
+
+.btn-danger:hover {
+  background: var(--danger-hover);
+  border-color: var(--danger-hover);
 }
 
 .btn-ghost {
@@ -913,21 +990,21 @@ input::placeholder, textarea::placeholder {
 }
 
 .priority-high {
-  background: rgba(239, 68, 68, 0.1);
-  color: #fca5a5;
-  border-color: rgba(239, 68, 68, 0.2);
+  background: var(--danger-light);
+  color: var(--danger);
+  border-color: var(--danger-light);
 }
 
 .priority-medium {
-  background: rgba(245, 158, 11, 0.1);
-  color: #fcd34d;
-  border-color: rgba(245, 158, 11, 0.2);
+  background: var(--warning-light);
+  color: var(--warning);
+  border-color: var(--warning-light);
 }
 
 .priority-low {
-  background: rgba(34, 197, 94, 0.1);
-  color: #86efac;
-  border-color: rgba(34, 197, 94, 0.2);
+  background: var(--success-light);
+  color: var(--success);
+  border-color: var(--success-light);
 }
 
 /* Empty States */

--- a/mobile.html
+++ b/mobile.html
@@ -33,7 +33,7 @@
 z-index:100;box-shadow:var(--shadow-sm)}
     .header-content{padding:var(--space-3) 0}
     .header-top{display:flex;justify-content:space-between;align-items:center;margin-bottom:var(--space-4)}
-    h1{font-size:var(--text-2xl);font-weight:700;margin:0;letter-spacing:-.025em;background:linear-gradient(135deg,var(--text-primary),var(--accent));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
+    h1{font-size:var(--text-2xl);font-weight:700;margin:0;letter-spacing:-.025em;background:linear-gradient(135deg,var(--text-primary),var(--purple));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
     .header-controls{display:flex;gap:var(--space-2);flex-wrap:wrap;align-items:center}
     input,select,button,textarea{font-family:inherit;font-size:var(--text-sm);line-height:1.4;border:1px solid var(--border);border-radius:var(--radius);transition:.2s all;-webkit-appearance:none;appearance:none}
     input,select,textarea{background:var(--bg-secondary);color:var(--text-primary);padding:var(--space-3);min-height:var(--button-height);box-shadow:var(--shadow-sm)}
@@ -46,6 +46,12 @@ z-index:100;box-shadow:var(--shadow-sm)}
     .btn-primary:hover,.btn-primary:focus{background:var(--accent-hover);border-color:var(--accent-hover)}
     .btn-success{background:var(--success);color:var(--bg-primary);border-color:var(--success);font-weight:600}
     .btn-success:hover,.btn-success:focus{background:var(--success-hover);border-color:var(--success-hover)}
+    .btn-warning{background:var(--warning);color:var(--bg-primary);border-color:var(--warning);font-weight:600}
+    .btn-warning:hover,.btn-warning:focus{background:var(--warning-hover);border-color:var(--warning-hover)}
+    .btn-danger{background:var(--danger);color:var(--bg-primary);border-color:var(--danger);font-weight:600}
+    .btn-danger:hover,.btn-danger:focus{background:var(--danger-hover);border-color:var(--danger-hover)}
+    .btn-purple{background:var(--purple);color:var(--bg-primary);border-color:var(--purple);font-weight:600}
+    .btn-purple:hover,.btn-purple:focus{background:var(--purple-hover);border-color:var(--purple-hover)}
     .btn-ghost{background:var(--bg-secondary);color:var(--text-secondary);border-color:var(--border)}
     .btn-ghost:hover,.btn-ghost:focus{background:var(--bg-tertiary);color:var(--text-primary);border-color:var(--border-light)}
     .btn-compact{padding:var(--space-2) var(--space-3);min-height:36px;font-size:var(--text-xs)}
@@ -72,9 +78,9 @@ z-index:100;box-shadow:var(--shadow-sm)}
     .task-meta{display:flex;flex-direction:column;gap:var(--space-1);font-size:var(--text-xs);color:var(--text-muted)}
     .task-meta-row{display:flex;gap:var(--space-2);align-items:center;flex-wrap:wrap}
     .priority-badge{padding:2px var(--space-2);border-radius:var(--radius-sm);font-size:var(--text-xs);font-weight:500;border:1px solid transparent;flex-shrink:0}
-    .priority-high{background:rgba(239,68,68,.1);color:#fca5a5;border-color:rgba(239,68,68,.2)}
-    .priority-medium{background:rgba(245,158,11,.1);color:#fcd34d;border-color:rgba(245,158,11,.2)}
-    .priority-low{background:rgba(34,197,94,.1);color:#86efac;border-color:rgba(34,197,94,.2)}
+    .priority-high{background:var(--danger-light);color:var(--danger);border-color:var(--danger-light)}
+    .priority-medium{background:var(--warning-light);color:var(--warning);border-color:var(--warning-light)}
+    .priority-low{background:var(--success-light);color:var(--success);border-color:var(--success-light)}
     input[type="checkbox"]{width:18px;height:18px;cursor:pointer;margin-top:2px}
     .sync-status{padding:var(--space-1) var(--space-2);border-radius:var(--radius-sm);font-size:var(--text-xs);font-weight:600;border:1px solid transparent}
     .sync-status.online{background:rgba(34,197,94,.1);color:var(--success);border-color:rgba(34,197,94,.2)}
@@ -134,8 +140,8 @@ z-index:100;box-shadow:var(--shadow-sm)}
         </div>
         <div class="header-controls">
           <input id="q" class="search-input" placeholder="Search reminders or #tags" aria-label="Search reminders" />
-          <button id="voiceBtn" class="btn-ghost btn-compact" type="button" title="Voice quick add" aria-label="Start voice input">🎙️</button>
-          <button id="notifBtn" class="btn-ghost btn-compact" type="button" title="Enable notifications" aria-label="Enable notifications">🔔</button>
+          <button id="voiceBtn" class="btn-warning btn-compact" type="button" title="Voice quick add" aria-label="Start voice input">🎙️</button>
+          <button id="notifBtn" class="btn-purple btn-compact" type="button" title="Enable notifications" aria-label="Enable notifications">🔔</button>
           <button id="addQuickBtn" class="btn-primary btn-compact" type="button" title="Add quick reminder" aria-label="Add quick reminder">+</button>
           <div class="menu-wrap">
             <button id="moreBtn" class="btn-ghost btn-compact" aria-haspopup="true" aria-expanded="false" aria-controls="moreMenu" title="More actions" aria-label="More actions">⋯</button>
@@ -150,8 +156,8 @@ z-index:100;box-shadow:var(--shadow-sm)}
           </div>
         </div>
         <div class="header-controls" style="margin-top: var(--space-2);">
-          <button id="googleSignInBtn" class="btn-ghost" type="button" aria-label="Sign in with Google">Sign in with Google</button>
-          <button id="googleSignOutBtn" class="btn-ghost hidden" type="button" aria-label="Sign out">
+          <button id="googleSignInBtn" class="btn-purple" type="button" aria-label="Sign in with Google">Sign in with Google</button>
+          <button id="googleSignOutBtn" class="btn-danger hidden" type="button" aria-label="Sign out">
             <img id="googleAvatar" class="google-avatar hidden" alt="Google avatar" />
             Sign out
           </button>
@@ -209,7 +215,7 @@ z-index:100;box-shadow:var(--shadow-sm)}
             </div>
             <div class="form-row">
               <button id="saveBtn" class="btn-success flex-1" type="button">Save Reminder</button>
-              <button id="cancelEditBtn" class="btn-ghost flex-1 hidden" type="button">Cancel</button>
+              <button id="cancelEditBtn" class="btn-danger flex-1 hidden" type="button">Cancel</button>
             </div>
           </div>
           <div id="status" class="status-message" aria-live="polite"></div>


### PR DESCRIPTION
## Summary
- add complementary red, orange, and purple CSS variables and utility classes
- introduce warning, danger, and purple button styles with accessible priority badges
- refresh header gradient and components to use extended palette

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68c53623d34483278196cbabea966342