### PR TITLE
Add quick actions and persistent dashboard widgets

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,130 @@
       color: rgb(220 38 38);
       border-color: rgba(248, 113, 113, 0.35);
     }
+
+    @keyframes widget-pop {
+      0% {
+        opacity: 0;
+        transform: translateY(8px) scale(0.98);
+      }
+      60% {
+        opacity: 1;
+        transform: translateY(-2px) scale(1.02);
+      }
+      100% {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+    }
+
+    @keyframes dashboard-bump {
+      0% {
+        transform: scale(1);
+      }
+      35% {
+        transform: scale(1.08);
+      }
+      100% {
+        transform: scale(1);
+      }
+    }
+
+    @keyframes dashboard-highlight {
+      0% {
+        box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.45);
+      }
+      70% {
+        box-shadow: 0 0 0 12px rgba(59, 130, 246, 0);
+      }
+      100% {
+        box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
+      }
+    }
+
+    .animate-widget-pop {
+      animation: widget-pop 0.38s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    .dashboard-bump {
+      animation: dashboard-bump 0.45s ease;
+    }
+
+    .dashboard-highlight {
+      animation: dashboard-highlight 0.85s ease-out;
+    }
+
+    .quick-action-btn {
+      transition: transform 0.18s ease, box-shadow 0.18s ease;
+      box-shadow: 0 18px 45px -18px rgba(76, 29, 149, 0.35);
+    }
+
+    .quick-action-btn:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 24px 55px -20px rgba(67, 56, 202, 0.45);
+    }
+
+    .quick-action-btn:focus-visible {
+      outline: 2px solid rgba(99, 102, 241, 0.9);
+      outline-offset: 3px;
+    }
+
+    .widget-control-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 2.25rem;
+      height: 2.25rem;
+      border-radius: 9999px;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      background: rgba(248, 250, 252, 0.9);
+      color: rgb(100 116 139);
+      font-weight: 600;
+      transition: transform 0.18s ease, box-shadow 0.18s ease, background-color 0.18s ease;
+    }
+
+    .dark .widget-control-btn {
+      background: rgba(15, 23, 42, 0.7);
+      border-color: rgba(71, 85, 105, 0.65);
+      color: rgb(203 213 225);
+    }
+
+    .widget-control-btn:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 16px 35px -20px rgba(30, 64, 175, 0.55);
+    }
+
+    .widget-control-btn:focus-visible {
+      outline: 2px solid rgba(59, 130, 246, 0.85);
+      outline-offset: 2px;
+    }
+
+    .widget-control-btn[disabled] {
+      opacity: 0.4;
+      cursor: not-allowed;
+      transform: none;
+      box-shadow: none;
+    }
+
+    .widget-control-btn span[aria-hidden="true"] {
+      font-size: 1rem;
+      line-height: 1;
+    }
+
+    [data-widget-theme="inverted"] .widget-control-btn {
+      background: rgba(255, 255, 255, 0.18);
+      border-color: rgba(255, 255, 255, 0.35);
+      color: rgba(255, 255, 255, 0.94);
+    }
+
+    [data-widget-theme="inverted"] .widget-control-btn:hover {
+      box-shadow: 0 16px 35px -18px rgba(15, 23, 42, 0.45);
+    }
+
+    .dark [data-widget-theme="inverted"] .widget-control-btn {
+      background: rgba(15, 23, 42, 0.65);
+      border-color: rgba(148, 163, 184, 0.45);
+      color: rgb(226 232 240);
+    }
   </style>
   <script
     defer
@@ -172,53 +296,155 @@
           </div>
 
           <div class="space-y-6">
