### PR TITLE
Add reminder category support and grouping

### DIFF
--- a/index.html
+++ b/index.html
@@ -760,7 +760,7 @@
               <input id="title" class="w-full px-4 py-3 border border-slate-300/80 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-slate-900/10 focus:border-slate-400 dark:focus:border-slate-500 transition-colors" placeholder="Reminder title" />
             </div>
             <div id="dateFeedback" class="text-sm text-slate-500 hidden"></div>
-            <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 sm:grid-cols-4 gap-4">
               <div class="space-y-2">
                 <label for="date" class="block text-sm font-medium text-slate-700 dark:text-slate-300">Date</label>
                 <input id="date" type="date" class="w-full px-4 py-3 border border-slate-300/80 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-slate-900/10 focus:border-slate-400 dark:focus:border-slate-500 transition-colors" />
@@ -776,6 +776,21 @@
                   <option selected>Medium</option>
                   <option>Low</option>
                 </select>
+              </div>
+              <div class="space-y-2">
+                <label for="category" class="block text-sm font-medium text-slate-700 dark:text-slate-300">Category</label>
+                <input
+                  id="category"
+                  list="categorySuggestions"
+                  class="w-full px-4 py-3 border border-slate-300/80 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-slate-900/10 focus:border-slate-400 dark:focus:border-slate-500 transition-colors"
+                  placeholder="e.g., Admin"
+                />
+                <datalist id="categorySuggestions">
+                  <option value="General"></option>
+                  <option value="Admin"></option>
+                  <option value="Planning"></option>
+                  <option value="Communication"></option>
+                </datalist>
               </div>
             </div>
             <div class="space-y-2">
@@ -797,18 +812,32 @@
 
         <div class="bg-[var(--card)] rounded-xl border border-slate-200/70 dark:border-slate-700/60 shadow-sm p-8">
           <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
-            <div class="flex gap-2">
+            <div class="flex gap-2 flex-wrap">
               <button class="px-4 py-2 rounded-md border border-slate-300 bg-white text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700/60" data-filter="today" type="button">Today</button>
               <button class="px-4 py-2 rounded-md border border-slate-300 bg-white text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700/60" data-filter="overdue" type="button">Overdue</button>
               <button class="px-4 py-2 rounded-md border border-slate-300 bg-white text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700/60" data-filter="all" type="button">All</button>
               <button class="px-4 py-2 rounded-md border border-slate-300 bg-white text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700/60" data-filter="done" type="button">Done</button>
             </div>
-            <label for="sort" class="sr-only">Sort reminders</label>
-            <select id="sort" class="px-4 py-2 border border-slate-300/80 dark:border-slate-600 rounded-md bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-slate-900/10 focus:border-slate-400 dark:focus:border-slate-500 transition-colors">
-              <option value="smart">Smart sort</option>
-              <option value="time">Time</option>
-              <option value="priority">Priority</option>
-            </select>
+            <div class="flex items-center gap-3">
+              <div>
+                <label for="categoryFilter" class="sr-only">Filter by category</label>
+                <select
+                  id="categoryFilter"
+                  class="px-4 py-2 border border-slate-300/80 dark:border-slate-600 rounded-md bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-slate-900/10 focus:border-slate-400 dark:focus:border-slate-500 transition-colors"
+                >
+                  <option value="all" selected>All categories</option>
+                  <option value="General">General</option>
+                </select>
+              </div>
+              <div>
+                <label for="sort" class="sr-only">Sort reminders</label>
+                <select id="sort" class="px-4 py-2 border border-slate-300/80 dark:border-slate-600 rounded-md bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-slate-900/10 focus:border-slate-400 dark:focus:border-slate-500 transition-colors">
+                  <option value="smart">Smart sort</option>
+                  <option value="time">Time</option>
+                  <option value="priority">Priority</option>
+                </select>
+              </div>
+            </div>
           </div>
           
           <div class="flex flex-wrap gap-6 mb-6 text-slate-600 dark:text-slate-400">
@@ -1222,6 +1251,7 @@
       timeSel: '#time',
       detailsSel: '#details',
       prioritySel: '#priority',
