### PR TITLE
Build actionable teacher dashboard overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,59 +135,168 @@
   </nav>
   <main class="min-h-screen">
     <section data-view="dashboard" id="view-dashboard">
-      <!-- Enhanced Feature Section -->
-      <section id="features" aria-labelledby="inside-heading" class="py-24 bg-slate-50 dark:bg-slate-900 relative">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div class="text-center mb-16">
-            <h2 id="inside-heading" class="text-4xl font-bold text-slate-900 dark:text-slate-100 mb-4">
-              Everything You Need to Teach
-            </h2>
-            <p class="text-xl text-slate-600 dark:text-slate-400 max-w-3xl mx-auto">
-              Streamline your workflow with powerful tools designed to make teaching more organized and effective.
-            </p>
+      <section id="dashboard-overview" aria-labelledby="dashboard-heading" class="pt-24 pb-16 bg-slate-50 dark:bg-slate-900">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 space-y-10">
+          <div class="relative overflow-hidden rounded-3xl bg-white dark:bg-slate-800 shadow-2xl border border-white/60 dark:border-slate-700/60">
+            <div class="absolute inset-0 bg-gradient-to-br from-blue-100 via-emerald-100 to-amber-100 opacity-60 dark:from-slate-800 dark:via-slate-900 dark:to-slate-900"></div>
+            <div class="relative z-10 p-8 sm:p-10">
+              <div class="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                <div class="space-y-2">
+                  <p class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Today's overview</p>
+                  <h1 id="dashboard-heading" class="text-3xl sm:text-4xl font-bold text-slate-900 dark:text-slate-100 leading-tight">Your teaching day at a glance</h1>
+                  <p id="dashboard-date" class="text-lg text-slate-600 dark:text-slate-300"></p>
+                </div>
+                <div class="flex flex-wrap gap-3">
+                  <a href="#planner" class="inline-flex items-center gap-2 rounded-full bg-blue-600 text-white px-5 py-2.5 text-sm font-semibold shadow-md hover:bg-blue-700 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500">Open weekly planner<span aria-hidden="true">→</span></a>
+                  <a href="#reminders" class="inline-flex items-center gap-2 rounded-full bg-white/80 text-blue-700 px-5 py-2.5 text-sm font-semibold shadow border border-blue-100 hover:bg-white transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400">Review reminders<span aria-hidden="true">→</span></a>
+                </div>
+              </div>
+              <div class="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
+                <div class="rounded-2xl bg-white/90 dark:bg-slate-900/60 border border-slate-200/70 dark:border-slate-700/70 p-5 shadow-sm">
+                  <p class="text-sm font-medium text-slate-500 dark:text-slate-400">Lessons today</p>
+                  <p id="dashboard-lesson-count" class="mt-1 text-3xl font-bold text-slate-900 dark:text-white">0</p>
+                  <p id="dashboard-next-lesson" class="mt-2 text-sm text-slate-500 dark:text-slate-400"></p>
+                </div>
+                <div class="rounded-2xl bg-white/90 dark:bg-slate-900/60 border border-slate-200/70 dark:border-slate-700/70 p-5 shadow-sm">
+                  <p class="text-sm font-medium text-slate-500 dark:text-slate-400">Deadlines this week</p>
+                  <p id="dashboard-deadline-count" class="mt-1 text-3xl font-bold text-slate-900 dark:text-white">0</p>
+                  <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">Countdowns auto-refresh</p>
+                </div>
+                <div class="rounded-2xl bg-white/90 dark:bg-slate-900/60 border border-slate-200/70 dark:border-slate-700/70 p-5 shadow-sm">
+                  <p class="text-sm font-medium text-slate-500 dark:text-slate-400">Reminders to action</p>
+                  <p id="dashboard-reminder-count" class="mt-1 text-3xl font-bold text-slate-900 dark:text-white">0</p>
+                  <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">Due today or overdue</p>
+                </div>
+              </div>
+            </div>
           </div>
-          
-          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            <!-- Enhanced Reminders Card -->
-            <div class="group relative p-8 rounded-2xl glass-effect hover:shadow-2xl transition-all duration-300 hover:-translate-y-2">
-              <div class="absolute inset-0 bg-gradient-to-br from-blue-500/10 to-purple-500/10 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-              <div class="relative z-10">
-                <div class="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-gradient-to-br from-blue-500 to-purple-600 text-white mb-6 group-hover:scale-110 transition-transform duration-300">
-                  <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6l4 2"></path>
-                  </svg>
+
+          <div class="space-y-6">
+            <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+              <section class="xl:col-span-2 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-3xl p-8 shadow-xl" aria-labelledby="lessons-heading">
+                <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                  <div>
+                    <h2 id="lessons-heading" class="text-2xl font-semibold text-slate-900 dark:text-slate-100">Today's lessons</h2>
+                    <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">Keep track of sessions, locations, and focus areas for a smooth teaching flow.</p>
+                  </div>
+                  <p class="inline-flex items-center gap-2 text-sm font-medium text-blue-600 dark:text-blue-300 bg-blue-50 dark:bg-blue-500/10 px-3 py-1.5 rounded-full" id="dashboard-lesson-status" aria-live="polite"></p>
                 </div>