-            <div class="grid grid-cols-1 xl:grid-cols-4 gap-6">
-              <section class="xl:col-span-2 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-3xl p-8 shadow-xl" aria-labelledby="lessons-heading">
-                <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-                  <div>
-                    <h2 id="lessons-heading" class="text-2xl font-semibold text-slate-900 dark:text-slate-100">Today's lessons</h2>
-                    <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">Keep track of sessions, locations, and focus areas for a smooth teaching flow.</p>
+            <div class="grid grid-cols-1 xl:grid-cols-4 gap-6" data-dashboard-area="primary">
+              <section
+                data-dashboard-widget="lessons"
+                data-widget-title="Today's lessons"
+                class="xl:col-span-2 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-3xl p-8 shadow-xl transition-all duration-200 hover:shadow-2xl"
+                aria-labelledby="lessons-heading"
+              >
+                <div
+                  class="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 dark:border-slate-700 pb-4"
+                  data-widget-header
+                >
+                  <div class="flex min-w-0 flex-1 items-center gap-3">
+                    <span
+                      class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-blue-100 text-blue-600 dark:bg-blue-500/10 dark:text-blue-200 text-xl"
+                      aria-hidden="true"
+                    >📘</span>
+                    <div class="min-w-0 space-y-1">
+                      <div class="flex flex-wrap items-center gap-2">
+                        <h2 id="lessons-heading" class="text-xl font-semibold text-slate-900 dark:text-slate-100">Today's lessons</h2>
+                        <span
+                          id="dashboard-lesson-status"
+                          class="hidden rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-600 dark:bg-blue-500/10 dark:text-blue-200"
+                          aria-live="polite"
+                        ></span>
+                      </div>
+                      <p class="text-sm text-slate-500 dark:text-slate-400">
+                        Keep track of sessions, locations, and focus areas for a smooth teaching flow.
+                      </p>
+                    </div>
                   </div>
-                  <p class="inline-flex items-center gap-2 text-sm font-medium text-blue-600 dark:text-blue-300 bg-blue-50 dark:bg-blue-500/10 px-3 py-1.5 rounded-full" id="dashboard-lesson-status" aria-live="polite"></p>
+                  <div class="flex items-center gap-2">
+                    <div class="hidden overflow-hidden rounded-full border border-slate-200 dark:border-slate-700 sm:flex" role="group" aria-label="Reorder widget">
+                      <button type="button" class="widget-control-btn" data-widget-action="move-up" aria-label="Move widget up">
+                        <span aria-hidden="true">↑</span>
+                      </button>
+                      <button type="button" class="widget-control-btn" data-widget-action="move-down" aria-label="Move widget down">
+                        <span aria-hidden="true">↓</span>
+                      </button>
+                    </div>
+                    <button type="button" class="widget-control-btn" data-widget-action="collapse" aria-expanded="true" aria-label="Collapse widget">
+                      <span aria-hidden="true" data-icon>−</span>
+                      <span class="sr-only">Collapse widget</span>
+                    </button>
+                    <button type="button" class="widget-control-btn" data-widget-action="hide" aria-label="Hide widget">
+                      <span aria-hidden="true">✕</span>
+                      <span class="sr-only">Hide widget</span>
+                    </button>
+                  </div>
                 </div>
-                <div class="mt-6">
-                  <ul id="dashboard-lessons-list" class="space-y-4" aria-live="polite" aria-busy="false"></ul>
-                  <p id="dashboard-lessons-empty" class="hidden text-sm text-slate-500 dark:text-slate-400">No lessons captured for today yet. Add the key sessions below to build your timetable.</p>
+                <div data-widget-body class="space-y-6 pt-4">
+                  <div>
+                    <div id="dashboard-lessons-skeleton" class="space-y-3 rounded-2xl bg-white/60 p-4 text-slate-400 dark:bg-slate-900/40 dark:text-slate-500 animate-pulse" aria-hidden="true">
+                      <div class="h-4 w-2/3 rounded bg-slate-200/80 dark:bg-slate-700/70"></div>
+                      <div class="h-4 w-1/2 rounded bg-slate-200/60 dark:bg-slate-700/60"></div>
+                      <div class="mt-4 h-20 rounded-2xl bg-slate-100/80 dark:bg-slate-800/60"></div>
+                    </div>
+                    <ul id="dashboard-lessons-list" class="hidden space-y-4" aria-live="polite" aria-busy="true"></ul>
+                    <p id="dashboard-lessons-empty" class="hidden text-sm text-slate-500 dark:text-slate-400">
+                      No lessons scheduled yet. Add today's sessions below or jump into the planner to map the rest of your week.
+                    </p>
+                  </div>
+                  <form id="lesson-form" class="grid grid-cols-1 gap-3 md:grid-cols-5" aria-describedby="lesson-feedback">
+                    <div>
+                      <label for="lesson-subject" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Lesson or group</label>
+                      <input id="lesson-subject" name="lesson-subject" type="text" required placeholder="e.g. Year 8 Science" class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                    </div>
+                    <div>
+                      <label for="lesson-start" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Start</label>
+                      <input id="lesson-start" name="lesson-start" type="time" required class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                    </div>
+                    <div>
+                      <label for="lesson-end" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Finish</label>
+                      <input id="lesson-end" name="lesson-end" type="time" required class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                    </div>
+                    <div>
+                      <label for="lesson-location" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Location</label>
+                      <input id="lesson-location" name="lesson-location" type="text" placeholder="e.g. Lab 2" class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                    </div>
+                    <div class="flex items-end">
+                      <button type="submit" class="inline-flex w-full items-center justify-center rounded-xl bg-blue-600 px-4 py-2.5 font-semibold text-white shadow transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500">Add lesson</button>
+                    </div>
+                  </form>
+                  <p id="lesson-feedback" class="hidden text-sm font-medium"></p>
                 </div>
