### PR TITLE
feat: add dark theme variables

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,10 @@
       --surface: #F8FAFC;
       --text: #1F2937;
     }
+    [data-theme="dark"] {
+      --surface: #0b1220;
+      --text: #f8fafc;
+    }
   </style>
   <nav aria-label="Primary" class="flex gap-4 p-4">
     <button data-route="dashboard" id="nav-dashboard" class="px-2 py-1 rounded bg-slate-200">Dashboard</button>


### PR DESCRIPTION
## Summary
- add `[data-theme="dark"]` CSS rule defining surface and text colors

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden to registry)*
- `npx jest` *(fails: 403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_b_68c5538e6cc4832796ad3df380e480a8