### PR TITLE
Initialize Firebase SDK for authentication

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,15 @@
       gap: 0.25rem;
     }
   </style>
+  <script
+    defer
+    src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"
+  ></script>
+  <script
+    defer
+    src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"
+  ></script>
+  <script defer src="./js/firebase-init.js"></script>
   <script defer src="./js/main.js"></script>
 </head>
 <body id="top" class="bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 antialiased leading-7 min-h-screen">

--- a/js/firebase-init.js
+++ b/js/firebase-init.js
@@ -1,9 +1,17 @@
 /* firebase-init.js */
 const firebaseConfig = {
-  // TODO: replace with your Firebase project configuration
+  apiKey: 'AIzaSyAmAMiz0zG3dAhZJhOy1DYj8fKVDObL36c',
+  authDomain: 'memory-cue-app.firebaseapp.com',
+  projectId: 'memory-cue-app',
+  storageBucket: 'memory-cue-app.firebasestorage.app',
+  messagingSenderId: '751284466633',
+  appId: '1:751284466633:web:3b10742970bef1a5d5ee18',
+  measurementId: 'G-R0V4M7VCE6'
 };
 
-if (!firebase.apps.length) {
+if (typeof firebase === 'undefined') {
+  console.warn('Firebase SDK not available; auth features disabled.');
+} else if (!firebase.apps.length) {
   try {
     firebase.initializeApp(firebaseConfig);
   } catch (err) {


### PR DESCRIPTION
## Summary
- load Firebase App/Auth compat SDKs and firebase-init before the main bundle so firebase.auth is available
- configure firebase-init with the Memory Cue project settings and guard against missing SDKs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68c9ff0cafbc8327ab81c1adca739fbc