### PR TITLE
Add meta description and manifest link to index

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,11 +3,13 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="description" content="Memory Cue is a comprehensive teacher organiser combining dashboards, reminders, planners, notes, and resources in one streamlined app." />
   <title>Memory Cue — Teacher One-Stop Shop Organiser</title>
   <meta name="theme-color" content="#10b981" media="(prefers-color-scheme: light)">
   <meta name="theme-color" content="#0f172a" media="(prefers-color-scheme: dark)">
   <link rel="preconnect" href="https://www.gstatic.com" crossorigin>
   <link rel="dns-prefetch" href="https://www.gstatic.com">
+  <link rel="manifest" href="manifest.webmanifest">
   <!-- Tailwind v4 (Play CDN) -->
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
   <style>


### PR DESCRIPTION
## Summary
- add a descriptive meta tag for Memory Cue in the head of index.html
- link the manifest file after the dns-prefetch tag to enable PWA support

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9172b0aa483248daf02559037fda0