### PR TITLE
Sync desktop reminders with shared module

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,42 @@
       flex-wrap: wrap;
       gap: 0.25rem;
     }
+
+    .sync-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.35rem 0.75rem;
+      border-radius: 9999px;
+      font-size: 0.875rem;
+      font-weight: 600;
+      border: 1px solid transparent;
+      background: rgba(148, 163, 184, 0.18);
+      color: rgb(100 116 139);
+      transition: all 0.2s ease;
+    }
+
+    .dark .sync-status {
+      background: rgba(71, 85, 105, 0.35);
+      color: rgb(203 213 225);
+    }
+
+    .sync-status.online {
+      background: rgba(34, 197, 94, 0.18);
+      color: rgb(22 163 74);
+      border-color: rgba(34, 197, 94, 0.25);
+    }
+
+    .dark .sync-status.online {
+      color: rgb(134 239 172);
+      border-color: rgba(34, 197, 94, 0.35);
+    }
+
+    .sync-status.error {
+      background: rgba(248, 113, 113, 0.2);
+      color: rgb(220 38 38);
+      border-color: rgba(248, 113, 113, 0.35);
+    }
   </style>
   <script
     defer
@@ -160,7 +196,10 @@
     <section data-view="reminders" id="view-reminders" hidden>
       <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-16">
         <div class="bg-white dark:bg-slate-800 rounded-2xl shadow-xl p-8 mb-8">
-          <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-6">Create Reminder</h2>
+          <div class="flex flex-wrap items-center justify-between gap-3 mb-6">
+            <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Create Reminder</h2>
+            <span id="syncStatus" class="sync-status offline" role="status" aria-live="polite" aria-atomic="true">Offline</span>
+          </div>
           <div class="space-y-4">
             <div class="space-y-2">
               <label for="title" class="block text-sm font-medium text-slate-700 dark:text-slate-300">Title</label>
@@ -274,6 +313,7 @@
             <div class="flex gap-2">
               <button id="save-note" class="px-4 py-2 rounded-lg bg-emerald-500 text-white" type="button">Save</button>
               <button id="load-note" class="px-4 py-2 rounded-lg bg-blue-500 text-white" type="button">Load</button>
+              <button id="delete-note" class="px-4 py-2 rounded-lg bg-rose-500 text-white" type="button">Delete</button>
               <button id="clear-note" class="px-4 py-2 rounded-lg bg-red-500 text-white" type="button">Clear</button>
             </div>
             <label for="saved-notes" class="text-sm font-medium text-slate-700 dark:text-slate-300">Saved notes</label>
@@ -316,6 +356,31 @@
       </div>
     </div>
   </footer>
+  <script type="module">
+    import { initReminders } from './js/reminders.js';
+
+    initReminders({
+      titleSel: '#title',
+      dateSel: '#date',
+      timeSel: '#time',
+      prioritySel: '#priority',
+      saveBtnSel: '#saveBtn',
+      cancelEditBtnSel: '#cancelEditBtn',
+      listSel: '#reminderList',
+      statusSel: '#status',
+      syncStatusSel: '#syncStatus',
+      filterBtnsSel: '[data-filter]',
+      sortSel: '#sort',
+      countTodaySel: '#inlineTodayCount',
+      countOverdueSel: '#inlineOverdueCount',
+      countTotalSel: '#inlineTotalCount',
+      countCompletedSel: '#inlineCompletedCount',
+      emptyStateSel: '#emptyState',
+      listWrapperSel: '#remindersWrapper',
+      dateFeedbackSel: '#dateFeedback',
+      variant: 'desktop'
+    });
+  </script>
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>

