### PR TITLE
feat: enable class-based dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,39 +18,27 @@
     .pt-safe-top { padding-top: env(safe-area-inset-top); }
   </style>
 </head>
-<body id="top" class="bg-[var(--surface)] text-[var(--text)] antialiased leading-7">
-  <style>
-    :root{
-      --brand: #10b981;
-      --accent: #0ea5e9;
-      --surface: #F8FAFC;
-      --text: #1F2937;
-    }
-    [data-theme="dark"] {
-      --surface: #0b1220;
-      --text: #f8fafc;
-    }
-  </style>
+<body id="top" class="bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 antialiased leading-7">
   <nav aria-label="Primary" class="flex gap-4 p-4">
-    <button data-route="dashboard" id="nav-dashboard" class="px-2 py-1 rounded bg-slate-200">Dashboard</button>
-    <button data-route="reminders" id="nav-reminders" class="px-2 py-1 rounded bg-slate-200">Reminders</button>
-    <button data-route="planner" id="nav-planner" class="px-2 py-1 rounded bg-slate-200">Planner</button>
-    <button data-route="notes" id="nav-notes" class="px-2 py-1 rounded bg-slate-200">Notes</button>
-    <button data-route="resources" id="nav-resources" class="px-2 py-1 rounded bg-slate-200">Resources</button>
-    <button data-route="templates" id="nav-templates" class="px-2 py-1 rounded bg-slate-200">Templates</button>
-    <button data-route="settings" id="nav-settings" class="px-2 py-1 rounded bg-slate-200">Settings</button>
-    <button id="theme-toggle" class="px-2 py-1 rounded bg-slate-200">Theme</button>
-    <button id="sign-in-btn" class="px-2 py-1 rounded bg-slate-200">Sign In</button>
-    <button id="sign-out-btn" class="px-2 py-1 rounded bg-slate-200" hidden>Sign Out</button>
+    <button data-route="dashboard" id="nav-dashboard" class="px-2 py-1 rounded bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100">Dashboard</button>
+    <button data-route="reminders" id="nav-reminders" class="px-2 py-1 rounded bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100">Reminders</button>
+    <button data-route="planner" id="nav-planner" class="px-2 py-1 rounded bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100">Planner</button>
+    <button data-route="notes" id="nav-notes" class="px-2 py-1 rounded bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100">Notes</button>
+    <button data-route="resources" id="nav-resources" class="px-2 py-1 rounded bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100">Resources</button>
+    <button data-route="templates" id="nav-templates" class="px-2 py-1 rounded bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100">Templates</button>
+    <button data-route="settings" id="nav-settings" class="px-2 py-1 rounded bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100">Settings</button>
+    <button id="theme-toggle" class="px-2 py-1 rounded bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100">Theme</button>
+    <button id="sign-in-btn" class="px-2 py-1 rounded bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100">Sign In</button>
+    <button id="sign-out-btn" class="px-2 py-1 rounded bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100" hidden>Sign Out</button>
   </nav>
   <main class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
     <section data-view="dashboard" id="view-dashboard">
       <!-- Hero -->
       <section class="pt-24 pb-16 text-center">
         <h1 class="text-4xl sm:text-5xl font-bold tracking-tight">Memory Cue</h1>
-        <p class="mt-4 text-lg text-slate-700">All your classroom tools in one place.</p>
+        <p class="mt-4 text-lg text-slate-700 dark:text-slate-300">All your classroom tools in one place.</p>
         <div class="mt-8 flex flex-col sm:flex-row justify-center gap-4">
-          <a href="#" class="inline-flex items-center justify-center rounded-xl bg-[var(--brand)] text-white px-6 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--brand)] transition-opacity motion-safe:duration-200 motion-safe:hover:opacity-90">Get started</a>
+          <a href="#" class="inline-flex items-center justify-center rounded-xl bg-brand-600 text-white px-6 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand-600 transition-opacity motion-safe:duration-200 motion-safe:hover:opacity-90">Get started</a>
         </div>
       </section>
 
@@ -59,22 +47,22 @@
         <h2 id="inside-heading" class="text-2xl font-semibold text-center">What's inside</h2>
         <div class="mt-8 grid grid-cols-1 sm:grid-cols-3 gap-8">
           <!-- Reminders -->
-          <div class="p-8 rounded-xl bg-white shadow flex flex-col items-start transition-transform motion-safe:duration-200 motion-safe:hover:-translate-y-0.5">
-            <svg class="w-6 h-6 text-[var(--brand)] mb-4" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l4 2"/></svg>
+          <div class="p-8 rounded-xl bg-white dark:bg-slate-800 shadow flex flex-col items-start transition-transform motion-safe:duration-200 motion-safe:hover:-translate-y-0.5">
+            <svg class="w-6 h-6 text-brand-600 mb-4" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l4 2"/></svg>
             <h3 class="font-medium">Reminders</h3>
-            <p class="mt-2 text-sm text-slate-700">Set tasks and forget the forgetting.</p>
+            <p class="mt-2 text-sm text-slate-700 dark:text-slate-300">Set tasks and forget the forgetting.</p>
           </div>
           <!-- Planner -->
