### PR TITLE
Add Supabase auth and resources integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,16 +216,10 @@
       color: rgb(226 232 240);
     }
   </style>
-  <script
-    defer
-    src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"
-  ></script>
-  <script
-    defer
-    src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"
-  ></script>
-  <script defer src="./js/firebase-init.js"></script>
-  <script defer src="./js/main.js"></script>
+  <script type="module">
+    window.__SUPABASE_ENV__ = typeof import.meta !== 'undefined' && import.meta ? import.meta.env : undefined;
+  </script>
+  <script type="module" src="./js/main.js"></script>
 </head>
 <body id="top" class="bg-[var(--bg)] text-[var(--fg)] antialiased leading-7 min-h-screen">
   <a class="skip-link" href="#mainContent">Skip to main content</a>
@@ -244,20 +238,50 @@
           <button data-route="settings" id="nav-settings" class="px-3 py-2 rounded-lg hover:bg-white/20 text-white/80 hover:text-white transition-all duration-200">Settings</button>
         </div>
 
-        <div class="flex items-center space-x-2">
-          <button
-            id="theme-toggle"
-            class="px-3 py-2 rounded-lg hover:bg-white/20 text-white/80 hover:text-white transition-all duration-200"
-            aria-label="Activate dark mode"
-            aria-pressed="false"
-            data-icon-dark="🌙"
-            data-icon-light="☀️"
-          >🌙</button>
-          <button
-            id="sign-in-btn"
-            class="px-4 py-2 rounded-lg bg-[var(--card)] text-[var(--accent)] font-semibold transition-all duration-200 hover:ring-2 hover:ring-[var(--accent)] hover:ring-offset-2 hover:scale-105"
-          >Sign In</button>
-          <button id="sign-out-btn" class="px-4 py-2 rounded-lg bg-red-500 text-white font-semibold hover:bg-red-600 transition-all duration-200 hover:scale-105" hidden>Sign Out</button>
+        <div class="flex flex-col items-end gap-2">
+          <div class="flex flex-wrap items-center justify-end gap-3">
+            <button
+              id="theme-toggle"
+              class="px-3 py-2 rounded-lg hover:bg-white/20 text-white/80 hover:text-white transition-all duration-200"
+              aria-label="Activate dark mode"
+              aria-pressed="false"
+              data-icon-dark="🌙"
+              data-icon-light="☀️"
+            >🌙</button>
+            <div
+              id="user-badge"
+              class="hidden items-center gap-2 rounded-full bg-white/10 px-3 py-1.5 text-sm font-semibold text-white shadow-inner"
+            >
+              <span
+                id="user-badge-initial"
+                class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-emerald-500 text-white"
+                aria-hidden="true"
+              >T</span>
+              <span id="user-badge-email" class="max-w-[160px] truncate text-white/90"></span>
+            </div>
+            <form id="auth-form" class="flex flex-wrap items-center justify-end gap-2">
+              <label for="auth-email" class="sr-only">Email address</label>
+              <input
+                id="auth-email"
+                type="email"
+                required
+                autocomplete="email"
+                placeholder="you@school.edu"
+                class="w-48 rounded-lg border border-white/40 bg-white/10 px-3 py-2 text-sm font-medium text-white placeholder-white/60 shadow-inner outline-none ring-emerald-300 transition focus:border-transparent focus:ring-2"
+              />
+              <button
+                id="sign-in-btn"
+                type="submit"
+                class="rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
+              >Send link</button>
+            </form>
+            <button
+              id="sign-out-btn"
+              type="button"
+              class="hidden rounded-lg bg-red-500 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-red-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-300"
+            >Sign out</button>
+          </div>
+          <p id="auth-feedback" class="hidden text-xs font-medium text-white/80" role="status" aria-live="polite"></p>
         </div>
       </div>
     </div>
@@ -821,10 +845,67 @@
       </div>
     </section>
     <section data-view="resources" id="view-resources" hidden tabindex="-1">