-                <form id="lesson-form" class="mt-6 grid grid-cols-1 gap-3 md:grid-cols-5" aria-describedby="lesson-feedback">
-                  <div>
-                    <label for="lesson-subject" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Lesson or group</label>
-                    <input id="lesson-subject" name="lesson-subject" type="text" required placeholder="e.g. Year 8 Science" class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
-                  </div>
-                  <div>
-                    <label for="lesson-start" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Start</label>
-                    <input id="lesson-start" name="lesson-start" type="time" required class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
-                  </div>
-                  <div>
-                    <label for="lesson-end" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Finish</label>
-                    <input id="lesson-end" name="lesson-end" type="time" required class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
-                  </div>
-                  <div>
-                    <label for="lesson-location" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Location</label>
-                    <input id="lesson-location" name="lesson-location" type="text" placeholder="e.g. Lab 2" class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
-                  </div>
-                  <div class="flex items-end">
-                    <button type="submit" class="w-full inline-flex justify-center items-center rounded-xl bg-blue-600 text-white font-semibold px-4 py-2.5 shadow hover:bg-blue-700 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500">Add lesson</button>
-                  </div>
-                </form>
-                <p id="lesson-feedback" class="hidden mt-3 text-sm font-medium"></p>
               </section>
 
-              <section class="bg-gradient-to-br from-sky-500 via-indigo-500 to-emerald-500 text-white rounded-3xl shadow-xl border border-white/40 p-8 flex flex-col" aria-labelledby="weather-heading">
-                <div class="flex items-start justify-between gap-3">
-                  <div>
-                    <h2 id="weather-heading" class="text-2xl font-semibold">Outdoor planning</h2>
-                    <p class="mt-1 text-sm text-white/80">Check the forecast before excursions or sport.</p>
+              <section
+                data-dashboard-widget="weather"
+                data-widget-title="Outdoor planning"
+                data-widget-theme="inverted"
+                class="bg-gradient-to-br from-sky-500 via-indigo-500 to-emerald-500 text-white rounded-3xl shadow-xl border border-white/40 p-8 transition-all duration-200 hover:shadow-2xl"
+                aria-labelledby="weather-heading"
+              >
+                <div
+                  class="flex flex-wrap items-center justify-between gap-3 border-b border-white/40 pb-4"
+                  data-widget-header
+                >
+                  <div class="flex min-w-0 flex-1 items-center gap-3">
+                    <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/20 text-xl" aria-hidden="true">🌦️</span>
+                    <div class="min-w-0 space-y-1">
+                      <h2 id="weather-heading" class="text-xl font-semibold">Outdoor planning</h2>
+                      <p class="text-sm text-white/80">Check the forecast before excursions or sport.</p>
+                    </div>
                   </div>
