### PR TITLE
Define hover color variables for mobile theme

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -21,7 +21,9 @@
       --text-primary:#f8fafc; --text-secondary:#cbd5e1; --text-muted:#94a3b8;
       --accent:#38bdf8; --accent-hover:#0ea5e9;
       --success:#22c55e; --success-hover:#16a34a;
-      --warning:#f59e0b; --danger:#ef4444;
+      --warning:#f59e0b; --warning-hover:#ea580c;
+      --danger:#ef4444; --danger-hover:#dc2626;
+      --purple:#8b5cf6; --purple-hover:#7c3aed;
       --border:#334155; --border-light:#475569;
       --space-1:4px; --space-2:8px; --space-3:12px; --space-4:16px; --space-5:20px; --space-6:24px; --space-8:32px;
       --text-xs:11px; --text-sm:13px; --text-base:15px; --text-lg:17px; --text-xl:19px; --text-2xl:22px;


### PR DESCRIPTION
## Summary
- add the purple accent variables used by the mobile header gradient and buttons
- define hover colors for the warning and danger button styles to match the desktop palette

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cf91bf6a448327a667a3525fdc0615