### PR TITLE
Refine resources tab layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1124,7 +1124,7 @@
     </section>
     <section data-view="resources" id="view-resources" hidden tabindex="-1">
       <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-16 space-y-8">
-        <header class="space-y-6">
+        <header class="space-y-8">
           <div class="flex flex-wrap items-start justify-between gap-4">
             <div class="space-y-2">
               <p class="text-sm font-semibold uppercase tracking-wide text-emerald-600 dark:text-emerald-300">Resource library</p>
@@ -1133,102 +1133,119 @@
             </div>
             <p id="activity-status" class="hidden text-sm font-medium text-slate-500 dark:text-slate-400"></p>
           </div>
-          <div class="flex flex-wrap items-center gap-3">
-            <div class="flex flex-wrap items-center gap-2" role="group" aria-label="Subjects">
-              <button type="button" data-subject="all" data-default="true" class="subject-filter inline-flex items-center rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200">All subjects</button>
-              <button type="button" data-subject="HPE" class="subject-filter inline-flex items-center rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200">HPE</button>
-              <button type="button" data-subject="English" class="subject-filter inline-flex items-center rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200">English</button>
-              <button type="button" data-subject="HASS" class="subject-filter inline-flex items-center rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200">HASS</button>
+          <div class="grid gap-6 lg:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)]">
+            <div class="space-y-4 rounded-2xl border border-slate-200 bg-white/85 p-6 shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-900/50">
+              <div class="flex flex-wrap items-center gap-2" role="group" aria-label="Subjects">
+                <button type="button" data-subject="all" data-default="true" class="subject-filter inline-flex items-center rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200">All subjects</button>
+                <button type="button" data-subject="HPE" class="subject-filter inline-flex items-center rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200">HPE</button>
+                <button type="button" data-subject="English" class="subject-filter inline-flex items-center rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200">English</button>
+                <button type="button" data-subject="HASS" class="subject-filter inline-flex items-center rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200">HASS</button>
+              </div>
+              <div class="flex flex-wrap items-center gap-3">
+                <div class="flex flex-wrap items-center gap-2" role="group" aria-label="Lesson phase">
+                  <button type="button" data-phase="any" class="phase-filter inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200">Any phase</button>
+                  <button type="button" data-phase="start" class="phase-filter inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200">Start</button>
+                  <button type="button" data-phase="middle" class="phase-filter inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200">Middle</button>
+                  <button type="button" data-phase="end" class="phase-filter inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200">End</button>
+                </div>
+                <button
+                  type="button"
+                  id="activity-pinned-toggle"
+                  aria-pressed="false"
+                  class="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-white px-3 py-1.5 text-sm font-semibold text-amber-600 shadow-sm transition hover:-translate-y-0.5 hover:border-amber-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-300 dark:border-amber-400/40 dark:bg-amber-500/10 dark:text-amber-200"
+                >
+                  <span aria-hidden="true" class="text-base">★</span>
+                  <span>Pinned</span>
+                </button>
+                <button
+                  type="button"
+                  id="activity-ideas-button"
+                  data-open-modal="activity-ideas"
+                  class="inline-flex items-center gap-2 rounded-full border border-emerald-300 bg-emerald-50 px-4 py-2 text-sm font-semibold text-emerald-700 shadow-sm transition hover:-translate-y-0.5 hover:bg-emerald-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-200"
+                >
+                  <span aria-hidden="true" class="text-base" data-idea-icon>✨</span>
+                  <span data-idea-label>Get ideas</span>
+                </button>
+                <label for="activity-search" class="sr-only">Search activities</label>
+                <div class="relative order-last w-full sm:order-none sm:flex-1 sm:min-w-[220px] md:max-w-xs lg:max-w-sm">
+                  <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-slate-400" aria-hidden="true">🔍</span>
+                  <input
+                    id="activity-search"
+                    type="search"
+                    placeholder="Search activities"
+                    class="w-full rounded-full border border-slate-200 bg-white px-4 py-2 pl-10 text-sm text-slate-700 shadow-sm outline-none transition focus:border-emerald-400 focus:ring-2 focus:ring-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100"
+                  />
+                </div>
+              </div>
             </div>