+      categorySel: '#category',
       saveBtnSel: '#saveBtn',
       cancelEditBtnSel: '#cancelEditBtn',
       listSel: '#reminderList',
@@ -1229,6 +1259,8 @@
       syncStatusSel: '#syncStatus',
       filterBtnsSel: '[data-filter]',
       sortSel: '#sort',
+      categoryFilterSel: '#categoryFilter',
+      categoryOptionsSel: '#categorySuggestions',
       countTodaySel: '#inlineTodayCount',
       countOverdueSel: '#inlineOverdueCount',
       countTotalSel: '#inlineTotalCount',

--- a/js/main.js
+++ b/js/main.js
@@ -2168,6 +2168,15 @@ const dashboardController = (() => {
       if (reminder.priority) metaParts.push(`${reminder.priority} priority`);
       meta.textContent = metaParts.join(' • ');
       content.append(title, meta);
+      if (reminder.category){
+        const chipRow = document.createElement('div');
+        chipRow.className = 'flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400';
+        const chip = document.createElement('span');
+        chip.className = 'inline-flex items-center rounded-full border border-sky-200/80 bg-sky-50/70 px-2 py-0.5 font-medium text-sky-700 dark:border-sky-500/40 dark:bg-sky-500/10 dark:text-sky-200';
+        chip.textContent = reminder.category;
+        chipRow.appendChild(chip);
+        content.appendChild(chipRow);
+      }
       if (reminder.notes){
         const [firstLine] = String(reminder.notes).split('\n');
         if (firstLine){

--- a/mobile.html
+++ b/mobile.html
@@ -199,7 +199,7 @@ z-index:100;box-shadow:var(--shadow-sm)}
               <input id="title" placeholder="e.g., Email parents about camp #admin" aria-label="Reminder title" />
               <div id="dateFeedback" style="margin-top: 4px; font-size: 12px; color: var(--text-muted); display: none;"></div>
             </div>
-            <div class="form-row">
+            <div class="form-row" style="flex-wrap: wrap;">
               <div class="form-group flex-1">
                 <label class="sr-only" for="date">Date</label>
                 <input id="date" type="date" aria-label="Due date" />
@@ -214,6 +214,16 @@ z-index:100;box-shadow:var(--shadow-sm)}
                   <option>High</option><option selected>Medium</option><option>Low</option>
                 </select>
               </div>
+              <div class="form-group" style="min-width: 140px;">
+                <label class="sr-only" for="category">Category</label>
+                <input id="category" list="categorySuggestions" placeholder="Category" aria-label="Category" />
+              </div>
+              <datalist id="categorySuggestions">
+                <option value="General"></option>
+                <option value="Admin"></option>
+                <option value="Planning"></option>
+                <option value="Communication"></option>
+              </datalist>
             </div>
             <div class="form-group">
               <label class="sr-only" for="details">Details</label>
@@ -248,6 +258,13 @@ z-index:100;box-shadow:var(--shadow-sm)}
                 <button class="btn-ghost" data-filter="overdue" type="button">Overdue</button>
                 <button class="btn-ghost" data-filter="all" type="button">All</button>
                 <button class="btn-ghost" data-filter="done" type="button">Done</button>
+              </div>
+              <div class="sort-control">
+                <label class="sr-only" for="categoryFilter">Category</label>
+                <select id="categoryFilter">
+                  <option value="all" selected>All categories</option>
+                  <option value="General">General</option>
+                </select>
               </div>
               <div class="sort-control">
                 <label class="sr-only" for="sort">Sort</label>
@@ -317,6 +334,7 @@ z-index:100;box-shadow:var(--shadow-sm)}
       timeSel: '#time',
       detailsSel: '#details',
       prioritySel: '#priority',
+      categorySel: '#category',
       saveBtnSel: '#saveBtn',
       cancelEditBtnSel: '#cancelEditBtn',
       listSel: '#list',
