### PR TITLE
Add Supabase-backed pinned activity controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -870,6 +870,15 @@
               <button type="button" data-phase="middle" class="phase-filter inline-flex items-center rounded-full border border-slate-200 bg-white/70 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200">Middle</button>
               <button type="button" data-phase="end" class="phase-filter inline-flex items-center rounded-full border border-slate-200 bg-white/70 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200">End</button>
             </div>
+            <button
+              type="button"
+              id="activity-pinned-toggle"
+              aria-pressed="false"
+              class="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white/80 px-3 py-1.5 text-sm font-semibold text-slate-600 transition hover:-translate-y-0.5 hover:border-amber-400 hover:text-amber-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-300 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200"
+            >
+              <span aria-hidden="true" class="text-base">★</span>
+              <span>Pinned</span>
+            </button>
             <label for="activity-search" class="sr-only">Search activities</label>
             <div class="relative flex-1 min-w-[220px] max-w-md">
               <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-slate-400" aria-hidden="true">🔍</span>


### PR DESCRIPTION
## Summary
- add a pinned toggle and star control to the resources page UI
- sync activity pins with the Supabase `activity_pins` table with optimistic updates
- allow users to filter and persist pinned-only views alongside existing filters

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cdcec40bd88327abb5e14c15953a3a