### PR TITLE
feat: schedule persistent reminders

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -324,6 +324,11 @@ z-index:100;box-shadow:var(--shadow-sm)}
     // ---- Edit state ----
     let editingId = null;
 
+    // Reminder scheduling state
+    const reminderTimers = {};
+    let scheduledReminders = {};
+    try { scheduledReminders = JSON.parse(localStorage.getItem('scheduledReminders') || '{}'); } catch { scheduledReminders = {}; }
+
     const TZ = 'Australia/Adelaide';
     const timeFmt = new Intl.DateTimeFormat('en-AU', { timeZone: TZ, hour:'2-digit', minute:'2-digit' });
     const dayFmt  = new Intl.DateTimeFormat('en-AU', { timeZone: TZ, weekday:'long', day:'numeric', month:'long' });
@@ -748,10 +753,30 @@ z-index:100;box-shadow:var(--shadow-sm)}
       };
       items = [item, ...items]; render(); saveToFirebase(item);
       tryCalendarSync(item);
+      scheduleReminder(item);
       return item;
     }
-    function toggleDone(id){ const it = items.find(x=>x.id===id); if(!it) return; it.done=!it.done; it.updatedAt=Date.now(); saveToFirebase(it); tryCalendarSync(it); render(); }
-    function removeItem(id){ items = items.filter(x=>x.id!==id); render(); deleteFromFirebase(id); }
+    function toggleDone(id){ const it = items.find(x=>x.id===id); if(!it) return; it.done=!it.done; it.updatedAt=Date.now(); saveToFirebase(it); tryCalendarSync(it); render(); if(it.done) cancelReminder(id); else scheduleReminder(it); }
+    function removeItem(id){ items = items.filter(x=>x.id!==id); render(); deleteFromFirebase(id); cancelReminder(id); }
+
+    // Reminder scheduling
+    function saveScheduled(){ localStorage.setItem('scheduledReminders', JSON.stringify(scheduledReminders)); }
+    function cancelReminder(id){ if(reminderTimers[id]){ clearTimeout(reminderTimers[id]); delete reminderTimers[id]; } if(scheduledReminders[id]){ delete scheduledReminders[id]; saveScheduled(); } }
+    function showReminder(item){ try{ new Notification(item.title, { body: 'Due now', tag: item.id }); }catch{} }
+    function scheduleReminder(item){
+      if(!item || !item.id) return;
+      if(!item.due || item.done){ cancelReminder(item.id); return; }
+      // store for persistence
+      scheduledReminders[item.id] = { id: item.id, title: item.title, due: item.due };
+      saveScheduled();
+      // clear existing timer
+      if(reminderTimers[item.id]){ clearTimeout(reminderTimers[item.id]); delete reminderTimers[item.id]; }
+      if(!('Notification' in window) || Notification.permission !== 'granted'){ return; }
+      const delay = new Date(item.due).getTime() - Date.now();
+      if(delay <= 0){ showReminder(item); cancelReminder(item.id); return; }
+      reminderTimers[item.id] = setTimeout(() => { showReminder(item); cancelReminder(item.id); }, delay);
+    }
+    function rescheduleAllReminders(){ Object.values(scheduledReminders).forEach(it => scheduleReminder(it)); }
 
     // Rendering
     function render(){
@@ -850,7 +875,7 @@ z-index:100;box-shadow:var(--shadow-sm)}
           const p = parseQuickWhen(tNew); if (p.time) { due = new Date(`${p.date}T${p.time}:00`).toISOString(); }
         }
         it.title = tNew; it.priority = priority.value; it.due = due; it.updatedAt = Date.now();
-        saveToFirebase(it); tryCalendarSync(it); render(); resetForm(); toast('Reminder updated');
+        saveToFirebase(it); tryCalendarSync(it); render(); scheduleReminder(it); resetForm(); toast('Reminder updated');
         return;
       }
 
@@ -1005,6 +1030,7 @@ z-index:100;box-shadow:var(--shadow-sm)}
     })();
 
     // Initial render
+    rescheduleAllReminders();
     render();
   </script>
 </body>

--- a/service-worker.js
+++ b/service-worker.js
@@ -159,3 +159,12 @@ async function networkFirstWithTimeout(req, timeoutMs, offlineFallbackUrl) {
     });
   }
 }
+
+self.addEventListener('push', (event) => {
+  let data = {};
+  try { data = event.data.json(); }
+  catch { data = { body: event.data && event.data.text() }; }
+  const title = data.title || 'Memory Cue Reminder';
+  const options = { body: data.body || '', data };
+  event.waitUntil(self.registration.showNotification(title, options));
+});


### PR DESCRIPTION
## Summary
- schedule local notifications for reminders and persist them across reloads
- reschedule pending reminders on startup
- handle push events in service worker for future backend notifications

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_b_68c5372aba18832785f0fe81f021cc6f