### PR TITLE
Ensure Caramellatte theme works without build step

### DIFF
--- a/styles/daisy-themes.css
+++ b/styles/daisy-themes.css
@@ -1,9 +1,50 @@
 /* Custom DaisyUI themes for Memory Cue */
+
+/*
+ * DaisyUI exposes an `@plugin "daisyui/theme"` block for authoring custom
+ * themes at build time. Because Memory Cue serves plain CSS via CDN we mirror
+ * those variables in a standard selector so the browser can apply them without
+ * a build step. The variables are kept in sync with the plugin block for
+ * anyone running Tailwind locally.
+ */
 @plugin "daisyui/theme" {
   name: "caramellatte";
   default: false;
   prefersdark: false;
   color-scheme: "light";
+  --color-base-100: oklch(98% 0.016 73.684);
+  --color-base-200: oklch(95% 0.038 75.164);
+  --color-base-300: oklch(90% 0.076 70.697);
+  --color-base-content: oklch(40% 0.123 38.172);
+  --color-primary: oklch(0% 0 0);
+  --color-primary-content: oklch(100% 0 0);
+  --color-secondary: oklch(22.45% 0.075 37.85);
+  --color-secondary-content: oklch(90% 0.076 70.697);
+  --color-accent: oklch(46.44% 0.111 37.85);
+  --color-accent-content: oklch(90% 0.076 70.697);
+  --color-neutral: oklch(55% 0.195 38.402);
+  --color-neutral-content: oklch(98% 0.016 73.684);
+  --color-info: oklch(42% 0.199 265.638);
+  --color-info-content: oklch(90% 0.076 70.697);
+  --color-success: oklch(43% 0.095 166.913);
+  --color-success-content: oklch(90% 0.076 70.697);
+  --color-warning: oklch(82% 0.189 84.429);
+  --color-warning-content: oklch(41% 0.112 45.904);
+  --color-error: oklch(70% 0.191 22.216);
+  --color-error-content: oklch(39% 0.141 25.723);
+  --radius-selector: 2rem;
+  --radius-field: 0.5rem;
+  --radius-box: 1rem;
+  --size-selector: 0.25rem;
+  --size-field: 0.25rem;
+  --border: 2px;
+  --depth: 1;
+  --noise: 1;
+}
+
+:root[data-theme="caramellatte"],
+[data-theme="caramellatte"] {
+  color-scheme: light;
   --color-base-100: oklch(98% 0.016 73.684);
   --color-base-200: oklch(95% 0.038 75.164);
   --color-base-300: oklch(90% 0.076 70.697);


### PR DESCRIPTION
## Summary
- document the purpose of the DaisyUI Caramellatte theme definition
- mirror the theme variables on a standard selector so the CDN build can apply them at runtime

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d629b34b70832793d7f88838480a9f