### PR TITLE
Fix header navigation by loading main script and guarding auth

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,6 +141,7 @@
     // Set current year
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
+  <script src="./js/main.js"></script>
   <!-- Reminder logic -->
   <script type="module">
     import { initReminders } from './js/reminders.js';

--- a/js/main.js
+++ b/js/main.js
@@ -22,30 +22,33 @@ window.addEventListener('hashchange', () => {
 show((location.hash || '#dashboard').slice(1));
 
 // Firebase auth
-const auth = firebase.auth();
 const signInBtn = document.getElementById('sign-in-btn');
 const signOutBtn = document.getElementById('sign-out-btn');
 
-signInBtn?.addEventListener('click', async () => {
-  try {
-    const provider = new firebase.auth.GoogleAuthProvider();
-    await auth.signInWithPopup(provider);
-  } catch (err) {
-    alert(err.message);
-  }
-});
+if (typeof firebase !== 'undefined' && firebase.auth) {
+  const auth = firebase.auth();
 
-signOutBtn?.addEventListener('click', () => auth.signOut());
+  signInBtn?.addEventListener('click', async () => {
+    try {
+      const provider = new firebase.auth.GoogleAuthProvider();
+      await auth.signInWithPopup(provider);
+    } catch (err) {
+      alert(err.message);
+    }
+  });
 
-auth.onAuthStateChanged((user) => {
-  if (user) {
-    signInBtn.hidden = true;
-    signOutBtn.hidden = false;
-  } else {
-    signInBtn.hidden = false;
-    signOutBtn.hidden = true;
-  }
-});
+  signOutBtn?.addEventListener('click', () => auth.signOut());
+
+  auth.onAuthStateChanged((user) => {
+    if (user) {
+      signInBtn.hidden = true;
+      signOutBtn.hidden = false;
+    } else {
+      signInBtn.hidden = false;
+      signOutBtn.hidden = true;
+    }
+  });
+}
 
 // Theme toggle
 const themeToggle = document.getElementById('theme-toggle');


### PR DESCRIPTION
## Summary
- Load main.js on index page so navigation and theme toggle work
- Protect Firebase auth logic so page functions even without Firebase

## Testing
- `npm test` *(fails: jest: not found)*
- `npx jest` *(fails: 403 Forbidden to registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_b_68c69440d44483279c9c5a46c8735156