### PR TITLE
Add SRI and defer to CDN scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,12 @@
   <!-- PWA manifest -->
   <link rel="manifest" href="manifest.webmanifest" />
   <!-- Tailwind v4 (Play CDN) -->
-  <script defer src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+  <script
+    defer
+    src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"
+    integrity="sha384-YJvHoUr6w1FlD9gzD41c9ztiiG5wIJ9fhnawEIqr4iNzJgEpeI++XwO6yjHdcDte"
+    crossorigin="anonymous"
+  ></script>
   <style>
     html { scroll-behavior: smooth; }
     /* Your existing Tailwind / other styles here */
@@ -437,8 +442,18 @@
       </div>
     </div>
   </footer>
-  <script defer src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
-  <script defer src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
+  <script
+    defer
+    src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"
+    integrity="sha384-+KqYOH8TSu3FKjN3ld86eZMYqq6lk+y2GjV1hyOW+1hT3Pk/aD8JFueZP1W3bPh1"
+    crossorigin="anonymous"
+  ></script>
+  <script
+    defer
+    src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"
+    integrity="sha384-+OubPIxtsLCp2uUuSsvWDuBB9oSIEDIYt2qQfYki+vDmSxc6GQsBbBPH6Z6x5wrq"
+    crossorigin="anonymous"
+  ></script>
   <script defer src="./js/firebase-init.js"></script>
   <script>
     // Set current year


### PR DESCRIPTION
## Summary
- add subresource integrity and crossorigin metadata to the Tailwind Play CDN script
- secure the Firebase compat loaders with matching integrity hashes and anonymous CORS

## Testing
- npm test *(fails: jest executable is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c93d32d43c8324aa2e53f5a71ae380