### PR TITLE
Add daily list tabs and Firestore workflow

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,26 @@ const closeCueButton = document.getElementById('closeCueModal');
 const modalBackdropButton = cueModal?.querySelector('.modal-backdrop button');
 const titleInput = document.getElementById('title');
 
+const cuesTab = document.getElementById('tab-cues');
+const dailyTab = document.getElementById('tab-daily');
+const cuesView = document.getElementById('cues-view');
+const dailyListView = document.getElementById('daily-list-view');
+const dailyListHeader = document.getElementById('daily-list-header');
+const quickAddForm = document.getElementById('quick-add-form');
+const quickAddInput = document.getElementById('quick-add-input');
+const dailyTasksContainer = document.getElementById('daily-tasks-container');
+const clearCompletedBtn = document.getElementById('clear-completed-btn');
+
+const FIREBASE_CONFIG = {
+  apiKey: 'AIzaSyAmAMiz0zG3dAhZJhOy1DYj8fKVDObL36c',
+  authDomain: 'memory-cue-app.firebaseapp.com',
+  projectId: 'memory-cue-app',
+  storageBucket: 'memory-cue-app.firebasestorage.app',
+  messagingSenderId: '751284466633',
+  appId: '1:751284466633:web:3b10742970bef1a5d5ee18',
+  measurementId: 'G-R0V4M7VCE6'
+};
+
 const focusTitleInput = () => {
   if (!titleInput) return;
   window.setTimeout(() => {
@@ -65,7 +85,263 @@ document.addEventListener('cue:close', () => {
   openCueButton?.focus();
 });
 
-initReminders({
+async function setupDailyList(remindersReadyPromise) {
+  if (
+    !cuesTab ||
+    !dailyTab ||
+    !cuesView ||
+    !dailyListView ||
+    !dailyListHeader ||
+    !quickAddForm ||
+    !quickAddInput ||
+    !dailyTasksContainer ||
+    !clearCompletedBtn
+  ) {
+    return;
+  }
+
+  const locale = (() => {
+    try {
+      return (typeof navigator !== 'undefined' && navigator.language) || 'en-US';
+    } catch {
+      return 'en-US';
+    }
+  })();
+
+  let headerFormatter;
+  try {
+    headerFormatter = new Intl.DateTimeFormat(locale, { month: 'long', day: 'numeric', year: 'numeric' });
+  } catch {
+    headerFormatter = new Intl.DateTimeFormat('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+  }
+
+  let firestoreDepsPromise;
+
+  const ensureFirestoreDeps = async () => {
+    if (!firestoreDepsPromise) {
+      firestoreDepsPromise = (async () => {
+        try {
+          await remindersReadyPromise;
+        } catch (error) {
+          console.warn('Reminders failed to initialise before Daily List', error);
+        }
+        const [{ getApps, getApp, initializeApp }, firestoreModule] = await Promise.all([
+          import('https://www.gstatic.com/firebasejs/12.2.1/firebase-app.js'),
+          import('https://www.gstatic.com/firebasejs/12.2.1/firebase-firestore.js')
+        ]);
+        const { getFirestore, doc, getDoc, setDoc, arrayUnion } = firestoreModule;
+        let app;
+        const apps = getApps();
+        if (apps.length) {
+          app = getApp();
+        } else {
+          app = initializeApp(FIREBASE_CONFIG);
+        }
+        const db = getFirestore(app);
+        return { db, doc, getDoc, setDoc, arrayUnion };
+      })();
+    }
+    return firestoreDepsPromise;
+  };
+
+  const getTodayId = () => {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  };
+
+  const formatHeaderDate = (dateId) => {
+    const [year, month, day] = dateId.split('-').map((part) => parseInt(part, 10));
+    const displayDate = new Date(year || 0, (month || 1) - 1, day || 1);
+    return headerFormatter.format(displayDate);
+  };
+
+  const setHeaderForDate = (dateId) => {
+    dailyListHeader.textContent = `Today's List – ${formatHeaderDate(dateId)}`;
+  };
+
+  let dailyTasks = [];
+
+  const updateClearCompletedState = () => {
+    const hasCompleted = dailyTasks.some((task) => task && task.completed);
+    clearCompletedBtn.disabled = !hasCompleted;
+  };
+
+  const renderDailyTasks = () => {
+    dailyTasksContainer.innerHTML = '';
+    if (!dailyTasks.length) {
+      const empty = document.createElement('p');
+      empty.className = 'text-sm text-slate-500 dark:text-slate-400';
+      empty.textContent = 'No tasks for today yet. Add one above to get started.';
+      dailyTasksContainer.appendChild(empty);
+      return;
+    }
+
+    const list = document.createElement('ul');
+    list.className = 'space-y-3';
+
+    dailyTasks.forEach((task, index) => {
+      const item = document.createElement('li');
+      item.className =
+        'flex items-center gap-3 rounded-xl border border-slate-200/80 bg-white/80 p-3 shadow-sm dark:border-slate-700/60 dark:bg-slate-900/40';
+
+      const label = document.createElement('label');
+      label.className = 'flex flex-1 items-center gap-3 cursor-pointer';
+
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.className = 'checkbox checkbox-sm';
+      checkbox.dataset.index = String(index);
+      checkbox.checked = Boolean(task?.completed);
+
+      const textSpan = document.createElement('span');
+      textSpan.className = `flex-1 text-sm ${
+        task?.completed ? 'line-through text-slate-400 dark:text-slate-500' : 'text-slate-700 dark:text-slate-100'
+      }`;
+      textSpan.textContent = typeof task?.text === 'string' ? task.text : '';
+
+      label.append(checkbox, textSpan);
+      item.append(label);
+      list.append(item);
+    });
+
+    dailyTasksContainer.append(list);
+  };
+
+  const loadDailyList = async () => {
+    const todayId = getTodayId();
+    setHeaderForDate(todayId);
+    dailyTasksContainer.innerHTML =
+      '<p class="text-sm text-slate-500 dark:text-slate-400">Loading today&#39;s tasks…</p>';
+
+    try {
+      const deps = await ensureFirestoreDeps();
+      const docRef = deps.doc(deps.db, 'dailyLists', todayId);
+      const snapshot = await deps.getDoc(docRef);
+      const data = snapshot.exists() ? snapshot.data() : null;
+      const tasks = Array.isArray(data?.tasks) ? data.tasks : [];
+      dailyTasks = tasks.map((task) => ({
+        text: typeof task?.text === 'string' ? task.text : '',
+        completed: Boolean(task?.completed)
+      }));
+      renderDailyTasks();
+      updateClearCompletedState();
+    } catch (error) {
+      console.error("Failed to load today's daily list", error);
+      dailyTasks = [];
+      const errorMessage = document.createElement('p');
+      errorMessage.className = 'text-sm text-rose-500 dark:text-rose-400';
+      errorMessage.textContent = "We couldn't load today's tasks. Please try again soon.";
+      dailyTasksContainer.innerHTML = '';
+      dailyTasksContainer.append(errorMessage);
+      updateClearCompletedState();
+    }
+  };
+
+  const activateTab = (view) => {
+    const showDaily = view === 'daily';
+    const wasDailyVisible = !dailyListView.classList.contains('hidden');
+
+    cuesTab.classList.toggle('tab-active', !showDaily);
+    cuesTab.setAttribute('aria-selected', String(!showDaily));
+    dailyTab.classList.toggle('tab-active', showDaily);
+    dailyTab.setAttribute('aria-selected', String(showDaily));
+
+    cuesView.classList.toggle('hidden', showDaily);
+    dailyListView.classList.toggle('hidden', !showDaily);
+
+    if (showDaily && !wasDailyVisible) {
+      loadDailyList();
+    }
+  };
+
+  cuesTab.addEventListener('click', () => {
+    activateTab('cues');
+  });
+
+  dailyTab.addEventListener('click', () => {
+    activateTab('daily');
+  });
+
+  quickAddForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const value = quickAddInput.value.trim();
+    if (!value) {
+      quickAddInput.focus();
+      return;
+    }
+
+    const newTask = { text: value, completed: false };
+
+    try {
+      const deps = await ensureFirestoreDeps();
+      const todayId = getTodayId();
+      const docRef = deps.doc(deps.db, 'dailyLists', todayId);
+      await deps.setDoc(docRef, { tasks: deps.arrayUnion(newTask) }, { merge: true });
+      quickAddInput.value = '';
+      await loadDailyList();
+      quickAddInput.focus();
+    } catch (error) {
+      console.error('Failed to add task to daily list', error);
+    }
+  });
+
+  dailyTasksContainer.addEventListener('change', async (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement) || target.type !== 'checkbox') {
+      return;
+    }
+
+    const index = Number.parseInt(target.dataset.index || '', 10);
+    if (Number.isNaN(index) || !dailyTasks[index]) {
+      return;
+    }
+
+    const checked = target.checked;
+    const updatedTasks = dailyTasks.map((task, taskIndex) =>
+      taskIndex === index ? { ...task, completed: checked } : task
+    );
+
+    try {
+      const deps = await ensureFirestoreDeps();
+      const todayId = getTodayId();
+      const docRef = deps.doc(deps.db, 'dailyLists', todayId);
+      await deps.setDoc(docRef, { tasks: updatedTasks }, { merge: true });
+      dailyTasks = updatedTasks;
+      renderDailyTasks();
+      updateClearCompletedState();
+    } catch (error) {
+      console.error('Failed to update daily task status', error);
+      target.checked = !checked;
+    }
+  });
+
+  clearCompletedBtn.addEventListener('click', async () => {
+    const remaining = dailyTasks.filter((task) => !task?.completed);
+    if (remaining.length === dailyTasks.length) {
+      return;
+    }
+
+    try {
+      const deps = await ensureFirestoreDeps();
+      const todayId = getTodayId();
+      const docRef = deps.doc(deps.db, 'dailyLists', todayId);
+      await deps.setDoc(docRef, { tasks: remaining }, { merge: true });
+      dailyTasks = remaining;
+      renderDailyTasks();
+      updateClearCompletedState();
+    } catch (error) {
+      console.error('Failed to clear completed daily tasks', error);
+    }
+  });
+
+  setHeaderForDate(getTodayId());
+  updateClearCompletedState();
+}
+
+const remindersInitPromise = initReminders({
   titleSel: '#title',
   dateSel: '#date',
   timeSel: '#time',
@@ -90,4 +366,9 @@ initReminders({
   listWrapperSel: '#remindersWrapper',
   dateFeedbackSel: '#dateFeedback',
   variant: 'desktop'
+}).catch((error) => {
+  console.error('Failed to initialise reminders', error);
+  throw error;
 });
+
+void setupDailyList(remindersInitPromise);

--- a/index.html
+++ b/index.html
@@ -755,109 +755,114 @@
     </section>
     <section data-view="reminders" id="view-reminders" hidden tabindex="-1">
       <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-16">
-        <div class="bg-[var(--card)] rounded-xl border border-slate-200/70 dark:border-slate-700/60 shadow-sm p-8 mb-8">
-          <div class="flex flex-wrap items-center justify-between gap-3 mb-6">
-            <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Create Reminder</h2>
-            <div class="flex items-center gap-3">
-              <span id="syncStatus" class="sync-status offline" role="status" aria-live="polite" aria-atomic="true">Offline</span>
-              <button
-                id="voiceBtn"
-                type="button"
-                class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-emerald-500 text-lg shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 hover:bg-emerald-600 text-white"
-                title="Voice quick add"
-                aria-label="Start voice input"
-              >
-                <span aria-hidden="true">🎙️</span>
-                <span class="sr-only">Start voice input</span>
-              </button>
-            </div>
-          </div>
-          <div class="space-y-4">
-            <button id="openCueModal" type="button" class="btn btn-primary">Add New Cue</button>
-            <div id="status" class="text-sm" role="status" aria-live="polite" aria-atomic="true"></div>
-            <dialog id="cue-modal" class="modal">
-              <div class="modal-box space-y-6">
-                <div class="space-y-1">
-                  <h3 class="text-lg font-semibold text-base-content">Add a new Cue</h3>
-                  <p class="text-sm text-base-content/70">Capture a reminder with a title, timing, and details.</p>
-                </div>
-                <form id="cue-form" class="space-y-4" novalidate>
-                  <div class="space-y-2">
-                    <label for="title" class="block text-sm font-medium text-base-content/80">Title</label>
-                    <input
-                      id="title"
-                      class="input input-bordered w-full"
-                      placeholder="Reminder title"
-                      type="text"
-                    />
-                  </div>
-                  <div id="dateFeedback" class="text-sm text-base-content/70 hidden"></div>
-                  <div class="grid grid-cols-1 gap-4 sm:grid-cols-4">
-                    <div class="space-y-2">
-                      <label for="date" class="block text-sm font-medium text-base-content/80">Date</label>
-                      <input id="date" type="date" class="input input-bordered w-full" />
-                    </div>
-                    <div class="space-y-2">
-                      <label for="time" class="block text-sm font-medium text-base-content/80">Time</label>
-                      <input id="time" type="time" class="input input-bordered w-full" />
-                    </div>
-                    <div class="space-y-2">
-                      <label for="priority" class="block text-sm font-medium text-base-content/80">Priority</label>
-                      <select id="priority" class="select select-bordered w-full">
-                        <option>High</option>
-                        <option selected>Medium</option>
-                        <option>Low</option>
-                      </select>
-                    </div>
-                    <div class="space-y-2">
-                      <label for="category" class="block text-sm font-medium text-base-content/80">Category</label>
-                      <input
-                        id="category"
-                        list="categorySuggestions"
-                        class="input input-bordered w-full"
-                        placeholder="e.g., School – Communication &amp; Families"
-                      />
-                      <datalist id="categorySuggestions">
-                        <option value="General"></option>
-                        <option value="General Appointments"></option>
-                        <option value="Home &amp; Personal"></option>
-                        <option value="School – Appointments/Meetings"></option>
-                        <option value="School – Communication &amp; Families"></option>
-                        <option value="School – Excursions &amp; Events"></option>
-                        <option value="School – Grading &amp; Assessment"></option>
-                        <option value="School – Prep &amp; Resources"></option>
-                        <option value="School – To-Do"></option>
-                        <option value="Wellbeing &amp; Support"></option>
-                      </datalist>
-                    </div>
-                  </div>
-                  <div class="space-y-2">
-                    <label for="details" class="block text-sm font-medium text-base-content/80">Details</label>
-                    <textarea
-                      id="details"
-                      rows="3"
-                      class="textarea textarea-bordered w-full"
-                      placeholder="Add details or notes (optional)"
-                    ></textarea>
-                  </div>
-                  <div class="modal-action flex w-full flex-wrap items-center gap-3">
-                    <button id="cancelEditBtn" class="btn btn-ghost hidden" type="button">Cancel Edit</button>
-                    <div class="ml-auto flex gap-2">
-                      <button id="closeCueModal" type="button" class="btn btn-outline">Cancel</button>
-                      <button id="saveBtn" class="btn btn-primary" type="button">Save Cue</button>
-                    </div>
-                  </div>
-                </form>
+        <div class="tabs tabs-boxed mb-8" role="tablist" aria-label="Reminders and daily list navigation">
+          <button id="tab-cues" type="button" role="tab" aria-selected="true" aria-controls="cues-view" class="tab tab-active">Cues</button>
+          <button id="tab-daily" type="button" role="tab" aria-selected="false" aria-controls="daily-list-view" class="tab">Today's List</button>
+        </div>
+        <div id="cues-view" role="tabpanel" aria-labelledby="tab-cues">
+          <div class="bg-[var(--card)] rounded-xl border border-slate-200/70 dark:border-slate-700/60 shadow-sm p-8 mb-8">
+            <div class="flex flex-wrap items-center justify-between gap-3 mb-6">
+              <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Create Reminder</h2>
+              <div class="flex items-center gap-3">
+                <span id="syncStatus" class="sync-status offline" role="status" aria-live="polite" aria-atomic="true">Offline</span>
+                <button
+                  id="voiceBtn"
+                  type="button"
+                  class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-emerald-500 text-lg shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 hover:bg-emerald-600 text-white"
+                  title="Voice quick add"
+                  aria-label="Start voice input"
+                >
+                  <span aria-hidden="true">🎙️</span>
+                  <span class="sr-only">Start voice input</span>
+                </button>
               </div>
-              <form method="dialog" class="modal-backdrop">
-                <button aria-label="Close">close</button>
-              </form>
-            </dialog>
+            </div>
+            <div class="space-y-4">
+              <button id="openCueModal" type="button" class="btn btn-primary">Add New Cue</button>
+              <div id="status" class="text-sm" role="status" aria-live="polite" aria-atomic="true"></div>
+              <dialog id="cue-modal" class="modal">
+                <div class="modal-box space-y-6">
+                  <div class="space-y-1">
+                    <h3 class="text-lg font-semibold text-base-content">Add a new Cue</h3>
+                    <p class="text-sm text-base-content/70">Capture a reminder with a title, timing, and details.</p>
+                  </div>
+                  <form id="cue-form" class="space-y-4" novalidate>
+                    <div class="space-y-2">
+                      <label for="title" class="block text-sm font-medium text-base-content/80">Title</label>
+                      <input
+                        id="title"
+                        class="input input-bordered w-full"
+                        placeholder="Reminder title"
+                        type="text"
+                      />
+                    </div>
+                    <div id="dateFeedback" class="text-sm text-base-content/70 hidden"></div>
+                    <div class="grid grid-cols-1 gap-4 sm:grid-cols-4">
+                      <div class="space-y-2">
+                        <label for="date" class="block text-sm font-medium text-base-content/80">Date</label>
+                        <input id="date" type="date" class="input input-bordered w-full" />
+                      </div>
+                      <div class="space-y-2">
+                        <label for="time" class="block text-sm font-medium text-base-content/80">Time</label>
+                        <input id="time" type="time" class="input input-bordered w-full" />
+                      </div>
+                      <div class="space-y-2">
+                        <label for="priority" class="block text-sm font-medium text-base-content/80">Priority</label>
+                        <select id="priority" class="select select-bordered w-full">
+                          <option>High</option>
+                          <option selected>Medium</option>
+                          <option>Low</option>
+                        </select>
+                      </div>
+                      <div class="space-y-2">
+                        <label for="category" class="block text-sm font-medium text-base-content/80">Category</label>
+                        <input
+                          id="category"
+                          list="categorySuggestions"
+                          class="input input-bordered w-full"
+                          placeholder="e.g., School – Communication &amp; Families"
+                        />
+                        <datalist id="categorySuggestions">
+                          <option value="General"></option>
+                          <option value="General Appointments"></option>
+                          <option value="Home &amp; Personal"></option>
+                          <option value="School – Appointments/Meetings"></option>
+                          <option value="School – Communication &amp; Families"></option>
+                          <option value="School – Excursions &amp; Events"></option>
+                          <option value="School – Grading &amp; Assessment"></option>
+                          <option value="School – Prep &amp; Resources"></option>
+                          <option value="School – To-Do"></option>
+                          <option value="Wellbeing &amp; Support"></option>
+                        </datalist>
+                      </div>
+                    </div>
+                    <div class="space-y-2">
+                      <label for="details" class="block text-sm font-medium text-base-content/80">Details</label>
+                      <textarea
+                        id="details"
+                        rows="3"
+                        class="textarea textarea-bordered w-full"
+                        placeholder="Add details or notes (optional)"
+                      ></textarea>
+                    </div>
+                    <div class="modal-action flex w-full flex-wrap items-center gap-3">
+                      <button id="cancelEditBtn" class="btn btn-ghost hidden" type="button">Cancel Edit</button>
+                      <div class="ml-auto flex gap-2">
+                        <button id="closeCueModal" type="button" class="btn btn-outline">Cancel</button>
+                        <button id="saveBtn" class="btn btn-primary" type="button">Save Cue</button>
+                      </div>
+                    </div>
+                  </form>
+                </div>
+                <form method="dialog" class="modal-backdrop">
+                  <button aria-label="Close">close</button>
+                </form>
+              </dialog>
           </div>
         </div>
 
-        <div class="bg-[var(--card)] rounded-xl border border-slate-200/70 dark:border-slate-700/60 shadow-sm p-8">
-          <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
+          <div class="bg-[var(--card)] rounded-xl border border-slate-200/70 dark:border-slate-700/60 shadow-sm p-8">
+            <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
             <div class="flex gap-2 flex-wrap">
               <button class="px-4 py-2 rounded-md border border-slate-300 bg-white text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700/60" data-filter="today" type="button">Today</button>
               <button class="px-4 py-2 rounded-md border border-slate-300 bg-white text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700/60" data-filter="overdue" type="button">Overdue</button>
@@ -895,28 +900,49 @@
             </div>
           </div>
           
-          <div class="flex flex-wrap gap-6 mb-6 text-slate-600 dark:text-slate-400">
-            <div class="flex items-center gap-2">
-              <div class="w-3 h-3 bg-blue-500 rounded-full"></div>
-              <span>Today: <span id="inlineTodayCount" class="font-semibold text-slate-900 dark:text-slate-100">0</span></span>
+            <div class="flex flex-wrap gap-6 mb-6 text-slate-600 dark:text-slate-400">
+              <div class="flex items-center gap-2">
+                <div class="w-3 h-3 bg-blue-500 rounded-full"></div>
+                <span>Today: <span id="inlineTodayCount" class="font-semibold text-slate-900 dark:text-slate-100">0</span></span>
+              </div>
+              <div class="flex items-center gap-2">
+                <div class="w-3 h-3 bg-amber-500 rounded-full"></div>
+                <span>Overdue: <span id="inlineOverdueCount" class="font-semibold text-slate-900 dark:text-slate-100">0</span></span>
+              </div>
+              <div class="flex items-center gap-2">
+                <div class="w-3 h-3 bg-slate-400 rounded-full"></div>
+                <span>Total: <span id="inlineTotalCount" class="font-semibold text-slate-900 dark:text-slate-100">0</span></span>
+              </div>
+              <div class="flex items-center gap-2">
+                <div class="w-3 h-3 bg-emerald-500 rounded-full"></div>
+                <span>Completed: <span id="inlineCompletedCount" class="font-semibold text-slate-900 dark:text-slate-100">0</span></span>
+              </div>
             </div>
-            <div class="flex items-center gap-2">
-              <div class="w-3 h-3 bg-amber-500 rounded-full"></div>
-              <span>Overdue: <span id="inlineOverdueCount" class="font-semibold text-slate-900 dark:text-slate-100">0</span></span>
-            </div>
-            <div class="flex items-center gap-2">
-              <div class="w-3 h-3 bg-slate-400 rounded-full"></div>
-              <span>Total: <span id="inlineTotalCount" class="font-semibold text-slate-900 dark:text-slate-100">0</span></span>
-            </div>
-            <div class="flex items-center gap-2">
-              <div class="w-3 h-3 bg-emerald-500 rounded-full"></div>
-              <span>Completed: <span id="inlineCompletedCount" class="font-semibold text-slate-900 dark:text-slate-100">0</span></span>
+
+            <div id="remindersWrapper" class="space-y-4">
+              <p id="emptyState" class="text-slate-500 dark:text-slate-400 text-sm">Add your first reminder to see it here.</p>
+              <ul id="reminderList" class="space-y-4"></ul>
             </div>
           </div>
-
-          <div id="remindersWrapper" class="space-y-4">
-            <p id="emptyState" class="text-slate-500 dark:text-slate-400 text-sm">Add your first reminder to see it here.</p>
-            <ul id="reminderList" class="space-y-4"></ul>
+        </div>
+        <div id="daily-list-view" class="hidden" role="tabpanel" aria-labelledby="tab-daily">
+          <div class="bg-[var(--card)] rounded-xl border border-slate-200/70 dark:border-slate-700/60 shadow-sm p-8">
+            <div class="flex flex-wrap items-center justify-between gap-3">
+              <h2 id="daily-list-header" class="text-2xl font-bold text-slate-900 dark:text-slate-100"></h2>
+            </div>
+            <form id="quick-add-form" class="mt-6 flex flex-col gap-3 sm:flex-row" autocomplete="off">
+              <label for="quick-add-input" class="sr-only">Quick add task</label>
+              <input
+                id="quick-add-input"
+                type="text"
+                class="input input-bordered flex-1"
+                placeholder="Add a task for today"
+                required
+              />
+              <button type="submit" class="btn btn-primary">Add</button>
+            </form>
+            <div id="daily-tasks-container" class="mt-6 space-y-3" aria-live="polite"></div>
+            <button id="clear-completed-btn" type="button" class="btn btn-sm btn-outline mt-4">Clear Completed Tasks</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add DaisyUI tab navigation to the Reminders view and wrap the existing cues experience in its own panel
- introduce a Daily List panel with a quick-add form, task list container, and clear completed control
- wire up Firestore-backed daily task loading, quick add, completion toggles, and cleanup logic with shared Firebase config reuse

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d5f330c44c83279b45a1ca819a3cf4