### PR TITLE
Align mobile action buttons with app theme

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -140,9 +140,9 @@ z-index:100;box-shadow:var(--shadow-sm)}
         </div>
         <div class="header-controls">
           <input id="q" class="search-input" placeholder="Search reminders or #tags" aria-label="Search reminders" />
-          <button id="voiceBtn" class="btn-warning btn-compact" type="button" title="Voice quick add" aria-label="Start voice input">🎙️</button>
-          <button id="notifBtn" class="btn-purple btn-compact" type="button" title="Enable notifications" aria-label="Enable notifications">🔔</button>
-          <button id="addQuickBtn" class="btn-primary btn-compact" type="button" title="Add quick reminder" aria-label="Add quick reminder">+</button>
+          <button id="voiceBtn" class="btn-success btn-compact" type="button" title="Voice quick add" aria-label="Start voice input">🎙️</button>
+          <button id="notifBtn" class="btn-success btn-compact" type="button" title="Enable notifications" aria-label="Enable notifications">🔔</button>
+          <button id="addQuickBtn" class="btn-success btn-compact" type="button" title="Add quick reminder" aria-label="Add quick reminder">+</button>
           <div class="menu-wrap">
             <button id="moreBtn" class="btn-ghost btn-compact" aria-haspopup="true" aria-expanded="false" aria-controls="moreMenu" title="More actions" aria-label="More actions">⋯</button>
             <div id="moreMenu" class="menu hidden" role="menu" aria-label="More actions">


### PR DESCRIPTION
## Summary
- Use the app's success theme color for mobile header actions (voice, notifications, add quick reminder) to maintain a consistent look

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden fetching autoprefixer)*

------
https://chatgpt.com/codex/tasks/task_b_68c69c04c1f88327b1b2ee2ba4362a51