### PR TITLE
Seed reminders with school and general categories

### DIFF
--- a/index.html
+++ b/index.html
@@ -783,13 +783,13 @@
                   id="category"
                   list="categorySuggestions"
                   class="w-full px-4 py-3 border border-slate-300/80 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-slate-900/10 focus:border-slate-400 dark:focus:border-slate-500 transition-colors"
-                  placeholder="e.g., Admin"
+                  placeholder="e.g., School – To-Do"
                 />
                 <datalist id="categorySuggestions">
                   <option value="General"></option>
-                  <option value="Admin"></option>
-                  <option value="Planning"></option>
-                  <option value="Communication"></option>
+                  <option value="General Appointments"></option>
+                  <option value="School – Appointments/Meetings"></option>
+                  <option value="School – To-Do"></option>
                 </datalist>
               </div>
             </div>
@@ -827,6 +827,9 @@
                 >
                   <option value="all" selected>All categories</option>
                   <option value="General">General</option>
+                  <option value="General Appointments">General Appointments</option>
+                  <option value="School – Appointments/Meetings">School – Appointments/Meetings</option>
+                  <option value="School – To-Do">School – To-Do</option>
                 </select>
               </div>
               <div>

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -7,6 +7,12 @@ let notificationCleanupBound = false;
 const SERVICE_WORKER_SCRIPT = 'service-worker.js';
 let serviceWorkerReadyPromise = null;
 const DEFAULT_CATEGORY = 'General';
+const SEEDED_CATEGORIES = Object.freeze([
+  DEFAULT_CATEGORY,
+  'General Appointments',
+  'School – Appointments/Meetings',
+  'School – To-Do',
+]);
 
 function getGlobalScope() {
   if (typeof globalThis !== 'undefined') return globalThis;
@@ -792,7 +798,13 @@ export async function initReminders(sel = {}) {
         item.category = normalizeCategory(item.category);
       }
     });
-    const allCategories = Array.from(new Set(items.map(item => (item && item.category) ? item.category : DEFAULT_CATEGORY))).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+    const categorySet = new Set(SEEDED_CATEGORIES.map(cat => normalizeCategory(cat)));
+    items.forEach(item => {
+      if (item && typeof item === 'object') {
+        categorySet.add(normalizeCategory(item.category));
+      }
+    });
+    const allCategories = Array.from(categorySet).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
 
     if (categoryFilter) {
       const previous = categoryFilterValue;

--- a/mobile.html
+++ b/mobile.html
@@ -216,13 +216,13 @@ z-index:100;box-shadow:var(--shadow-sm)}
               </div>
               <div class="form-group" style="min-width: 140px;">
                 <label class="sr-only" for="category">Category</label>
-                <input id="category" list="categorySuggestions" placeholder="Category" aria-label="Category" />
+                <input id="category" list="categorySuggestions" placeholder="School – To-Do" aria-label="Category" />
               </div>
               <datalist id="categorySuggestions">
                 <option value="General"></option>
-                <option value="Admin"></option>
-                <option value="Planning"></option>
-                <option value="Communication"></option>
+                <option value="General Appointments"></option>
+                <option value="School – Appointments/Meetings"></option>
+                <option value="School – To-Do"></option>
               </datalist>
             </div>
             <div class="form-group">
@@ -264,6 +264,9 @@ z-index:100;box-shadow:var(--shadow-sm)}
                 <select id="categoryFilter">
                   <option value="all" selected>All categories</option>
                   <option value="General">General</option>
+                  <option value="General Appointments">General Appointments</option>
+                  <option value="School – Appointments/Meetings">School – Appointments/Meetings</option>
+                  <option value="School – To-Do">School – To-Do</option>
                 </select>
               </div>
               <div class="sort-control">

--- a/reminders.categories.test.js
+++ b/reminders.categories.test.js
@@ -176,3 +176,60 @@ test('mobile reminders group uncategorised items under General', async () => {
   const excursionItems = document.querySelectorAll('[data-category="Excursion"]');
   expect(excursionItems).toHaveLength(1);
 });
+
+test('category selectors include school and general presets', async () => {
+  document.body.innerHTML = `
+    <input id="title" />
+    <input id="date" />
+    <input id="time" />
+    <textarea id="details"></textarea>
+    <select id="priority"><option selected>Medium</option></select>
+    <input id="category" list="categorySuggestions" />
+    <datalist id="categorySuggestions"></datalist>
+    <button id="saveBtn" type="button"></button>
+    <button id="cancelEditBtn" type="button"></button>
+    <div id="status"></div>
+    <div id="syncStatus"></div>
+    <select id="categoryFilter"><option value="all" selected>All</option></select>
+  `;
+
+  await initReminders({
+    titleSel: '#title',
+    dateSel: '#date',
+    timeSel: '#time',
+    detailsSel: '#details',
+    prioritySel: '#priority',
+    categorySel: '#category',
+    saveBtnSel: '#saveBtn',
+    cancelEditBtnSel: '#cancelEditBtn',
+    statusSel: '#status',
+    syncStatusSel: '#syncStatus',
+    categoryFilterSel: '#categoryFilter',
+    categoryOptionsSel: '#categorySuggestions',
+    firebaseDeps: createFirebaseStubs(),
+  });
+
+  const datalistValues = Array.from(document.querySelectorAll('#categorySuggestions option')).map((opt) => opt.value);
+  expect(datalistValues).toEqual([
+    'General',
+    'General Appointments',
+    'School – Appointments/Meetings',
+    'School – To-Do',
+  ]);
+
+  const filterOptions = Array.from(document.querySelectorAll('#categoryFilter option'));
+  expect(filterOptions.map((opt) => opt.value)).toEqual([
+    'all',
+    'General',
+    'General Appointments',
+    'School – Appointments/Meetings',
+    'School – To-Do',
+  ]);
+  expect(filterOptions.map((opt) => opt.textContent)).toEqual([
+    'All categories',
+    'General',
+    'General Appointments',
+    'School – Appointments/Meetings',
+    'School – To-Do',
+  ]);
+});


### PR DESCRIPTION
## Summary
- seed the reminders UI with preset categories for general tasks, general appointments, and school appointments/to-dos
- update the desktop and mobile forms so their category inputs and filters surface the new presets immediately
- cover the presets with a unit test to ensure both the datalist and filter render the seeded options

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68ce3415c7c08327bc4221ae76c4637b