### PR TITLE
Ensure reminders clean up notifications

### DIFF
--- a/js/__tests__/reminders.notifications.test.js
+++ b/js/__tests__/reminders.notifications.test.js
@@ -1,0 +1,146 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const { beforeEach, afterEach, describe, expect, test } = require('@jest/globals');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadRemindersModule() {
+  const filePath = path.resolve(__dirname, '../reminders.js');
+  let source = fs.readFileSync(filePath, 'utf8');
+  source = source.replace(/export\s+async\s+function\s+initReminders/, 'async function initReminders');
+  source += '\nmodule.exports = { initReminders };\n';
+  const module = { exports: {} };
+  const sandbox = {
+    module,
+    exports: module.exports,
+    require,
+    console,
+    setTimeout,
+    clearTimeout,
+    window,
+    document,
+    localStorage,
+    navigator,
+    Notification,
+    fetch: global.fetch,
+    Blob: global.Blob,
+    Response: global.Response,
+    URL: global.URL,
+  };
+  vm.runInNewContext(source, sandbox, { filename: filePath });
+  return module.exports;
+}
+
+describe('reminder notification management', () => {
+  let api;
+  let firebaseDeps;
+
+  class MockNotification {
+    static permission = 'granted';
+    static requestPermission = jest.fn().mockResolvedValue('granted');
+
+    constructor(title, options) {
+      this.title = title;
+      this.options = options;
+      this.onclose = null;
+      this.onclick = null;
+      this._listeners = { close: [], click: [] };
+      this.close = jest.fn(() => {
+        this.closed = true;
+        if (typeof this.onclose === 'function') {
+          this.onclose();
+        }
+        this._listeners.close.forEach((handler) => handler());
+      });
+    }
+
+    addEventListener(event, handler) {
+      if (!this._listeners[event]) {
+        this._listeners[event] = [];
+      }
+      this._listeners[event].push(handler);
+    }
+  }
+
+  beforeEach(async () => {
+    jest.resetModules();
+    document.body.innerHTML = '<div id="status"></div>';
+    global.fetch = jest.fn();
+    window.fetch = global.fetch;
+    global.Notification = MockNotification;
+    window.Notification = MockNotification;
+    navigator.clipboard = navigator.clipboard || { writeText: jest.fn().mockResolvedValue() };
+
+    firebaseDeps = {
+      initializeApp: jest.fn(() => ({})),
+      initializeFirestore: jest.fn(() => ({})),
+      getFirestore: jest.fn(() => ({})),
+      doc: jest.fn(() => ({})),
+      setDoc: jest.fn(() => Promise.resolve()),
+      deleteDoc: jest.fn(() => Promise.resolve()),
+      onSnapshot: jest.fn(() => () => {}),
+      collection: jest.fn(() => ({})),
+      query: jest.fn(() => ({})),
+      orderBy: jest.fn(() => ({})),
+      persistentLocalCache: jest.fn(() => ({})),
+      serverTimestamp: jest.fn(() => new Date()),
+      getAuth: jest.fn(() => ({})),
+      onAuthStateChanged: jest.fn((auth, cb) => { cb(null); return jest.fn(); }),
+      GoogleAuthProvider: jest.fn(function Provider() {}),
+      signInWithPopup: jest.fn(() => Promise.resolve()),
+      signInWithRedirect: jest.fn(() => Promise.resolve()),
+      getRedirectResult: jest.fn(() => Promise.resolve(null)),
+      signOut: jest.fn(() => Promise.resolve()),
+    };
+
+    const remindersModule = loadRemindersModule();
+    api = await remindersModule.initReminders({ statusSel: '#status', firebaseDeps });
+  });
+
+  afterEach(() => {
+    api?.closeActiveNotifications();
+    localStorage.clear();
+    jest.clearAllTimers();
+  });
+
+  function createImmediateReminder(id = 'rem-1') {
+    return {
+      id,
+      title: 'Test reminder',
+      due: new Date(Date.now() - 60_000).toISOString(),
+      done: false,
+      priority: 'Medium',
+    };
+  }
+
+  test('cancelReminder closes active notifications', () => {
+    const reminder = createImmediateReminder('cancel-close');
+    api.scheduleReminder(reminder);
+    const active = api.getActiveNotifications();
+    const notification = active.get(reminder.id);
+    expect(notification).toBeDefined();
+    notification.close.mockClear();
+
+    api.cancelReminder(reminder.id);
+
+    expect(notification.close).toHaveBeenCalledTimes(1);
+    expect(active.has(reminder.id)).toBe(false);
+  });
+
+  test('pagehide dismisses all active notifications', () => {
+    const reminder = createImmediateReminder('pagehide-close');
+    api.scheduleReminder(reminder);
+    const active = api.getActiveNotifications();
+    const notification = active.get(reminder.id);
+    expect(notification).toBeDefined();
+    notification.close.mockClear();
+
+    window.dispatchEvent(new Event('pagehide'));
+
+    expect(notification.close).toHaveBeenCalledTimes(1);
+    expect(active.size).toBe(0);
+  });
+});

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -1,9 +1,37 @@
 // Shared reminder logic used by both the mobile and desktop pages.
 // This module wires up Firebase/Firestore and all reminder UI handlers.
 
