### PR TITLE
Add defer attributes to blocking scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="dns-prefetch" href="https://www.gstatic.com">
   <link rel="manifest" href="manifest.webmanifest">
   <!-- Tailwind v4 (Play CDN) -->
-  <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
   <style>
     html { scroll-behavior: smooth; }
     /* Your existing Tailwind / other styles here */
@@ -436,14 +436,14 @@
       </div>
     </div>
   </footer>
-  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
-  <script src="./js/firebase-init.js"></script>
+  <script defer src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
+  <script defer src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
+  <script defer src="./js/firebase-init.js"></script>
   <script>
     // Set current year
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
-  <script src="./js/main.js"></script>
+  <script defer src="./js/main.js"></script>
   <!-- Reminder logic -->
   <script type="module">
     import { initReminders } from './js/reminders.js';


### PR DESCRIPTION
## Summary
- add the defer attribute to each non-module script tag in index.html so they do not block page rendering
- attempted to fetch CDN resources to compute SRI hashes but network access was blocked by the environment

## Testing
- `npm test` *(fails: `jest` binary not found because dependencies cannot be installed without registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68c919f8242483249c99d0e31874b773