### PR TITLE
Add Caramellatte theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="caramellatte">
 <head>
   <!-- === SUPABASE CONFIG (put before your main JS) === -->
 <script>
@@ -333,6 +333,13 @@
 
         <div class="flex flex-col items-end gap-2">
           <div class="flex flex-wrap items-center justify-end gap-3">
+            <button
+              id="theme-toggle"
+              type="button"
+              class="btn btn-sm btn-ghost border border-white/10 text-white/80 hover:border-white/30 hover:bg-white/15 hover:text-white transition-all duration-200"
+              data-icon-dark="🌙"
+              data-icon-light="☀️"
+            ></button>
             <div class="dropdown dropdown-end">
               <button
                 type="button"

--- a/js/main.js
+++ b/js/main.js
@@ -944,7 +944,10 @@ function updateThemeToggleState(isDark){
 }
 
 function setTheme(t){
-  document.documentElement.classList.toggle('dark', t === 'dark');
+  const isDark = t === 'dark';
+  document.documentElement.classList.toggle('dark', isDark);
+  const dataTheme = isDark ? 'dark' : 'caramellatte';
+  document.documentElement.setAttribute('data-theme', dataTheme);
   localStorage.setItem('theme', t);
 }
 


### PR DESCRIPTION
## Summary
- set the default document theme to the custom Caramellatte DaisyUI palette
- add a quick theme toggle button to the primary navigation
- ensure toggling updates both the dark class and DaisyUI data-theme attribute

## Testing
- npm test -- --runTestsByPath theme-toggle.test.js

------
https://chatgpt.com/codex/tasks/task_b_68d629770aa48327998a5a67bca43828