### PR TITLE
feat: add note saving and formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,9 +121,17 @@
       <div id="planner-week" class="p-4 bg-white dark:bg-slate-800 rounded shadow"></div>
     </section>
     <section data-view="notes" id="view-notes" hidden>
-      <textarea id="quick-note" class="w-full border p-2" rows="5" placeholder="Write a quick note..."></textarea>
-      <div class="mt-2 flex gap-2">
-        <button id="save-note" class="px-4 py-2 bg-brand-600 text-white rounded">Save</button>
+      <div class="flex gap-2 mb-2">
+        <button id="bullet-btn" class="px-2 py-1 bg-slate-200 dark:bg-slate-700 rounded">&bull;</button>
+        <button id="number-btn" class="px-2 py-1 bg-slate-200 dark:bg-slate-700 rounded">1.</button>
+      </div>
+      <div id="quick-note" class="w-full border p-2 h-40 overflow-auto" contenteditable="true" aria-label="Write a quick note..."></div>
+      <div class="mt-2 flex flex-wrap gap-2">
+        <button id="save-note" type="button" class="px-4 py-2 bg-brand-600 text-white rounded">Save</button>
+        <select id="saved-notes" class="border p-2 flex-1">
+          <option value="">Select a note</option>
+        </select>
+        <button id="load-note" class="px-4 py-2 bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100 rounded">Load</button>
         <button id="clear-note" class="px-4 py-2 bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100 rounded">Clear</button>
       </div>
     </section>
@@ -145,7 +153,6 @@
     // Set current year
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
-  <script src="./js/main.js"></script>
   <!-- Reminder logic -->
   <script type="module">
     import { initReminders } from './js/reminders.js';

--- a/js/main.js
+++ b/js/main.js
@@ -94,13 +94,58 @@ renderWeek();
 
 // Notes
 const noteEl = document.getElementById('quick-note');
+const savedSelect = document.getElementById('saved-notes');
+
+function getNotes(){
+  try {
+    const raw = localStorage.getItem('saved-notes');
+    return raw ? JSON.parse(raw) : [];
+  } catch (e) {
+    console.error('Failed to parse saved notes', e);
+    return [];
+  }
+}
+
+function saveNotes(notes){
+  localStorage.setItem('saved-notes', JSON.stringify(notes));
+}
+
+function refreshSelect(){
+  if(!savedSelect) return;
+  const notes = getNotes();
+  savedSelect.innerHTML = '<option value="">Select a note</option>' +
+    notes.map((n, i) => `<option value="${i}">${n.title}</option>`).join('');
+}
+
 if(noteEl){
-  noteEl.value = localStorage.getItem('quick-note') || '';
+  refreshSelect();
+
   document.getElementById('save-note')?.addEventListener('click', () => {
-    localStorage.setItem('quick-note', noteEl.value);
+    const content = noteEl.innerHTML;
+    const title = content.replace(/<[^>]+>/g, '').slice(0, 20) || 'Untitled';
+    const notes = getNotes();
+    notes.push({ title, content });
+    saveNotes(notes);
+    refreshSelect();
   });
+
+  document.getElementById('load-note')?.addEventListener('click', () => {
+    const idx = savedSelect?.value;
+    const notes = getNotes();
+    if(idx !== '' && notes[idx]){
+      noteEl.innerHTML = notes[idx].content;
+    }
+  });
+
   document.getElementById('clear-note')?.addEventListener('click', () => {
-    noteEl.value = '';
-    localStorage.removeItem('quick-note');
+    noteEl.innerHTML = '';
+  });
+
+  document.getElementById('bullet-btn')?.addEventListener('click', () => {
+    document.execCommand('insertUnorderedList');
+  });
+
+  document.getElementById('number-btn')?.addEventListener('click', () => {
+    document.execCommand('insertOrderedList');
   });
 }


### PR DESCRIPTION
## Summary
- add toolbar with bullet and number formatting to notes section
- enable saving and loading multiple notes from local storage
- harden note storage parsing and remove duplicate script include

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c69c37e7b883279526591e58ee138e