--- a/js/main.js
+++ b/js/main.js
@@ -144,483 +144,13 @@ const preferred = localStorage.getItem('theme') || (window.matchMedia('(prefers-
 setTheme(preferred);
 updateThemeToggleState(preferred === 'dark');
 
-// Reminders
-const reminderInputs = {
-  title: document.getElementById('title'),
-  date: document.getElementById('date'),
-  time: document.getElementById('time'),
-  priority: document.getElementById('priority'),
-};
-const saveReminderBtn = document.getElementById('saveBtn');
-const cancelEditReminderBtn = document.getElementById('cancelEditBtn');
-const reminderStatus = document.getElementById('status');
-const dateFeedback = document.getElementById('dateFeedback');
-const reminderList = document.getElementById('reminderList');
-const emptyState = document.getElementById('emptyState');
-const filterButtons = [...document.querySelectorAll('[data-filter]')];
-const sortSelect = document.getElementById('sort');
-const reminderCounts = {
-  today: document.getElementById('inlineTodayCount'),
-  overdue: document.getElementById('inlineOverdueCount'),
-  total: document.getElementById('inlineTotalCount'),
-  completed: document.getElementById('inlineCompletedCount'),
-};
-
-const REMINDER_STORAGE_KEY = 'memoryCue.desktopReminders';
-let reminders = loadStoredReminders();
-let activeFilter = 'all';
-let sortMode = sortSelect?.value || 'smart';
-let editingReminderId = null;
-const priorityRank = { High: 3, Medium: 2, Low: 1 };
-const dayLabelFormatter = new Intl.DateTimeFormat('en-AU', { weekday: 'long' });
-const shortDateFormatter = new Intl.DateTimeFormat('en-AU', { month: 'short', day: 'numeric' });
-const timeFormatter = new Intl.DateTimeFormat('en-AU', { hour: 'numeric', minute: '2-digit' });
-const MS_IN_DAY = 86400000;
-
-function loadStoredReminders(){
-  try {
-    const raw = localStorage.getItem(REMINDER_STORAGE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) {
-      return parsed.map((item) => ({
-        id: item.id || `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
-        title: item.title || '',
-        date: item.date || '',
-        time: item.time || '',
-        priority: item.priority || 'Medium',
-        completed: Boolean(item.completed),
-        createdAt: item.createdAt || Date.now(),
-        updatedAt: item.updatedAt || Date.now(),
-      }));
-    }
-  } catch (err) {
-    console.warn('Unable to load reminders', err);
-  }
-  return [];
-}
-
-function persistReminders(){
-  try {
-    localStorage.setItem(REMINDER_STORAGE_KEY, JSON.stringify(reminders));
-  } catch (err) {
-    console.warn('Unable to save reminders', err);
-  }
-}
-
+// Date utilities shared across planner and notes
 function toDateKey(date){
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
 }
-
-function getTodayKey(){
-  return toDateKey(new Date());
-}
-
-function reminderDueDate(rem){
-  if (!rem?.date) return null;
-  const time = rem.time && rem.time.includes(':') ? rem.time : '00:00';
-  const iso = `${rem.date}T${time}`;
-  const due = new Date(iso);
-  return Number.isNaN(due.getTime()) ? null : due;
-}
-
-function isReminderToday(rem){
-  const due = reminderDueDate(rem);
-  if (!due) return false;
-  return toDateKey(due) === getTodayKey();
-}
-
-function isReminderOverdue(rem){
-  const due = reminderDueDate(rem);
-  if (!due) return false;
-  return due < new Date() && !rem.completed;
-}
-
-function priorityValue(priority){
-  return priorityRank[priority] ?? 0;
-}
-
-function escapeHtml(str){
-  return String(str).replace(/[&<>"']/g, (ch) => ({
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&#39;',
-  })[ch]);
-}
-
-function formatDue(rem){
-  const due = reminderDueDate(rem);
-  if (!due) return 'No due date';
-  const dayLabel = dayLabelFormatter.format(due);
-  const dateLabel = shortDateFormatter.format(due);
-  if (rem.time) {
-    return `${dayLabel}, ${dateLabel} at ${timeFormatter.format(due)}`;
-  }
-  return `${dayLabel}, ${dateLabel}`;
-}
-
-function filterReminders(list){
-  const todayKey = getTodayKey();
-  return list.filter((rem) => {
-    const due = reminderDueDate(rem);
-    switch (activeFilter) {
-      case 'today':
-        return Boolean(due) && toDateKey(due) === todayKey;
-      case 'overdue':
-        return Boolean(due) && due < new Date() && !rem.completed;
-      case 'done':
-        return rem.completed;
-      default:
-        return true;
-    }
-  });
-}
-
-function sortReminders(list){
-  const arr = [...list];
-  arr.sort((a, b) => {
-    const aDue = reminderDueDate(a);
-    const bDue = reminderDueDate(b);
-    const aTime = aDue ? aDue.getTime() : Number.POSITIVE_INFINITY;
-    const bTime = bDue ? bDue.getTime() : Number.POSITIVE_INFINITY;
-
-    if (sortMode === 'priority') {
-      return priorityValue(b.priority) - priorityValue(a.priority);
-    }
-
-    if (sortMode === 'time') {
-      return aTime - bTime;
-    }
-
-    if (a.completed !== b.completed) {
-      return a.completed ? 1 : -1;
-    }
-
-    const overdueDiff = (isReminderOverdue(b) ? 1 : 0) - (isReminderOverdue(a) ? 1 : 0);
-    if (overdueDiff !== 0) {
-      return overdueDiff;
-    }
-
-    if (aTime !== bTime) {
-      return aTime - bTime;
-    }
-
-    const priorityDiff = priorityValue(b.priority) - priorityValue(a.priority);
-    if (priorityDiff !== 0) {
-      return priorityDiff;
-    }
-
-    return (b.updatedAt || 0) - (a.updatedAt || 0);
-  });
-  return arr;
-}
-
-function updateCounts(){
-  const total = reminders.length;
-  const todayCount = reminders.filter(isReminderToday).length;
-  const overdueCount = reminders.filter(isReminderOverdue).length;
-  const completedCount = reminders.filter((rem) => rem.completed).length;
-
-  if (reminderCounts.today) reminderCounts.today.textContent = String(todayCount);
-  if (reminderCounts.overdue) reminderCounts.overdue.textContent = String(overdueCount);
-  if (reminderCounts.total) reminderCounts.total.textContent = String(total);
-  if (reminderCounts.completed) reminderCounts.completed.textContent = String(completedCount);
-}
-
-function updateEmptyState(hasItems, hasAny){
-  if (emptyState) {
-    if (!hasAny) {
-      emptyState.textContent = 'Add your first reminder to see it here.';
-      emptyState.classList.remove('hidden');
-    } else if (!hasItems) {
-      emptyState.textContent = 'No reminders match this filter yet.';
-      emptyState.classList.remove('hidden');
-    } else {
-      emptyState.classList.add('hidden');
-    }
-  }
-  if (reminderList) {
-    reminderList.classList.toggle('hidden', !hasItems);
-  }
-}
-
-function createReminderElement(rem){
-  const li = document.createElement('li');
-  li.dataset.id = rem.id;
-  li.className = 'p-4 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm';
-  const dueLabel = formatDue(rem);
-  const priorityClasses = rem.priority === 'High'
-    ? 'border-red-200 text-red-600 bg-red-100/70 dark:border-red-400/30 dark:text-red-300 dark:bg-red-500/10'
-    : rem.priority === 'Medium'
-      ? 'border-amber-200 text-amber-600 bg-amber-100/70 dark:border-amber-400/30 dark:text-amber-300 dark:bg-amber-500/10'
-      : 'border-emerald-200 text-emerald-600 bg-emerald-100/70 dark:border-emerald-400/30 dark:text-emerald-300 dark:bg-emerald-500/10';
-  const titleClasses = rem.completed
-    ? 'line-through text-slate-400 dark:text-slate-500'
-    : 'text-slate-900 dark:text-slate-100';
-  const statusLabel = rem.completed ? 'Completed' : 'Active';
-  const statusClasses = rem.completed ? 'text-emerald-600 dark:text-emerald-400' : 'text-slate-500 dark:text-slate-400';
-
-  li.innerHTML = `
-    <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-      <div>
-        <p class="text-lg font-semibold ${titleClasses}">${escapeHtml(rem.title)}</p>
-        <div class="mt-2 flex flex-wrap gap-3 text-sm text-slate-500 dark:text-slate-400">
-          <span class="inline-flex items-center gap-2">
-            <span class="inline-flex h-2 w-2 rounded-full bg-blue-400"></span>
-            ${escapeHtml(dueLabel)}
-          </span>
-          <span class="inline-flex items-center gap-2 px-2 py-1 rounded-full border ${priorityClasses}">
-            ${escapeHtml(rem.priority)} priority
-          </span>
-          <span class="${statusClasses}">${statusLabel}</span>
-        </div>
-      </div>
-      <div class="flex flex-wrap gap-2 text-sm font-medium">
-        <button data-action="toggle" class="px-3 py-2 rounded-lg ${rem.completed ? 'bg-amber-500 text-white hover:bg-amber-600' : 'bg-emerald-500 text-white hover:bg-emerald-600'}">
-          ${rem.completed ? 'Mark active' : 'Mark done'}
-        </button>
-        <button data-action="edit" class="px-3 py-2 rounded-lg bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-200 hover:bg-slate-300 dark:hover:bg-slate-600">Edit</button>
-        <button data-action="delete" class="px-3 py-2 rounded-lg bg-red-500 text-white hover:bg-red-600">Delete</button>
-      </div>
-    </div>
-  `;
-  return li;
-}
-
-function clearStatus(){
-  if (!reminderStatus) return;
-  reminderStatus.textContent = '';
-  reminderStatus.className = 'text-sm';
-}
-
-function setStatus(message, tone = 'info'){
-  if (!reminderStatus) return;
-  reminderStatus.textContent = message;
-  reminderStatus.className = 'text-sm mt-2';
-  if (tone === 'error') {
-    reminderStatus.classList.add('text-rose-500');
-  } else if (tone === 'success') {
-    reminderStatus.classList.add('text-emerald-500');
-  } else {
-    reminderStatus.classList.add('text-slate-500');
-  }
-}
-
-function populateForm(rem){
-  if (reminderInputs.title) reminderInputs.title.value = rem.title || '';
-  if (reminderInputs.date) reminderInputs.date.value = rem.date || '';
-  if (reminderInputs.time) reminderInputs.time.value = rem.time || '';
-  if (reminderInputs.priority) reminderInputs.priority.value = rem.priority || 'Medium';
-}
-
-function resetForm(){
-  if (reminderInputs.title) reminderInputs.title.value = '';
-  if (reminderInputs.date) reminderInputs.date.value = '';
-  if (reminderInputs.time) reminderInputs.time.value = '';
-  if (reminderInputs.priority) reminderInputs.priority.value = 'Medium';
-  editingReminderId = null;
-  if (saveReminderBtn) saveReminderBtn.textContent = 'Save Reminder';
-  cancelEditReminderBtn?.classList.add('hidden');
-  updateDateFeedback();
-}
-
-function renderReminders(){
-  const filtered = sortReminders(filterReminders(reminders));
-  updateCounts();
-
-  if (reminderList) {
-    reminderList.innerHTML = '';
-    filtered.forEach((rem) => {
-      reminderList.appendChild(createReminderElement(rem));
-    });
-  }
-
-  updateEmptyState(filtered.length > 0, reminders.length > 0);
-}
-
-function saveReminder(){
-  const titleValue = reminderInputs.title?.value.trim() || '';
-  if (!titleValue) {
-    setStatus('Please enter a reminder title.', 'error');
-    reminderInputs.title?.focus();
-    return;
-  }
-
-  const reminderData = {
-    title: titleValue,
-    date: reminderInputs.date?.value || '',
-    time: reminderInputs.time?.value || '',
-    priority: reminderInputs.priority?.value || 'Medium',
-  };
-
-  if (editingReminderId) {
-    const existing = reminders.find((rem) => rem.id === editingReminderId);
-    if (existing) {
-      Object.assign(existing, reminderData, { updatedAt: Date.now() });
-      setStatus('Reminder updated.', 'success');
-    }
-  } else {
-    reminders.push({
-      id: `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
-      ...reminderData,
-      completed: false,
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-    });
-    setStatus('Reminder saved.', 'success');
-  }
-
-  persistReminders();
-  renderReminders();
-  resetForm();
-}
-
-function enterEditMode(rem){
-  editingReminderId = rem.id;
-  populateForm(rem);
-  if (saveReminderBtn) saveReminderBtn.textContent = 'Update Reminder';
-  cancelEditReminderBtn?.classList.remove('hidden');
-  setStatus('Editing reminder…', 'info');
-  reminderInputs.title?.focus();
-  updateDateFeedback();
-}
-
-function handleListClick(event){
-  const actionBtn = event.target.closest('[data-action]');
-  if (!actionBtn) return;
-  const item = actionBtn.closest('li[data-id]');
-  if (!item) return;
-  const reminder = reminders.find((rem) => rem.id === item.dataset.id);
-  if (!reminder) return;
-
-  switch (actionBtn.dataset.action) {
-    case 'toggle':
-      reminder.completed = !reminder.completed;
-      reminder.updatedAt = Date.now();
-      persistReminders();
-      renderReminders();
-      setStatus(reminder.completed ? 'Reminder marked as done.' : 'Reminder marked as active.', 'success');
-      break;
-    case 'edit':
-      enterEditMode(reminder);
-      break;
-    case 'delete':
-      reminders = reminders.filter((rem) => rem.id !== reminder.id);
-      persistReminders();
-      renderReminders();
-      setStatus('Reminder removed.', 'info');
-      break;
-    default:
-      break;
-  }
-}
-
-function updateActiveFilter(){
-  filterButtons.forEach((btn) => {
-    const isActive = btn.dataset.filter === activeFilter;
-    btn.setAttribute('aria-pressed', String(isActive));
-    btn.classList.toggle('ring-2', isActive);
-    btn.classList.toggle('ring-offset-2', isActive);
-    btn.classList.toggle('ring-purple-400', isActive);
-  });
-}
-
-function updateDateFeedback(){
-  if (!dateFeedback) return;
-  const dateValue = reminderInputs.date?.value;
-  if (!dateValue) {
-    dateFeedback.textContent = '';
-    dateFeedback.classList.add('hidden');
-    dateFeedback.classList.remove('text-emerald-500', 'text-amber-500', 'text-rose-500');
-    dateFeedback.classList.add('text-slate-500');
-    return;
-  }
-
-  const due = reminderDueDate({ date: dateValue, time: reminderInputs.time?.value || '' });
-  if (!due) {
-    dateFeedback.textContent = 'Enter a valid date to track your reminder.';
-    dateFeedback.classList.remove('hidden', 'text-emerald-500', 'text-amber-500', 'text-rose-500');
-    dateFeedback.classList.add('text-slate-500');
-    return;
-  }
-
-  const today = new Date();
-  const dueMidnight = new Date(due);
-  dueMidnight.setHours(0, 0, 0, 0);
-  const todayMidnight = new Date(today);
-  todayMidnight.setHours(0, 0, 0, 0);
-  const diffDays = Math.round((dueMidnight.getTime() - todayMidnight.getTime()) / MS_IN_DAY);
-
-  let message;
-  if (diffDays === 0) {
-    message = 'Due today';
-  } else if (diffDays === 1) {
-    message = 'Due tomorrow';
-  } else if (diffDays > 1) {
-    message = `Due in ${diffDays} days`;
-  } else if (diffDays === -1) {
-    message = 'Was due yesterday';
-  } else {
-    message = `Overdue by ${Math.abs(diffDays)} days`;
-  }
-
-  const timePart = reminderInputs.time?.value ? ` • ${timeFormatter.format(due)}` : '';
-  const detail = `${dayLabelFormatter.format(due)}, ${shortDateFormatter.format(due)}${timePart}`;
-  dateFeedback.textContent = `${message} (${detail})`;
-  dateFeedback.classList.remove('hidden', 'text-emerald-500', 'text-amber-500', 'text-rose-500', 'text-slate-500');
-  if (diffDays < 0) {
-    dateFeedback.classList.add('text-rose-500');
-  } else if (diffDays === 0) {
-    dateFeedback.classList.add('text-emerald-500');
-  } else if (diffDays === 1) {
-    dateFeedback.classList.add('text-amber-500');
-  } else {
-    dateFeedback.classList.add('text-slate-500');
-  }
-}
-
-saveReminderBtn?.addEventListener('click', (event) => {
-  event.preventDefault();
-  saveReminder();
-});
-
-cancelEditReminderBtn?.addEventListener('click', () => {
-  resetForm();
-  setStatus('Edit cancelled.', 'info');
-});
-
-reminderInputs.date?.addEventListener('input', () => {
-  clearStatus();
-  updateDateFeedback();
-});
-reminderInputs.time?.addEventListener('input', () => {
-  clearStatus();
-  updateDateFeedback();
-});
-
-reminderList?.addEventListener('click', handleListClick);
-
-filterButtons.forEach((btn) => {
-  btn.addEventListener('click', () => {
-    activeFilter = btn.dataset.filter || 'all';
-    updateActiveFilter();
-    renderReminders();
-  });
-});
-
-sortSelect?.addEventListener('change', () => {
-  sortMode = sortSelect.value;
-  renderReminders();
-});
-
-updateActiveFilter();
-renderReminders();
-updateDateFeedback();
 
 // Planner
 const plannerWeekEl = document.getElementById('planner-week');
@@ -721,9 +251,20 @@ if (plannerWeekEl && plannerGrid) {
   renderPlanner();
 }
 
+function escapeHtml(str){
+  return String(str).replace(/[&<>"']/g, (ch) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  })[ch]);
+}
+
 // Notes
 const noteEl = document.getElementById('quick-note');
 const savedSelect = document.getElementById('saved-notes');
+let activeNoteIndex = null;
 
 function getNotes(){
   return JSON.parse(localStorage.getItem('saved-notes') || '[]');
@@ -733,11 +274,20 @@ function saveNotes(notes){
   localStorage.setItem('saved-notes', JSON.stringify(notes));
 }
 
-function refreshSelect(){
+function refreshSelect(selectedValue = ''){
   if(!savedSelect) return;
   const notes = getNotes();
   savedSelect.innerHTML = '<option value="">Select a note</option>' +
-    notes.map((n, i) => `<option value="${i}">${n.title}</option>`).join('');
+    notes.map((n, i) => `<option value="${i}">${escapeHtml(n.title)}</option>`).join('');
+
+  if(selectedValue !== ''){
+    const parsed = Number.parseInt(selectedValue, 10);
+    if(!Number.isNaN(parsed) && notes[parsed]){
+      savedSelect.value = String(parsed);
+      return;
+    }
+  }
+  savedSelect.value = '';
 }
 
 if(noteEl){
@@ -749,19 +299,44 @@ if(noteEl){
     const notes = getNotes();
     notes.push({ title, content });
     saveNotes(notes);
-    refreshSelect();
+    const newIndex = notes.length - 1;
+    refreshSelect(String(newIndex));
+    activeNoteIndex = newIndex;
   });
 
   document.getElementById('load-note')?.addEventListener('click', () => {
     const idx = savedSelect?.value;
+    if(idx === '' || idx == null) return;
+    const parsedIndex = Number.parseInt(idx, 10);
+    if(Number.isNaN(parsedIndex)) return;
     const notes = getNotes();
-    if(idx !== '' && notes[idx]){
-      noteEl.innerHTML = notes[idx].content;
+    if(notes[parsedIndex]){
+      noteEl.innerHTML = notes[parsedIndex].content;
+      activeNoteIndex = parsedIndex;
+    }
+  });
+
+  document.getElementById('delete-note')?.addEventListener('click', () => {
+    const idx = savedSelect?.value;
+    if(idx === '' || idx == null) return;
+    const indexNum = Number.parseInt(idx, 10);
+    if(Number.isNaN(indexNum)) return;
+    const notes = getNotes();
+    if(!notes[indexNum]) return;
+    notes.splice(indexNum, 1);
+    saveNotes(notes);
+    refreshSelect();
+    if(activeNoteIndex === indexNum){
+      noteEl.innerHTML = '';
+      activeNoteIndex = null;
+    } else if(activeNoteIndex !== null && activeNoteIndex > indexNum){
+      activeNoteIndex -= 1;
     }
   });
 
   document.getElementById('clear-note')?.addEventListener('click', () => {
     noteEl.innerHTML = '';
+    activeNoteIndex = null;
   });
 
   document.getElementById('bullet-btn')?.addEventListener('click', () => {

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -36,6 +36,9 @@ export async function initReminders(sel = {}) {
   const filterBtns = $$(sel.filterBtnsSel);
   const countTodayEl = $(sel.countTodaySel);
   const countWeekEl = $(sel.countWeekSel);
+  const countOverdueEl = $(sel.countOverdueSel);
+  const countTotalEl = $(sel.countTotalSel);
+  const countCompletedEl = $(sel.countCompletedSel);
   const googleAvatar = $(sel.googleAvatarSel);
   const googleUserName = $(sel.googleUserNameSel);
   const dateFeedback = $(sel.dateFeedbackSel);
@@ -53,6 +56,11 @@ export async function initReminders(sel = {}) {
   const testSync = $(sel.testSyncSel);
   const openSettings = $(sel.openSettingsSel);
   const settingsSection = $(sel.settingsSectionSel);
+  const emptyStateEl = $(sel.emptyStateSel);
+  const listWrapper = $(sel.listWrapperSel);
+  const variant = sel.variant || 'mobile';
+  const emptyInitialText = sel.emptyStateInitialText || 'Add your first reminder to see it here.';
+  const emptyFilteredText = sel.emptyStateFilteredText || 'No reminders match this filter yet.';
 
    // Placeholder for Firebase modules loaded later
    let initializeApp, initializeFirestore, getFirestore, doc, setDoc, deleteDoc,
@@ -153,6 +161,8 @@ export async function initReminders(sel = {}) {
   const timeFmt = new Intl.DateTimeFormat('en-AU', { timeZone: TZ, hour: '2-digit', minute: '2-digit' });
   const dayFmt = new Intl.DateTimeFormat('en-AU', { timeZone: TZ, weekday: 'long', day: 'numeric', month: 'long' });
   const dateOnlyFmt = new Intl.DateTimeFormat('en-CA', { timeZone: TZ, year: 'numeric', month: '2-digit', day: '2-digit' });
+  const desktopDayLabelFmt = new Intl.DateTimeFormat('en-AU', { timeZone: TZ, weekday: 'long' });
+  const desktopShortDateFmt = new Intl.DateTimeFormat('en-AU', { timeZone: TZ, month: 'short', day: 'numeric' });
   function formatDateLocal(d) {
     const parts = dateOnlyFmt.formatToParts(d);
     const y = parts.find(p => p.type === 'year').value;
@@ -258,6 +268,11 @@ export async function initReminders(sel = {}) {
       if(googleUserName) googleUserName.textContent = user.displayName || user.email || '';
       setupFirestoreSync();
     } else {
+      syncStatus?.classList.remove('online','error');
+      if(syncStatus){
+        syncStatus.classList.add('offline');
+        syncStatus.textContent = 'Offline';
+      }
       googleSignInBtn?.classList.remove('hidden');
       googleSignOutBtn?.classList.add('hidden');
       if(googleAvatar){ googleAvatar.classList.add('hidden'); googleAvatar.src=''; }
@@ -315,6 +330,25 @@ export async function initReminders(sel = {}) {
   function scheduleReminder(item){ if(!item||!item.id) return; if(!item.due || item.done){ cancelReminder(item.id); return; } scheduledReminders[item.id]={ id:item.id, title:item.title, due:item.due }; saveScheduled(); if(reminderTimers[item.id]){ clearTimeout(reminderTimers[item.id]); delete reminderTimers[item.id]; } if(!('Notification' in window) || Notification.permission!=='granted'){ return; } const delay=new Date(item.due).getTime()-Date.now(); if(delay<=0){ showReminder(item); cancelReminder(item.id); return; } reminderTimers[item.id]=setTimeout(()=>{ showReminder(item); cancelReminder(item.id); }, delay); }
   function rescheduleAllReminders(){ Object.values(scheduledReminders).forEach(it=>scheduleReminder(it)); }
 
+  const desktopPriorityClasses = {
+    High: 'border-red-200 text-red-600 bg-red-100/70 dark:border-red-400/30 dark:text-red-300 dark:bg-red-500/10',
+    Medium: 'border-amber-200 text-amber-600 bg-amber-100/70 dark:border-amber-400/30 dark:text-amber-300 dark:bg-amber-500/10',
+    Low: 'border-emerald-200 text-emerald-600 bg-emerald-100/70 dark:border-emerald-400/30 dark:text-emerald-300 dark:bg-emerald-500/10'
+  };
+
+  function formatDesktopDue(item){
+    if(!item?.due) return 'No due date';
+    try {
+      const due = new Date(item.due);
+      const dayLabel = desktopDayLabelFmt.format(due);
+      const dateLabel = desktopShortDateFmt.format(due);
+      const timeLabel = fmtTime(due);
+      return `${dayLabel}, ${dateLabel}${timeLabel ? ` at ${timeLabel}` : ''}`;
+    } catch {
+      return 'No due date';
+    }
+  }
+
   function render(){
     const now = new Date();
     const adlNow = new Date(now.toLocaleString('en-US', { timeZone: TZ }));
@@ -324,8 +358,13 @@ export async function initReminders(sel = {}) {
     const w1 = endOfWeek(adlNow);
     const todays = items.filter(x => x.due && new Date(x.due) >= t0 && new Date(x.due) <= t1 && !x.done);
     const weeks  = items.filter(x => x.due && new Date(x.due) >= w0 && new Date(x.due) <= w1 && !x.done);
+    const overdueCount = items.filter(x => !x.done && x.due && new Date(x.due) < adlNow).length;
+    const completedCount = items.filter(x => x.done).length;
     if(countTodayEl) countTodayEl.textContent = String(todays.length);
     if(countWeekEl) countWeekEl.textContent = String(weeks.length);
+    if(countOverdueEl) countOverdueEl.textContent = String(overdueCount);
+    if(countTotalEl) countTotalEl.textContent = String(items.length);
+    if(countCompletedEl) countCompletedEl.textContent = String(completedCount);
 
     let rows = items.slice();
     const queryStr = q?.value.trim().toLowerCase() || '';
@@ -333,16 +372,107 @@ export async function initReminders(sel = {}) {
     rows = rows.filter(r => {
       if(filter==='done') return r.done;
       if(filter==='overdue') return !r.done && r.due && new Date(r.due) < adlNow;
-      if(filter==='today'){ if(!r.due) return true; const dueAdl = new Date(new Date(r.due).toLocaleString('en-US',{timeZone:TZ})); return dueAdl >= t0 && dueAdl <= t1; }
+      if(filter==='today'){
+        if(!r.due) return true;
+        const dueAdl = new Date(new Date(r.due).toLocaleString('en-US',{timeZone:TZ}));
+        return dueAdl >= t0 && dueAdl <= t1;
+      }
       return true;
     });
-    rows.sort((a,b)=>{ if(sortKey==='time') return (+new Date(a.due||0))-(+new Date(b.due||0)); if(sortKey==='priority') return priorityWeight(b.priority)-priorityWeight(a.priority); return smartCompare(a,b); });
-    filterBtns.forEach(btn => btn.classList.toggle('active', btn.getAttribute('data-filter')===filter));
-    if(!list) return;
-    if(rows.length===0){ list.innerHTML = '<div class="text-muted">No reminders found.</div>'; return; }
+    rows.sort((a,b)=>{
+      if(sortKey==='time') return (+new Date(a.due||0))-(+new Date(b.due||0));
+      if(sortKey==='priority') return priorityWeight(b.priority)-priorityWeight(a.priority);
+      return smartCompare(a,b);
+    });
+
+    filterBtns.forEach(btn => {
+      const isActive = btn.getAttribute('data-filter')===filter;
+      btn.classList.toggle('active', isActive);
+      btn.classList.toggle('ring-2', isActive);
+      btn.classList.toggle('ring-offset-2', isActive);
+      btn.classList.toggle('ring-purple-400', isActive);
+      btn.setAttribute('aria-pressed', String(isActive));
+    });
+
+    const hasAny = items.length > 0;
+    const hasRows = rows.length > 0;
+
+    if(emptyStateEl){
+      if(!hasAny){
+        emptyStateEl.textContent = emptyInitialText;
+        emptyStateEl.classList.remove('hidden');
+      } else if(!hasRows){
+        emptyStateEl.textContent = emptyFilteredText;
+        emptyStateEl.classList.remove('hidden');
+      } else {
+        emptyStateEl.classList.add('hidden');
+      }
+    }
+
+    if(listWrapper){
+      listWrapper.classList.toggle('has-items', hasRows);
+    }
+
+    if(!list){
+      return;
+    }
+
+    if(!hasRows){
+      if(emptyStateEl){
+        list.innerHTML = '';
+        list.classList.add('hidden');
+      } else {
+        list.innerHTML = '<div class="text-muted">No reminders found.</div>';
+        list.classList.remove('hidden');
+      }
+      return;
+    }
+
+    list.classList.remove('hidden');
     list.replaceChildren();
     const frag = document.createDocumentFragment();
+    const listIsSemantic = list.tagName === 'UL' || list.tagName === 'OL';
     rows.forEach(r => {
+      if(variant === 'desktop'){
+        const itemEl = document.createElement(listIsSemantic ? 'li' : 'div');
+        itemEl.dataset.id = r.id;
+        itemEl.className = 'p-4 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm';
+        const dueLabel = formatDesktopDue(r);
+        const priorityClass = desktopPriorityClasses[r.priority] || desktopPriorityClasses.Medium;
+        const titleClasses = r.done ? 'line-through text-slate-400 dark:text-slate-500' : 'text-slate-900 dark:text-slate-100';
+        const statusLabel = r.done ? 'Completed' : 'Active';
+        const statusClasses = r.done ? 'text-emerald-600 dark:text-emerald-400' : 'text-slate-500 dark:text-slate-400';
+        const toggleClasses = r.done
+          ? 'px-3 py-2 rounded-lg bg-amber-500 text-white hover:bg-amber-600'
+          : 'px-3 py-2 rounded-lg bg-emerald-500 text-white hover:bg-emerald-600';
+        itemEl.innerHTML = `
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <p class="text-lg font-semibold ${titleClasses}">${escapeHtml(r.title)}</p>
+        <div class="mt-2 flex flex-wrap gap-3 text-sm text-slate-500 dark:text-slate-400">
+          <span class="inline-flex items-center gap-2">
+            <span class="inline-flex h-2 w-2 rounded-full bg-blue-400"></span>
+            ${escapeHtml(dueLabel)}
+          </span>
+          <span class="inline-flex items-center gap-2 px-2 py-1 rounded-full border ${priorityClass}">
+            ${escapeHtml(r.priority)} priority
+          </span>
+          <span class="${statusClasses}">${statusLabel}</span>
+        </div>
+      </div>
+      <div class="flex flex-wrap gap-2 text-sm font-medium">
+        <button data-action="toggle" class="${toggleClasses}">${r.done ? 'Mark active' : 'Mark done'}</button>
+        <button data-action="edit" class="px-3 py-2 rounded-lg bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-200 hover:bg-slate-300 dark:hover:bg-slate-600">Edit</button>
+        <button data-action="delete" class="px-3 py-2 rounded-lg bg-red-500 text-white hover:bg-red-600">Delete</button>
+      </div>
+    </div>`;
+        itemEl.querySelector('[data-action="toggle"]').addEventListener('click', () => toggleDone(r.id));
+        itemEl.querySelector('[data-action="edit"]').addEventListener('click', () => loadForEdit(r.id));
+        itemEl.querySelector('[data-action="delete"]').addEventListener('click', () => removeItem(r.id));
+        frag.appendChild(itemEl);
+        return;
+      }
+
       const div = document.createElement('div');
       div.className = 'task-item' + (r.done ? ' completed' : '');
       const dueTxt = r.due ? `${fmtTime(new Date(r.due))} • ${fmtDayDate(r.due.slice(0,10))}` : 'No due date';


### PR DESCRIPTION
## Summary
- load the shared reminders module on the desktop page to reuse Firestore sync and expose a sync status indicator
- extend `reminders.js` with a desktop rendering variant, extra counts, and improved empty-state handling while keeping the sync status classes in sync with auth state
- remove the legacy local reminder code from `main.js`, leaving shared date and HTML helpers for the planner and notes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca4c9ecdc88324b09f30f006bd29ae