### PR TITLE
Respect system theme preference

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -58,7 +58,8 @@ function toggleTheme(){
   setTheme(current === 'dark' ? 'light' : 'dark');
 }
 themeToggle?.addEventListener('click', toggleTheme);
-setTheme(localStorage.getItem('theme') || 'light');
+const preferred = localStorage.getItem('theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+setTheme(preferred);
 
 // Reminders
 function onAddReminder(e){

--- a/theme-toggle.test.js
+++ b/theme-toggle.test.js
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment jsdom
+ */
+const { test, expect, beforeEach } = require('@jest/globals');
+
+beforeEach(() => {
+  // Minimal DOM with theme toggle button
+  document.body.innerHTML = '<button id="theme-toggle"></button>';
+  // Stub matchMedia to avoid errors and default to light mode
+  window.matchMedia = window.matchMedia || function(){
+    return { matches: false, addListener: () => {}, removeListener: () => {} };
+  };
+  // Clear localStorage and provide firebase stub used in main.js
+  localStorage.clear();
+  global.firebase = {
+    auth: Object.assign(
+      () => ({
+        signInWithPopup: jest.fn(),
+        signOut: jest.fn(),
+        onAuthStateChanged: jest.fn(),
+      }),
+      { GoogleAuthProvider: function(){} }
+    ),
+  };
+  jest.resetModules();
+  require('./js/main.js');
+});
+
+test('toggle persists theme', () => {
+  const btn = document.getElementById('theme-toggle');
+  // Default should be light
+  expect(localStorage.getItem('theme')).toBe('light');
+  btn.click();
+  expect(localStorage.getItem('theme')).toBe('dark');
+  btn.click();
+  expect(localStorage.getItem('theme')).toBe('light');
+});


### PR DESCRIPTION
## Summary
- Default theme now follows stored preference or the browser's color scheme.
- Add Jest test verifying theme toggle writes to localStorage.

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden for autoprefixer package)*
- `npx jest` *(fails: 403 Forbidden for jest package)*

------
https://chatgpt.com/codex/tasks/task_b_68c5546b64d48327be071a320677320f