-                  <button id="weather-refresh" type="button" class="inline-flex items-center gap-2 rounded-full bg-white/20 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide hover:bg-white/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white">Refresh</button>
+                  <div class="flex items-center gap-2">
+                    <div class="hidden overflow-hidden rounded-full border border-white/40 sm:flex" role="group" aria-label="Reorder widget">
+                      <button type="button" class="widget-control-btn" data-widget-action="move-up" aria-label="Move widget up">
+                        <span aria-hidden="true">↑</span>
+                      </button>
+                      <button type="button" class="widget-control-btn" data-widget-action="move-down" aria-label="Move widget down">
+                        <span aria-hidden="true">↓</span>
+                      </button>
+                    </div>
+                    <button type="button" class="widget-control-btn" data-widget-action="collapse" aria-expanded="true" aria-label="Collapse widget">
+                      <span aria-hidden="true" data-icon>−</span>
+                      <span class="sr-only">Collapse widget</span>
+                    </button>
+                    <button type="button" class="widget-control-btn" data-widget-action="hide" aria-label="Hide widget">
+                      <span aria-hidden="true">✕</span>
+                      <span class="sr-only">Hide widget</span>
+                    </button>
+                  </div>
                 </div>
-                <div class="mt-8 space-y-4" aria-live="polite">
-                  <div id="weather-status" class="text-sm text-white/80">Finding your forecast…</div>
+                <div data-widget-body class="space-y-6 pt-4" aria-live="polite">
+                  <div class="flex flex-wrap items-center justify-between gap-3">
+                    <p id="weather-status" class="text-sm text-white/80">Finding your forecast…</p>
+                    <button
+                      id="weather-refresh"
+                      type="button"
+                      class="inline-flex items-center gap-2 rounded-full bg-white/20 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide hover:bg-white/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                    >
+                      Refresh
+                    </button>
+                  </div>
+                  <div id="weather-skeleton" class="space-y-4 rounded-2xl bg-white/10 p-4 text-white/80 animate-pulse" aria-hidden="true">
+                    <div class="flex items-end gap-4">
+                      <div class="h-14 w-14 rounded-full bg-white/20"></div>
+                      <div class="space-y-2">
+                        <div class="h-6 w-24 rounded bg-white/20"></div>
+                        <div class="h-4 w-32 rounded bg-white/10"></div>
+                      </div>
+                    </div>
+                    <div class="grid grid-cols-2 gap-3 text-xs">
+                      <div class="h-4 w-24 rounded bg-white/10"></div>
+                      <div class="h-4 w-16 rounded bg-white/10"></div>
+                      <div class="h-4 w-20 rounded bg-white/10"></div>
+                      <div class="h-4 w-20 rounded bg-white/10"></div>
+                    </div>
+                  </div>
                   <div id="weather-summary" class="hidden space-y-6">
                     <div class="flex items-end gap-4">
                       <span id="weather-icon" class="text-5xl" aria-hidden="true">☀️</span>
@@ -251,62 +477,202 @@
               </section>
             </div>
 
-            <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
-              <section class="xl:col-span-2 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-3xl p-8 shadow-xl" aria-labelledby="deadlines-heading">
-                <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-                  <div>
-                    <h2 id="deadlines-heading" class="text-2xl font-semibold text-slate-900 dark:text-slate-100">Upcoming deadlines</h2>
-                    <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">Deadlines due in the next seven days with live countdowns.</p>
+            <aside
+              id="dashboard-hidden-tray"
+              class="hidden rounded-3xl border border-dashed border-slate-300 dark:border-slate-600 bg-white/80 px-6 py-5 shadow-sm dark:bg-slate-900/40"
+            >
+              <div class="flex flex-wrap items-center gap-3">
+                <p class="text-sm font-semibold text-slate-600 dark:text-slate-300">Hidden dashboard widgets</p>
+                <div id="dashboard-hidden-list" class="flex flex-wrap gap-2"></div>
+                <button
+                  type="button"
+                  id="dashboard-show-all"
+                  class="hidden inline-flex items-center gap-2 rounded-full bg-slate-900/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white/85 dark:text-slate-900 dark:hover:bg-white"
+                >
+                  <span aria-hidden="true">↺</span>
+                  Restore all
+                </button>
+              </div>
+              <p class="mt-3 text-xs text-slate-500 dark:text-slate-400">
+                Use the widget chrome to collapse, hide, or reorder cards. Restore any hidden widgets here.
+              </p>
+            </aside>
+
+            <div class="grid grid-cols-1 xl:grid-cols-3 gap-6" data-dashboard-area="secondary">
+              <section
+                data-dashboard-widget="deadlines"
+                data-widget-title="Upcoming deadlines"
+                class="xl:col-span-2 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-3xl p-8 shadow-xl transition-all duration-200 hover:shadow-2xl"
+                aria-labelledby="deadlines-heading"
+              >
+                <div
+                  class="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 dark:border-slate-700 pb-4"
+                  data-widget-header
+                >
+                  <div class="flex min-w-0 flex-1 items-start gap-3">
+                    <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-amber-100 text-amber-600 dark:bg-amber-500/10 dark:text-amber-200 text-xl" aria-hidden="true">⏰</span>
+                    <div class="min-w-0 space-y-1">
+                      <h2 id="deadlines-heading" class="text-xl font-semibold text-slate-900 dark:text-slate-100">Upcoming deadlines</h2>
+                      <p class="text-sm text-slate-500 dark:text-slate-400">Deadlines due in the next seven days with live countdowns.</p>
+                    </div>
                   </div>
