### PR TITLE
Improve mobile menu accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,15 +139,25 @@
         
         <!-- Mobile Navigation Button -->
         <div class="nav-mobile items-center">
-          <button id="mobile-menu-btn" class="px-3 py-2 rounded-lg hover:bg-white/20 text-white transition-all duration-200">
+          <button
+            id="mobile-menu-btn"
+            class="px-3 py-2 rounded-lg hover:bg-white/20 text-white transition-all duration-200"
+            aria-label="Open navigation menu"
+            aria-controls="mobile-menu"
+            aria-expanded="false"
+          >
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
             </svg>
           </button>
         </div>
-        
+
         <div class="flex items-center space-x-2">
-          <button id="theme-toggle" class="px-3 py-2 rounded-lg hover:bg-white/20 text-white/80 hover:text-white transition-all duration-200">🌙</button>
+          <button
+            id="theme-toggle"
+            class="px-3 py-2 rounded-lg hover:bg-white/20 text-white/80 hover:text-white transition-all duration-200"
+            aria-label="Toggle theme"
+          >🌙</button>
           <button id="sign-in-btn" class="px-4 py-2 rounded-lg bg-white text-purple-600 font-semibold hover:bg-white/90 transition-all duration-200 hover:scale-105">Sign In</button>
           <button id="sign-out-btn" class="px-4 py-2 rounded-lg bg-red-500 text-white font-semibold hover:bg-red-600 transition-all duration-200 hover:scale-105" hidden>Sign Out</button>
         </div>

--- a/js/main.js
+++ b/js/main.js
@@ -5,14 +5,25 @@ const mobileMenuBtn = document.getElementById('mobile-menu-btn');
 const mobileMenu = document.getElementById('mobile-menu');
 
 function toggleMobileMenu() {
-  mobileMenu.classList.toggle('open');
+  if (!mobileMenu) return;
+  const isOpen = mobileMenu.classList.toggle('open');
+  mobileMenu.hidden = !isOpen;
+  if (mobileMenuBtn) {
+    mobileMenuBtn.setAttribute('aria-expanded', String(isOpen));
+  }
 }
 
 function closeMobileMenu() {
+  if (!mobileMenu) return;
   mobileMenu.classList.remove('open');
+  mobileMenu.hidden = true;
+  mobileMenuBtn?.setAttribute('aria-expanded', 'false');
 }
 
 mobileMenuBtn?.addEventListener('click', toggleMobileMenu);
+if (mobileMenu) {
+  closeMobileMenu();
+}
 
 // Close mobile menu when clicking outside
 document.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- add accessibility labels to the mobile navigation and theme toggle buttons
- update the mobile menu scripting to sync aria-expanded and hidden state when opening or closing the menu

## Testing
- npm test -- --watchAll=false *(fails: jest not found because npm install cannot access registry due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c946a6b8c08324a89ad074cf8fbdc7