### PR TITLE
Ensure nav highlights expose aria-current for active route

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -39,14 +39,27 @@ function show(view){
   history.replaceState(null, '', `#${view}`);
   
   // Update active navigation states
-  document.querySelectorAll('[data-route]').forEach(btn => {
-    btn.classList.remove('bg-white/20', 'text-white');
-    btn.classList.add('hover:bg-white/20', 'text-white/80', 'hover:text-white');
-    if (btn.dataset.route === view) {
-      btn.classList.add('bg-white/20', 'text-white');
-      btn.classList.remove('hover:bg-white/20', 'text-white/80', 'hover:text-white');
-    }
-  });
+  function updateNavButtons(buttons, isActiveNav){
+    buttons.forEach(btn => {
+      const isActive = isActiveNav && btn.dataset.route === view;
+      btn.classList.remove('bg-white/20', 'text-white');
+      btn.classList.add('hover:bg-white/20', 'text-white/80', 'hover:text-white');
+      if (isActive) {
+        btn.setAttribute('aria-current', 'page');
+        btn.classList.add('bg-white/20', 'text-white');
+        btn.classList.remove('hover:bg-white/20', 'text-white/80', 'hover:text-white');
+      } else {
+        btn.removeAttribute('aria-current');
+      }
+    });
+  }
+
+  const isMobileNav = typeof window.matchMedia === 'function'
+    ? window.matchMedia('(max-width: 768px)').matches
+    : false;
+
+  updateNavButtons(document.querySelectorAll('.nav-desktop [data-route]'), !isMobileNav);
+  updateNavButtons(document.querySelectorAll('#mobile-menu [data-route]'), isMobileNav);
   
   // Close mobile menu after navigation
   closeMobileMenu();


### PR DESCRIPTION
## Summary
- update the `show` router helper to mark only the active navigation button with `aria-current="page"`
- mirror the same accessible state management for the mobile menu while avoiding duplicate `aria-current` flags when desktop navigation is visible

## Testing
- npm test *(fails: jest is not installed in the environment; npm install blocked with 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c956e033a083248e97ebcf6cd78f97