-                  <span class="inline-flex items-center gap-2 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-500/10 dark:text-amber-200 px-3 py-1 text-xs font-semibold uppercase tracking-wide">Next 7 days</span>
+                  <div class="flex items-center gap-2">
+                    <span class="inline-flex items-center gap-2 rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700 dark:bg-amber-500/10 dark:text-amber-200">Next 7 days</span>
+                    <div class="hidden overflow-hidden rounded-full border border-slate-200 dark:border-slate-700 sm:flex" role="group" aria-label="Reorder widget">
+                      <button type="button" class="widget-control-btn" data-widget-action="move-up" aria-label="Move widget up">
+                        <span aria-hidden="true">↑</span>
+                      </button>
+                      <button type="button" class="widget-control-btn" data-widget-action="move-down" aria-label="Move widget down">
+                        <span aria-hidden="true">↓</span>
+                      </button>
+                    </div>
+                    <button type="button" class="widget-control-btn" data-widget-action="collapse" aria-expanded="true" aria-label="Collapse widget">
+                      <span aria-hidden="true" data-icon>−</span>
+                      <span class="sr-only">Collapse widget</span>
+                    </button>
+                    <button type="button" class="widget-control-btn" data-widget-action="hide" aria-label="Hide widget">
+                      <span aria-hidden="true">✕</span>
+                      <span class="sr-only">Hide widget</span>
+                    </button>
+                  </div>
                 </div>
-                <div class="mt-6">
-                  <ul id="dashboard-deadlines-list" class="space-y-4" aria-live="polite" aria-busy="false"></ul>
-                  <p id="dashboard-deadlines-empty" class="hidden text-sm text-slate-500 dark:text-slate-400">No deadlines due within the next week. You can add one below to keep it on your radar.</p>
+                <div data-widget-body class="space-y-6 pt-4">
+                  <div>
+                    <div id="dashboard-deadlines-skeleton" class="space-y-3 rounded-2xl border border-dashed border-slate-200/80 bg-white/70 p-4 text-slate-500 animate-pulse dark:border-slate-700/70 dark:bg-slate-900/40" aria-hidden="true">
+                      <div class="h-4 w-1/2 rounded bg-slate-200/70 dark:bg-slate-700/70"></div>
+                      <div class="h-16 rounded-2xl bg-slate-100/90 dark:bg-slate-800/60"></div>
+                      <div class="h-4 w-2/3 rounded bg-slate-200/70 dark:bg-slate-700/70"></div>
+                    </div>
+                    <ul id="dashboard-deadlines-list" class="hidden space-y-4" aria-live="polite" aria-busy="true"></ul>
+                    <p id="dashboard-deadlines-empty" class="hidden text-sm text-slate-500 dark:text-slate-400">
+                      No deadlines due within the next week. Add the next milestone below so the countdown stays on your radar.
+                    </p>
+                  </div>
+                  <form id="deadline-form" class="grid grid-cols-1 gap-3 md:grid-cols-5" aria-describedby="deadline-feedback">
+                    <div class="md:col-span-2">
+                      <label for="deadline-title" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Deadline</label>
+                      <input id="deadline-title" name="deadline-title" type="text" required placeholder="e.g. Year 9 essays" class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
+                    </div>
+                    <div>
+                      <label for="deadline-due" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Due</label>
+                      <input id="deadline-due" name="deadline-due" type="datetime-local" required class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
+                    </div>
+                    <div>
+                      <label for="deadline-course" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Class / group</label>
+                      <input id="deadline-course" name="deadline-course" type="text" placeholder="Optional" class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
+                    </div>
+                    <div class="flex items-end">
+                      <button type="submit" class="inline-flex w-full items-center justify-center rounded-xl bg-amber-500 px-4 py-2.5 font-semibold text-white shadow transition hover:bg-amber-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500">Add deadline</button>
+                    </div>
+                  </form>
+                  <p id="deadline-feedback" class="hidden text-sm font-medium"></p>
                 </div>