@@ -329,6 +347,8 @@ z-index:100;box-shadow:var(--shadow-sm)}
       loadNotesBtnSel: '#loadNotesBtn',
       filterBtnsSel: '[data-filter]',
       sortSel: '#sort',
+      categoryFilterSel: '#categoryFilter',
+      categoryOptionsSel: '#categorySuggestions',
       countTodaySel: '#inlineTodayCount',
       countWeekSel: '#inlineWeekCount',
       qSel: '#q',

--- a/reminders.categories.test.js
+++ b/reminders.categories.test.js
@@ -1,0 +1,178 @@
+/** @jest-environment jsdom */
+
+const { beforeAll, beforeEach, expect, test } = require('@jest/globals');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let initReminders;
+
+function loadRemindersModule() {
+  const filePath = path.resolve(__dirname, './js/reminders.js');
+  let source = fs.readFileSync(filePath, 'utf8');
+  source = source.replace(/export\s+async\s+function\s+initReminders/, 'async function initReminders');
+  source += '\nmodule.exports = { initReminders };\n';
+  const NotificationRef = typeof global.Notification === 'undefined' ? undefined : global.Notification;
+  const BlobRef = typeof global.Blob === 'undefined' ? undefined : global.Blob;
+  const ResponseRef = typeof global.Response === 'undefined' ? undefined : global.Response;
+  const URLRef = typeof global.URL === 'undefined' ? undefined : global.URL;
+  const module = { exports: {} };
+  const sandbox = {
+    module,
+    exports: module.exports,
+    require,
+    console,
+    setTimeout,
+    clearTimeout,
+    window,
+    document,
+    localStorage,
+    navigator,
+    Notification: NotificationRef,
+    fetch: global.fetch,
+    Blob: BlobRef,
+    Response: ResponseRef,
+    URL: URLRef,
+  };
+  vm.runInNewContext(source, sandbox, { filename: filePath });
+  return module.exports;
+}
+
+function createFirebaseStubs() {
+  return {
+    initializeApp: () => ({}),
+    initializeFirestore: () => ({}),
+    getFirestore: () => ({}),
+    doc: () => ({}),
+    setDoc: () => Promise.resolve(),
+    deleteDoc: () => Promise.resolve(),
+    onSnapshot: () => () => {},
+    collection: () => ({}),
+    query: () => ({}),
+    orderBy: () => ({}),
+    persistentLocalCache: () => ({}),
+    serverTimestamp: () => ({}),
+    getAuth: () => ({}),
+    onAuthStateChanged: (_auth, callback) => { callback(null); },
+    GoogleAuthProvider: function GoogleAuthProviderStub() {},
+    signInWithPopup: () => Promise.resolve(),
+    signInWithRedirect: () => Promise.resolve(),
+    getRedirectResult: () => Promise.resolve(),
+    signOut: () => Promise.resolve(),
+  };
+}
+
+beforeAll(() => {
+  ({ initReminders } = loadRemindersModule());
+});
+
+beforeEach(() => {
+  localStorage.clear();
+  document.body.innerHTML = '';
+});
+
+test('desktop reminders render grouped category headings', async () => {
+  document.body.innerHTML = `
+    <input id="title" />
+    <input id="date" />
+    <input id="time" />
+    <textarea id="details"></textarea>
+    <select id="priority"><option>High</option></select>
+    <input id="category" list="categorySuggestions" />
+    <datalist id="categorySuggestions"></datalist>
+    <button id="saveBtn" type="button"></button>
+    <button id="cancelEditBtn" type="button"></button>
+    <div id="remindersWrapper"><p id="emptyState"></p><ul id="reminderList"></ul></div>
+    <div id="status"></div>
+    <div id="syncStatus"></div>
+    <select id="categoryFilter"><option value="all" selected>All</option></select>
+  `;
+
+  const controller = await initReminders({
+    titleSel: '#title',
+    dateSel: '#date',
+    timeSel: '#time',
+    detailsSel: '#details',
+    prioritySel: '#priority',
+    categorySel: '#category',
+    saveBtnSel: '#saveBtn',
+    cancelEditBtnSel: '#cancelEditBtn',
+    listSel: '#reminderList',
+    statusSel: '#status',
+    syncStatusSel: '#syncStatus',
+    emptyStateSel: '#emptyState',
+    listWrapperSel: '#remindersWrapper',
+    categoryFilterSel: '#categoryFilter',
+    categoryOptionsSel: '#categorySuggestions',
+    variant: 'desktop',
+    firebaseDeps: createFirebaseStubs(),
+  });
+
+  const now = Date.now();
+  controller.__testing.setItems([
+    { id: 'a', title: 'Send excursion forms', priority: 'High', category: 'Admin', done: false, due: new Date(now + 3600e3).toISOString() },
+    { id: 'b', title: 'Call families', priority: 'Medium', category: 'Communication', done: false, due: new Date(now + 7200e3).toISOString() },
+    { id: 'c', title: 'Print rubrics', priority: 'Low', category: 'Admin', done: false, due: new Date(now + 10800e3).toISOString() },
+  ]);
+
+  const headings = Array.from(document.querySelectorAll('[data-category-heading]'));
+  expect(headings.map((heading) => heading.dataset.categoryHeading)).toEqual(['Admin', 'Communication']);
+
+  const adminItems = document.querySelectorAll('[data-category="Admin"]');
+  expect(adminItems).toHaveLength(2);
+
+  const communicationItems = document.querySelectorAll('[data-category="Communication"]');
+  expect(communicationItems).toHaveLength(1);
+});
+
+test('mobile reminders group uncategorised items under General', async () => {
+  document.body.innerHTML = `
+    <input id="title" />
+    <input id="date" />
+    <input id="time" />
+    <textarea id="details"></textarea>
+    <select id="priority"><option>High</option></select>
+    <input id="category" list="categorySuggestions" />
+    <datalist id="categorySuggestions"></datalist>
+    <button id="saveBtn" type="button"></button>
+    <button id="cancelEditBtn" type="button"></button>
+    <div id="wrapper"><div id="list"></div></div>
+    <div id="status"></div>
+    <div id="syncStatus"></div>
+    <select id="categoryFilter"><option value="all" selected>All</option></select>
+  `;
+
+  const controller = await initReminders({
+    titleSel: '#title',
+    dateSel: '#date',
+    timeSel: '#time',
+    detailsSel: '#details',
+    prioritySel: '#priority',
+    categorySel: '#category',
+    saveBtnSel: '#saveBtn',
+    cancelEditBtnSel: '#cancelEditBtn',
+    listSel: '#list',
+    statusSel: '#status',
+    syncStatusSel: '#syncStatus',
+    listWrapperSel: '#wrapper',
+    categoryFilterSel: '#categoryFilter',
+    categoryOptionsSel: '#categorySuggestions',
+    variant: 'mobile',
+    firebaseDeps: createFirebaseStubs(),
+  });
+
+  const now = Date.now();
+  controller.__testing.setItems([
+    { id: 'a', title: 'Pack equipment', priority: 'High', done: false, category: '', due: new Date(now + 3600e3).toISOString() },
+    { id: 'b', title: 'Book bus', priority: 'Medium', category: 'Excursion', done: false, due: new Date(now + 5400e3).toISOString() },
+  ]);
+
+  const headings = Array.from(document.querySelectorAll('[data-category-heading]'));
+  expect(headings.map((heading) => heading.dataset.categoryHeading)).toEqual(['Excursion', 'General']);
+
+  const generalItems = document.querySelectorAll('[data-category="General"]');
+  expect(generalItems).toHaveLength(1);
+
+  const excursionItems = document.querySelectorAll('[data-category="Excursion"]');
+  expect(excursionItems).toHaveLength(1);
+});


### PR DESCRIPTION
## Summary
- add a category field, datalist suggestions, and category filter controls to both desktop and mobile reminder forms
- persist reminder categories through Firestore sync, notifications, exports, and render reminders grouped by category with filter-aware headings
- show category chips in the dashboard reminder widget and cover the new grouping behaviour with jsdom tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68ce2c9c70cc83279563e4c8bf9f599a