### PR TITLE
Fix Firebase module errors and copy button reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,10 +141,6 @@
     // Set current year
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
-  <!-- Firebase SDKs (compat versions for existing logic) -->
-  <script defer src="https://www.gstatic.com/firebasejs/12.2.1/firebase-app.js"></script>
-  <script defer src="https://www.gstatic.com/firebasejs/12.2.1/firebase-firestore.js"></script>
-  <script defer src="https://www.gstatic.com/firebasejs/12.2.1/firebase-auth.js"></script>
   <!-- Reminder logic -->
   <script type="module">
     import { initReminders } from './js/reminders.js';

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -34,6 +34,7 @@ export function initReminders(sel = {}) {
   const notifBtn = $(sel.notifBtnSel);
   const moreBtn = $(sel.moreBtnSel);
   const moreMenu = $(sel.moreMenuSel);
+  const copyMtlBtn = $(sel.copyMtlBtnSel);
   const importFile = $(sel.importFileSel);
   const exportBtn = $(sel.exportBtnSel);
   const syncAllBtn = $(sel.syncAllBtnSel);


### PR DESCRIPTION
## Summary
- remove redundant Firebase SDK script tags so modules load correctly
- define copyMtlBtn reference in reminders logic

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/autoprefixer)*

------
https://chatgpt.com/codex/tasks/task_b_68c690c21df8832780f65b8c0fd1791c