### PR TITLE
Load main script on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     .hidden { display: none; }
     /* Safe area helper used by header (Tailwind doesn't ship this) */
     .pt-safe-top { padding-top: env(safe-area-inset-top); }
-    
+
     /* Custom modern gradients */
     .card-gradient {
       background: linear-gradient(135deg, rgba(102, 126, 234, 0.1) 0%, rgba(118, 75, 162, 0.1) 100%);
@@ -54,6 +54,7 @@
       gap: 0.25rem;
     }
   </style>
+  <script defer src="./js/main.js"></script>
 </head>
 <body id="top" class="bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 antialiased leading-7 min-h-screen">
   <!-- Modern Navigation -->


### PR DESCRIPTION
## Summary
- load the existing main JavaScript bundle on the landing page so the header controls are wired up when the document finishes parsing

## Testing
- npm test *(fails: jest is not installed because npm install is blocked by 403 responses in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c967edaf608324b2d276ef1eef3ef4