### PR TITLE
Add safe-area padding to mobile header

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -39,8 +39,8 @@
          font-size:var(--text-base);line-height:1.5;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;
          -webkit-tap-highlight-color:transparent;}
     .container{max-width:520px;margin:0 auto;padding:0 var(--space-3)}
-    header{position:sticky;top:0;background:rgba(11,18,32,.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border);
-z-index:100;box-shadow:var(--shadow-sm)}
+    header{position:sticky;top:0;padding-top:env(safe-area-inset-top,0px);background:rgba(11,18,32,.85);backdrop-filter:blur(12px);
+border-bottom:1px solid var(--border);z-index:100;box-shadow:var(--shadow-sm)}
     .header-content{padding:var(--space-3) 0}
     .header-top{display:flex;justify-content:space-between;align-items:center;margin-bottom:var(--space-4)}
     h1{font-size:var(--text-2xl);font-weight:700;margin:0;letter-spacing:-.025em;background:linear-gradient(135deg,var(--text-primary),var(--purple));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}


### PR DESCRIPTION
## Summary
- add a `safe-area-inset-top` padding to the sticky mobile header so content clears device notches
- kept existing header spacing so the vertical rhythm matches the previous layout
- manually verified the layout in a WebKit iPhone 12 preview to confirm the header no longer overlaps the cutout

## Testing
- npm start (manual responsive preview)


------
https://chatgpt.com/codex/tasks/task_b_68cf93cff1248327abaa43aeaafe09c3