-      <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-16">
-        <div class="bg-[var(--card)] rounded-2xl shadow-xl p-8 text-center text-slate-500 dark:text-slate-400">
-          <p>Curated teaching resources will appear here soon.</p>
+      <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-16 space-y-8">
+        <header class="space-y-6">
+          <div class="flex flex-wrap items-start justify-between gap-4">
+            <div class="space-y-2">
+              <p class="text-sm font-semibold uppercase tracking-wide text-emerald-600 dark:text-emerald-300">Resource library</p>
+              <h2 class="text-3xl font-bold text-slate-900 dark:text-slate-100">Activities for every lesson phase</h2>
+              <p class="text-sm text-slate-500 dark:text-slate-400">Browse ready-to-go activities curated for HPE, English, and HASS.</p>
+            </div>
+            <p id="activity-status" class="hidden text-sm font-medium text-slate-500 dark:text-slate-400"></p>
+          </div>
+          <div class="flex flex-wrap items-center gap-3">
+            <div class="flex flex-wrap items-center gap-2" role="group" aria-label="Subjects">
+              <button type="button" data-subject="all" data-default="true" class="subject-filter inline-flex items-center rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200">All subjects</button>
+              <button type="button" data-subject="HPE" class="subject-filter inline-flex items-center rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200">HPE</button>
+              <button type="button" data-subject="English" class="subject-filter inline-flex items-center rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200">English</button>
+              <button type="button" data-subject="HASS" class="subject-filter inline-flex items-center rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200">HASS</button>
+            </div>
+          </div>
+          <div class="flex flex-wrap items-center gap-3">
+            <div class="flex flex-wrap items-center gap-2" role="group" aria-label="Lesson phase">
+              <button type="button" data-phase="any" class="phase-filter inline-flex items-center rounded-full border border-slate-200 bg-white/70 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200">Any phase</button>
+              <button type="button" data-phase="start" class="phase-filter inline-flex items-center rounded-full border border-slate-200 bg-white/70 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200">Start</button>
+              <button type="button" data-phase="middle" class="phase-filter inline-flex items-center rounded-full border border-slate-200 bg-white/70 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200">Middle</button>
+              <button type="button" data-phase="end" class="phase-filter inline-flex items-center rounded-full border border-slate-200 bg-white/70 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200">End</button>
+            </div>
+            <label for="activity-search" class="sr-only">Search activities</label>
+            <div class="relative flex-1 min-w-[220px] max-w-md">
+              <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-slate-400" aria-hidden="true">🔍</span>
+              <input
+                id="activity-search"
+                type="search"
+                placeholder="Search activities"
+                class="w-full rounded-full border border-slate-200 bg-white px-4 py-2 pl-10 text-sm text-slate-700 shadow-sm outline-none transition focus:border-emerald-400 focus:ring-2 focus:ring-emerald-300 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100"
+              />
+            </div>
+          </div>
+        </header>
+        <div id="activity-loading" class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div class="animate-pulse rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+            <div class="h-5 w-3/5 rounded bg-slate-200/80 dark:bg-slate-700/60"></div>
+            <div class="mt-4 h-3 w-full rounded bg-slate-200/60 dark:bg-slate-700/50"></div>
+            <div class="mt-2 h-3 w-4/5 rounded bg-slate-200/60 dark:bg-slate-700/50"></div>
+            <div class="mt-4 h-8 w-1/2 rounded-full bg-slate-200/70 dark:bg-slate-700/60"></div>
+          </div>
+          <div class="animate-pulse rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+            <div class="h-5 w-2/3 rounded bg-slate-200/80 dark:bg-slate-700/60"></div>
+            <div class="mt-4 h-3 w-full rounded bg-slate-200/60 dark:bg-slate-700/50"></div>
+            <div class="mt-2 h-3 w-3/4 rounded bg-slate-200/60 dark:bg-slate-700/50"></div>
+            <div class="mt-4 h-8 w-1/3 rounded-full bg-slate-200/70 dark:bg-slate-700/60"></div>
+          </div>
+          <div class="animate-pulse rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900/40 max-sm:hidden sm:block">
+            <div class="h-5 w-1/2 rounded bg-slate-200/80 dark:bg-slate-700/60"></div>
+            <div class="mt-4 h-3 w-full rounded bg-slate-200/60 dark:bg-slate-700/50"></div>
+            <div class="mt-2 h-3 w-2/3 rounded bg-slate-200/60 dark:bg-slate-700/50"></div>
+            <div class="mt-4 h-8 w-2/5 rounded-full bg-slate-200/70 dark:bg-slate-700/60"></div>
+          </div>
         </div>
+        <p id="activity-empty" class="hidden rounded-2xl border border-slate-200 bg-white/80 p-8 text-center text-sm text-slate-500 shadow-sm dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300">
+          No activities match your filters just yet. Adjust your subject, phase, or search to explore more ideas.
+        </p>
+        <div id="activity-results" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3"></div>
       </div>
     </section>
     <section data-view="templates" id="view-templates" hidden tabindex="-1">


### PR DESCRIPTION
## Summary
- replace the firebase-driven header controls with a Supabase email link sign-in form, user badge, and sign-out action
- initialise the Supabase client lazily with dynamic environment resolution, persist user profiles, and expose activity helpers for other modules
- rebuild the Resources view with subject/phase filters, search UI, skeleton loading, and Supabase-backed activity cards

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cd9ab01adc8327a92580d1f75215e2