### PR TITLE
Improve dashboard theming and empty states

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,39 +95,31 @@
     }
 
     .sync-status {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.35rem;
-      padding: 0.35rem 0.75rem;
-      border-radius: 9999px;
-      font-size: 0.875rem;
-      font-weight: 600;
-      border: 1px solid transparent;
-      background: rgba(148, 163, 184, 0.18);
-      color: rgb(100 116 139);
       transition: all 0.2s ease;
     }
 
-    .dark .sync-status {
-      background: rgba(71, 85, 105, 0.35);
-      color: rgb(203 213 225);
-    }
-
     .sync-status.online {
-      background: rgba(34, 197, 94, 0.18);
+      background: rgba(22, 163, 74, 0.12);
       color: rgb(22 163 74);
-      border-color: rgba(34, 197, 94, 0.25);
+      border-color: rgba(22, 163, 74, 0.3);
     }
 
     .dark .sync-status.online {
-      color: rgb(134 239 172);
-      border-color: rgba(34, 197, 94, 0.35);
+      background: rgba(34, 197, 94, 0.16);
+      color: rgb(187 247 208);
+      border-color: rgba(34, 197, 94, 0.4);
     }
 
     .sync-status.error {
-      background: rgba(248, 113, 113, 0.2);
+      background: rgba(248, 113, 113, 0.16);
       color: rgb(220 38 38);
-      border-color: rgba(248, 113, 113, 0.35);
+      border-color: rgba(248, 113, 113, 0.32);
+    }
+
+    .dark .sync-status.error {
+      background: rgba(248, 113, 113, 0.22);
+      color: rgb(254 205 211);
+      border-color: rgba(248, 113, 113, 0.45);
     }
 
     @keyframes widget-pop {
@@ -417,50 +409,50 @@
     <section data-view="dashboard" id="view-dashboard" tabindex="-1">
       <section id="dashboard-overview" aria-labelledby="dashboard-heading" class="pt-24 pb-16 bg-[var(--bg)]">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 space-y-10">
-          <div class="relative overflow-hidden rounded-3xl bg-[var(--card)] shadow-2xl border border-white/60 dark:border-slate-700/60">
+          <div class="relative overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow-sm transition-shadow duration-200 hover:shadow-md border border-gray-200 dark:border-gray-700">
             <div class="absolute inset-0 bg-gradient-to-br from-blue-100 via-emerald-100 to-amber-100 opacity-60 dark:from-slate-800 dark:via-slate-900 dark:to-slate-900"></div>
             <div class="relative z-10 p-8 sm:p-10">
               <div class="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
                 <div class="space-y-2">
-                  <p class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Today's overview</p>
-                  <h1 id="dashboard-heading" class="text-3xl sm:text-4xl font-bold text-slate-900 dark:text-slate-100 leading-tight">Your teaching day at a glance</h1>
-                  <p id="dashboard-date" class="text-lg text-slate-600 dark:text-slate-300"></p>
+                  <p class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-500">Today's overview</p>
+                  <h1 id="dashboard-heading" class="text-3xl sm:text-4xl font-bold text-gray-900 dark:text-gray-100 leading-tight">Your teaching day at a glance</h1>
+                  <p id="dashboard-date" class="text-lg text-gray-600 dark:text-gray-400"></p>
                 </div>
                 <div class="flex flex-wrap gap-3">
-                  <a href="#planner" class="inline-flex items-center gap-2 rounded-full bg-blue-600 text-white px-5 py-2.5 text-sm font-semibold shadow-md hover:bg-blue-700 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500">Open weekly planner<span aria-hidden="true">→</span></a>
-                  <a href="#reminders" class="inline-flex items-center gap-2 rounded-full bg-white/80 text-blue-700 px-5 py-2.5 text-sm font-semibold shadow border border-blue-100 hover:bg-white transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400">Review reminders<span aria-hidden="true">→</span></a>
+                  <a href="#planner" class="inline-flex items-center gap-2 rounded-full bg-emerald-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:bg-emerald-500 dark:hover:bg-emerald-400">Open weekly planner<span aria-hidden="true">→</span></a>
+                  <a href="#reminders" class="inline-flex items-center gap-2 rounded-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-5 py-2.5 text-sm font-semibold text-gray-900 dark:text-gray-100 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:bg-gray-50 dark:hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-300 dark:focus-visible:outline-gray-600">Review reminders<span aria-hidden="true">→</span></a>
                 </div>
               </div>
               <div class="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
-                <div class="rounded-2xl bg-white/90 dark:bg-slate-900/60 border border-slate-200/70 dark:border-slate-700/70 p-5 shadow-sm">
-                  <p class="text-sm font-medium text-slate-500 dark:text-slate-400">Lessons today</p>
-                  <p id="dashboard-lesson-count" class="mt-1 text-3xl font-bold text-slate-900 dark:text-white">0</p>
-                  <p id="dashboard-next-lesson" class="mt-2 text-sm text-slate-500 dark:text-slate-400"></p>
+                <div class="rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 p-6 shadow-sm transition-shadow duration-200 hover:shadow-md">
+                  <p class="text-sm font-medium text-gray-500 dark:text-gray-500">Lessons today</p>
+                  <p id="dashboard-lesson-count" class="mt-1 text-3xl font-bold text-gray-900 dark:text-gray-100">0</p>
+                  <p id="dashboard-next-lesson" class="mt-2 text-sm text-gray-500 dark:text-gray-500"></p>
                 </div>
-                <div class="rounded-2xl bg-white/90 dark:bg-slate-900/60 border border-slate-200/70 dark:border-slate-700/70 p-5 shadow-sm">
-                  <p class="text-sm font-medium text-slate-500 dark:text-slate-400">Deadlines this week</p>
-                  <p id="dashboard-deadline-count" class="mt-1 text-3xl font-bold text-slate-900 dark:text-white">0</p>
-                  <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">Countdowns auto-refresh</p>
+                <div class="rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 p-6 shadow-sm transition-shadow duration-200 hover:shadow-md">
+                  <p class="text-sm font-medium text-gray-500 dark:text-gray-500">Deadlines this week</p>
+                  <p id="dashboard-deadline-count" class="mt-1 text-3xl font-bold text-gray-900 dark:text-gray-100">0</p>
+                  <p class="mt-2 text-sm text-gray-500 dark:text-gray-500">Countdowns auto-refresh</p>
                 </div>
-                <div class="rounded-2xl bg-white/90 dark:bg-slate-900/60 border border-slate-200/70 dark:border-slate-700/70 p-5 shadow-sm">
-                  <p class="text-sm font-medium text-slate-500 dark:text-slate-400">Reminders to action</p>
-                  <p id="dashboard-reminder-count" class="mt-1 text-3xl font-bold text-slate-900 dark:text-white">0</p>
-                  <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">Due today or overdue</p>
+                <div class="rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 p-6 shadow-sm transition-shadow duration-200 hover:shadow-md">
+                  <p class="text-sm font-medium text-gray-500 dark:text-gray-500">Reminders to action</p>
+                  <p id="dashboard-reminder-count" class="mt-1 text-3xl font-bold text-gray-900 dark:text-gray-100">0</p>
+                  <p class="mt-2 text-sm text-gray-500 dark:text-gray-500">Due today or overdue</p>
                 </div>
               </div>
             </div>
           </div>
 
           <div class="space-y-6">
-            <div class="grid grid-cols-1 xl:grid-cols-4 gap-6" data-dashboard-area="primary">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" data-dashboard-area="primary">
               <section
                 data-dashboard-widget="lessons"
                 data-widget-title="Today's lessons"
-                class="xl:col-span-2 bg-[var(--card)] border border-slate-200 dark:border-slate-700 rounded-3xl p-8 shadow-xl transition-all duration-200 hover:shadow-2xl"
+                class="md:col-span-2 lg:col-span-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md"
                 aria-labelledby="lessons-heading"
               >
                 <div
-                  class="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 dark:border-slate-700 pb-4"
+                  class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 dark:border-gray-700 pb-4"
                   data-widget-header
                 >
                   <div class="flex min-w-0 flex-1 items-center gap-3">
@@ -470,7 +462,7 @@
                     >📘</span>
                     <div class="min-w-0 space-y-1">
                       <div class="flex flex-wrap items-center gap-2">
-                        <h2 id="lessons-heading" class="text-xl font-semibold text-slate-900 dark:text-slate-100">Today's lessons</h2>
+                        <h2 id="lessons-heading" class="text-xl font-semibold text-gray-900 dark:text-gray-100">Today's lessons</h2>
                         <span
                           id="dashboard-lesson-status"
                           class="hidden rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-600 dark:bg-blue-500/10 dark:text-blue-200"
@@ -479,13 +471,13 @@
                           aria-atomic="true"
                         ></span>
                       </div>
-                      <p class="text-sm text-slate-500 dark:text-slate-400">
+                      <p class="text-sm text-gray-500 dark:text-gray-500">
                         Keep track of sessions, locations, and focus areas for a smooth teaching flow.
                       </p>
                     </div>
                   </div>
                   <div class="flex items-center gap-2">
-                    <div class="hidden overflow-hidden rounded-full border border-slate-200 dark:border-slate-700 sm:flex" role="group" aria-label="Reorder widget">
+                    <div class="hidden overflow-hidden rounded-full border border-gray-200 dark:border-gray-700 sm:flex" role="group" aria-label="Reorder widget">
                       <button type="button" class="widget-control-btn" data-widget-action="move-up" aria-label="Move widget up">
                         <span aria-hidden="true">↑</span>
                       </button>
@@ -505,32 +497,30 @@
                 </div>
                 <div data-widget-body class="space-y-6 pt-4">
                   <div>
-                    <div id="dashboard-lessons-skeleton" class="space-y-3 rounded-2xl bg-white/60 p-4 text-slate-400 dark:bg-slate-900/40 dark:text-slate-500 animate-pulse" aria-hidden="true">
-                      <div class="h-4 w-2/3 rounded bg-slate-200/80 dark:bg-slate-700/70"></div>
-                      <div class="h-4 w-1/2 rounded bg-slate-200/60 dark:bg-slate-700/60"></div>
-                      <div class="mt-4 h-20 rounded-2xl bg-slate-100/80 dark:bg-slate-800/60"></div>
+                    <div id="dashboard-lessons-skeleton" class="space-y-3 rounded-2xl bg-white/60 p-4 text-gray-500 dark:bg-gray-900/40 dark:text-gray-500 animate-pulse" aria-hidden="true">
+                      <div class="h-4 w-2/3 rounded bg-gray-200/80 dark:bg-gray-700/70"></div>
+                      <div class="h-4 w-1/2 rounded bg-gray-200/60 dark:bg-gray-700/60"></div>
+                      <div class="mt-4 h-20 rounded-2xl bg-gray-100/80 dark:bg-gray-800/60"></div>
                     </div>
                     <ul id="dashboard-lessons-list" class="hidden space-y-4" aria-live="polite" aria-busy="true"></ul>
-                    <p id="dashboard-lessons-empty" class="hidden text-sm text-slate-500 dark:text-slate-400">
-                      No lessons scheduled yet. Add today's sessions below or jump into the planner to map the rest of your week.
-                    </p>
+                    <div id="dashboard-lessons-empty" class="hidden"></div>
                   </div>
                   <form id="lesson-form" class="grid grid-cols-1 gap-3 md:grid-cols-5" aria-describedby="lesson-feedback">
                     <div>
-                      <label for="lesson-subject" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Lesson or group</label>
-                      <input id="lesson-subject" name="lesson-subject" type="text" required placeholder="e.g. Year 8 Science" class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                      <label for="lesson-subject" class="block text-sm font-medium text-gray-600 dark:text-gray-400">Lesson or group</label>
+                      <input id="lesson-subject" name="lesson-subject" type="text" required placeholder="e.g. Year 8 Science" class="mt-1 w-full rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
                     </div>
                     <div>
-                      <label for="lesson-start" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Start</label>
-                      <input id="lesson-start" name="lesson-start" type="time" required class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                      <label for="lesson-start" class="block text-sm font-medium text-gray-600 dark:text-gray-400">Start</label>
+                      <input id="lesson-start" name="lesson-start" type="time" required class="mt-1 w-full rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
                     </div>
                     <div>
-                      <label for="lesson-end" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Finish</label>
-                      <input id="lesson-end" name="lesson-end" type="time" required class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                      <label for="lesson-end" class="block text-sm font-medium text-gray-600 dark:text-gray-400">Finish</label>
+                      <input id="lesson-end" name="lesson-end" type="time" required class="mt-1 w-full rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
                     </div>
                     <div>
-                      <label for="lesson-location" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Location</label>
-                      <input id="lesson-location" name="lesson-location" type="text" placeholder="e.g. Lab 2" class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                      <label for="lesson-location" class="block text-sm font-medium text-gray-600 dark:text-gray-400">Location</label>
+                      <input id="lesson-location" name="lesson-location" type="text" placeholder="e.g. Lab 2" class="mt-1 w-full rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
                     </div>
                     <div class="flex items-end">
                       <button type="submit" class="inline-flex w-full items-center justify-center rounded-xl bg-blue-600 px-4 py-2.5 font-semibold text-white shadow transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500">Add lesson</button>
@@ -544,7 +534,7 @@
                 data-dashboard-widget="weather"
                 data-widget-title="Outdoor planning"
                 data-widget-theme="inverted"
-                class="bg-gradient-to-br from-sky-500 via-indigo-500 to-emerald-500 text-white rounded-3xl shadow-xl border border-white/40 p-8 transition-all duration-200 hover:shadow-2xl"
+                class="md:col-span-2 lg:col-span-1 bg-gradient-to-br from-sky-500 via-indigo-500 to-emerald-500 text-white rounded-lg shadow-sm border border-white/40 p-6 transition-shadow duration-200 hover:shadow-md"
                 aria-labelledby="weather-heading"
               >
                 <div
@@ -637,46 +627,46 @@
 
             <aside
               id="dashboard-hidden-tray"
-              class="hidden rounded-3xl border border-dashed border-slate-300 dark:border-slate-600 bg-white/80 px-6 py-5 shadow-sm dark:bg-slate-900/40"
+              class="hidden rounded-lg border border-dashed border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-6 py-5 shadow-sm"
             >
               <div class="flex flex-wrap items-center gap-3">
-                <p class="text-sm font-semibold text-slate-600 dark:text-slate-300">Hidden dashboard widgets</p>
+                <p class="text-sm font-semibold text-gray-600 dark:text-gray-400">Hidden dashboard widgets</p>
                 <div id="dashboard-hidden-list" class="flex flex-wrap gap-2"></div>
                 <button
                   type="button"
                   id="dashboard-show-all"
-                  class="hidden inline-flex items-center gap-2 rounded-full bg-slate-900/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white/85 dark:text-slate-900 dark:hover:bg-white"
+                  class="hidden inline-flex items-center gap-2 rounded-full bg-gray-900/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white/85 dark:text-gray-900 dark:text-gray-100 dark:hover:bg-white"
                 >
                   <span aria-hidden="true">↺</span>
                   Restore all
                 </button>
               </div>
-              <p class="mt-3 text-xs text-slate-500 dark:text-slate-400">
+              <p class="mt-3 text-xs text-gray-500 dark:text-gray-500">
                 Use the widget chrome to collapse, hide, or reorder cards. Restore any hidden widgets here.
               </p>
             </aside>
 
-            <div class="grid grid-cols-1 xl:grid-cols-3 gap-6" data-dashboard-area="secondary">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" data-dashboard-area="secondary">
               <section
                 data-dashboard-widget="deadlines"
                 data-widget-title="Upcoming deadlines"
-                class="xl:col-span-2 bg-[var(--card)] border border-slate-200 dark:border-slate-700 rounded-3xl p-8 shadow-xl transition-all duration-200 hover:shadow-2xl"
+                class="md:col-span-1 lg:col-span-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md"
                 aria-labelledby="deadlines-heading"
               >
                 <div
-                  class="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 dark:border-slate-700 pb-4"
+                  class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 dark:border-gray-700 pb-4"
                   data-widget-header
                 >
                   <div class="flex min-w-0 flex-1 items-start gap-3">
                     <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-amber-100 text-amber-600 dark:bg-amber-500/10 dark:text-amber-200 text-xl" aria-hidden="true">⏰</span>
                     <div class="min-w-0 space-y-1">
-                      <h2 id="deadlines-heading" class="text-xl font-semibold text-slate-900 dark:text-slate-100">Upcoming deadlines</h2>
-                      <p class="text-sm text-slate-500 dark:text-slate-400">Deadlines due in the next seven days with live countdowns.</p>
+                      <h2 id="deadlines-heading" class="text-xl font-semibold text-gray-900 dark:text-gray-100">Upcoming deadlines</h2>
+                      <p class="text-sm text-gray-500 dark:text-gray-500">Deadlines due in the next seven days with live countdowns.</p>
                     </div>
                   </div>
                   <div class="flex items-center gap-2">
                     <span class="inline-flex items-center gap-2 rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700 dark:bg-amber-500/10 dark:text-amber-200">Next 7 days</span>
-                    <div class="hidden overflow-hidden rounded-full border border-slate-200 dark:border-slate-700 sm:flex" role="group" aria-label="Reorder widget">
+                    <div class="hidden overflow-hidden rounded-full border border-gray-200 dark:border-gray-700 sm:flex" role="group" aria-label="Reorder widget">
                       <button type="button" class="widget-control-btn" data-widget-action="move-up" aria-label="Move widget up">
                         <span aria-hidden="true">↑</span>
                       </button>
@@ -696,28 +686,26 @@
                 </div>
                 <div data-widget-body class="space-y-6 pt-4">
                   <div>
-                    <div id="dashboard-deadlines-skeleton" class="space-y-3 rounded-2xl border border-dashed border-slate-200/80 bg-white/70 p-4 text-slate-500 animate-pulse dark:border-slate-700/70 dark:bg-slate-900/40" aria-hidden="true">
-                      <div class="h-4 w-1/2 rounded bg-slate-200/70 dark:bg-slate-700/70"></div>
-                      <div class="h-16 rounded-2xl bg-slate-100/90 dark:bg-slate-800/60"></div>
-                      <div class="h-4 w-2/3 rounded bg-slate-200/70 dark:bg-slate-700/70"></div>
+                    <div id="dashboard-deadlines-skeleton" class="space-y-3 rounded-2xl border border-dashed border-gray-200 bg-white/70 p-4 text-gray-500 dark:text-gray-500 animate-pulse dark:border-gray-700/70 dark:bg-gray-900/40" aria-hidden="true">
+                      <div class="h-4 w-1/2 rounded bg-gray-200/70 dark:bg-gray-700/70"></div>
+                      <div class="h-16 rounded-2xl bg-gray-100/90 dark:bg-gray-800/60"></div>
+                      <div class="h-4 w-2/3 rounded bg-gray-200/70 dark:bg-gray-700/70"></div>
                     </div>
                     <ul id="dashboard-deadlines-list" class="hidden space-y-4" aria-live="polite" aria-busy="true"></ul>
-                    <p id="dashboard-deadlines-empty" class="hidden text-sm text-slate-500 dark:text-slate-400">
-                      No deadlines due within the next week. Add the next milestone below so the countdown stays on your radar.
-                    </p>
+                    <div id="dashboard-deadlines-empty" class="hidden"></div>
                   </div>
                   <form id="deadline-form" class="grid grid-cols-1 gap-3 md:grid-cols-5" aria-describedby="deadline-feedback">
                     <div class="md:col-span-2">
-                      <label for="deadline-title" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Deadline</label>
-                      <input id="deadline-title" name="deadline-title" type="text" required placeholder="e.g. Year 9 essays" class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
+                      <label for="deadline-title" class="block text-sm font-medium text-gray-600 dark:text-gray-400">Deadline</label>
+                      <input id="deadline-title" name="deadline-title" type="text" required placeholder="e.g. Year 9 essays" class="mt-1 w-full rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
                     </div>
                     <div>
-                      <label for="deadline-due" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Due</label>
-                      <input id="deadline-due" name="deadline-due" type="datetime-local" required class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
+                      <label for="deadline-due" class="block text-sm font-medium text-gray-600 dark:text-gray-400">Due</label>
+                      <input id="deadline-due" name="deadline-due" type="datetime-local" required class="mt-1 w-full rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
                     </div>
                     <div>
-                      <label for="deadline-course" class="block text-sm font-medium text-slate-600 dark:text-slate-300">Class / group</label>
-                      <input id="deadline-course" name="deadline-course" type="text" placeholder="Optional" class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
+                      <label for="deadline-course" class="block text-sm font-medium text-gray-600 dark:text-gray-400">Class / group</label>
+                      <input id="deadline-course" name="deadline-course" type="text" placeholder="Optional" class="mt-1 w-full rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
                     </div>
                     <div class="flex items-end">
                       <button type="submit" class="inline-flex w-full items-center justify-center rounded-xl bg-amber-500 px-4 py-2.5 font-semibold text-white shadow transition hover:bg-amber-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500">Add deadline</button>
@@ -730,28 +718,28 @@
               <section
                 data-dashboard-widget="reminders"
                 data-widget-title="Reminders needing attention"
-                class="bg-[var(--card)] border border-slate-200 dark:border-slate-700 rounded-3xl p-8 shadow-xl transition-all duration-200 hover:shadow-2xl"
+                class="md:col-span-2 lg:col-span-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md"
                 aria-labelledby="reminders-heading"
               >
                 <div
-                  class="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 dark:border-slate-700 pb-4"
+                  class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 dark:border-gray-700 pb-4"
                   data-widget-header
                 >
                   <div class="flex min-w-0 flex-1 items-start gap-3">
-                    <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-slate-900 text-white text-xl dark:bg-white dark:text-slate-900" aria-hidden="true">🔔</span>
+                    <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-gray-900 text-white text-xl dark:bg-white dark:text-gray-900 dark:text-gray-100" aria-hidden="true">🔔</span>
                     <div class="min-w-0 space-y-1">
-                      <h2 id="reminders-heading" class="text-xl font-semibold text-slate-900 dark:text-slate-100">Reminders needing attention</h2>
-                      <p class="text-sm text-slate-500 dark:text-slate-400">These are pulled automatically from the Reminders board and show tasks due today or overdue.</p>
+                      <h2 id="reminders-heading" class="text-xl font-semibold text-gray-900 dark:text-gray-100">Reminders needing attention</h2>
+                      <p class="text-sm text-gray-500 dark:text-gray-500">These are pulled automatically from the Reminders board and show tasks due today or overdue.</p>
                     </div>
                   </div>
                   <div class="flex items-center gap-2">
                     <a
                       href="#reminders"
-                      class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900 dark:bg-white dark:text-slate-900 dark:focus-visible:outline-white"
+                      class="inline-flex items-center gap-2 rounded-full bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:bg-emerald-500 dark:hover:bg-emerald-400"
                     >
                       Open reminders<span aria-hidden="true">→</span>
                     </a>
-                    <div class="hidden overflow-hidden rounded-full border border-slate-200 dark:border-slate-700 sm:flex" role="group" aria-label="Reorder widget">
+                    <div class="hidden overflow-hidden rounded-full border border-gray-200 dark:border-gray-700 sm:flex" role="group" aria-label="Reorder widget">
                       <button type="button" class="widget-control-btn" data-widget-action="move-up" aria-label="Move widget up">
                         <span aria-hidden="true">↑</span>
                       </button>
@@ -771,15 +759,13 @@
                 </div>
                 <div data-widget-body class="space-y-6 pt-4">
                   <div>
-                    <div id="dashboard-reminders-skeleton" class="space-y-3 rounded-2xl border border-dashed border-slate-200 bg-white/70 p-4 text-slate-500 animate-pulse dark:border-slate-700 dark:bg-slate-900/40" aria-hidden="true">
-                      <div class="h-4 w-1/3 rounded bg-slate-200/70 dark:bg-slate-700/70"></div>
-                      <div class="h-16 rounded-2xl bg-slate-100/90 dark:bg-slate-800/60"></div>
-                      <div class="h-4 w-1/2 rounded bg-slate-200/60 dark:bg-slate-700/60"></div>
+                    <div id="dashboard-reminders-skeleton" class="space-y-3 rounded-2xl border border-dashed border-gray-200 bg-white/70 p-4 text-gray-500 dark:text-gray-500 animate-pulse dark:border-gray-700 dark:bg-gray-900/40" aria-hidden="true">
+                      <div class="h-4 w-1/3 rounded bg-gray-200/70 dark:bg-gray-700/70"></div>
+                      <div class="h-16 rounded-2xl bg-gray-100/90 dark:bg-gray-800/60"></div>
+                      <div class="h-4 w-1/2 rounded bg-gray-200/60 dark:bg-gray-700/60"></div>
                     </div>
                     <ul id="dashboard-reminders-list" class="hidden space-y-4" aria-live="polite" aria-busy="true"></ul>
-                    <p id="dashboard-reminders-empty" class="hidden text-sm text-slate-500 dark:text-slate-400">
-                      You're all clear for now. New reminders will pop in here automatically as they become due.
-                    </p>
+                    <div id="dashboard-reminders-empty" class="hidden"></div>
                   </div>
                 </div>
               </section>
@@ -788,22 +774,22 @@
                 id="dashboard-activity-container"
                 data-dashboard-widget="activity"
                 data-widget-title="Recent activity"
-                class="bg-[var(--card)] border border-slate-200 dark:border-slate-700 rounded-3xl p-8 shadow-xl transition-all duration-200 hover:shadow-2xl"
+                class="md:col-span-1 lg:col-span-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md"
                 aria-labelledby="activity-heading"
               >
                 <div
-                  class="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 dark:border-slate-700 pb-4"
+                  class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 dark:border-gray-700 pb-4"
                   data-widget-header
                 >
                   <div class="flex min-w-0 flex-1 items-start gap-3">
                     <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-blue-100 text-blue-600 text-xl dark:bg-blue-500/10 dark:text-blue-200" aria-hidden="true">🗂️</span>
                     <div class="min-w-0 space-y-1">
-                      <h2 id="activity-heading" class="text-xl font-semibold text-slate-900 dark:text-slate-100">Recent activity</h2>
-                      <p class="text-sm text-slate-500 dark:text-slate-400">Keep track of updates across lessons, deadlines, and reminders.</p>
+                      <h2 id="activity-heading" class="text-xl font-semibold text-gray-900 dark:text-gray-100">Recent activity</h2>
+                      <p class="text-sm text-gray-500 dark:text-gray-500">Keep track of updates across lessons, deadlines, and reminders.</p>
                     </div>
                   </div>
                   <div class="flex items-center gap-2">
-                    <div class="hidden overflow-hidden rounded-full border border-slate-200 dark:border-slate-700 sm:flex" role="group" aria-label="Reorder widget">
+                    <div class="hidden overflow-hidden rounded-full border border-gray-200 dark:border-gray-700 sm:flex" role="group" aria-label="Reorder widget">
                       <button type="button" class="widget-control-btn" data-widget-action="move-up" aria-label="Move widget up">
                         <span aria-hidden="true">↑</span>
                       </button>
@@ -823,16 +809,16 @@
                 </div>
                 <div data-widget-body class="space-y-6 pt-4">
                   <div id="dashboard-activity-loading" class="space-y-3" aria-live="polite">
-                    <div class="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+                    <div class="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-500">
                       <span class="inline-flex h-2 w-2 animate-ping rounded-full bg-blue-500"></span>
                       <span>Preparing your activity feed…</span>
                     </div>
-                    <div class="rounded-2xl border border-dashed border-slate-200 bg-white/70 p-4 text-slate-500 animate-pulse dark:border-slate-700 dark:bg-slate-900/40" aria-hidden="true">
-                      <div class="h-3 w-2/3 rounded bg-slate-200/70 dark:bg-slate-700/70"></div>
-                      <div class="mt-2 h-3 w-1/2 rounded bg-slate-200/60 dark:bg-slate-700/60"></div>
+                    <div class="rounded-2xl border border-dashed border-gray-200 bg-white/70 p-4 text-gray-500 dark:text-gray-500 animate-pulse dark:border-gray-700 dark:bg-gray-900/40" aria-hidden="true">
+                      <div class="h-3 w-2/3 rounded bg-gray-200/70 dark:bg-gray-700/70"></div>
+                      <div class="mt-2 h-3 w-1/2 rounded bg-gray-200/60 dark:bg-gray-700/60"></div>
                     </div>
                   </div>
-                  <p id="dashboard-activity-empty" class="hidden text-sm text-slate-500 dark:text-slate-400">Actions you take will appear here so you can jump straight back to them.</p>
+                  <div id="dashboard-activity-empty" class="hidden"></div>
                   <ul id="dashboard-activity-list" class="hidden space-y-3" aria-live="polite" aria-busy="true"></ul>
                 </div>
               </section>
@@ -866,11 +852,11 @@
           </div>
         </div>
         <div id="cues-view" class="space-y-8">
-          <div class="bg-[var(--card)] rounded-xl border border-slate-200/70 dark:border-slate-700/60 shadow-sm p-8">
+          <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md">
             <div class="flex flex-wrap items-center justify-between gap-3 mb-6">
-              <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Create Reminder</h2>
+              <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Create Reminder</h2>
               <div class="flex items-center gap-3">
-                <span id="syncStatus" class="sync-status offline" role="status" aria-live="polite" aria-atomic="true">Offline</span>
+                <span id="syncStatus" class="sync-status offline inline-flex items-center gap-1 rounded-full border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 px-3 py-1 text-xs font-medium text-gray-600 dark:text-gray-400" role="status" aria-live="polite" aria-atomic="true">Offline</span>
                 <button
                 id="voiceBtn"
                 type="button"
@@ -884,7 +870,7 @@
             </div>
           </div>
           <div class="space-y-4">
-            <button id="openCueModal" type="button" class="btn btn-primary">Add New Cue</button>
+            <button id="openCueModal" type="button" class="inline-flex items-center justify-center gap-2 rounded-full bg-emerald-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:bg-emerald-500 dark:hover:bg-emerald-400">Add New Cue</button>
             <div id="status" class="text-sm" role="status" aria-live="polite" aria-atomic="true"></div>
             <dialog id="cue-modal" class="modal">
               <div class="modal-box space-y-6">
@@ -968,20 +954,20 @@
           </div>
         </div>
 
-        <div class="bg-[var(--card)] rounded-xl border border-slate-200/70 dark:border-slate-700/60 shadow-sm p-8">
+        <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md">
           <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
             <div class="flex gap-2 flex-wrap">
-              <button class="px-4 py-2 rounded-md border border-slate-300 bg-white text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700/60" data-filter="today" type="button">Today</button>
-              <button class="px-4 py-2 rounded-md border border-slate-300 bg-white text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700/60" data-filter="overdue" type="button">Overdue</button>
-              <button class="px-4 py-2 rounded-md border border-slate-300 bg-white text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700/60" data-filter="all" type="button">All</button>
-              <button class="px-4 py-2 rounded-md border border-slate-300 bg-white text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700/60" data-filter="done" type="button">Done</button>
+              <button class="px-4 py-2 rounded-md border border-gray-200 bg-white text-gray-600 dark:text-gray-400 transition-colors hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700/60" data-filter="today" type="button">Today</button>
+              <button class="px-4 py-2 rounded-md border border-gray-200 bg-white text-gray-600 dark:text-gray-400 transition-colors hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700/60" data-filter="overdue" type="button">Overdue</button>
+              <button class="px-4 py-2 rounded-md border border-gray-200 bg-white text-gray-600 dark:text-gray-400 transition-colors hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700/60" data-filter="all" type="button">All</button>
+              <button class="px-4 py-2 rounded-md border border-gray-200 bg-white text-gray-600 dark:text-gray-400 transition-colors hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700/60" data-filter="done" type="button">Done</button>
             </div>
             <div class="flex items-center gap-3">
               <div>
                 <label for="categoryFilter" class="sr-only">Filter by category</label>
                 <select
                   id="categoryFilter"
-                  class="px-4 py-2 border border-slate-300/80 dark:border-slate-600 rounded-md bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-slate-900/10 focus:border-slate-400 dark:focus:border-slate-500 transition-colors"
+                  class="px-4 py-2 border border-gray-200 dark:border-gray-700 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-gray-900/10 focus:border-gray-300 dark:focus:border-gray-600 transition-colors"
                 >
                   <option value="all" selected>All categories</option>
                   <option value="General">General</option>
@@ -998,7 +984,7 @@
               </div>
               <div>
                 <label for="sort" class="sr-only">Sort reminders</label>
-                <select id="sort" class="px-4 py-2 border border-slate-300/80 dark:border-slate-600 rounded-md bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-slate-900/10 focus:border-slate-400 dark:focus:border-slate-500 transition-colors">
+                <select id="sort" class="px-4 py-2 border border-gray-200 dark:border-gray-700 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-gray-900/10 focus:border-gray-300 dark:focus:border-gray-600 transition-colors">
                   <option value="smart">Smart sort</option>
                   <option value="time">Time</option>
                   <option value="priority">Priority</option>
@@ -1007,34 +993,34 @@
             </div>
           </div>
           
-          <div class="flex flex-wrap gap-6 mb-6 text-slate-600 dark:text-slate-400">
+          <div class="flex flex-wrap gap-6 mb-6 text-gray-600 dark:text-gray-400">
             <div class="flex items-center gap-2">
               <div class="w-3 h-3 bg-blue-500 rounded-full"></div>
-              <span>Today: <span id="inlineTodayCount" class="font-semibold text-slate-900 dark:text-slate-100">0</span></span>
+              <span>Today: <span id="inlineTodayCount" class="font-semibold text-gray-900 dark:text-gray-100">0</span></span>
             </div>
             <div class="flex items-center gap-2">
               <div class="w-3 h-3 bg-amber-500 rounded-full"></div>
-              <span>Overdue: <span id="inlineOverdueCount" class="font-semibold text-slate-900 dark:text-slate-100">0</span></span>
+              <span>Overdue: <span id="inlineOverdueCount" class="font-semibold text-gray-900 dark:text-gray-100">0</span></span>
             </div>
             <div class="flex items-center gap-2">
-              <div class="w-3 h-3 bg-slate-400 rounded-full"></div>
-              <span>Total: <span id="inlineTotalCount" class="font-semibold text-slate-900 dark:text-slate-100">0</span></span>
+              <div class="w-3 h-3 bg-gray-400 rounded-full"></div>
+              <span>Total: <span id="inlineTotalCount" class="font-semibold text-gray-900 dark:text-gray-100">0</span></span>
             </div>
             <div class="flex items-center gap-2">
               <div class="w-3 h-3 bg-emerald-500 rounded-full"></div>
-              <span>Completed: <span id="inlineCompletedCount" class="font-semibold text-slate-900 dark:text-slate-100">0</span></span>
+              <span>Completed: <span id="inlineCompletedCount" class="font-semibold text-gray-900 dark:text-gray-100">0</span></span>
             </div>
           </div>
 
           <div id="remindersWrapper" class="space-y-4">
-            <p id="emptyState" class="text-slate-500 dark:text-slate-400 text-sm">Add your first reminder to see it here.</p>
+            <div id="emptyState" class="text-sm"></div>
             <ul id="reminderList" class="space-y-4"></ul>
           </div>
         </div>
         </div>
         <div id="daily-list-view" class="hidden">
-          <div class="bg-[var(--card)] rounded-xl border border-slate-200/70 dark:border-slate-700/60 shadow-sm p-8 space-y-4">
-            <h2 id="daily-list-header" class="text-2xl font-bold text-slate-900 dark:text-slate-100"></h2>
+          <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md space-y-4">
+            <h2 id="daily-list-header" class="text-2xl font-bold text-gray-900 dark:text-gray-100"></h2>
             <p
               id="daily-list-permission-notice"
               class="hidden rounded-lg border border-amber-300/70 bg-amber-100/80 px-4 py-3 text-sm text-amber-900 dark:border-amber-400/50 dark:bg-amber-500/10 dark:text-amber-100"
@@ -1076,20 +1062,20 @@
     </section>
     <section data-view="planner" id="view-planner" hidden tabindex="-1">
       <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-16">
-        <div class="bg-[var(--card)] rounded-2xl shadow-xl p-8 mb-8">
+        <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md mb-8">
           <div class="flex flex-wrap items-center gap-4 justify-between">
             <div>
-              <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Weekly Planner</h2>
-              <p class="text-sm text-slate-500 dark:text-slate-400">Navigate between weeks to map lessons and key tasks.</p>
+              <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Weekly Planner</h2>
+              <p class="text-sm text-gray-500 dark:text-gray-500">Navigate between weeks to map lessons and key tasks.</p>
             </div>
             <div class="flex gap-2">
-              <button id="planner-prev" class="px-4 py-2 rounded-lg bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-200" type="button">◀</button>
+              <button id="planner-prev" class="px-4 py-2 rounded-lg bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400" type="button">◀</button>
               <button id="planner-today" class="px-4 py-2 rounded-lg bg-purple-600 text-white" type="button">This Week</button>
-              <button id="planner-next" class="px-4 py-2 rounded-lg bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-200" type="button">▶</button>
+              <button id="planner-next" class="px-4 py-2 rounded-lg bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400" type="button">▶</button>
             </div>
           </div>
           <div class="mt-6">
-            <h3 id="planner-week" class="text-lg font-semibold text-slate-900 dark:text-slate-100"></h3>
+            <h3 id="planner-week" class="text-lg font-semibold text-gray-900 dark:text-gray-100"></h3>
             <div id="planner-grid" class="mt-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"></div>
           </div>
         </div>
@@ -1097,18 +1083,18 @@
     </section>
     <section data-view="notes" id="view-notes" hidden tabindex="-1">
       <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-16">
-        <div class="bg-[var(--card)] rounded-2xl shadow-xl p-8">
+        <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md">
           <div class="flex flex-wrap items-center gap-4 justify-between mb-4">
             <div>
-              <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Quick Notes</h2>
-              <p class="text-sm text-slate-500 dark:text-slate-400">Capture ideas and convert them into reusable snippets.</p>
+              <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Quick Notes</h2>
+              <p class="text-sm text-gray-500 dark:text-gray-500">Capture ideas and convert them into reusable snippets.</p>
             </div>
             <div class="flex gap-2">
-              <button id="bullet-btn" class="px-3 py-2 rounded-lg bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-200" type="button" aria-label="Insert bullet list">• List</button>
-              <button id="number-btn" class="px-3 py-2 rounded-lg bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-200" type="button" aria-label="Insert numbered list">1. List</button>
+              <button id="bullet-btn" class="px-3 py-2 rounded-lg bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400" type="button" aria-label="Insert bullet list">• List</button>
+              <button id="number-btn" class="px-3 py-2 rounded-lg bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400" type="button" aria-label="Insert numbered list">1. List</button>
             </div>
           </div>
-          <div id="quick-note" class="min-h-[240px] p-4 border border-slate-300 dark:border-slate-700 rounded-xl bg-white/60 dark:bg-slate-900/40" contenteditable="true" aria-label="Quick note editor"></div>
+          <div id="quick-note" class="min-h-[240px] p-4 border border-gray-200 dark:border-gray-700 rounded-xl bg-white/60 dark:bg-gray-900/40" contenteditable="true" aria-label="Quick note editor"></div>
           <div class="flex flex-wrap gap-3 items-center mt-4">
             <div class="flex gap-2">
               <button id="save-note" class="px-4 py-2 rounded-lg bg-emerald-500 text-white" type="button">Save</button>
@@ -1116,8 +1102,8 @@
               <button id="delete-note" class="px-4 py-2 rounded-lg bg-rose-500 text-white" type="button">Delete</button>
               <button id="clear-note" class="px-4 py-2 rounded-lg bg-red-500 text-white" type="button">Clear</button>
             </div>
-            <label for="saved-notes" class="text-sm font-medium text-slate-700 dark:text-slate-300">Saved notes</label>
-            <select id="saved-notes" class="px-4 py-2 rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100"></select>
+            <label for="saved-notes" class="text-sm font-medium text-gray-600 dark:text-gray-400">Saved notes</label>
+            <select id="saved-notes" class="px-4 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"></select>
           </div>
         </div>
       </div>
@@ -1128,25 +1114,25 @@
           <div class="flex flex-wrap items-start justify-between gap-4">
             <div class="space-y-2">
               <p class="text-sm font-semibold uppercase tracking-wide text-emerald-600 dark:text-emerald-300">Resource library</p>
-              <h2 class="text-3xl font-bold text-slate-900 dark:text-slate-100">Activities for every lesson phase</h2>
-              <p class="text-sm text-slate-500 dark:text-slate-400">Browse ready-to-go activities curated for HPE, English, and HASS.</p>
+              <h2 class="text-3xl font-bold text-gray-900 dark:text-gray-100">Activities for every lesson phase</h2>
+              <p class="text-sm text-gray-500 dark:text-gray-500">Browse ready-to-go activities curated for HPE, English, and HASS.</p>
             </div>
-            <p id="activity-status" class="hidden text-sm font-medium text-slate-500 dark:text-slate-400"></p>
+            <p id="activity-status" class="hidden text-sm font-medium text-gray-500 dark:text-gray-500"></p>
           </div>
           <div class="grid gap-6 lg:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)]">
-            <div class="space-y-4 rounded-2xl border border-slate-200 bg-white/85 p-6 shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-900/50">
+            <div class="space-y-4 rounded-2xl border border-gray-200 bg-white/85 p-6 shadow-sm backdrop-blur dark:border-gray-700 dark:bg-gray-900/50">
               <div class="flex flex-wrap items-center gap-2" role="group" aria-label="Subjects">
-                <button type="button" data-subject="all" data-default="true" class="subject-filter inline-flex items-center rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200">All subjects</button>
-                <button type="button" data-subject="HPE" class="subject-filter inline-flex items-center rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200">HPE</button>
-                <button type="button" data-subject="English" class="subject-filter inline-flex items-center rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200">English</button>
-                <button type="button" data-subject="HASS" class="subject-filter inline-flex items-center rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200">HASS</button>
+                <button type="button" data-subject="all" data-default="true" class="subject-filter inline-flex items-center rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-semibold text-gray-600 dark:text-gray-400 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-gray-700 dark:bg-gray-800/70 dark:text-gray-400">All subjects</button>
+                <button type="button" data-subject="HPE" class="subject-filter inline-flex items-center rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-semibold text-gray-600 dark:text-gray-400 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-gray-700 dark:bg-gray-800/70 dark:text-gray-400">HPE</button>
+                <button type="button" data-subject="English" class="subject-filter inline-flex items-center rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-semibold text-gray-600 dark:text-gray-400 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-gray-700 dark:bg-gray-800/70 dark:text-gray-400">English</button>
+                <button type="button" data-subject="HASS" class="subject-filter inline-flex items-center rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-semibold text-gray-600 dark:text-gray-400 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-gray-700 dark:bg-gray-800/70 dark:text-gray-400">HASS</button>
               </div>
               <div class="flex flex-wrap items-center gap-3">
                 <div class="flex flex-wrap items-center gap-2" role="group" aria-label="Lesson phase">
-                  <button type="button" data-phase="any" class="phase-filter inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200">Any phase</button>
-                  <button type="button" data-phase="start" class="phase-filter inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200">Start</button>
-                  <button type="button" data-phase="middle" class="phase-filter inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200">Middle</button>
-                  <button type="button" data-phase="end" class="phase-filter inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200">End</button>
+                  <button type="button" data-phase="any" class="phase-filter inline-flex items-center rounded-full border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 shadow-sm transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-gray-700 dark:bg-gray-800/70 dark:text-gray-400">Any phase</button>
+                  <button type="button" data-phase="start" class="phase-filter inline-flex items-center rounded-full border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 shadow-sm transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-gray-700 dark:bg-gray-800/70 dark:text-gray-400">Start</button>
+                  <button type="button" data-phase="middle" class="phase-filter inline-flex items-center rounded-full border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 shadow-sm transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-gray-700 dark:bg-gray-800/70 dark:text-gray-400">Middle</button>
+                  <button type="button" data-phase="end" class="phase-filter inline-flex items-center rounded-full border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 shadow-sm transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:border-gray-700 dark:bg-gray-800/70 dark:text-gray-400">End</button>
                 </div>
                 <button
                   type="button"
@@ -1168,18 +1154,18 @@
                 </button>
                 <label for="activity-search" class="sr-only">Search activities</label>
                 <div class="relative order-last w-full sm:order-none sm:flex-1 sm:min-w-[220px] md:max-w-xs lg:max-w-sm">
-                  <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-slate-400" aria-hidden="true">🔍</span>
+                  <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-gray-500 dark:text-gray-500" aria-hidden="true">🔍</span>
                   <input
                     id="activity-search"
                     type="search"
                     placeholder="Search activities"
-                    class="w-full rounded-full border border-slate-200 bg-white px-4 py-2 pl-10 text-sm text-slate-700 shadow-sm outline-none transition focus:border-emerald-400 focus:ring-2 focus:ring-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100"
+                    class="w-full rounded-full border border-gray-200 bg-white px-4 py-2 pl-10 text-sm text-gray-600 dark:text-gray-400 shadow-sm outline-none transition focus:border-emerald-400 focus:ring-2 focus:ring-emerald-300 dark:border-gray-700 dark:bg-gray-800/70 dark:text-gray-100"
                   />
                 </div>
               </div>
             </div>
-            <div class="space-y-4 rounded-2xl border border-slate-200 bg-white/85 p-6 shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-900/50">
-              <h3 class="text-lg font-semibold text-slate-800 dark:text-slate-100">Add your own idea</h3>
+            <div class="space-y-4 rounded-2xl border border-gray-200 bg-white/85 p-6 shadow-sm backdrop-blur dark:border-gray-700 dark:bg-gray-900/50">
+              <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Add your own idea</h3>
               <form id="idea-form" class="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 <input
                   id="idea-title"
@@ -1187,13 +1173,13 @@
                   type="text"
                   required
                   placeholder="Title (e.g., 3-2-1 Exit Ticket)"
-                  class="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100"
+                  class="rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-gray-700 dark:bg-gray-800/70 dark:text-gray-100"
                 />
                 <select
                   id="idea-subject"
                   name="idea-subject"
                   required
-                  class="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100"
+                  class="rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-gray-700 dark:bg-gray-800/70 dark:text-gray-100"
                 >
                   <option value="" disabled selected>Subject</option>
                   <option>HPE</option><option>English</option><option>HASS</option>
@@ -1202,7 +1188,7 @@
                   id="idea-phase"
                   name="idea-phase"
                   required
-                  class="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100"
+                  class="rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-gray-700 dark:bg-gray-800/70 dark:text-gray-100"
                 >
                   <option value="" disabled selected>Phase</option>
                   <option value="start">Start</option><option value="middle">Middle</option><option value="end">End</option>
@@ -1212,21 +1198,21 @@
                   name="idea-url"
                   type="url"
                   placeholder="Optional link (https://…)"
-                  class="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100 sm:col-span-2"
+                  class="rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-gray-700 dark:bg-gray-800/70 dark:text-gray-100 sm:col-span-2"
                 />
                 <input
                   id="idea-keywords"
                   name="idea-keywords"
                   type="text"
                   placeholder="Keywords (comma, separated)"
-                  class="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100 sm:col-span-2"
+                  class="rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-gray-700 dark:bg-gray-800/70 dark:text-gray-100 sm:col-span-2"
                 />
                 <textarea
                   id="idea-description"
                   name="idea-description"
                   rows="3"
                   placeholder="Short description"
-                  class="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100 sm:col-span-2"
+                  class="rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-gray-700 dark:bg-gray-800/70 dark:text-gray-100 sm:col-span-2"
                 ></textarea>
                 <button
                   id="idea-save"
@@ -1237,11 +1223,11 @@
                 </button>
               </form>
               <div class="flex flex-wrap gap-2" id="idea-quick-filters">
-                <span class="text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">View</span>
-                <button id="filter-mine" type="button" class="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
+                <span class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-500">View</span>
+                <button id="filter-mine" type="button" class="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-gray-700 dark:bg-gray-800/70 dark:text-gray-400">
                   My ideas
                 </button>
-                <button id="filter-all" type="button" class="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
+                <button id="filter-all" type="button" class="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:border-gray-700 dark:bg-gray-800/70 dark:text-gray-400">
                   All ideas
                 </button>
               </div>
@@ -1266,19 +1252,19 @@
             </button>
           </div>
           <div id="activity-ideas-loading" class="hidden grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            <div class="animate-pulse rounded-2xl border border-emerald-200/70 bg-white/80 p-5 shadow-sm dark:border-emerald-500/30 dark:bg-slate-900/50">
+            <div class="animate-pulse rounded-2xl border border-emerald-200/70 bg-white/80 p-5 shadow-sm dark:border-emerald-500/30 dark:bg-gray-900/50">
               <div class="h-5 w-3/4 rounded bg-emerald-200/70 dark:bg-emerald-500/40"></div>
               <div class="mt-4 h-3 w-full rounded bg-emerald-200/50 dark:bg-emerald-500/20"></div>
               <div class="mt-2 h-3 w-4/5 rounded bg-emerald-200/50 dark:bg-emerald-500/20"></div>
               <div class="mt-4 h-8 w-2/3 rounded-full bg-emerald-200/60 dark:bg-emerald-500/30"></div>
             </div>
-            <div class="animate-pulse rounded-2xl border border-emerald-200/70 bg-white/80 p-5 shadow-sm dark:border-emerald-500/30 dark:bg-slate-900/50">
+            <div class="animate-pulse rounded-2xl border border-emerald-200/70 bg-white/80 p-5 shadow-sm dark:border-emerald-500/30 dark:bg-gray-900/50">
               <div class="h-5 w-2/3 rounded bg-emerald-200/70 dark:bg-emerald-500/40"></div>
               <div class="mt-4 h-3 w-full rounded bg-emerald-200/50 dark:bg-emerald-500/20"></div>
               <div class="mt-2 h-3 w-3/4 rounded bg-emerald-200/50 dark:bg-emerald-500/20"></div>
               <div class="mt-4 h-8 w-1/2 rounded-full bg-emerald-200/60 dark:bg-emerald-500/30"></div>
             </div>
-            <div class="animate-pulse rounded-2xl border border-emerald-200/70 bg-white/80 p-5 shadow-sm max-sm:hidden dark:border-emerald-500/30 dark:bg-slate-900/50">
+            <div class="animate-pulse rounded-2xl border border-emerald-200/70 bg-white/80 p-5 shadow-sm max-sm:hidden dark:border-emerald-500/30 dark:bg-gray-900/50">
               <div class="h-5 w-1/2 rounded bg-emerald-200/70 dark:bg-emerald-500/40"></div>
               <div class="mt-4 h-3 w-full rounded bg-emerald-200/50 dark:bg-emerald-500/20"></div>
               <div class="mt-2 h-3 w-2/3 rounded bg-emerald-200/50 dark:bg-emerald-500/20"></div>
@@ -1287,49 +1273,47 @@
           </div>
           <p
             id="activity-ideas-empty"
-            class="hidden rounded-xl border border-emerald-200/70 bg-white/80 p-6 text-sm text-emerald-800 shadow-sm dark:border-emerald-500/30 dark:bg-slate-900/60 dark:text-emerald-100"
+            class="hidden rounded-xl border border-emerald-200/70 bg-white/80 p-6 text-sm text-emerald-800 shadow-sm dark:border-emerald-500/30 dark:bg-gray-900/60 dark:text-emerald-100"
           >
             No ideas yet. Try adjusting your notes and generate again.
           </p>
           <div id="activity-ideas-list" class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"></div>
         </div>
         <div id="activity-loading" class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          <div class="animate-pulse rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
-            <div class="h-5 w-3/5 rounded bg-slate-200/80 dark:bg-slate-700/60"></div>
-            <div class="mt-4 h-3 w-full rounded bg-slate-200/60 dark:bg-slate-700/50"></div>
-            <div class="mt-2 h-3 w-4/5 rounded bg-slate-200/60 dark:bg-slate-700/50"></div>
-            <div class="mt-4 h-8 w-1/2 rounded-full bg-slate-200/70 dark:bg-slate-700/60"></div>
+          <div class="animate-pulse rounded-2xl border border-gray-200 bg-white/80 p-5 shadow-sm dark:border-gray-700 dark:bg-gray-900/40">
+            <div class="h-5 w-3/5 rounded bg-gray-200/80 dark:bg-gray-700/60"></div>
+            <div class="mt-4 h-3 w-full rounded bg-gray-200/60 dark:bg-gray-700/50"></div>
+            <div class="mt-2 h-3 w-4/5 rounded bg-gray-200/60 dark:bg-gray-700/50"></div>
+            <div class="mt-4 h-8 w-1/2 rounded-full bg-gray-200/70 dark:bg-gray-700/60"></div>
           </div>
-          <div class="animate-pulse rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
-            <div class="h-5 w-2/3 rounded bg-slate-200/80 dark:bg-slate-700/60"></div>
-            <div class="mt-4 h-3 w-full rounded bg-slate-200/60 dark:bg-slate-700/50"></div>
-            <div class="mt-2 h-3 w-3/4 rounded bg-slate-200/60 dark:bg-slate-700/50"></div>
-            <div class="mt-4 h-8 w-1/3 rounded-full bg-slate-200/70 dark:bg-slate-700/60"></div>
+          <div class="animate-pulse rounded-2xl border border-gray-200 bg-white/80 p-5 shadow-sm dark:border-gray-700 dark:bg-gray-900/40">
+            <div class="h-5 w-2/3 rounded bg-gray-200/80 dark:bg-gray-700/60"></div>
+            <div class="mt-4 h-3 w-full rounded bg-gray-200/60 dark:bg-gray-700/50"></div>
+            <div class="mt-2 h-3 w-3/4 rounded bg-gray-200/60 dark:bg-gray-700/50"></div>
+            <div class="mt-4 h-8 w-1/3 rounded-full bg-gray-200/70 dark:bg-gray-700/60"></div>
           </div>
-          <div class="animate-pulse rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900/40 max-sm:hidden sm:block">
-            <div class="h-5 w-1/2 rounded bg-slate-200/80 dark:bg-slate-700/60"></div>
-            <div class="mt-4 h-3 w-full rounded bg-slate-200/60 dark:bg-slate-700/50"></div>
-            <div class="mt-2 h-3 w-2/3 rounded bg-slate-200/60 dark:bg-slate-700/50"></div>
-            <div class="mt-4 h-8 w-2/5 rounded-full bg-slate-200/70 dark:bg-slate-700/60"></div>
+          <div class="animate-pulse rounded-2xl border border-gray-200 bg-white/80 p-5 shadow-sm dark:border-gray-700 dark:bg-gray-900/40 max-sm:hidden sm:block">
+            <div class="h-5 w-1/2 rounded bg-gray-200/80 dark:bg-gray-700/60"></div>
+            <div class="mt-4 h-3 w-full rounded bg-gray-200/60 dark:bg-gray-700/50"></div>
+            <div class="mt-2 h-3 w-2/3 rounded bg-gray-200/60 dark:bg-gray-700/50"></div>
+            <div class="mt-4 h-8 w-2/5 rounded-full bg-gray-200/70 dark:bg-gray-700/60"></div>
           </div>
         </div>
-        <p id="activity-empty" class="hidden rounded-2xl border border-slate-200 bg-white/80 p-8 text-center text-sm text-slate-500 shadow-sm dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300">
-          No activities match your filters just yet. Adjust your subject, phase, or search to explore more ideas.
-        </p>
+        <div id="activity-empty" class="hidden"></div>
         <div id="activity-results" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3"></div>
       </div>
     </section>
     <section data-view="templates" id="view-templates" hidden tabindex="-1">
       <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-16">
-        <div class="bg-[var(--card)] rounded-2xl shadow-xl p-8 text-center text-slate-500 dark:text-slate-400">
-          <p>Template gallery coming soon.</p>
+        <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md">
+          <div id="templates-empty"></div>
         </div>
       </div>
     </section>
     <section data-view="settings" id="view-settings" hidden tabindex="-1">
       <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-16">
-        <div class="bg-[var(--card)] rounded-2xl shadow-xl p-8 text-center text-slate-500 dark:text-slate-400">
-          <p>Customisation settings will live here.</p>
+        <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md">
+          <div id="settings-empty"></div>
         </div>
       </div>
     </section>
@@ -1352,7 +1336,7 @@
     <button
       type="button"
       data-quick-action="note"
-      class="quick-action-btn bg-white/90 text-xl text-slate-900 shadow-md backdrop-blur focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-300 hover:bg-white dark:bg-slate-800/70 dark:text-slate-100 dark:hover:bg-slate-700/80 dark:focus-visible:outline-slate-500 border border-white/60 dark:border-slate-600/60"
+      class="quick-action-btn bg-white/90 text-xl text-gray-900 dark:text-gray-100 shadow-md backdrop-blur focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-300 hover:bg-white dark:bg-gray-800/70 dark:text-gray-100 dark:hover:bg-gray-700/80 dark:focus-visible:outline-gray-500 border border-white/60 dark:border-gray-700/60"
       title="Create note"
       aria-label="Create note"
     >
@@ -1370,14 +1354,14 @@
       <span class="sr-only">New lesson plan</span>
     </button>
   </nav>
-  <footer class="bg-slate-900 text-white py-8">
+  <footer class="bg-gray-900 text-white py-8">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex flex-col sm:flex-row justify-between items-center gap-4">
-        <p class="text-sm text-slate-400">© <span id="year"></span> Memory Cue. All rights reserved.</p>
+        <p class="text-sm text-gray-500 dark:text-gray-500">© <span id="year"></span> Memory Cue. All rights reserved.</p>
         <div class="flex gap-4">
-          <a href="#" class="text-slate-400 hover:text-white transition">Privacy</a>
-          <a href="#" class="text-slate-400 hover:text-white transition">Terms</a>
-          <a href="#" class="text-slate-400 hover:text-white transition">Support</a>
+          <a href="#" class="text-gray-500 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition">Privacy</a>
+          <a href="#" class="text-gray-500 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition">Terms</a>
+          <a href="#" class="text-gray-500 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition">Support</a>
         </div>
       </div>
     </div>
@@ -1385,7 +1369,7 @@
   <div id="activity-ideas-modal" class="fixed inset-0 z-50 hidden" aria-hidden="true" inert>
     <div class="min-h-dvh w-full bg-black/50 flex items-center justify-center">
       <div
-        class="w-full max-w-lg rounded-2xl bg-white p-6 shadow-lg dark:bg-slate-900"
+        class="w-full max-w-lg rounded-2xl bg-white p-6 shadow-lg dark:bg-gray-900"
         role="dialog"
         aria-modal="true"
         aria-labelledby="ideas-title"
@@ -1395,7 +1379,7 @@
           <button
             type="button"
             data-close-modal
-            class="rounded px-2 py-1 text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
+            class="rounded px-2 py-1 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800"
             aria-label="Close"
           >
             ✕
@@ -1404,18 +1388,18 @@
         <div class="mt-4 space-y-3" id="ideas-body">
           <form id="activity-ideas-form" class="space-y-5" novalidate>
             <div class="space-y-2">
-              <h2 id="activity-ideas-modal-title" class="text-xl font-semibold text-slate-900 dark:text-slate-100">
+              <h2 id="activity-ideas-modal-title" class="text-xl font-semibold text-gray-900 dark:text-gray-100">
                 Generate fresh lesson ideas
               </h2>
-              <p id="activity-ideas-modal-description" class="text-sm text-slate-500 dark:text-slate-400">
+              <p id="activity-ideas-modal-description" class="text-sm text-gray-500 dark:text-gray-500">
                 Share your lesson focus and we'll suggest practical activities tailored to your class.
               </p>
             </div>
-            <label class="block text-sm font-semibold text-slate-800 dark:text-slate-200">
+            <label class="block text-sm font-semibold text-gray-900 dark:text-gray-100 dark:text-gray-400">
               Subject
               <select
                 name="subject"
-                class="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+                class="mt-1 w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 dark:text-gray-100 shadow-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
                 required
                 data-autofocus="true"
               >
@@ -1424,11 +1408,11 @@
                 <option value="HASS">HASS</option>
               </select>
             </label>
-            <label class="block text-sm font-semibold text-slate-800 dark:text-slate-200">
+            <label class="block text-sm font-semibold text-gray-900 dark:text-gray-100 dark:text-gray-400">
               Lesson phase
               <select
                 name="phase"
-                class="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+                class="mt-1 w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 dark:text-gray-100 shadow-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
                 required
               >
                 <option value="start">Start</option>
@@ -1436,12 +1420,12 @@
                 <option value="end">End</option>
               </select>
             </label>
-            <label class="block text-sm font-semibold text-slate-800 dark:text-slate-200">
+            <label class="block text-sm font-semibold text-gray-900 dark:text-gray-100 dark:text-gray-400">
               Notes for AI (optional)
               <textarea
                 name="notes"
                 rows="4"
-                class="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+                class="mt-1 w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 dark:text-gray-100 shadow-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
                 placeholder="Specific learning goals, equipment available, class dynamics…"
               ></textarea>
             </label>
@@ -1449,7 +1433,7 @@
               <button
                 type="button"
                 data-close-modal
-                class="rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+                class="rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-semibold text-gray-600 dark:text-gray-400 transition hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700"
               >
                 Cancel
               </button>

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -191,8 +191,12 @@ export async function initReminders(sel = {}) {
   const categoryFilter = $(sel.categoryFilterSel);
   const categoryDatalist = $(sel.categoryOptionsSel);
   const variant = sel.variant || 'mobile';
-  const emptyInitialText = sel.emptyStateInitialText || 'Add your first reminder to see it here.';
-  const emptyFilteredText = sel.emptyStateFilteredText || 'No reminders match this filter yet.';
+  const emptyInitialText = sel.emptyStateInitialText || 'Create your first reminder to keep important tasks in view.';
+  const emptyFilteredText = sel.emptyStateFilteredText || 'No reminders match the current filter. Adjust your filters or add a new cue.';
+  const sharedEmptyStateMount = (typeof window !== 'undefined' && typeof window.memoryCueMountEmptyState === 'function') ? window.memoryCueMountEmptyState : null;
+  const sharedEmptyStateCtaClasses = (typeof window !== 'undefined' && typeof window.memoryCueEmptyStateCtaClasses === 'string')
+    ? window.memoryCueEmptyStateCtaClasses
+    : 'inline-flex items-center gap-2 rounded-full bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:bg-emerald-500 dark:hover:bg-emerald-400';
   const reminderLandingPath = sel.reminderLandingPath || (variant === 'desktop' ? 'index.html#reminders' : 'mobile.html');
 
   const dispatchCueEvent = (name, detail = {}) => {
@@ -896,18 +900,18 @@ export async function initReminders(sel = {}) {
       btn.classList.toggle('active', isActive);
       btn.setAttribute('aria-pressed', String(isActive));
       if (!btn.classList.contains('btn-ghost')) {
-        btn.classList.toggle('bg-slate-900', isActive);
+        btn.classList.toggle('bg-gray-900', isActive);
         btn.classList.toggle('text-white', isActive);
-        btn.classList.toggle('border-slate-900', isActive);
-        btn.classList.toggle('dark:bg-slate-200', isActive);
-        btn.classList.toggle('dark:text-slate-900', isActive);
-        btn.classList.toggle('dark:border-slate-200', isActive);
+        btn.classList.toggle('border-gray-900', isActive);
+        btn.classList.toggle('dark:bg-gray-100', isActive);
+        btn.classList.toggle('dark:text-gray-900', isActive);
+        btn.classList.toggle('dark:border-gray-100', isActive);
         btn.classList.toggle('bg-white', !isActive);
-        btn.classList.toggle('text-slate-700', !isActive);
-        btn.classList.toggle('border-slate-300', !isActive);
-        btn.classList.toggle('dark:bg-slate-800', !isActive);
-        btn.classList.toggle('dark:text-slate-200', !isActive);
-        btn.classList.toggle('dark:border-slate-600', !isActive);
+        btn.classList.toggle('text-gray-600', !isActive);
+        btn.classList.toggle('border-gray-200', !isActive);
+        btn.classList.toggle('dark:bg-gray-800', !isActive);
+        btn.classList.toggle('dark:text-gray-400', !isActive);
+        btn.classList.toggle('dark:border-gray-700', !isActive);
       }
     });
 
@@ -916,10 +920,27 @@ export async function initReminders(sel = {}) {
 
     if(emptyStateEl){
       if(!hasAny){
-        emptyStateEl.textContent = emptyInitialText;
+        if(sharedEmptyStateMount){
+          sharedEmptyStateMount(emptyStateEl, {
+            icon: 'bell',
+            title: 'Create your first cue',
+            description: emptyInitialText,
+            action: `<button type="button" class="${sharedEmptyStateCtaClasses}" data-trigger="open-cue">Create reminder</button>`
+          });
+        } else {
+          emptyStateEl.textContent = emptyInitialText;
+        }
         emptyStateEl.classList.remove('hidden');
       } else if(!hasRows){
-        emptyStateEl.textContent = emptyFilteredText;
+        if(sharedEmptyStateMount){
+          sharedEmptyStateMount(emptyStateEl, {
+            icon: 'sparkles',
+            title: 'No reminders match this view',
+            description: emptyFilteredText
+          });
+        } else {
+          emptyStateEl.textContent = emptyFilteredText;
+        }
         emptyStateEl.classList.remove('hidden');
       } else {
         emptyStateEl.classList.add('hidden');
@@ -967,8 +988,8 @@ export async function initReminders(sel = {}) {
         headingWrapper.style.listStyle = 'none';
       }
       headingWrapper.className = variant === 'desktop'
-        ? 'text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400'
-        : 'text-xs font-semibold uppercase text-slate-400';
+        ? 'text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-500'
+        : 'text-xs font-semibold uppercase text-gray-500 dark:text-gray-500';
       if (!firstGroup) {
         headingWrapper.style.marginTop = variant === 'desktop' ? '1.25rem' : '1rem';
       }
@@ -976,12 +997,12 @@ export async function initReminders(sel = {}) {
       headingInner.setAttribute('role', 'heading');
       headingInner.setAttribute('aria-level', '3');
       headingInner.className = variant === 'desktop'
-        ? 'flex items-center justify-between gap-2 px-1 text-slate-500 dark:text-slate-400'
-        : 'flex items-center justify-between gap-2 text-slate-400';
+        ? 'flex items-center justify-between gap-2 px-1 text-gray-500 dark:text-gray-500'
+        : 'flex items-center justify-between gap-2 text-gray-500 dark:text-gray-500';
       const headingLabel = document.createElement('span');
       headingLabel.textContent = catName;
       const headingCount = document.createElement('span');
-      headingCount.className = 'text-[0.7rem] font-medium text-slate-400 dark:text-slate-500';
+      headingCount.className = 'text-[0.7rem] font-medium text-gray-500 dark:text-gray-500';
       headingCount.textContent = `${catRows.length} ${catRows.length === 1 ? 'item' : 'items'}`;
       headingInner.append(headingLabel, headingCount);
       headingWrapper.appendChild(headingInner);
@@ -1016,7 +1037,7 @@ export async function initReminders(sel = {}) {
           <h3 class="card-title text-base sm:text-lg font-semibold ${titleClasses}">${escapeHtml(r.title)}</h3>
           <div class="flex flex-wrap items-center gap-2 text-xs sm:text-sm text-base-content/70">
             <span class="badge badge-outline gap-2 text-[0.7rem] sm:text-xs">
-              <span class="h-2 w-2 rounded-full bg-slate-400"></span>
+              <span class="h-2 w-2 rounded-full bg-gray-400"></span>
               ${escapeHtml(dueLabel)}
             </span>
             <span class="badge badge-outline border-primary text-primary gap-2 text-[0.7rem] sm:text-xs">


### PR DESCRIPTION
## Summary
- align dashboard hero, cards, and controls with the new light/dark color palette, consistent border/shadow styling, and upgraded CTA buttons
- add a reusable empty state helper that renders lucide icons and richer messaging for dashboard, reminders, resources, templates, and settings views
- refresh reminders board UI with the new filter color rules, updated sync indicator, and modernized empty state actions

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_b_68d649fd881883279ba22fe282928d70