-import { initializeApp } from 'https://www.gstatic.com/firebasejs/12.2.1/firebase-app.js';
-import { initializeFirestore, getFirestore, doc, setDoc, deleteDoc, onSnapshot, collection, query, orderBy, persistentLocalCache, serverTimestamp } from 'https://www.gstatic.com/firebasejs/12.2.1/firebase-firestore.js';
-import { getAuth, onAuthStateChanged, GoogleAuthProvider, signInWithPopup, signInWithRedirect, getRedirectResult, signOut } from 'https://www.gstatic.com/firebasejs/12.2.1/firebase-auth.js';
+const activeNotifications = new Map();
+let notificationCleanupBound = false;
+
+function closeActiveNotifications() {
+  for (const notification of Array.from(activeNotifications.values())) {
+    try {
+      notification.close();
+    } catch {
+      // Ignore close errors so cleanup can continue for remaining notifications.
+    }
+  }
+  activeNotifications.clear();
+}
+
+function bindNotificationCleanupHandlers() {
+  if (notificationCleanupBound) {
+    return;
+  }
+  if (typeof window === 'undefined' || typeof window.addEventListener !== 'function') {
+    return;
+  }
+  const cleanup = () => closeActiveNotifications();
+  ['pagehide', 'beforeunload'].forEach((eventName) => {
+    try {
+      window.addEventListener(eventName, cleanup);
+    } catch {
+      // Ignore environments that do not support these events.
+    }
+  });
+  notificationCleanupBound = true;
+}
 
 /**
  * Initialise the reminders UI and sync logic.
@@ -62,11 +90,15 @@ export async function initReminders(sel = {}) {
   const emptyInitialText = sel.emptyStateInitialText || 'Add your first reminder to see it here.';
   const emptyFilteredText = sel.emptyStateFilteredText || 'No reminders match this filter yet.';
 
+  bindNotificationCleanupHandlers();
+
    // Placeholder for Firebase modules loaded later
    let initializeApp, initializeFirestore, getFirestore, doc, setDoc, deleteDoc,
      onSnapshot, collection, query, orderBy, persistentLocalCache, serverTimestamp,
      getAuth, onAuthStateChanged, GoogleAuthProvider, signInWithPopup,
-     signInWithRedirect, getRedirectResult, signOut;
+      signInWithRedirect, getRedirectResult, signOut;
+
+  const firebaseDeps = sel.firebaseDeps;
 
    // Notes (runs before Firebase modules load)
    function initNotebook() {
@@ -109,14 +141,18 @@ export async function initReminders(sel = {}) {
    }
    initNotebook();
 
-   try {
-     ({ initializeApp } = await import('https://www.gstatic.com/firebasejs/12.2.1/firebase-app.js'));
-     ({ initializeFirestore, getFirestore, doc, setDoc, deleteDoc, onSnapshot, collection, query, orderBy, persistentLocalCache, serverTimestamp } = await import('https://www.gstatic.com/firebasejs/12.2.1/firebase-firestore.js'));
-     ({ getAuth, onAuthStateChanged, GoogleAuthProvider, signInWithPopup, signInWithRedirect, getRedirectResult, signOut } = await import('https://www.gstatic.com/firebasejs/12.2.1/firebase-auth.js'));
-   } catch (err) {
-     console.warn('Firebase modules failed to load:', err);
-     toast('Firebase failed to load; notes available offline');
-     return;
+   if (firebaseDeps) {
+     ({ initializeApp, initializeFirestore, getFirestore, doc, setDoc, deleteDoc, onSnapshot, collection, query, orderBy, persistentLocalCache, serverTimestamp, getAuth, onAuthStateChanged, GoogleAuthProvider, signInWithPopup, signInWithRedirect, getRedirectResult, signOut } = firebaseDeps);
+   } else {
+     try {
+       ({ initializeApp } = await import('https://www.gstatic.com/firebasejs/12.2.1/firebase-app.js'));
+       ({ initializeFirestore, getFirestore, doc, setDoc, deleteDoc, onSnapshot, collection, query, orderBy, persistentLocalCache, serverTimestamp } = await import('https://www.gstatic.com/firebasejs/12.2.1/firebase-firestore.js'));
+       ({ getAuth, onAuthStateChanged, GoogleAuthProvider, signInWithPopup, signInWithRedirect, getRedirectResult, signOut } = await import('https://www.gstatic.com/firebasejs/12.2.1/firebase-auth.js'));
+     } catch (err) {
+       console.warn('Firebase modules failed to load:', err);
+       toast('Firebase failed to load; notes available offline');
+       return;
+     }
    }
 
    // Firebase
@@ -325,9 +361,58 @@ export async function initReminders(sel = {}) {
   function removeItem(id){ items=items.filter(x=>x.id!==id); render(); deleteFromFirebase(id); cancelReminder(id); }
 
   function saveScheduled(){ localStorage.setItem('scheduledReminders', JSON.stringify(scheduledReminders)); }
-  function cancelReminder(id){ if(reminderTimers[id]){ clearTimeout(reminderTimers[id]); delete reminderTimers[id]; } if(scheduledReminders[id]){ delete scheduledReminders[id]; saveScheduled(); } }
-  function showReminder(item){ try{ new Notification(item.title,{ body:'Due now', tag:item.id }); }catch{} }
-  function scheduleReminder(item){ if(!item||!item.id) return; if(!item.due || item.done){ cancelReminder(item.id); return; } scheduledReminders[item.id]={ id:item.id, title:item.title, due:item.due }; saveScheduled(); if(reminderTimers[item.id]){ clearTimeout(reminderTimers[item.id]); delete reminderTimers[item.id]; } if(!('Notification' in window) || Notification.permission!=='granted'){ return; } const delay=new Date(item.due).getTime()-Date.now(); if(delay<=0){ showReminder(item); cancelReminder(item.id); return; } reminderTimers[item.id]=setTimeout(()=>{ showReminder(item); cancelReminder(item.id); }, delay); }
+  function clearReminderState(id, { closeNotification = true } = {}){
+    if(closeNotification){
+      const active = activeNotifications.get(id);
+      if(active){
+        try { active.close(); } catch {}
+        activeNotifications.delete(id);
+      }
+    }
+    if(reminderTimers[id]){ clearTimeout(reminderTimers[id]); delete reminderTimers[id]; }
+    if(scheduledReminders[id]){ delete scheduledReminders[id]; saveScheduled(); }
+  }
+  function cancelReminder(id){ clearReminderState(id); }
+  function showReminder(item){
+    if(!item || !item.id || !('Notification' in window)) return;
+    try{
+      const existing = activeNotifications.get(item.id);
+      if(existing && typeof existing.close === 'function'){
+        try { existing.close(); } catch {}
+      }
+      const notification = new Notification(item.title,{ body:'Due now', tag:item.id });
+      activeNotifications.set(item.id, notification);
+      const remove = () => {
+        if(activeNotifications.get(item.id) === notification){
+          activeNotifications.delete(item.id);
+        }
+      };
+      if(typeof notification.addEventListener === 'function'){
+        notification.addEventListener('close', remove);
+        notification.addEventListener('click', remove);
+      }
+      notification.onclose = remove;
+      notification.onclick = remove;
+    }catch{}
+  }
+  function scheduleReminder(item){
+    if(!item||!item.id) return;
+    if(!item.due || item.done){ cancelReminder(item.id); return; }
+    scheduledReminders[item.id]={ id:item.id, title:item.title, due:item.due };
+    saveScheduled();
+    if(reminderTimers[item.id]){ clearTimeout(reminderTimers[item.id]); delete reminderTimers[item.id]; }
+    if(!('Notification' in window) || Notification.permission!=='granted'){ return; }
+    const delay=new Date(item.due).getTime()-Date.now();
+    if(delay<=0){
+      showReminder(item);
+      clearReminderState(item.id,{ closeNotification:false });
+      return;
+    }
+    reminderTimers[item.id]=setTimeout(()=>{
+      showReminder(item);
+      clearReminderState(item.id,{ closeNotification:false });
+    }, delay);
+  }
   function rescheduleAllReminders(){ Object.values(scheduledReminders).forEach(it=>scheduleReminder(it)); }
 
   const desktopPriorityClasses = {
@@ -614,4 +699,10 @@ export async function initReminders(sel = {}) {
 
   rescheduleAllReminders();
   render();
+  return {
+    cancelReminder,
+    scheduleReminder,
+    closeActiveNotifications,
+    getActiveNotifications: () => activeNotifications,
+  };
 }


### PR DESCRIPTION
## Summary
- track active web notifications in the reminders module and close them when cancelled or on page unload
- update reminder scheduling to retain notifications until users dismiss them and allow tests to inject Firebase stubs
- add Jest coverage that exercises notification cleanup via cancelReminder and the unload handler

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68ca596f29308324b07aa129ace2ef32