### PR TITLE
Retune reminder visuals for professional tone

### DIFF
--- a/index.html
+++ b/index.html
@@ -749,7 +749,7 @@
     </section>
     <section data-view="reminders" id="view-reminders" hidden tabindex="-1">
       <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-16">
-        <div class="bg-[var(--card)] rounded-2xl shadow-xl p-8 mb-8">
+        <div class="bg-[var(--card)] rounded-xl border border-slate-200/70 dark:border-slate-700/60 shadow-sm p-8 mb-8">
           <div class="flex flex-wrap items-center justify-between gap-3 mb-6">
             <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Create Reminder</h2>
             <span id="syncStatus" class="sync-status offline" role="status" aria-live="polite" aria-atomic="true">Offline</span>
@@ -757,21 +757,21 @@
           <div class="space-y-4">
             <div class="space-y-2">
               <label for="title" class="block text-sm font-medium text-slate-700 dark:text-slate-300">Title</label>
-              <input id="title" class="w-full px-4 py-3 border border-slate-300 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all duration-200" placeholder="Reminder title" />
+              <input id="title" class="w-full px-4 py-3 border border-slate-300/80 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-slate-900/10 focus:border-slate-400 dark:focus:border-slate-500 transition-colors" placeholder="Reminder title" />
             </div>
             <div id="dateFeedback" class="text-sm text-slate-500 hidden"></div>
             <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
               <div class="space-y-2">
                 <label for="date" class="block text-sm font-medium text-slate-700 dark:text-slate-300">Date</label>
-                <input id="date" type="date" class="w-full px-4 py-3 border border-slate-300 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all duration-200" />
+                <input id="date" type="date" class="w-full px-4 py-3 border border-slate-300/80 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-slate-900/10 focus:border-slate-400 dark:focus:border-slate-500 transition-colors" />
               </div>
               <div class="space-y-2">
                 <label for="time" class="block text-sm font-medium text-slate-700 dark:text-slate-300">Time</label>
-                <input id="time" type="time" class="w-full px-4 py-3 border border-slate-300 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all duration-200" />
+                <input id="time" type="time" class="w-full px-4 py-3 border border-slate-300/80 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-slate-900/10 focus:border-slate-400 dark:focus:border-slate-500 transition-colors" />
               </div>
               <div class="space-y-2">
                 <label for="priority" class="block text-sm font-medium text-slate-700 dark:text-slate-300">Priority</label>
-                <select id="priority" class="w-full px-4 py-3 border border-slate-300 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all duration-200">
+                <select id="priority" class="w-full px-4 py-3 border border-slate-300/80 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-slate-900/10 focus:border-slate-400 dark:focus:border-slate-500 transition-colors">
                   <option>High</option>
                   <option selected>Medium</option>
                   <option>Low</option>
@@ -783,28 +783,28 @@
               <textarea
                 id="details"
                 rows="3"
-                class="w-full px-4 py-3 border border-slate-300 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all duration-200"
+                class="w-full px-4 py-3 border border-slate-300/80 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-slate-900/10 focus:border-slate-400 dark:focus:border-slate-500 transition-colors"
                 placeholder="Add details or notes (optional)"
               ></textarea>
             </div>
             <div class="flex gap-4">
-              <button id="saveBtn" class="flex-1 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 text-white rounded-xl font-semibold hover:from-purple-700 hover:to-blue-700 hover:scale-105 transition-all duration-200 shadow-lg" type="button">Save Reminder</button>
-              <button id="cancelEditBtn" class="flex-1 px-6 py-3 bg-red-500 text-white rounded-xl font-semibold hover:bg-red-600 hover:scale-105 transition-all duration-200 shadow-lg hidden" type="button">Cancel</button>
+              <button id="saveBtn" class="flex-1 px-6 py-3 bg-slate-900 text-white rounded-lg font-semibold hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900/40 transition-colors shadow-sm" type="button">Save Reminder</button>
+              <button id="cancelEditBtn" class="flex-1 px-6 py-3 border border-slate-300/80 dark:border-slate-600 text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 rounded-lg font-medium hover:bg-slate-50 dark:hover:bg-slate-700/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400/40 transition-colors shadow-sm hidden" type="button">Cancel</button>
             </div>
             <div id="status" class="text-sm" role="status" aria-live="polite" aria-atomic="true"></div>
           </div>
         </div>
-        
-        <div class="bg-[var(--card)] rounded-2xl shadow-xl p-8">
+
+        <div class="bg-[var(--card)] rounded-xl border border-slate-200/70 dark:border-slate-700/60 shadow-sm p-8">
           <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
             <div class="flex gap-2">