-          <div class="p-8 rounded-xl bg-white shadow flex flex-col items-start transition-transform motion-safe:duration-200 motion-safe:hover:-translate-y-0.5">
-            <svg class="w-6 h-6 text-[var(--brand)] mb-4" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M3 5h18M3 12h18M3 19h18"/></svg>
+          <div class="p-8 rounded-xl bg-white dark:bg-slate-800 shadow flex flex-col items-start transition-transform motion-safe:duration-200 motion-safe:hover:-translate-y-0.5">
+            <svg class="w-6 h-6 text-brand-600 mb-4" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M3 5h18M3 12h18M3 19h18"/></svg>
             <h3 class="font-medium">Planner</h3>
-            <p class="mt-2 text-sm text-slate-700">Organize your day at a glance.</p>
+            <p class="mt-2 text-sm text-slate-700 dark:text-slate-300">Organize your day at a glance.</p>
           </div>
           <!-- Notes -->
-          <div class="p-8 rounded-xl bg-white shadow flex flex-col items-start transition-transform motion-safe:duration-200 motion-safe:hover:-translate-y-0.5">
-            <svg class="w-6 h-6 text-[var(--brand)] mb-4" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M5 3h14v18H5z"/></svg>
+          <div class="p-8 rounded-xl bg-white dark:bg-slate-800 shadow flex flex-col items-start transition-transform motion-safe:duration-200 motion-safe:hover:-translate-y-0.5">
+            <svg class="w-6 h-6 text-brand-600 mb-4" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M5 3h14v18H5z"/></svg>
             <h3 class="font-medium">Notes</h3>
-            <p class="mt-2 text-sm text-slate-700">Capture ideas before they fade.</p>
+            <p class="mt-2 text-sm text-slate-700 dark:text-slate-300">Capture ideas before they fade.</p>
           </div>
         </div>
       </section>
@@ -82,33 +70,33 @@
     <section data-view="reminders" id="view-reminders" hidden>
       <form id="add-reminder-form" class="mb-4 flex gap-2">
         <input name="reminder" class="border p-2 flex-1" placeholder="New reminder" />
-        <button type="submit" class="px-4 py-2 bg-[var(--brand)] text-white rounded">Add</button>
+        <button type="submit" class="px-4 py-2 bg-brand-600 text-white rounded">Add</button>
       </form>
       <ul id="reminders-list" class="list-disc pl-5"></ul>
     </section>
     <section data-view="planner" id="view-planner" hidden>
       <div class="flex gap-2 mb-4">
-        <button id="planner-prev" class="px-2 py-1 bg-slate-200 rounded">Prev</button>
-        <button id="planner-today" class="px-2 py-1 bg-slate-200 rounded">Today</button>
-        <button id="planner-next" class="px-2 py-1 bg-slate-200 rounded">Next</button>
+        <button id="planner-prev" class="px-2 py-1 bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100 rounded">Prev</button>
+        <button id="planner-today" class="px-2 py-1 bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100 rounded">Today</button>
+        <button id="planner-next" class="px-2 py-1 bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100 rounded">Next</button>
       </div>
-      <div id="planner-week" class="p-4 bg-white rounded shadow"></div>
+      <div id="planner-week" class="p-4 bg-white dark:bg-slate-800 rounded shadow"></div>
     </section>
     <section data-view="notes" id="view-notes" hidden>
       <textarea id="quick-note" class="w-full border p-2" rows="5" placeholder="Write a quick note..."></textarea>
       <div class="mt-2 flex gap-2">
-        <button id="save-note" class="px-4 py-2 bg-[var(--brand)] text-white rounded">Save</button>
-        <button id="clear-note" class="px-4 py-2 bg-slate-200 rounded">Clear</button>
+        <button id="save-note" class="px-4 py-2 bg-brand-600 text-white rounded">Save</button>
+        <button id="clear-note" class="px-4 py-2 bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100 rounded">Clear</button>
       </div>
     </section>
     <section data-view="resources" id="view-resources" hidden></section>
     <section data-view="templates" id="view-templates" hidden></section>
     <section data-view="settings" id="view-settings" hidden></section>
   </main>
-  <footer class="border-t border-slate-200 py-8 mt-16">
+  <footer class="border-t border-slate-200 dark:border-slate-700 py-8 mt-16">
     <div class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between text-sm">
       <p>&copy; <span id="year"></span> Memory Cue</p>
-      <a href="#top" class="text-[var(--brand)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--brand)]">Back to top</a>
+      <a href="#top" class="text-brand-600 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand-600">Back to top</a>
     </div>
   </footer>
   <script>

--- a/js/main.js
+++ b/js/main.js
@@ -50,11 +50,11 @@ auth.onAuthStateChanged((user) => {
 // Theme toggle
 const themeToggle = document.getElementById('theme-toggle');
 function setTheme(t){
-  document.documentElement.dataset.theme = t;
+  document.documentElement.classList.toggle('dark', t === 'dark');
   localStorage.setItem('theme', t);
 }
 function toggleTheme(){
-  const current = document.documentElement.dataset.theme || 'light';
+  const current = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
   setTheme(current === 'dark' ? 'light' : 'dark');
 }
 themeToggle?.addEventListener('click', toggleTheme);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["./*.html", "./**/*.html", "./**/*.js"],
-  // darkMode: "class", // uncomment if you want to toggle via a .dark class
+  darkMode: "class",
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- enable Tailwind's class-based dark mode
- replace CSS variables with Tailwind light/dark utility classes
- toggle theme by adding/removing `dark` class on `<html>`

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - autoprefixer)*

------
https://chatgpt.com/codex/tasks/task_b_68c55662bdc08327b74cb9f6356d8d4d