### PR TITLE
Expand reminder category presets

### DIFF
--- a/index.html
+++ b/index.html
@@ -795,13 +795,19 @@
                   id="category"
                   list="categorySuggestions"
                   class="w-full px-4 py-3 border border-slate-300/80 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-slate-900/10 focus:border-slate-400 dark:focus:border-slate-500 transition-colors"
-                  placeholder="e.g., School – To-Do"
+                  placeholder="e.g., School – Communication & Families"
                 />
                 <datalist id="categorySuggestions">
                   <option value="General"></option>
                   <option value="General Appointments"></option>
+                  <option value="Home &amp; Personal"></option>
                   <option value="School – Appointments/Meetings"></option>
+                  <option value="School – Communication &amp; Families"></option>
+                  <option value="School – Excursions &amp; Events"></option>
+                  <option value="School – Grading &amp; Assessment"></option>
+                  <option value="School – Prep &amp; Resources"></option>
                   <option value="School – To-Do"></option>
+                  <option value="Wellbeing &amp; Support"></option>
                 </datalist>
               </div>
             </div>
@@ -840,8 +846,14 @@
                   <option value="all" selected>All categories</option>
                   <option value="General">General</option>
                   <option value="General Appointments">General Appointments</option>
+                  <option value="Home &amp; Personal">Home &amp; Personal</option>
                   <option value="School – Appointments/Meetings">School – Appointments/Meetings</option>
+                  <option value="School – Communication &amp; Families">School – Communication &amp; Families</option>
+                  <option value="School – Excursions &amp; Events">School – Excursions &amp; Events</option>
+                  <option value="School – Grading &amp; Assessment">School – Grading &amp; Assessment</option>
+                  <option value="School – Prep &amp; Resources">School – Prep &amp; Resources</option>
                   <option value="School – To-Do">School – To-Do</option>
+                  <option value="Wellbeing &amp; Support">Wellbeing &amp; Support</option>
                 </select>
               </div>
               <div>

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -10,8 +10,14 @@ const DEFAULT_CATEGORY = 'General';
 const SEEDED_CATEGORIES = Object.freeze([
   DEFAULT_CATEGORY,
   'General Appointments',
+  'Home & Personal',
   'School – Appointments/Meetings',
+  'School – Communication & Families',
+  'School – Excursions & Events',
+  'School – Grading & Assessment',
+  'School – Prep & Resources',
   'School – To-Do',
+  'Wellbeing & Support',
 ]);
 
 function getGlobalScope() {

--- a/mobile.html
+++ b/mobile.html
@@ -218,13 +218,19 @@ border-bottom:1px solid var(--border);z-index:100;box-shadow:var(--shadow-sm)}
               </div>
               <div class="form-group" style="min-width: 140px;">
                 <label class="sr-only" for="category">Category</label>
-                <input id="category" list="categorySuggestions" placeholder="School – To-Do" aria-label="Category" />
+                <input id="category" list="categorySuggestions" placeholder="School – Communication &amp; Families" aria-label="Category" />
               </div>
               <datalist id="categorySuggestions">
                 <option value="General"></option>
                 <option value="General Appointments"></option>
+                <option value="Home &amp; Personal"></option>
                 <option value="School – Appointments/Meetings"></option>
+                <option value="School – Communication &amp; Families"></option>
+                <option value="School – Excursions &amp; Events"></option>
+                <option value="School – Grading &amp; Assessment"></option>
+                <option value="School – Prep &amp; Resources"></option>
                 <option value="School – To-Do"></option>
+                <option value="Wellbeing &amp; Support"></option>
               </datalist>
             </div>
             <div class="form-group">
@@ -267,8 +273,14 @@ border-bottom:1px solid var(--border);z-index:100;box-shadow:var(--shadow-sm)}
                   <option value="all" selected>All categories</option>
                   <option value="General">General</option>
                   <option value="General Appointments">General Appointments</option>
+                  <option value="Home &amp; Personal">Home &amp; Personal</option>
                   <option value="School – Appointments/Meetings">School – Appointments/Meetings</option>
+                  <option value="School – Communication &amp; Families">School – Communication &amp; Families</option>
+                  <option value="School – Excursions &amp; Events">School – Excursions &amp; Events</option>
+                  <option value="School – Grading &amp; Assessment">School – Grading &amp; Assessment</option>
+                  <option value="School – Prep &amp; Resources">School – Prep &amp; Resources</option>
                   <option value="School – To-Do">School – To-Do</option>
+                  <option value="Wellbeing &amp; Support">Wellbeing &amp; Support</option>
                 </select>
               </div>
               <div class="sort-control">

--- a/reminders.categories.test.js
+++ b/reminders.categories.test.js
@@ -213,8 +213,14 @@ test('category selectors include school and general presets', async () => {
   expect(datalistValues).toEqual([
     'General',
     'General Appointments',
+    'Home & Personal',
     'School – Appointments/Meetings',
+    'School – Communication & Families',
+    'School – Excursions & Events',
+    'School – Grading & Assessment',
+    'School – Prep & Resources',
     'School – To-Do',
+    'Wellbeing & Support',
   ]);
 
   const filterOptions = Array.from(document.querySelectorAll('#categoryFilter option'));
@@ -222,14 +228,26 @@ test('category selectors include school and general presets', async () => {
     'all',
     'General',
     'General Appointments',
+    'Home & Personal',
     'School – Appointments/Meetings',
+    'School – Communication & Families',
+    'School – Excursions & Events',
+    'School – Grading & Assessment',
+    'School – Prep & Resources',
     'School – To-Do',
+    'Wellbeing & Support',
   ]);
   expect(filterOptions.map((opt) => opt.textContent)).toEqual([
     'All categories',
     'General',
     'General Appointments',
+    'Home & Personal',
     'School – Appointments/Meetings',
+    'School – Communication & Families',
+    'School – Excursions & Events',
+    'School – Grading & Assessment',
+    'School – Prep & Resources',
     'School – To-Do',
+    'Wellbeing & Support',
   ]);
 });


### PR DESCRIPTION
## Summary
- expand the seeded reminder categories with additional school and personal options
- update desktop and mobile category selectors and placeholders to surface the new presets
- adjust the category preset test to cover the extended list

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cf96711aac8327b16b1e84d9b3f398