### PR TITLE
Update Get Started CTA to use reminders route

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,10 +199,10 @@
           </p>
           
           <div class="mt-12 flex flex-col sm:flex-row justify-center gap-6">
-            <a href="#" class="group relative inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-white bg-white/20 rounded-xl backdrop-blur-sm border border-white/30 hover:bg-white/30 hover:scale-105 transition-all duration-300 shadow-lg hover:shadow-xl">
+            <button type="button" data-route="reminders" class="group relative inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-white bg-white/20 rounded-xl backdrop-blur-sm border border-white/30 hover:bg-white/30 hover:scale-105 transition-all duration-300 shadow-lg hover:shadow-xl">
               <span class="relative z-10">Get Started Free</span>
-              <div class="absolute inset-0 rounded-xl bg-gradient-to-r from-purple-500 to-blue-500 opacity-0 group-hover:opacity-20 transition-opacity duration-300"></div>
-            </a>
+              <span aria-hidden="true" class="absolute inset-0 rounded-xl bg-gradient-to-r from-purple-500 to-blue-500 opacity-0 group-hover:opacity-20 transition-opacity duration-300"></span>
+            </button>
             <a href="#features" class="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-white border-2 border-white/30 rounded-xl hover:bg-white/10 hover:scale-105 transition-all duration-300">
               Learn More
               <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">


### PR DESCRIPTION
## Summary
- convert the hero "Get Started Free" link into a button that hooks into the existing SPA routing
- reuse the CTA styling while marking the decorative gradient as aria-hidden for accessibility

## Testing
- npm install *(fails: registry access is forbidden in this environment)*
- npm test *(fails: jest is unavailable because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c94c11aa648324a72e37d2deb3bca3