### PR TITLE
Remove hero tagline from landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,15 +189,6 @@
         </div>
         
         <div class="relative z-10 text-center px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto pt-16">
-          <h1 class="text-5xl sm:text-6xl lg:text-7xl font-bold tracking-tight text-white mb-8 floating-animation">
-            <span class="block">Memory Cue</span>
-            <span class="block text-3xl sm:text-4xl lg:text-5xl font-light text-white/90 mt-4">Your Teaching Companion</span>
-          </h1>
-          
-          <p class="mt-8 text-xl sm:text-2xl text-white/90 max-w-3xl mx-auto leading-relaxed">
-            Transform your classroom experience with our all-in-one platform. Organize, plan, and inspire with tools designed specifically for educators.
-          </p>
-          
           <div class="mt-12 flex flex-col sm:flex-row justify-center gap-6">
             <button
               id="get-started-btn"


### PR DESCRIPTION
## Summary
- remove the hero heading and descriptive paragraph from the dashboard landing section

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c94f9398bc8324ac814b63932010cb