-              <button class="px-4 py-2 bg-gradient-to-r from-blue-500 to-purple-500 text-white rounded-lg font-medium hover:from-blue-600 hover:to-purple-600 transition-all duration-200" data-filter="today" type="button">Today</button>
-              <button class="px-4 py-2 bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded-lg font-medium hover:bg-slate-300 dark:hover:bg-slate-600 transition-all duration-200" data-filter="overdue" type="button">Overdue</button>
-              <button class="px-4 py-2 bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded-lg font-medium hover:bg-slate-300 dark:hover:bg-slate-600 transition-all duration-200" data-filter="all" type="button">All</button>
-              <button class="px-4 py-2 bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded-lg font-medium hover:bg-slate-300 dark:hover:bg-slate-600 transition-all duration-200" data-filter="done" type="button">Done</button>
+              <button class="px-4 py-2 rounded-md border border-slate-300 bg-white text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700/60" data-filter="today" type="button">Today</button>
+              <button class="px-4 py-2 rounded-md border border-slate-300 bg-white text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700/60" data-filter="overdue" type="button">Overdue</button>
+              <button class="px-4 py-2 rounded-md border border-slate-300 bg-white text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700/60" data-filter="all" type="button">All</button>
+              <button class="px-4 py-2 rounded-md border border-slate-300 bg-white text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700/60" data-filter="done" type="button">Done</button>
             </div>
             <label for="sort" class="sr-only">Sort reminders</label>
-            <select id="sort" class="px-4 py-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-purple-500">
+            <select id="sort" class="px-4 py-2 border border-slate-300/80 dark:border-slate-600 rounded-md bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-slate-900/10 focus:border-slate-400 dark:focus:border-slate-500 transition-colors">
               <option value="smart">Smart sort</option>
               <option value="time">Time</option>
               <option value="priority">Priority</option>