-                <h3 class="text-xl font-semibold text-slate-900 dark:text-slate-100 mb-3">Smart Reminders</h3>
-                <p class="text-slate-600 dark:text-slate-400 leading-relaxed">Set intelligent reminders for grading, parent meetings, and important deadlines. Never miss what matters most.</p>
-              </div>
+                <div class="mt-6">
+                  <ul id="dashboard-lessons-list" class="space-y-4" aria-live="polite" aria-busy="false"></ul>
+                  <p id="dashboard-lessons-empty" class="hidden text-sm text-slate-500 dark:text-slate-400">No lessons captured for today yet. Add the key sessions below to build your timetable.</p>
+                </div>
+                <form id="lesson-form" class="mt-6 grid grid-cols-1 gap-3 md:grid-cols-5" aria-describedby="lesson-feedback">
+                  <div>
+                    <label for="lesson-subject" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Lesson or group</label>
+                    <input id="lesson-subject" name="lesson-subject" type="text" required placeholder="e.g. Year 8 Science" class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                  </div>
+                  <div>
+                    <label for="lesson-start" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Start</label>
+                    <input id="lesson-start" name="lesson-start" type="time" required class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                  </div>
+                  <div>
+                    <label for="lesson-end" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Finish</label>
+                    <input id="lesson-end" name="lesson-end" type="time" required class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                  </div>
+                  <div>
+                    <label for="lesson-location" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Location</label>
+                    <input id="lesson-location" name="lesson-location" type="text" placeholder="e.g. Lab 2" class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                  </div>
+                  <div class="flex items-end">
+                    <button type="submit" class="w-full inline-flex justify-center items-center rounded-xl bg-blue-600 text-white font-semibold px-4 py-2.5 shadow hover:bg-blue-700 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500">Add lesson</button>
+                  </div>
+                </form>
+                <p id="lesson-feedback" class="hidden mt-3 text-sm font-medium"></p>
+              </section>
+
+              <section class="bg-gradient-to-br from-sky-500 via-indigo-500 to-emerald-500 text-white rounded-3xl shadow-xl border border-white/40 p-8 flex flex-col" aria-labelledby="weather-heading">
+                <div class="flex items-start justify-between gap-3">
+                  <div>
+                    <h2 id="weather-heading" class="text-2xl font-semibold">Outdoor planning</h2>
+                    <p class="mt-1 text-sm text-white/80">Check the forecast before excursions or sport.</p>
+                  </div>
+                  <button id="weather-refresh" type="button" class="inline-flex items-center gap-2 rounded-full bg-white/20 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide hover:bg-white/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white">Refresh</button>
+                </div>
+                <div class="mt-8 space-y-4" aria-live="polite">
+                  <div id="weather-status" class="text-sm text-white/80">Finding your forecast…</div>
+                  <div id="weather-summary" class="hidden space-y-6">
+                    <div class="flex items-end gap-4">
+                      <span id="weather-icon" class="text-5xl" aria-hidden="true">☀️</span>
+                      <div>
+                        <p id="weather-temperature" class="text-5xl font-semibold">--°C</p>
+                        <p id="weather-description" class="text-lg text-white/90"></p>
+                      </div>
+                    </div>
+                    <dl class="grid grid-cols-2 gap-4 text-sm text-white/80">
+                      <div>
+                        <dt class="font-semibold text-white/90">Location</dt>
+                        <dd id="weather-location">Loading…</dd>
+                      </div>
+                      <div>
+                        <dt class="font-semibold text-white/90">Wind</dt>
+                        <dd id="weather-wind">-- km/h</dd>
+                      </div>
+                      <div>
+                        <dt class="font-semibold text-white/90">Rain chance</dt>
+                        <dd id="weather-rain">--%</dd>
+                      </div>
+                      <div>
+                        <dt class="font-semibold text-white/90">Sunset</dt>
+                        <dd id="weather-sunset">--:--</dd>
+                      </div>
+                    </dl>
+                    <p id="weather-footnote" class="text-xs text-white/70"></p>
+                  </div>
+                </div>
+              </section>
             </div>
 
-            <!-- Enhanced Planner Card -->
-            <div class="group relative p-8 rounded-2xl glass-effect hover:shadow-2xl transition-all duration-300 hover:-translate-y-2">
-              <div class="absolute inset-0 bg-gradient-to-br from-teal-500/10 to-blue-500/10 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-              <div class="relative z-10">
-                <div class="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-gradient-to-br from-teal-500 to-blue-600 text-white mb-6 group-hover:scale-110 transition-transform duration-300">
-                  <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
-                  </svg>
+            <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+              <section class="xl:col-span-2 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-3xl p-8 shadow-xl" aria-labelledby="deadlines-heading">
+                <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                  <div>
+                    <h2 id="deadlines-heading" class="text-2xl font-semibold text-slate-900 dark:text-slate-100">Upcoming deadlines</h2>
+                    <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">Deadlines due in the next seven days with live countdowns.</p>
+                  </div>
+                  <span class="inline-flex items-center gap-2 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-500/10 dark:text-amber-200 px-3 py-1 text-xs font-semibold uppercase tracking-wide">Next 7 days</span>
                 </div>
-                <h3 class="text-xl font-semibold text-slate-900 dark:text-slate-100 mb-3">Lesson Planner</h3>
-                <p class="text-slate-600 dark:text-slate-400 leading-relaxed">Create detailed lesson plans with templates, objectives, and resources. Stay organized week by week.</p>
-              </div>
-            </div>
+                <div class="mt-6">
+                  <ul id="dashboard-deadlines-list" class="space-y-4" aria-live="polite" aria-busy="false"></ul>
+                  <p id="dashboard-deadlines-empty" class="hidden text-sm text-slate-500 dark:text-slate-400">No deadlines due within the next week. You can add one below to keep it on your radar.</p>
+                </div>
+                <form id="deadline-form" class="mt-6 grid grid-cols-1 gap-3 md:grid-cols-5" aria-describedby="deadline-feedback">
+                  <div class="md:col-span-2">
+                    <label for="deadline-title" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Deadline</label>
+                    <input id="deadline-title" name="deadline-title" type="text" required placeholder="e.g. Year 9 essays" class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
+                  </div>
+                  <div>
+                    <label for="deadline-due" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Due</label>
+                    <input id="deadline-due" name="deadline-due" type="datetime-local" required class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
+                  </div>
+                  <div>
+                    <label for="deadline-course" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Class / group</label>
+                    <input id="deadline-course" name="deadline-course" type="text" placeholder="Optional" class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
+                  </div>
+                  <div class="flex items-end">
+                    <button type="submit" class="w-full inline-flex justify-center items-center rounded-xl bg-amber-500 text-white font-semibold px-4 py-2.5 shadow hover:bg-amber-600 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500">Add deadline</button>
+                  </div>
+                </form>
+                <p id="deadline-feedback" class="hidden mt-3 text-sm font-medium"></p>
+              </section>
 
-            <!-- Enhanced Notes Card -->
-            <div class="group relative p-8 rounded-2xl glass-effect hover:shadow-2xl transition-all duration-300 hover:-translate-y-2">
-              <div class="absolute inset-0 bg-gradient-to-br from-violet-500/10 to-purple-500/10 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-              <div class="relative z-10">
-                <div class="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-gradient-to-br from-violet-500 to-purple-600 text-white mb-6 group-hover:scale-110 transition-transform duration-300">
-                  <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"></path>
-                  </svg>
+              <section class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-3xl p-8 shadow-xl" aria-labelledby="reminders-heading">
+                <div class="flex flex-col gap-4">
+                  <div class="flex flex-col gap-2">
+                    <h2 id="reminders-heading" class="text-2xl font-semibold text-slate-900 dark:text-slate-100">Reminders needing attention</h2>
+                    <p class="text-sm text-slate-500 dark:text-slate-400">These are pulled automatically from the Reminders board and show tasks due today or overdue.</p>
+                  </div>
+                  <a href="#reminders" class="self-start inline-flex items-center gap-2 rounded-full bg-slate-900 text-white dark:bg-white dark:text-slate-900 px-4 py-2 text-sm font-semibold shadow hover:shadow-lg transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900 dark:focus-visible:outline-white">Open reminders<span aria-hidden="true">→</span></a>
                 </div>