-                <form id="deadline-form" class="mt-6 grid grid-cols-1 gap-3 md:grid-cols-5" aria-describedby="deadline-feedback">
-                  <div class="md:col-span-2">
-                    <label for="deadline-title" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Deadline</label>
-                    <input id="deadline-title" name="deadline-title" type="text" required placeholder="e.g. Year 9 essays" class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
-                  </div>
-                  <div>
-                    <label for="deadline-due" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Due</label>
-                    <input id="deadline-due" name="deadline-due" type="datetime-local" required class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
-                  </div>
-                  <div>
-                    <label for="deadline-course" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Class / group</label>
-                    <input id="deadline-course" name="deadline-course" type="text" placeholder="Optional" class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
-                  </div>
-                  <div class="flex items-end">
-                    <button type="submit" class="w-full inline-flex justify-center items-center rounded-xl bg-amber-500 text-white font-semibold px-4 py-2.5 shadow hover:bg-amber-600 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500">Add deadline</button>
-                  </div>
-                </form>
-                <p id="deadline-feedback" class="hidden mt-3 text-sm font-medium"></p>
               </section>
 
-              <section class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-3xl p-8 shadow-xl" aria-labelledby="reminders-heading">
-                <div class="flex flex-col gap-4">
-                  <div class="flex flex-col gap-2">
-                    <h2 id="reminders-heading" class="text-2xl font-semibold text-slate-900 dark:text-slate-100">Reminders needing attention</h2>
-                    <p class="text-sm text-slate-500 dark:text-slate-400">These are pulled automatically from the Reminders board and show tasks due today or overdue.</p>
+              <section
+                data-dashboard-widget="reminders"
+                data-widget-title="Reminders needing attention"
+                class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-3xl p-8 shadow-xl transition-all duration-200 hover:shadow-2xl"
+                aria-labelledby="reminders-heading"
+              >
+                <div
+                  class="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 dark:border-slate-700 pb-4"
+                  data-widget-header
+                >
+                  <div class="flex min-w-0 flex-1 items-start gap-3">
+                    <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-slate-900 text-white text-xl dark:bg-white dark:text-slate-900" aria-hidden="true">🔔</span>
+                    <div class="min-w-0 space-y-1">
+                      <h2 id="reminders-heading" class="text-xl font-semibold text-slate-900 dark:text-slate-100">Reminders needing attention</h2>
+                      <p class="text-sm text-slate-500 dark:text-slate-400">These are pulled automatically from the Reminders board and show tasks due today or overdue.</p>
+                    </div>
                   </div>