-          </div>
-          <div class="flex flex-wrap items-center gap-3">
-            <div class="flex flex-wrap items-center gap-2" role="group" aria-label="Lesson phase">
-              <button type="button" data-phase="any" class="phase-filter inline-flex items-center rounded-full border border-slate-200 bg-white/70 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200">Any phase</button>
-              <button type="button" data-phase="start" class="phase-filter inline-flex items-center rounded-full border border-slate-200 bg-white/70 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200">Start</button>
-              <button type="button" data-phase="middle" class="phase-filter inline-flex items-center rounded-full border border-slate-200 bg-white/70 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200">Middle</button>
-              <button type="button" data-phase="end" class="phase-filter inline-flex items-center rounded-full border border-slate-200 bg-white/70 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200">End</button>
+            <div class="space-y-4 rounded-2xl border border-slate-200 bg-white/85 p-6 shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-900/50">
+              <h3 class="text-lg font-semibold text-slate-800 dark:text-slate-100">Add your own idea</h3>
+              <form id="idea-form" class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <input
+                  id="idea-title"
+                  name="idea-title"
+                  type="text"
+                  required
+                  placeholder="Title (e.g., 3-2-1 Exit Ticket)"
+                  class="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100"
+                />
+                <select
+                  id="idea-subject"
+                  name="idea-subject"
+                  required
+                  class="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100"
+                >
+                  <option value="" disabled selected>Subject</option>
+                  <option>HPE</option><option>English</option><option>HASS</option>
+                </select>
+                <select
+                  id="idea-phase"
+                  name="idea-phase"
+                  required
+                  class="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100"
+                >
+                  <option value="" disabled selected>Phase</option>
+                  <option value="start">Start</option><option value="middle">Middle</option><option value="end">End</option>
+                </select>
+                <input
+                  id="idea-url"
+                  name="idea-url"
+                  type="url"
+                  placeholder="Optional link (https://…)"
+                  class="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100 sm:col-span-2"
+                />
+                <input
+                  id="idea-keywords"
+                  name="idea-keywords"
+                  type="text"
+                  placeholder="Keywords (comma, separated)"
+                  class="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100 sm:col-span-2"
+                />
+                <textarea
+                  id="idea-description"
+                  name="idea-description"
+                  rows="3"
+                  placeholder="Short description"
+                  class="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100 sm:col-span-2"
+                ></textarea>
+                <button
+                  id="idea-save"
+                  type="submit"
+                  class="inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 sm:col-span-2"
+                >
+                  Save idea
+                </button>
+              </form>
+              <div class="flex flex-wrap gap-2" id="idea-quick-filters">
+                <span class="text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">View</span>
+                <button id="filter-mine" type="button" class="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
+                  My ideas
+                </button>
+                <button id="filter-all" type="button" class="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
+                  All ideas
+                </button>
+              </div>
             </div>
-            <button
-              type="button"
-              id="activity-pinned-toggle"
-              aria-pressed="false"
-              class="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white/80 px-3 py-1.5 text-sm font-semibold text-slate-600 transition hover:-translate-y-0.5 hover:border-amber-400 hover:text-amber-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-300 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200"
-            >
-              <span aria-hidden="true" class="text-base">★</span>
-              <span>Pinned</span>
-            </button>
-            <button
-              type="button"
-              id="activity-ideas-button"
-              data-open-modal="activity-ideas"
-              class="inline-flex items-center gap-2 rounded-full border border-emerald-300 bg-emerald-50/80 px-4 py-2 text-sm font-semibold text-emerald-700 shadow-sm transition hover:-translate-y-0.5 hover:bg-emerald-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-200"
-            >
-              <span aria-hidden="true" class="text-base" data-idea-icon>✨</span>
-              <span data-idea-label>Get ideas</span>
-            </button>
-            <label for="activity-search" class="sr-only">Search activities</label>
-            <div class="relative flex-1 min-w-[220px] max-w-md">
-              <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-slate-400" aria-hidden="true">🔍</span>
-              <input
-                id="activity-search"
-                type="search"
-                placeholder="Search activities"
-                class="w-full rounded-full border border-slate-200 bg-white px-4 py-2 pl-10 text-sm text-slate-700 shadow-sm outline-none transition focus:border-emerald-400 focus:ring-2 focus:ring-emerald-300 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100"
-              />
-            </div>
-          </div>
-          <!-- Add Idea form -->
-          <form id="idea-form" class="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-3 items-end">
-            <input
-              id="idea-title"
-              name="idea-title"
-              type="text"
-              required
-              placeholder="Title (e.g., 3-2-1 Exit Ticket)"
-              class="rounded-xl border px-3 py-2"
-            />
-            <select id="idea-subject" name="idea-subject" required class="rounded-xl border px-3 py-2">
-              <option value="" disabled selected>Subject</option>
-              <option>HPE</option><option>English</option><option>HASS</option>
-            </select>
-            <select id="idea-phase" name="idea-phase" required class="rounded-xl border px-3 py-2">
-              <option value="" disabled selected>Phase</option>
-              <option value="start">Start</option><option value="middle">Middle</option><option value="end">End</option>
-            </select>
-            <input
-              id="idea-url"
-              name="idea-url"
-              type="url"
-              placeholder="Optional link (https://…)"
-              class="rounded-xl border px-3 py-2 sm:col-span-2"
-            />
-            <input
-              id="idea-keywords"
-              name="idea-keywords"
-              type="text"
-              placeholder="Keywords (comma, separated)"
-              class="rounded-xl border px-3 py-2"
-            />
-            <textarea
-              id="idea-description"
-              name="idea-description"
-              rows="2"
-              placeholder="Short description"
-              class="rounded-xl border px-3 py-2 sm:col-span-3"
-            ></textarea>
-            <button
-              id="idea-save"
-              type="submit"
-              class="rounded-xl bg-emerald-600 text-white px-4 py-2 font-semibold"
-            >
-              Save idea
-            </button>
-          </form>
-
-          <!-- Quick filters -->
-          <div class="flex gap-2 mt-3" id="idea-quick-filters">
-            <button id="filter-mine" type="button" class="rounded-full border px-3 py-1.5 text-sm">My ideas</button>
-            <button id="filter-all" type="button" class="rounded-full border px-3 py-1.5 text-sm">All ideas</button>
           </div>
         </header>
         <div


### PR DESCRIPTION
## Summary
- restructure the resources view header into two responsive cards so filters and the idea form have a clearer layout
- refresh control styling for filters, search, and idea submission to improve contrast and accessibility

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d63e1b86bc8327a31a14415fd92ae1