-                <h3 class="text-xl font-semibold text-slate-900 dark:text-slate-100 mb-3">Quick Notes</h3>
-                <p class="text-slate-600 dark:text-slate-400 leading-relaxed">Capture spontaneous ideas, student observations, and important thoughts instantly. Access anywhere.</p>
-              </div>
+                <div class="mt-6">
+                  <ul id="dashboard-reminders-list" class="space-y-4" aria-live="polite" aria-busy="false"></ul>
+                  <p id="dashboard-reminders-empty" class="hidden text-sm text-slate-500 dark:text-slate-400">You're all caught up! Urgent reminders will appear here automatically.</p>
+                </div>
+              </section>
             </div>
           </div>
         </div>

--- a/js/main.js
+++ b/js/main.js
@@ -152,6 +152,866 @@ function toDateKey(date){
   return `${year}-${month}-${day}`;
 }
 
+// Dashboard overview controller
+const dashboardController = (() => {
+  const lessonListEl = document.getElementById('dashboard-lessons-list');
+  const deadlinesListEl = document.getElementById('dashboard-deadlines-list');
+  const remindersListEl = document.getElementById('dashboard-reminders-list');
+  const weatherStatusEl = document.getElementById('weather-status');
+
+  const hasDashboard = lessonListEl || deadlinesListEl || remindersListEl || weatherStatusEl;
+  const locale = (typeof navigator !== 'undefined' && navigator.language) ? navigator.language : 'en-AU';
+
+  const headlineFormatter = new Intl.DateTimeFormat(locale, { weekday: 'long', month: 'long', day: 'numeric' });
+  const timeFormatter = new Intl.DateTimeFormat(locale, { hour: '2-digit', minute: '2-digit' });
+  const longTimeFormatter = new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: '2-digit' });
+  const dateTimeFormatter = new Intl.DateTimeFormat(locale, { weekday: 'short', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+  const dayLabelFormatter = new Intl.DateTimeFormat(locale, { weekday: 'short', month: 'short', day: 'numeric' });
+
+  const dateEl = document.getElementById('dashboard-date');
+  if (dateEl) {
+    dateEl.textContent = headlineFormatter.format(new Date());
+  }
+
+  if (!hasDashboard) {
+    return null;
+  }
+
+  const LESSON_STORAGE_KEY = 'memoryCue.dashboardLessons.v1';
+  const DEADLINE_STORAGE_KEY = 'memoryCue.dashboardDeadlines.v1';
+  const DEFAULT_WEATHER_LOCATION = { latitude: -33.8688, longitude: 151.2093, label: 'Sydney, AU' };
+  const WEATHER_CODE_MAP = {
+    0: { icon: '☀️', label: 'Clear sky' },
+    1: { icon: '🌤️', label: 'Mostly clear' },
+    2: { icon: '⛅️', label: 'Partly cloudy' },
+    3: { icon: '☁️', label: 'Overcast' },
+    45: { icon: '🌫️', label: 'Foggy' },
+    48: { icon: '🌫️', label: 'Ice fog' },
+    51: { icon: '🌦️', label: 'Light drizzle' },
+    53: { icon: '🌦️', label: 'Drizzle' },
+    55: { icon: '🌧️', label: 'Heavy drizzle' },
+    56: { icon: '🌧️', label: 'Freezing drizzle' },
+    57: { icon: '🌧️', label: 'Freezing drizzle' },
+    61: { icon: '🌧️', label: 'Light rain' },
+    63: { icon: '🌧️', label: 'Rain showers' },
+    65: { icon: '🌧️', label: 'Heavy rain' },
+    66: { icon: '🌧️', label: 'Freezing rain' },
+    67: { icon: '🌧️', label: 'Freezing rain' },
+    71: { icon: '🌨️', label: 'Light snow' },
+    73: { icon: '🌨️', label: 'Snow' },
+    75: { icon: '❄️', label: 'Heavy snow' },
+    77: { icon: '❄️', label: 'Snow grains' },
+    80: { icon: '🌦️', label: 'Light showers' },
+    81: { icon: '🌧️', label: 'Showers' },
+    82: { icon: '⛈️', label: 'Heavy showers' },
+    85: { icon: '🌨️', label: 'Snow showers' },
+    86: { icon: '🌨️', label: 'Heavy snow showers' },
+    95: { icon: '⛈️', label: 'Thunderstorm' },
+    96: { icon: '⛈️', label: 'Thunderstorm & hail' },
+    99: { icon: '⛈️', label: 'Thunderstorm & hail' },
+    default: { icon: 'ℹ️', label: 'Weather update' },
+  };
+
+  const overviewLessonCountEl = document.getElementById('dashboard-lesson-count');
+  const overviewDeadlineCountEl = document.getElementById('dashboard-deadline-count');
+  const overviewReminderCountEl = document.getElementById('dashboard-reminder-count');
+  const nextLessonEl = document.getElementById('dashboard-next-lesson');
+  const lessonStatusEl = document.getElementById('dashboard-lesson-status');
+  const lessonsEmptyEl = document.getElementById('dashboard-lessons-empty');
+  const lessonFeedbackEl = document.getElementById('lesson-feedback');
+  const deadlinesEmptyEl = document.getElementById('dashboard-deadlines-empty');
+  const deadlineFeedbackEl = document.getElementById('deadline-feedback');
+  const remindersEmptyEl = document.getElementById('dashboard-reminders-empty');
+  const weatherSummaryEl = document.getElementById('weather-summary');
+  const weatherIconEl = document.getElementById('weather-icon');
+  const weatherTempEl = document.getElementById('weather-temperature');
+  const weatherDescEl = document.getElementById('weather-description');
+  const weatherLocationEl = document.getElementById('weather-location');
+  const weatherWindEl = document.getElementById('weather-wind');
+  const weatherRainEl = document.getElementById('weather-rain');
+  const weatherSunsetEl = document.getElementById('weather-sunset');
+  const weatherFootnoteEl = document.getElementById('weather-footnote');
+  const weatherRefreshBtn = document.getElementById('weather-refresh');
+
+  const lessonForm = document.getElementById('lesson-form');
+  const lessonSubjectInput = document.getElementById('lesson-subject');
+  const lessonStartInput = document.getElementById('lesson-start');
+  const lessonEndInput = document.getElementById('lesson-end');
+  const lessonLocationInput = document.getElementById('lesson-location');
+
+  const deadlineForm = document.getElementById('deadline-form');
+  const deadlineTitleInput = document.getElementById('deadline-title');
+  const deadlineDueInput = document.getElementById('deadline-due');
+  const deadlineCourseInput = document.getElementById('deadline-course');
+
+  const counts = { lessons: 0, deadlines: 0, reminders: 0 };
+  let lessonFeedbackTimer = null;
+  let deadlineFeedbackTimer = null;
+  let isFetchingWeather = false;
+
+  function randomId(prefix = 'id'){
+    if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+      return crypto.randomUUID();
+    }
+    return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+
+  function safeRead(key){
+    try {
+      const raw = localStorage.getItem(key);
+      if (!raw) return null;
+      return JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  function safeWrite(key, value){
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // Ignore storage write failures (private browsing, etc.)
+    }
+  }
+
+  function createLesson(start, end, subject, location, focus = ''){
+    return { id: randomId('lesson'), start, end, subject, location: location || '', focus };
+  }
+
+  function createDeadline(baseDate, offsetDays, hour, minute, title, course, notes = ''){
+    const due = new Date(baseDate);
+    due.setHours(0, 0, 0, 0);
+    due.setDate(due.getDate() + offsetDays);
+    due.setHours(hour, minute, 0, 0);
+    return {
+      id: randomId('deadline'),
+      title,
+      due: due.toISOString(),
+      course: course || '',
+      notes,
+      done: false,
+    };
+  }
+
+  function seedLessons(){
+    const today = new Date();
+    const key = toDateKey(today);
+    return {
+      [key]: [
+        createLesson('08:45', '09:30', 'Year 8 Science', 'Lab 2', 'Energy transfer experiment'),
+        createLesson('10:15', '11:00', 'Year 10 English', 'Room 14', 'Draft persuasive speech feedback'),
+        createLesson('11:45', '12:30', 'Year 7 Pastoral Care', 'Outdoor court', 'Team-building circuits'),
+        createLesson('14:15', '15:00', 'Faculty collaboration', 'Library hub', 'Moderate assessment rubrics'),
+      ],
+    };
+  }
+
+  function seedDeadlines(){
+    const now = new Date();
+    return [
+      createDeadline(now, 1, 15, 30, 'Year 9 research outlines', '9A Humanities', 'Collect drafts and provide quick feedback.'),
+      createDeadline(now, 3, 9, 0, 'Staff PD reflection summary', 'Faculty', 'Submit summary to head of department.'),
+      createDeadline(now, 6, 12, 0, 'Newsletter highlights due', 'Whole school', 'Share classroom wins and reminders.'),
+    ];
+  }
+
+  function loadLessons(){
+    const stored = safeRead(LESSON_STORAGE_KEY);
+    if (stored && typeof stored === 'object' && stored.byDate) {
+      return stored;
+    }
+    const seeded = { version: 1, byDate: seedLessons() };
+    safeWrite(LESSON_STORAGE_KEY, seeded);
+    return seeded;
+  }
+
+  function loadDeadlines(){
+    const stored = safeRead(DEADLINE_STORAGE_KEY);
+    if (stored && Array.isArray(stored.items)) {
+      return stored;
+    }
+    const seeded = { version: 1, items: seedDeadlines() };
+    safeWrite(DEADLINE_STORAGE_KEY, seeded);
+    return seeded;
+  }
+
+  let lessonsState = loadLessons();
+  let deadlinesState = loadDeadlines();
+  let remindersState = [];
+
+  function saveLessons(){
+    safeWrite(LESSON_STORAGE_KEY, lessonsState);
+  }
+
+  function saveDeadlines(){
+    safeWrite(DEADLINE_STORAGE_KEY, deadlinesState);
+  }
+
+  function setFeedbackMessage(el, text, variant = 'info'){
+    if (!el) return;
+    const colorClasses = ['text-emerald-600', 'text-rose-600', 'text-slate-500'];
+    colorClasses.forEach(cls => el.classList.remove(cls));
+    if (!text){
+      el.textContent = '';
+      el.classList.add('hidden');
+      return;
+    }
+    const variantClass = variant === 'success'
+      ? 'text-emerald-600'
+      : variant === 'error'
+        ? 'text-rose-600'
+        : 'text-slate-500';
+    el.textContent = text;
+    el.classList.remove('hidden');
+    el.classList.add(variantClass);
+  }
+
+  function showLessonFeedback(message, variant){
+    if (!lessonFeedbackEl) return;
+    if (lessonFeedbackTimer) clearTimeout(lessonFeedbackTimer);
+    setFeedbackMessage(lessonFeedbackEl, message, variant);
+    if (message){
+      lessonFeedbackTimer = setTimeout(() => {
+        setFeedbackMessage(lessonFeedbackEl, '');
+      }, 4000);
+    }
+  }
+
+  function showDeadlineFeedback(message, variant){
+    if (!deadlineFeedbackEl) return;
+    if (deadlineFeedbackTimer) clearTimeout(deadlineFeedbackTimer);
+    setFeedbackMessage(deadlineFeedbackEl, message, variant);
+    if (message){
+      deadlineFeedbackTimer = setTimeout(() => {
+        setFeedbackMessage(deadlineFeedbackEl, '');
+      }, 4000);
+    }
+  }
+
+  function applyOverviewCounts(){
+    if (overviewLessonCountEl) overviewLessonCountEl.textContent = String(counts.lessons);
+    if (overviewDeadlineCountEl) overviewDeadlineCountEl.textContent = String(counts.deadlines);
+    if (overviewReminderCountEl) overviewReminderCountEl.textContent = String(counts.reminders);
+  }
+
+  function parseTimeToDate(baseDate, timeString){
+    if (!timeString) return null;
+    const [hourPart, minutePart] = timeString.split(':');
+    const hour = Number.parseInt(hourPart, 10);
+    const minute = Number.parseInt(minutePart, 10);
+    if (Number.isNaN(hour) || Number.isNaN(minute)) return null;
+    const dt = new Date(baseDate);
+    dt.setHours(hour, minute, 0, 0);
+    return dt;
+  }
+
+  function minutesFromTimeString(timeString){
+    if (!timeString) return Number.POSITIVE_INFINITY;
+    const [hourPart, minutePart] = timeString.split(':');
+    const hour = Number.parseInt(hourPart, 10);
+    const minute = Number.parseInt(minutePart, 10);
+    if (Number.isNaN(hour) || Number.isNaN(minute)) return Number.POSITIVE_INFINITY;
+    return hour * 60 + minute;
+  }
+
+  function formatDuration(ms){
+    const abs = Math.abs(ms);
+    const totalMinutes = Math.round(abs / 60000);
+    if (totalMinutes < 1) return 'moments';
+    if (totalMinutes < 60) return `${totalMinutes} min${totalMinutes === 1 ? '' : 's'}`;
+    const totalHours = Math.floor(totalMinutes / 60);
+    const remainingMinutes = totalMinutes % 60;
+    if (totalHours >= 24){
+      const days = Math.floor(totalHours / 24);
+      const remainingHours = totalHours % 24;
+      const dayLabel = `${days} day${days === 1 ? '' : 's'}`;
+      if (days >= 7 || remainingHours === 0) return dayLabel;
+      return `${dayLabel} ${remainingHours} hr${remainingHours === 1 ? '' : 's'}`;
+    }
+    const hourLabel = `${totalHours} hr${totalHours === 1 ? '' : 's'}`;
+    if (!remainingMinutes) return hourLabel;
+    return `${hourLabel} ${remainingMinutes} min`;
+  }
+
+  function buildLessonTimeLabel(dayDate, start, end){
+    const startDate = parseTimeToDate(dayDate, start);
+    const endDate = parseTimeToDate(dayDate, end);
+    if (startDate && endDate){
+      return `${longTimeFormatter.format(startDate)} – ${longTimeFormatter.format(endDate)}`;
+    }
+    if (startDate){
+      return longTimeFormatter.format(startDate);
+    }
+    return '';
+  }
+
+  function badgeClassForTone(tone){
+    switch (tone){
+      case 'active':
+        return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-200';
+      case 'soon':
+        return 'bg-amber-100 text-amber-700 dark:bg-amber-500/10 dark:text-amber-200';
+      case 'future':
+        return 'bg-blue-100 text-blue-700 dark:bg-blue-500/10 dark:text-blue-200';
+      case 'past':
+        return 'bg-slate-100 text-slate-500 dark:bg-slate-800/70 dark:text-slate-300';
+      default:
+        return 'bg-slate-100 text-slate-600 dark:bg-slate-800/70 dark:text-slate-300';
+    }
+  }
+
+  function formatLessonStatus(start, end, now){
+    if (!start){
+      return { label: 'Time to confirm', tone: 'neutral' };
+    }
+    if (now < start){
+      const diff = start - now;
+      return {
+        label: `Starts in ${formatDuration(diff)}`,
+        tone: diff <= 60 * 60 * 1000 ? 'soon' : 'future',
+      };
+    }
+    if (end && now <= end){
+      return { label: `In progress · ends ${longTimeFormatter.format(end)}`, tone: 'active' };
+    }
+    if (end){
+      return { label: `Finished ${formatDuration(now - end)} ago`, tone: 'past' };
+    }
+    return { label: 'Completed', tone: 'past' };
+  }
+
+  function renderLessons(){
+    if (!lessonListEl) return;
+    const today = new Date();
+    const todayKey = toDateKey(today);
+    const lessonArray = Array.isArray(lessonsState.byDate?.[todayKey]) ? lessonsState.byDate[todayKey].slice() : [];
+    lessonArray.sort((a, b) => minutesFromTimeString(a.start) - minutesFromTimeString(b.start));
+
+    lessonListEl.replaceChildren();
+    counts.lessons = lessonArray.length;
+    applyOverviewCounts();
+
+    if (lessonArray.length === 0){
+      if (lessonsEmptyEl) lessonsEmptyEl.classList.remove('hidden');
+      if (lessonStatusEl) lessonStatusEl.classList.add('hidden');
+      if (nextLessonEl) nextLessonEl.textContent = '';
+      return;
+    }
+
+    if (lessonsEmptyEl) lessonsEmptyEl.classList.add('hidden');
+
+    const now = new Date();
+    const fragment = document.createDocumentFragment();
+    let completed = 0;
+    let activeLesson = null;
+    let upcomingLesson = null;
+
+    lessonArray.forEach((lesson) => {
+      const start = parseTimeToDate(today, lesson.start);
+      const end = parseTimeToDate(today, lesson.end);
+
+      if (end && now > end) {
+        completed += 1;
+      }
+
+      if (start && end && start <= now && now <= end){
+        if (!activeLesson || (start < activeLesson.start)){
+          activeLesson = { lesson, start, end };
+        }
+      } else if (start && start > now){
+        if (!upcomingLesson || start < upcomingLesson.start){
+          upcomingLesson = { lesson, start, end };
+        }
+      }
+
+      const status = formatLessonStatus(start, end, now);
+      const li = document.createElement('li');
+      li.className = 'flex flex-col gap-4 rounded-2xl border border-slate-200 dark:border-slate-700 bg-white/80 dark:bg-slate-900/40 p-4 md:flex-row md:items-center md:justify-between';
+
+      const details = document.createElement('div');
+      details.className = 'space-y-1';
+      const heading = document.createElement('p');
+      heading.className = 'text-lg font-semibold text-slate-900 dark:text-slate-100';
+      heading.textContent = lesson.subject || 'Lesson';
+      const meta = document.createElement('p');
+      meta.className = 'text-sm text-slate-500 dark:text-slate-400';
+      const timeLabel = buildLessonTimeLabel(today, lesson.start, lesson.end);
+      const metaParts = [];
+      if (timeLabel) metaParts.push(timeLabel);
+      if (lesson.location) metaParts.push(lesson.location);
+      meta.textContent = metaParts.join(' • ');
+      details.append(heading, meta);
+      if (lesson.focus){
+        const focus = document.createElement('p');
+        focus.className = 'text-sm text-slate-500 dark:text-slate-400';
+        focus.textContent = lesson.focus;
+        details.appendChild(focus);
+      }
+
+      const actions = document.createElement('div');
+      actions.className = 'flex items-center gap-3 self-start md:self-auto';
+      const statusBadge = document.createElement('span');
+      statusBadge.className = `inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold ${badgeClassForTone(status.tone)}`;
+      statusBadge.textContent = status.label;
+      actions.appendChild(statusBadge);
+
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.className = 'text-sm font-semibold text-rose-600 hover:text-rose-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500';
+      removeBtn.textContent = 'Remove';
+      removeBtn.addEventListener('click', () => {
+        const current = lessonsState.byDate?.[todayKey];
+        if (!Array.isArray(current)) return;
+        lessonsState.byDate[todayKey] = current.filter(item => item.id !== lesson.id);
+        saveLessons();
+        showLessonFeedback('Lesson removed from today.', 'success');
+        renderLessons();
+      });
+      actions.appendChild(removeBtn);
+
+      li.append(details, actions);
+      fragment.appendChild(li);
+    });
+
+    lessonListEl.appendChild(fragment);
+
+    if (lessonStatusEl){
+      lessonStatusEl.classList.remove('hidden');
+      const finished = Math.min(completed, lessonArray.length);
+      lessonStatusEl.textContent = `${finished} of ${lessonArray.length} complete`;
+    }
+
+    if (nextLessonEl){
+      if (activeLesson){
+        const untilLabel = activeLesson.end ? longTimeFormatter.format(activeLesson.end) : longTimeFormatter.format(activeLesson.start);
+        nextLessonEl.textContent = `Now: ${activeLesson.lesson.subject} until ${untilLabel}`;
+      } else if (upcomingLesson){
+        nextLessonEl.textContent = `Next: ${upcomingLesson.lesson.subject} at ${longTimeFormatter.format(upcomingLesson.start)}`;
+      } else {
+        nextLessonEl.textContent = 'All lessons are wrapped up for today.';
+      }
+    }
+  }
+
+  function renderDeadlines(){
+    if (!deadlinesListEl) return;
+    const now = new Date();
+    const windowStart = new Date(now);
+    windowStart.setHours(0, 0, 0, 0);
+    const windowEnd = new Date(now);
+    windowEnd.setDate(windowEnd.getDate() + 7);
+    windowEnd.setHours(23, 59, 59, 999);
+
+    const all = Array.isArray(deadlinesState.items) ? deadlinesState.items : [];
+    const upcoming = all.filter(item => !item.done && item.due).filter(item => {
+      try {
+        const dueDate = new Date(item.due);
+        if (Number.isNaN(dueDate.getTime())) return false;
+        return dueDate >= windowStart && dueDate <= windowEnd;
+      } catch {
+        return false;
+      }
+    });
+    upcoming.sort((a, b) => new Date(a.due) - new Date(b.due));
+
+    deadlinesListEl.replaceChildren();
+    counts.deadlines = upcoming.length;
+    applyOverviewCounts();
+
+    if (!upcoming.length){
+      if (deadlinesEmptyEl) deadlinesEmptyEl.classList.remove('hidden');
+      return;
+    }
+
+    if (deadlinesEmptyEl) deadlinesEmptyEl.classList.add('hidden');
+
+    const fragment = document.createDocumentFragment();
+    upcoming.forEach((deadline) => {
+      const due = new Date(deadline.due);
+      const diff = due - now;
+      const overdue = diff < 0;
+      const highlightClass = overdue
+        ? 'bg-rose-100 text-rose-700 dark:bg-rose-500/10 dark:text-rose-200'
+        : diff <= 24 * 60 * 60 * 1000
+          ? 'bg-amber-100 text-amber-700 dark:bg-amber-500/10 dark:text-amber-200'
+          : 'bg-blue-100 text-blue-700 dark:bg-blue-500/10 dark:text-blue-200';
+      const statusLabel = overdue ? `Overdue by ${formatDuration(diff)}` : `Due in ${formatDuration(diff)}`;
+
+      const li = document.createElement('li');
+      li.className = 'rounded-2xl border border-slate-200 dark:border-slate-700 bg-white/80 dark:bg-slate-900/40 p-4';
+
+      const top = document.createElement('div');
+      top.className = 'flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between';
+
+      const info = document.createElement('div');
+      info.className = 'space-y-1';
+      const title = document.createElement('p');
+      title.className = 'text-lg font-semibold text-slate-900 dark:text-slate-100';
+      title.textContent = deadline.title || 'Deadline';
+      const meta = document.createElement('p');
+      meta.className = 'text-sm text-slate-500 dark:text-slate-400';
+      const dueLabel = overdue ? `Was due ${dateTimeFormatter.format(due)}` : `Due ${dateTimeFormatter.format(due)}`;
+      const metaPieces = [dueLabel];
+      if (deadline.course) metaPieces.push(deadline.course);
+      meta.textContent = metaPieces.join(' • ');
+      info.append(title, meta);
+      if (deadline.notes){
+        const note = document.createElement('p');
+        note.className = 'text-sm text-slate-500 dark:text-slate-400';
+        note.textContent = deadline.notes;
+        info.appendChild(note);
+      }
+
+      const actions = document.createElement('div');
+      actions.className = 'flex flex-col items-start sm:items-end gap-3';
+      const status = document.createElement('span');
+      status.className = `inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold ${highlightClass}`;
+      status.textContent = statusLabel;
+      const completeBtn = document.createElement('button');
+      completeBtn.type = 'button';
+      completeBtn.className = 'text-sm font-semibold text-emerald-600 hover:text-emerald-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500';
+      completeBtn.textContent = 'Mark done';
+      completeBtn.addEventListener('click', () => {
+        const index = deadlinesState.items.findIndex(item => item.id === deadline.id);
+        if (index === -1) return;
+        deadlinesState.items[index].done = true;
+        saveDeadlines();
+        showDeadlineFeedback('Deadline marked as complete.', 'success');
+        renderDeadlines();
+      });
+      actions.append(status, completeBtn);
+
+      top.append(info, actions);
+      li.appendChild(top);
+      fragment.appendChild(li);
+    });
+
+    deadlinesListEl.appendChild(fragment);
+  }
+
+  function renderReminders(){
+    if (!remindersListEl) return;
+    remindersListEl.replaceChildren();
+    const now = new Date();
+    const endOfDay = new Date(now);
+    endOfDay.setHours(23, 59, 59, 999);
+
+    const filtered = remindersState
+      .filter(item => item && !item.done && item.due)
+      .filter(item => {
+        try {
+          const dueDate = new Date(item.due);
+          if (Number.isNaN(dueDate.getTime())) return false;
+          return dueDate <= endOfDay;
+        } catch {
+          return false;
+        }
+      });
+
+    filtered.sort((a, b) => new Date(a.due) - new Date(b.due));
+
+    counts.reminders = filtered.length;
+    applyOverviewCounts();
+
+    if (!filtered.length){
+      if (remindersEmptyEl) remindersEmptyEl.classList.remove('hidden');
+      return;
+    }
+
+    if (remindersEmptyEl) remindersEmptyEl.classList.add('hidden');
+
+    const fragment = document.createDocumentFragment();
+    filtered.slice(0, 6).forEach((reminder) => {
+      const due = new Date(reminder.due);
+      const diff = due - now;
+      const overdue = diff < 0;
+      const soon = !overdue && diff <= 60 * 60 * 1000;
+      const highlightClass = overdue
+        ? 'bg-rose-100 text-rose-700 dark:bg-rose-500/10 dark:text-rose-200'
+        : soon
+          ? 'bg-amber-100 text-amber-700 dark:bg-amber-500/10 dark:text-amber-200'
+          : 'bg-blue-100 text-blue-700 dark:bg-blue-500/10 dark:text-blue-200';
+      let statusLabel = '';
+      if (overdue){
+        statusLabel = `Overdue by ${formatDuration(diff)}`;
+      } else if (soon){
+        statusLabel = `Due in ${formatDuration(diff)}`;
+      } else {
+        statusLabel = `Due today · ${timeFormatter.format(due)}`;
+      }
+
+      const li = document.createElement('li');
+      li.className = 'rounded-2xl border border-slate-200 dark:border-slate-700 bg-white/80 dark:bg-slate-900/40 p-4';
+
+      const header = document.createElement('div');
+      header.className = 'flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between';
+
+      const content = document.createElement('div');
+      content.className = 'space-y-1';
+      const title = document.createElement('p');
+      title.className = 'text-lg font-semibold text-slate-900 dark:text-slate-100';
+      title.textContent = reminder.title || 'Reminder';
+      const meta = document.createElement('p');
+      meta.className = 'text-sm text-slate-500 dark:text-slate-400';
+      const dueLabel = overdue
+        ? `Was due ${dateTimeFormatter.format(due)}`
+        : `Due ${timeFormatter.format(due)} (${dayLabelFormatter.format(due)})`;
+      const metaParts = [dueLabel];
+      if (reminder.priority) metaParts.push(`${reminder.priority} priority`);
+      meta.textContent = metaParts.join(' • ');
+      content.append(title, meta);
+      if (reminder.notes){
+        const [firstLine] = String(reminder.notes).split('\n');
+        if (firstLine){
+          const note = document.createElement('p');
+          note.className = 'text-sm text-slate-500 dark:text-slate-400';
+          note.textContent = firstLine;
+          content.appendChild(note);
+        }
+      }
+
+      const status = document.createElement('span');
+      status.className = `inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold ${highlightClass}`;
+      status.textContent = statusLabel;
+
+      header.append(content, status);
+      li.appendChild(header);
+      fragment.appendChild(li);
+    });
+
+    remindersListEl.appendChild(fragment);
+  }
+
+  function handleLessonSubmit(event){
+    event.preventDefault();
+    if (!lessonSubjectInput || !lessonStartInput || !lessonEndInput) return;
+    const subject = lessonSubjectInput.value.trim();
+    const start = lessonStartInput.value;
+    const end = lessonEndInput.value;
+    if (!subject){
+      showLessonFeedback('Add a lesson or group name first.', 'error');
+      lessonSubjectInput.focus();
+      return;
+    }
+    const startDate = parseTimeToDate(new Date(), start);
+    const endDate = parseTimeToDate(new Date(), end);
+    if (startDate && endDate && endDate <= startDate){
+      showLessonFeedback('Finish time must be after the start time.', 'error');
+      lessonEndInput.focus();
+      return;
+    }
+    const todayKey = toDateKey(new Date());
+    if (!Array.isArray(lessonsState.byDate?.[todayKey])){
+      if (!lessonsState.byDate) lessonsState.byDate = {};
+      lessonsState.byDate[todayKey] = [];
+    }
+    lessonsState.byDate[todayKey].push(createLesson(start, end, subject, lessonLocationInput?.value.trim() || ''));
+    saveLessons();
+    lessonForm?.reset();
+    lessonSubjectInput.focus();
+    showLessonFeedback('Lesson added to today.', 'success');
+    renderLessons();
+  }
+
+  function handleDeadlineSubmit(event){
+    event.preventDefault();
+    if (!deadlineTitleInput || !deadlineDueInput) return;
+    const title = deadlineTitleInput.value.trim();
+    const dueValue = deadlineDueInput.value;
+    if (!title){
+      showDeadlineFeedback('Add a deadline title.', 'error');
+      deadlineTitleInput.focus();
+      return;
+    }
+    if (!dueValue){
+      showDeadlineFeedback('Choose when this is due.', 'error');
+      deadlineDueInput.focus();
+      return;
+    }
+    const dueDate = new Date(dueValue);
+    if (Number.isNaN(dueDate.getTime())){
+      showDeadlineFeedback('Enter a valid due date and time.', 'error');
+      deadlineDueInput.focus();
+      return;
+    }
+    if (!Array.isArray(deadlinesState.items)){
+      deadlinesState.items = [];
+    }
+    deadlinesState.items.push({
+      id: randomId('deadline'),
+      title,
+      due: dueDate.toISOString(),
+      course: deadlineCourseInput?.value.trim() || '',
+      notes: '',
+      done: false,
+    });
+    saveDeadlines();
+    deadlineForm?.reset();
+    showDeadlineFeedback('Deadline saved for this week.', 'success');
+    renderDeadlines();
+  }
+
+  function setWeatherStatus(text, variant = 'info'){
+    if (!weatherStatusEl) return;
+    weatherStatusEl.textContent = text;
+    weatherStatusEl.classList.remove('text-rose-200', 'text-white/90', 'text-white/70', 'text-white/80');
+    if (variant === 'error'){
+      weatherStatusEl.classList.add('text-rose-200');
+    } else if (variant === 'success'){
+      weatherStatusEl.classList.add('text-white/90');
+    } else {
+      weatherStatusEl.classList.add('text-white/80');
+    }
+  }
+
+  async function fetchWeather(lat, lon){
+    const params = new URLSearchParams({
+      latitude: lat.toFixed(2),
+      longitude: lon.toFixed(2),
+      current_weather: 'true',
+      daily: 'precipitation_probability_max,sunrise,sunset',
+      timezone: 'auto',
+    });
+    const res = await fetch(`https://api.open-meteo.com/v1/forecast?${params.toString()}`);
+    if (!res.ok){
+      throw new Error('Weather fetch failed');
+    }
+    return res.json();
+  }
+
+  async function resolveLocationLabel(lat, lon, fallbackLabel){
+    try {
+      const params = new URLSearchParams({ latitude: lat.toFixed(2), longitude: lon.toFixed(2), count: '1', language: 'en' });
+      const res = await fetch(`https://geocoding-api.open-meteo.com/v1/reverse?${params.toString()}`);
+      if (!res.ok) throw new Error('Reverse geocode failed');
+      const data = await res.json();
+      const result = data?.results?.[0];
+      if (result){
+        const pieces = [result.name, result.admin1, result.country_code].filter(Boolean);
+        const unique = [];
+        pieces.forEach((piece) => {
+          if (!unique.includes(piece)) unique.push(piece);
+        });
+        return unique.join(', ');
+      }
+    } catch {
+      // ignore, fallback below
+    }
+    return fallbackLabel || `Lat ${lat.toFixed(2)}, Lon ${lon.toFixed(2)}`;
+  }
+
+  function renderWeather(data, locationLabel, { fallback } = {}){
+    if (!weatherSummaryEl) return;
+    const current = data?.current_weather;
+    if (!current) throw new Error('Weather data missing');
+    weatherSummaryEl.classList.remove('hidden');
+    const code = WEATHER_CODE_MAP[current.weathercode] || WEATHER_CODE_MAP.default;
+    if (weatherIconEl) weatherIconEl.textContent = code.icon;
+    if (weatherDescEl) weatherDescEl.textContent = code.label;
+    if (weatherTempEl) weatherTempEl.textContent = `${Math.round(current.temperature)}°C`;
+    if (weatherLocationEl) weatherLocationEl.textContent = locationLabel;
+    if (weatherWindEl) weatherWindEl.textContent = `${Math.round(current.windspeed)} km/h`;
+    if (weatherRainEl){
+      const rain = data?.daily?.precipitation_probability_max?.[0];
+      weatherRainEl.textContent = typeof rain === 'number' ? `${Math.round(rain)}%` : '—';
+    }
+    if (weatherSunsetEl){
+      const sunsetIso = data?.daily?.sunset?.[0];
+      weatherSunsetEl.textContent = sunsetIso ? longTimeFormatter.format(new Date(sunsetIso)) : '—';
+    }
+    if (weatherFootnoteEl){
+      const updatedAt = current.time ? longTimeFormatter.format(new Date(current.time)) : longTimeFormatter.format(new Date());
+      const notes = [`Updated ${updatedAt}`];
+      if (fallback) notes.push('Default location');
+      notes.push('Source: Open‑Meteo');
+      weatherFootnoteEl.textContent = notes.join(' • ');
+    }
+  }
+
+  async function loadWeatherFor(lat, lon, { fallback }){
+    try {
+      const data = await fetchWeather(lat, lon);
+      const label = await resolveLocationLabel(lat, lon, fallback ? DEFAULT_WEATHER_LOCATION.label : '');
+      renderWeather(data, label || DEFAULT_WEATHER_LOCATION.label, { fallback });
+      setWeatherStatus(fallback ? 'Showing default location forecast.' : 'Forecast updated just now.', 'success');
+    } catch (error) {
+      console.error('Weather load failed', error);
+      setWeatherStatus('Unable to load weather right now.', 'error');
+    }
+  }
+
+  function requestWeather({ preferGeolocation = true, message } = {}){
+    if (!weatherStatusEl) return;
+    if (isFetchingWeather) return;
+    isFetchingWeather = true;
+    setWeatherStatus(message || 'Fetching latest forecast…', 'info');
+    weatherSummaryEl?.classList.add('hidden');
+
+    const finish = () => {
+      isFetchingWeather = false;
+    };
+
+    if (preferGeolocation && navigator?.geolocation){
+      navigator.geolocation.getCurrentPosition(
+        (pos) => {
+          loadWeatherFor(pos.coords.latitude, pos.coords.longitude, { fallback: false }).finally(finish);
+        },
+        () => {
+          loadWeatherFor(DEFAULT_WEATHER_LOCATION.latitude, DEFAULT_WEATHER_LOCATION.longitude, { fallback: true }).finally(finish);
+        },
+        { maximumAge: 15 * 60 * 1000, timeout: 8000 }
+      );
+      return;
+    }
+
+    loadWeatherFor(DEFAULT_WEATHER_LOCATION.latitude, DEFAULT_WEATHER_LOCATION.longitude, { fallback: true }).finally(finish);
+  }
+
+  if (lessonForm){
+    lessonForm.addEventListener('submit', handleLessonSubmit);
+  }
+
+  if (deadlineForm){
+    deadlineForm.addEventListener('submit', handleDeadlineSubmit);
+  }
+
+  if (weatherRefreshBtn){
+    weatherRefreshBtn.addEventListener('click', () => {
+      requestWeather({ preferGeolocation: true, message: 'Refreshing forecast…' });
+    });
+  }
+
+  renderLessons();
+  renderDeadlines();
+  renderReminders();
+  requestWeather({ preferGeolocation: true });
+
+  setInterval(() => {
+    renderLessons();
+    renderDeadlines();
+    renderReminders();
+  }, 60 * 1000);
+
+  setInterval(() => {
+    requestWeather({ preferGeolocation: false, message: 'Updating forecast…' });
+  }, 30 * 60 * 1000);
+
+  return {
+    setReminders(items){
+      remindersState = Array.isArray(items) ? items.map(item => ({ ...item })) : [];
+      renderReminders();
+    },
+  };
+})();
+
+if (dashboardController) {
+  document.addEventListener('memoryCue:remindersUpdated', (event) => {
+    const detail = event?.detail;
+    const items = Array.isArray(detail?.items) ? detail.items : [];
+    dashboardController.setReminders(items);
+  });
+}
+
 // Planner
 const plannerWeekEl = document.getElementById('planner-week');
 const plannerGrid = document.getElementById('planner-grid');

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -486,6 +486,23 @@ export async function initReminders(sel = {}) {
     if(countTotalEl) countTotalEl.textContent = String(items.length);
     if(countCompletedEl) countCompletedEl.textContent = String(completedCount);
 
+    if (typeof document !== 'undefined' && typeof document.dispatchEvent === 'function') {
+      const payload = items.map(item => ({ ...item }));
+      try {
+        if (typeof CustomEvent === 'function') {
+          document.dispatchEvent(new CustomEvent('memoryCue:remindersUpdated', { detail: { items: payload } }));
+        } else if (document.createEvent) {
+          const evt = document.createEvent('CustomEvent');
+          if (evt && evt.initCustomEvent) {
+            evt.initCustomEvent('memoryCue:remindersUpdated', false, false, { items: payload });
+            document.dispatchEvent(evt);
+          }
+        }
+      } catch {
+        // Ignore dispatch errors so reminder rendering can continue.
+      }
+    }
+
     let rows = items.slice();
     const queryStr = q?.value.trim().toLowerCase() || '';
     if(queryStr){ rows = rows.filter(r => r.title.toLowerCase().includes(queryStr) || (r.notes||'').toLowerCase().includes(queryStr)); }


### PR DESCRIPTION
## Summary
- replace the placeholder dashboard with a lesson, deadline, reminder, and weather overview that surfaces the current day at a glance
- add local storage backed quick-add flows for lessons and deadlines, including live countdowns and next-lesson status updates
- broadcast reminder updates to the dashboard and fetch quick weather insights with refresh support

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cab008d8348327935a0dd2c308310d