-                  <a href="#reminders" class="self-start inline-flex items-center gap-2 rounded-full bg-slate-900 text-white dark:bg-white dark:text-slate-900 px-4 py-2 text-sm font-semibold shadow hover:shadow-lg transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900 dark:focus-visible:outline-white">Open reminders<span aria-hidden="true">→</span></a>
+                  <div class="flex items-center gap-2">
+                    <a
+                      href="#reminders"
+                      class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900 dark:bg-white dark:text-slate-900 dark:focus-visible:outline-white"
+                    >
+                      Open reminders<span aria-hidden="true">→</span>
+                    </a>
+                    <div class="hidden overflow-hidden rounded-full border border-slate-200 dark:border-slate-700 sm:flex" role="group" aria-label="Reorder widget">
+                      <button type="button" class="widget-control-btn" data-widget-action="move-up" aria-label="Move widget up">
+                        <span aria-hidden="true">↑</span>
+                      </button>
+                      <button type="button" class="widget-control-btn" data-widget-action="move-down" aria-label="Move widget down">
+                        <span aria-hidden="true">↓</span>
+                      </button>
+                    </div>
+                    <button type="button" class="widget-control-btn" data-widget-action="collapse" aria-expanded="true" aria-label="Collapse widget">
+                      <span aria-hidden="true" data-icon>−</span>
+                      <span class="sr-only">Collapse widget</span>
+                    </button>
+                    <button type="button" class="widget-control-btn" data-widget-action="hide" aria-label="Hide widget">
+                      <span aria-hidden="true">✕</span>
+                      <span class="sr-only">Hide widget</span>
+                    </button>
+                  </div>
                 </div>
-                <div class="mt-6">
-                  <ul id="dashboard-reminders-list" class="space-y-4" aria-live="polite" aria-busy="false"></ul>
-                  <p id="dashboard-reminders-empty" class="hidden text-sm text-slate-500 dark:text-slate-400">You're all caught up! Urgent reminders will appear here automatically.</p>
+                <div data-widget-body class="space-y-6 pt-4">
+                  <div>
+                    <div id="dashboard-reminders-skeleton" class="space-y-3 rounded-2xl border border-dashed border-slate-200 bg-white/70 p-4 text-slate-500 animate-pulse dark:border-slate-700 dark:bg-slate-900/40" aria-hidden="true">
+                      <div class="h-4 w-1/3 rounded bg-slate-200/70 dark:bg-slate-700/70"></div>
+                      <div class="h-16 rounded-2xl bg-slate-100/90 dark:bg-slate-800/60"></div>
+                      <div class="h-4 w-1/2 rounded bg-slate-200/60 dark:bg-slate-700/60"></div>
+                    </div>
+                    <ul id="dashboard-reminders-list" class="hidden space-y-4" aria-live="polite" aria-busy="true"></ul>
+                    <p id="dashboard-reminders-empty" class="hidden text-sm text-slate-500 dark:text-slate-400">
+                      You're all clear for now. New reminders will pop in here automatically as they become due.
+                    </p>
+                  </div>
                 </div>
               </section>
 
-              <section id="dashboard-activity-container" class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-3xl p-8 shadow-xl" aria-labelledby="activity-heading">
-                <div class="flex flex-col gap-4">
-                  <div class="space-y-2">
-                    <h2 id="activity-heading" class="text-2xl font-semibold text-slate-900 dark:text-slate-100">Recent activity</h2>
-                    <p class="text-sm text-slate-500 dark:text-slate-400">Keep track of updates across lessons, deadlines, and reminders.</p>
+              <section
+                id="dashboard-activity-container"
+                data-dashboard-widget="activity"
+                data-widget-title="Recent activity"
+                class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-3xl p-8 shadow-xl transition-all duration-200 hover:shadow-2xl"
+                aria-labelledby="activity-heading"
+              >
+                <div
+                  class="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 dark:border-slate-700 pb-4"
+                  data-widget-header
+                >
+                  <div class="flex min-w-0 flex-1 items-start gap-3">
+                    <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-blue-100 text-blue-600 text-xl dark:bg-blue-500/10 dark:text-blue-200" aria-hidden="true">🗂️</span>
+                    <div class="min-w-0 space-y-1">
+                      <h2 id="activity-heading" class="text-xl font-semibold text-slate-900 dark:text-slate-100">Recent activity</h2>
+                      <p class="text-sm text-slate-500 dark:text-slate-400">Keep track of updates across lessons, deadlines, and reminders.</p>
+                    </div>
                   </div>