--- a/js/main.js
+++ b/js/main.js
@@ -2135,10 +2135,10 @@ const dashboardController = (() => {
       const overdue = diff < 0;
       const soon = !overdue && diff <= 60 * 60 * 1000;
       const highlightClass = overdue
-        ? 'bg-rose-100 text-rose-700 dark:bg-rose-500/10 dark:text-rose-200'
+        ? 'bg-rose-50 text-rose-700 border-rose-200 dark:bg-rose-500/15 dark:text-rose-200 dark:border-rose-500/30'
         : soon
-          ? 'bg-amber-100 text-amber-700 dark:bg-amber-500/10 dark:text-amber-200'
-          : 'bg-blue-100 text-blue-700 dark:bg-blue-500/10 dark:text-blue-200';
+          ? 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-500/15 dark:text-amber-200 dark:border-amber-500/30'
+          : 'bg-sky-50 text-sky-700 border-sky-200 dark:bg-sky-500/15 dark:text-sky-200 dark:border-sky-500/30';
       let statusLabel = '';
       if (overdue){
         statusLabel = `Overdue by ${formatDuration(diff)}`;
@@ -2149,7 +2149,7 @@ const dashboardController = (() => {
       }
 
       const li = document.createElement('li');
-      li.className = 'rounded-2xl border border-slate-200 dark:border-slate-700 bg-white/80 dark:bg-slate-900/40 p-4';
+      li.className = 'rounded-xl border border-slate-200/80 dark:border-slate-700/60 bg-white dark:bg-slate-900/50 p-4 shadow-sm';
 
       const header = document.createElement('div');
       header.className = 'flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between';
@@ -2179,7 +2179,7 @@ const dashboardController = (() => {
       }
 
       const status = document.createElement('span');
-      status.className = `inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold ${highlightClass}`;
+      status.className = `inline-flex items-center rounded-md px-3 py-1 text-sm font-medium border ${highlightClass}`;
       status.textContent = statusLabel;
 
       header.append(content, status);

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -795,10 +795,21 @@ export async function initReminders(sel = {}) {
     filterBtns.forEach(btn => {
       const isActive = btn.getAttribute('data-filter')===filter;
       btn.classList.toggle('active', isActive);
-      btn.classList.toggle('ring-2', isActive);
-      btn.classList.toggle('ring-offset-2', isActive);
-      btn.classList.toggle('ring-purple-400', isActive);
       btn.setAttribute('aria-pressed', String(isActive));
+      if (!btn.classList.contains('btn-ghost')) {
+        btn.classList.toggle('bg-slate-900', isActive);
+        btn.classList.toggle('text-white', isActive);
+        btn.classList.toggle('border-slate-900', isActive);
+        btn.classList.toggle('dark:bg-slate-200', isActive);
+        btn.classList.toggle('dark:text-slate-900', isActive);
+        btn.classList.toggle('dark:border-slate-200', isActive);
+        btn.classList.toggle('bg-white', !isActive);
+        btn.classList.toggle('text-slate-700', !isActive);
+        btn.classList.toggle('border-slate-300', !isActive);
+        btn.classList.toggle('dark:bg-slate-800', !isActive);
+        btn.classList.toggle('dark:text-slate-200', !isActive);
+        btn.classList.toggle('dark:border-slate-600', !isActive);
+      }
     });
 
     const hasAny = items.length > 0;

--- a/mobile.html
+++ b/mobile.html
@@ -17,7 +17,7 @@
   ></script>
   <style>
     :root{
-      --bg-primary:#0b1220; --bg-secondary:#0f172a; --bg-tertiary:#1e293b;
+      --bg-primary:#0b1220; --bg-secondary:#0f172a; --bg-tertiary:#1e2536;
       --text-primary:#f8fafc; --text-secondary:#cbd5e1; --text-muted:#94a3b8;
       --accent:#38bdf8; --accent-hover:#0ea5e9;
       --success:#22c55e; --success-hover:#16a34a;
@@ -25,10 +25,10 @@
       --border:#334155; --border-light:#475569;
       --space-1:4px; --space-2:8px; --space-3:12px; --space-4:16px; --space-5:20px; --space-6:24px; --space-8:32px;
       --text-xs:11px; --text-sm:13px; --text-base:15px; --text-lg:17px; --text-xl:19px; --text-2xl:22px;
-      --radius-sm:8px; --radius:10px; --radius-md:12px; --radius-lg:14px;
+      --radius-sm:6px; --radius:8px; --radius-md:10px; --radius-lg:12px;
       --touch-target:44px; --button-height:42px;
       --shadow-sm:0 1px 2px 0 rgb(0 0 0 / 0.05);
-      --shadow:0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+      --shadow:0 1px 3px 0 rgb(0 0 0 / 0.06), 0 1px 2px -1px rgb(0 0 0 / 0.06);
       --shadow-md:0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
     }
     *{box-sizing:border-box} html,body{height:100%;margin:0;padding:0}
@@ -44,12 +44,12 @@ z-index:100;box-shadow:var(--shadow-sm)}
     h1{font-size:var(--text-2xl);font-weight:700;margin:0;letter-spacing:-.025em;background:linear-gradient(135deg,var(--text-primary),var(--purple));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
     .header-controls{display:flex;gap:var(--space-2);flex-wrap:wrap;align-items:center}
     input,select,button,textarea{font-family:inherit;font-size:var(--text-sm);line-height:1.4;border:1px solid var(--border);border-radius:var(--radius);transition:.2s all;-webkit-appearance:none;appearance:none}
-    input,select,textarea{background:var(--bg-secondary);color:var(--text-primary);padding:var(--space-3);min-height:var(--button-height);box-shadow:var(--shadow-sm)}
+    input,select,textarea{background:var(--bg-secondary);color:var(--text-primary);padding:var(--space-3);min-height:var(--button-height);box-shadow:none}
     input:focus,select:focus,textarea:focus{outline:none;border-color:var(--accent);box-shadow:0 0 0 2px rgba(56,189,248,.1)}
     input::placeholder,textarea::placeholder{color:var(--text-muted)}
     .search-input{flex:1;min-width:160px}
     button{cursor:pointer;font-weight:500;padding:var(--space-3);min-height:var(--touch-target);display:inline-flex;align-items:center;justify-content:center;gap:var(--space-1);white-space:nowrap;border:1px solid transparent;transition:.2s all;user-select:none;-webkit-user-select:none;touch-action:manipulation}
-    button:active{transform:scale(.98)}
+    button:active{transform:none}
     .btn-primary{background:var(--accent);color:var(--bg-primary);border-color:var(--accent);font-weight:600}
     .btn-primary:hover,.btn-primary:focus{background:var(--accent-hover);border-color:var(--accent-hover)}
     .btn-success{background:var(--success);color:var(--bg-primary);border-color:var(--success);font-weight:600}
@@ -68,8 +68,8 @@ z-index:100;box-shadow:var(--shadow-sm)}
     .tab-btn.active{color:var(--text-primary);background:var(--bg-tertiary);border-bottom-color:var(--accent)}
     .main-content{padding:var(--space-4) 0}
     .section{margin-bottom:var(--space-6)}
-    .card{background:var(--bg-secondary);border:1px solid var(--border);border-radius:var(--radius-lg);box-shadow:var(--shadow);overflow:hidden}
-    .card-header{padding:var(--space-4);border-bottom:1px solid var(--border);background:var(--bg-tertiary)}
+    .card{background:var(--bg-secondary);border:1px solid var(--border);border-radius:var(--radius-md);box-shadow:var(--shadow-sm);overflow:hidden}
+    .card-header{padding:var(--space-4);border-bottom:1px solid var(--border);background:var(--bg-secondary)}
     .card-content{padding:var(--space-4)}
     .card-title{font-size:var(--text-lg);font-weight:600;margin:0;color:var(--text-primary)}
     .section-subtitle{font-size:var(--text-xs);font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.05em;margin:var(--space-4) 0 var(--space-3)}
@@ -78,18 +78,18 @@ z-index:100;box-shadow:var(--shadow-sm)}
     .form-group{display:flex;flex-direction:column;gap:var(--space-1)}
     .form-group.flex-1{flex:1}
     .task-list{display:flex;flex-direction:column;gap:var(--space-3)}
-    .task-item{display:grid;grid-template-columns:auto 1fr auto;gap:var(--space-3);align-items:flex-start;padding:var(--space-4);background:var(--bg-tertiary);border:1px solid var(--border);border-radius:var(--radius-md);transition:.2s all}
-    .task-item:active{transform:scale(.99)}
+    .task-item{display:grid;grid-template-columns:auto 1fr auto;gap:var(--space-3);align-items:flex-start;padding:var(--space-4);background:var(--bg-secondary);border:1px solid var(--border);border-radius:var(--radius);box-shadow:var(--shadow-sm);transition:.2s color,.2s background-color}
+    .task-item:active{transform:none}
     .task-item.completed .task-title{text-decoration:line-through;color:var(--text-muted)}
     .task-content{min-width:0;padding-top:2px}
     .task-title{font-size:var(--text-base);font-weight:500;margin:0 0 var(--space-1);color:var(--text-primary)}
     .task-meta{display:flex;flex-direction:column;gap:var(--space-1);font-size:var(--text-xs);color:var(--text-muted)}
     .task-meta-row{display:flex;gap:var(--space-2);align-items:center;flex-wrap:wrap}
-    .priority-badge{padding:2px var(--space-2);border-radius:var(--radius-sm);font-size:var(--text-xs);font-weight:500;border:1px solid transparent;flex-shrink:0}
+    .priority-badge{padding:2px var(--space-2);border-radius:var(--radius-sm);font-size:var(--text-xs);font-weight:500;border:1px solid transparent;flex-shrink:0;letter-spacing:0.01em}
     .task-notes{margin-top:var(--space-2);font-size:var(--text-sm);color:var(--text-secondary);line-height:1.5}
-    .priority-high{background:var(--danger-light);color:var(--danger);border-color:var(--danger-light)}
-    .priority-medium{background:var(--warning-light);color:var(--warning);border-color:var(--warning-light)}
-    .priority-low{background:var(--success-light);color:var(--success);border-color:var(--success-light)}
+    .priority-high{background:rgba(220,38,38,.12);color:#b91c1c;border-color:rgba(220,38,38,.24)}
+    .priority-medium{background:rgba(217,119,6,.14);color:#b45309;border-color:rgba(217,119,6,.26)}
+    .priority-low{background:rgba(16,185,129,.12);color:#0f766e;border-color:rgba(16,185,129,.24)}
     input[type="checkbox"]{width:18px;height:18px;cursor:pointer;margin-top:2px}
     .sync-status{padding:var(--space-1) var(--space-2);border-radius:var(--radius-sm);font-size:var(--text-xs);font-weight:600;border:1px solid transparent}
     .sync-status.online{background:rgba(34,197,94,.1);color:var(--success);border-color:rgba(34,197,94,.2)}
@@ -114,7 +114,7 @@ z-index:100;box-shadow:var(--shadow-sm)}
     /* Inline agenda counters */
     .panel-header { display:grid; grid-template-columns: 1fr auto; gap: var(--space-3); align-items:center; }
     .summary-pills { display:flex; gap: var(--space-2); align-items:center; }
-    .pill { display:flex; align-items:center; gap:8px; padding:8px 10px; border:1px solid var(--border); background:var(--bg-tertiary); border-radius: var(--radius-sm); }
+    .pill { display:flex; align-items:center; gap:8px; padding:8px 10px; border:1px solid var(--border); background:var(--bg-secondary); border-radius: var(--radius-sm); }
     .pill .count { font-weight:700; font-size: 18px; line-height: 1; }
     .filters { display:flex; gap: var(--space-2); alignments:center; flex-wrap:wrap; justify-content:flex-end; }
     .filter-buttons { display:flex; gap: var(--space-2); }


### PR DESCRIPTION
## Summary
- soften the desktop reminder form and list with reduced radii, flatter buttons, and muted status indicators
- update reminder badge rendering logic to use subtler colours and lighter card shadows
- refresh the mobile reminder layout with tighter radii, minimal shadows, and calmer priority badges

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68ce222ea0408327b4068883a1e38b28