-                  <div id="dashboard-activity-loading" class="text-sm text-slate-500 dark:text-slate-400 flex items-center gap-2" aria-live="polite">
-                    <span class="inline-flex h-2 w-2 animate-ping rounded-full bg-blue-500"></span>
-                    <span>Preparing your activity feed…</span>
+                  <div class="flex items-center gap-2">
+                    <div class="hidden overflow-hidden rounded-full border border-slate-200 dark:border-slate-700 sm:flex" role="group" aria-label="Reorder widget">
+                      <button type="button" class="widget-control-btn" data-widget-action="move-up" aria-label="Move widget up">
+                        <span aria-hidden="true">↑</span>
+                      </button>
+                      <button type="button" class="widget-control-btn" data-widget-action="move-down" aria-label="Move widget down">
+                        <span aria-hidden="true">↓</span>
+                      </button>
+                    </div>
+                    <button type="button" class="widget-control-btn" data-widget-action="collapse" aria-expanded="true" aria-label="Collapse widget">
+                      <span aria-hidden="true" data-icon>−</span>
+                      <span class="sr-only">Collapse widget</span>
+                    </button>
+                    <button type="button" class="widget-control-btn" data-widget-action="hide" aria-label="Hide widget">
+                      <span aria-hidden="true">✕</span>
+                      <span class="sr-only">Hide widget</span>
+                    </button>
+                  </div>
+                </div>
+                <div data-widget-body class="space-y-6 pt-4">
+                  <div id="dashboard-activity-loading" class="space-y-3" aria-live="polite">
+                    <div class="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+                      <span class="inline-flex h-2 w-2 animate-ping rounded-full bg-blue-500"></span>
+                      <span>Preparing your activity feed…</span>
+                    </div>
+                    <div class="rounded-2xl border border-dashed border-slate-200 bg-white/70 p-4 text-slate-500 animate-pulse dark:border-slate-700 dark:bg-slate-900/40" aria-hidden="true">
+                      <div class="h-3 w-2/3 rounded bg-slate-200/70 dark:bg-slate-700/70"></div>
+                      <div class="mt-2 h-3 w-1/2 rounded bg-slate-200/60 dark:bg-slate-700/60"></div>
+                    </div>
                   </div>
                   <p id="dashboard-activity-empty" class="hidden text-sm text-slate-500 dark:text-slate-400">Actions you take will appear here so you can jump straight back to them.</p>
                   <ul id="dashboard-activity-list" class="hidden space-y-3" aria-live="polite" aria-busy="true"></ul>
@@ -468,6 +834,36 @@
       </div>
     </section>
   </main>
+  <nav
+    id="quick-action-toolbar"
+    aria-label="Quick actions"
+    class="fixed bottom-6 right-6 z-40 flex flex-col gap-3 max-sm:bottom-4 max-sm:right-4"
+  >
+    <button
+      type="button"
+      data-quick-action="reminder"
+      class="quick-action-btn inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-purple-600 via-indigo-500 to-blue-500 px-5 py-3 text-sm font-semibold text-white shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-purple-300"
+    >
+      <span aria-hidden="true" class="text-lg">🔔</span>
+      Add reminder
+    </button>
+    <button
+      type="button"
+      data-quick-action="note"
+      class="quick-action-btn inline-flex items-center gap-2 rounded-full bg-white/90 px-5 py-3 text-sm font-semibold text-slate-900 shadow-lg backdrop-blur focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-300 hover:bg-white dark:bg-slate-800/90 dark:text-slate-100 dark:hover:bg-slate-700/90"
+    >
+      <span aria-hidden="true" class="text-lg">📝</span>
+      Create note
+    </button>
+    <button
+      type="button"
+      data-quick-action="planner"
+      class="quick-action-btn inline-flex items-center gap-2 rounded-full bg-emerald-500 px-5 py-3 text-sm font-semibold text-white shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 hover:bg-emerald-600"
+    >
+      <span aria-hidden="true" class="text-lg">🗓️</span>
+      New lesson plan
+    </button>
+  </nav>
   <footer class="bg-slate-900 text-white py-8">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex flex-col sm:flex-row justify-between items-center gap-4">


### PR DESCRIPTION
## Summary
- add a floating quick-action toolbar with hooks into reminders, notes, and planner views
- wrap dashboard cards with collapsible chrome and persist layout preferences via localStorage
- introduce skeleton loaders, micro-animations, and richer empty copy across dashboard widgets

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cb3279ba94832789b21eb8f8a3d193