### PR TITLE
Refactor dashboard grid layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -446,9 +446,64 @@
           <div class="space-y-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" data-dashboard-area="primary">
               <section
+                data-dashboard-widget="reminders"
+                data-widget-title="Reminders needing attention"
+                class="order-1 md:col-span-2 lg:col-span-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md"
+                aria-labelledby="reminders-heading"
+              >
+                <div
+                  class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 dark:border-gray-700 pb-4"
+                  data-widget-header
+                >
+                  <div class="flex min-w-0 flex-1 items-start gap-3">
+                    <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-gray-900 text-white text-xl dark:bg-white dark:text-gray-900 dark:text-gray-100" aria-hidden="true">🔔</span>
+                    <div class="min-w-0 space-y-1">
+                      <h2 id="reminders-heading" class="text-xl font-semibold text-gray-900 dark:text-gray-100">Reminders needing attention</h2>
+                      <p class="text-sm text-gray-500 dark:text-gray-500">These are pulled automatically from the Reminders board and show tasks due today or overdue.</p>
+                    </div>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <a
+                      href="#reminders"
+                      class="inline-flex items-center gap-2 rounded-full bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:bg-emerald-500 dark:hover:bg-emerald-400"
+                    >
+                      Open reminders<span aria-hidden="true">→</span>
+                    </a>
+                    <div class="hidden overflow-hidden rounded-full border border-gray-200 dark:border-gray-700 sm:flex" role="group" aria-label="Reorder widget">
+                      <button type="button" class="widget-control-btn" data-widget-action="move-up" aria-label="Move widget up">
+                        <span aria-hidden="true">↑</span>
+                      </button>
+                      <button type="button" class="widget-control-btn" data-widget-action="move-down" aria-label="Move widget down">
+                        <span aria-hidden="true">↓</span>
+                      </button>
+                    </div>
+                    <button type="button" class="widget-control-btn" data-widget-action="collapse" aria-expanded="true" aria-label="Collapse widget">
+                      <span aria-hidden="true" data-icon>−</span>
+                      <span class="sr-only">Collapse widget</span>
+                    </button>
+                    <button type="button" class="widget-control-btn" data-widget-action="hide" aria-label="Hide widget">
+                      <span aria-hidden="true">✕</span>
+                      <span class="sr-only">Hide widget</span>
+                    </button>
+                  </div>
+                </div>
+                <div data-widget-body class="space-y-6 pt-4">
+                  <div>
+                    <div id="dashboard-reminders-skeleton" class="space-y-3 rounded-2xl border border-dashed border-gray-200 bg-white/70 p-4 text-gray-500 dark:text-gray-500 animate-pulse dark:border-gray-700 dark:bg-gray-900/40" aria-hidden="true">
+                      <div class="h-4 w-1/3 rounded bg-gray-200/70 dark:bg-gray-700/70"></div>
+                      <div class="h-16 rounded-2xl bg-gray-100/90 dark:bg-gray-800/60"></div>
+                      <div class="h-4 w-1/2 rounded bg-gray-200/60 dark:bg-gray-700/60"></div>
+                    </div>
+                    <ul id="dashboard-reminders-list" class="hidden space-y-4" aria-live="polite" aria-busy="true"></ul>
+                    <div id="dashboard-reminders-empty" class="hidden"></div>
+                  </div>
+                </div>
+              </section>
+
+              <section
                 data-dashboard-widget="lessons"
                 data-widget-title="Today's lessons"
-                class="md:col-span-2 lg:col-span-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md"
+                class="order-2 md:col-span-1 lg:col-span-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md"
                 aria-labelledby="lessons-heading"
               >
                 <div
@@ -531,10 +586,131 @@
               </section>
 
               <section
+                data-dashboard-widget="deadlines"
+                data-widget-title="Upcoming deadlines"
+                class="order-2 md:col-span-1 lg:col-span-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md"
+                aria-labelledby="deadlines-heading"
+              >
+                <div
+                  class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 dark:border-gray-700 pb-4"
+                  data-widget-header
+                >
+                  <div class="flex min-w-0 flex-1 items-start gap-3">
+                    <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-amber-100 text-amber-600 dark:bg-amber-500/10 dark:text-amber-200 text-xl" aria-hidden="true">⏰</span>
+                    <div class="min-w-0 space-y-1">
+                      <h2 id="deadlines-heading" class="text-xl font-semibold text-gray-900 dark:text-gray-100">Upcoming deadlines</h2>
+                      <p class="text-sm text-gray-500 dark:text-gray-500">Deadlines due in the next seven days with live countdowns.</p>
+                    </div>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <span class="inline-flex items-center gap-2 rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700 dark:bg-amber-500/10 dark:text-amber-200">Next 7 days</span>
+                    <div class="hidden overflow-hidden rounded-full border border-gray-200 dark:border-gray-700 sm:flex" role="group" aria-label="Reorder widget">
+                      <button type="button" class="widget-control-btn" data-widget-action="move-up" aria-label="Move widget up">
+                        <span aria-hidden="true">↑</span>
+                      </button>
+                      <button type="button" class="widget-control-btn" data-widget-action="move-down" aria-label="Move widget down">
+                        <span aria-hidden="true">↓</span>
+                      </button>
+                    </div>
+                    <button type="button" class="widget-control-btn" data-widget-action="collapse" aria-expanded="true" aria-label="Collapse widget">
+                      <span aria-hidden="true" data-icon>−</span>
+                      <span class="sr-only">Collapse widget</span>
+                    </button>
+                    <button type="button" class="widget-control-btn" data-widget-action="hide" aria-label="Hide widget">
+                      <span aria-hidden="true">✕</span>
+                      <span class="sr-only">Hide widget</span>
+                    </button>
+                  </div>
+                </div>
+                <div data-widget-body class="space-y-6 pt-4">
+                  <div>
+                    <div id="dashboard-deadlines-skeleton" class="space-y-3 rounded-2xl border border-dashed border-gray-200 bg-white/70 p-4 text-gray-500 dark:text-gray-500 animate-pulse dark:border-gray-700/70 dark:bg-gray-900/40" aria-hidden="true">
+                      <div class="h-4 w-1/2 rounded bg-gray-200/70 dark:bg-gray-700/70"></div>
+                      <div class="h-16 rounded-2xl bg-gray-100/90 dark:bg-gray-800/60"></div>
+                      <div class="h-4 w-2/3 rounded bg-gray-200/70 dark:bg-gray-700/70"></div>
+                    </div>
+                    <ul id="dashboard-deadlines-list" class="hidden space-y-4" aria-live="polite" aria-busy="true"></ul>
+                    <div id="dashboard-deadlines-empty" class="hidden"></div>
+                  </div>
+                  <form id="deadline-form" class="grid grid-cols-1 gap-3 md:grid-cols-5" aria-describedby="deadline-feedback">
+                    <div class="md:col-span-2">
+                      <label for="deadline-title" class="block text-sm font-medium text-gray-600 dark:text-gray-400">Deadline</label>
+                      <input id="deadline-title" name="deadline-title" type="text" required placeholder="e.g. Year 9 essays" class="mt-1 w-full rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
+                    </div>
+                    <div>
+                      <label for="deadline-due" class="block text-sm font-medium text-gray-600 dark:text-gray-400">Due</label>
+                      <input id="deadline-due" name="deadline-due" type="datetime-local" required class="mt-1 w-full rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
+                    </div>
+                    <div>
+                      <label for="deadline-course" class="block text-sm font-medium text-gray-600 dark:text-gray-400">Class / group</label>
+                      <input id="deadline-course" name="deadline-course" type="text" placeholder="Optional" class="mt-1 w-full rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
+                    </div>
+                    <div class="flex items-end">
+                      <button type="submit" class="inline-flex w-full items-center justify-center rounded-xl bg-amber-500 px-4 py-2.5 font-semibold text-white shadow transition hover:bg-amber-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500">Add deadline</button>
+                    </div>
+                  </form>
+                  <p id="deadline-feedback" class="hidden text-sm font-medium"></p>
+                </div>
+              </section>
+
+              <section
+                id="dashboard-activity-container"
+                data-dashboard-widget="activity"
+                data-widget-title="Recent activity"
+                class="order-3 md:col-span-2 lg:col-span-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md"
+                aria-labelledby="activity-heading"
+              >
+                <div
+                  class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 dark:border-gray-700 pb-4"
+                  data-widget-header
+                >
+                  <div class="flex min-w-0 flex-1 items-start gap-3">
+                    <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-blue-100 text-blue-600 text-xl dark:bg-blue-500/10 dark:text-blue-200" aria-hidden="true">🗂️</span>
+                    <div class="min-w-0 space-y-1">
+                      <h2 id="activity-heading" class="text-xl font-semibold text-gray-900 dark:text-gray-100">Recent activity</h2>
+                      <p class="text-sm text-gray-500 dark:text-gray-500">Keep track of updates across lessons, deadlines, and reminders.</p>
+                    </div>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <div class="hidden overflow-hidden rounded-full border border-gray-200 dark:border-gray-700 sm:flex" role="group" aria-label="Reorder widget">
+                      <button type="button" class="widget-control-btn" data-widget-action="move-up" aria-label="Move widget up">
+                        <span aria-hidden="true">↑</span>
+                      </button>
+                      <button type="button" class="widget-control-btn" data-widget-action="move-down" aria-label="Move widget down">
+                        <span aria-hidden="true">↓</span>
+                      </button>
+                    </div>
+                    <button type="button" class="widget-control-btn" data-widget-action="collapse" aria-expanded="true" aria-label="Collapse widget">
+                      <span aria-hidden="true" data-icon>−</span>
+                      <span class="sr-only">Collapse widget</span>
+                    </button>
+                    <button type="button" class="widget-control-btn" data-widget-action="hide" aria-label="Hide widget">
+                      <span aria-hidden="true">✕</span>
+                      <span class="sr-only">Hide widget</span>
+                    </button>
+                  </div>
+                </div>
+                <div data-widget-body class="space-y-6 pt-4">
+                  <div id="dashboard-activity-loading" class="space-y-3" aria-live="polite">
+                    <div class="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-500">
+                      <span class="inline-flex h-2 w-2 animate-ping rounded-full bg-blue-500"></span>
+                      <span>Preparing your activity feed…</span>
+                    </div>
+                    <div class="rounded-2xl border border-dashed border-gray-200 bg-white/70 p-4 text-gray-500 dark:text-gray-500 animate-pulse dark:border-gray-700 dark:bg-gray-900/40" aria-hidden="true">
+                      <div class="h-3 w-2/3 rounded bg-gray-200/70 dark:bg-gray-700/70"></div>
+                      <div class="mt-2 h-3 w-1/2 rounded bg-gray-200/60 dark:bg-gray-700/60"></div>
+                    </div>
+                  </div>
+                  <div id="dashboard-activity-empty" class="hidden"></div>
+                  <ul id="dashboard-activity-list" class="hidden space-y-3" aria-live="polite" aria-busy="true"></ul>
+                </div>
+              </section>
+
+              <section
                 data-dashboard-widget="weather"
                 data-widget-title="Outdoor planning"
                 data-widget-theme="inverted"
-                class="md:col-span-2 lg:col-span-1 bg-gradient-to-br from-sky-500 via-indigo-500 to-emerald-500 text-white rounded-lg shadow-sm border border-white/40 p-6 transition-shadow duration-200 hover:shadow-md"
+                class="order-3 md:col-span-1 lg:col-span-1 bg-gradient-to-br from-sky-500 via-indigo-500 to-emerald-500 text-white rounded-lg shadow-sm border border-white/40 p-6 transition-shadow duration-200 hover:shadow-md"
                 aria-labelledby="weather-heading"
               >
                 <div
@@ -646,182 +822,16 @@
               </p>
             </aside>
 
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" data-dashboard-area="secondary">
-              <section
-                data-dashboard-widget="deadlines"
-                data-widget-title="Upcoming deadlines"
-                class="md:col-span-1 lg:col-span-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md"
-                aria-labelledby="deadlines-heading"
-              >
-                <div
-                  class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 dark:border-gray-700 pb-4"
-                  data-widget-header
-                >
-                  <div class="flex min-w-0 flex-1 items-start gap-3">
-                    <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-amber-100 text-amber-600 dark:bg-amber-500/10 dark:text-amber-200 text-xl" aria-hidden="true">⏰</span>
-                    <div class="min-w-0 space-y-1">
-                      <h2 id="deadlines-heading" class="text-xl font-semibold text-gray-900 dark:text-gray-100">Upcoming deadlines</h2>
-                      <p class="text-sm text-gray-500 dark:text-gray-500">Deadlines due in the next seven days with live countdowns.</p>
-                    </div>
-                  </div>
-                  <div class="flex items-center gap-2">
-                    <span class="inline-flex items-center gap-2 rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700 dark:bg-amber-500/10 dark:text-amber-200">Next 7 days</span>
-                    <div class="hidden overflow-hidden rounded-full border border-gray-200 dark:border-gray-700 sm:flex" role="group" aria-label="Reorder widget">
-                      <button type="button" class="widget-control-btn" data-widget-action="move-up" aria-label="Move widget up">
-                        <span aria-hidden="true">↑</span>
-                      </button>
-                      <button type="button" class="widget-control-btn" data-widget-action="move-down" aria-label="Move widget down">
-                        <span aria-hidden="true">↓</span>
-                      </button>
-                    </div>
-                    <button type="button" class="widget-control-btn" data-widget-action="collapse" aria-expanded="true" aria-label="Collapse widget">
-                      <span aria-hidden="true" data-icon>−</span>
-                      <span class="sr-only">Collapse widget</span>
-                    </button>
-                    <button type="button" class="widget-control-btn" data-widget-action="hide" aria-label="Hide widget">
-                      <span aria-hidden="true">✕</span>
-                      <span class="sr-only">Hide widget</span>
-                    </button>
-                  </div>
-                </div>
-                <div data-widget-body class="space-y-6 pt-4">
-                  <div>
-                    <div id="dashboard-deadlines-skeleton" class="space-y-3 rounded-2xl border border-dashed border-gray-200 bg-white/70 p-4 text-gray-500 dark:text-gray-500 animate-pulse dark:border-gray-700/70 dark:bg-gray-900/40" aria-hidden="true">
-                      <div class="h-4 w-1/2 rounded bg-gray-200/70 dark:bg-gray-700/70"></div>
-                      <div class="h-16 rounded-2xl bg-gray-100/90 dark:bg-gray-800/60"></div>
-                      <div class="h-4 w-2/3 rounded bg-gray-200/70 dark:bg-gray-700/70"></div>
-                    </div>
-                    <ul id="dashboard-deadlines-list" class="hidden space-y-4" aria-live="polite" aria-busy="true"></ul>
-                    <div id="dashboard-deadlines-empty" class="hidden"></div>
-                  </div>
-                  <form id="deadline-form" class="grid grid-cols-1 gap-3 md:grid-cols-5" aria-describedby="deadline-feedback">
-                    <div class="md:col-span-2">
-                      <label for="deadline-title" class="block text-sm font-medium text-gray-600 dark:text-gray-400">Deadline</label>
-                      <input id="deadline-title" name="deadline-title" type="text" required placeholder="e.g. Year 9 essays" class="mt-1 w-full rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
-                    </div>
-                    <div>
-                      <label for="deadline-due" class="block text-sm font-medium text-gray-600 dark:text-gray-400">Due</label>
-                      <input id="deadline-due" name="deadline-due" type="datetime-local" required class="mt-1 w-full rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
-                    </div>
-                    <div>
-                      <label for="deadline-course" class="block text-sm font-medium text-gray-600 dark:text-gray-400">Class / group</label>
-                      <input id="deadline-course" name="deadline-course" type="text" placeholder="Optional" class="mt-1 w-full rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-amber-500" />
-                    </div>
-                    <div class="flex items-end">
-                      <button type="submit" class="inline-flex w-full items-center justify-center rounded-xl bg-amber-500 px-4 py-2.5 font-semibold text-white shadow transition hover:bg-amber-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500">Add deadline</button>
-                    </div>
-                  </form>
-                  <p id="deadline-feedback" class="hidden text-sm font-medium"></p>
-                </div>
-              </section>
-
-              <section
-                data-dashboard-widget="reminders"
-                data-widget-title="Reminders needing attention"
-                class="md:col-span-2 lg:col-span-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md"
-                aria-labelledby="reminders-heading"
-              >
-                <div
-                  class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 dark:border-gray-700 pb-4"
-                  data-widget-header
-                >
-                  <div class="flex min-w-0 flex-1 items-start gap-3">
-                    <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-gray-900 text-white text-xl dark:bg-white dark:text-gray-900 dark:text-gray-100" aria-hidden="true">🔔</span>
-                    <div class="min-w-0 space-y-1">
-                      <h2 id="reminders-heading" class="text-xl font-semibold text-gray-900 dark:text-gray-100">Reminders needing attention</h2>
-                      <p class="text-sm text-gray-500 dark:text-gray-500">These are pulled automatically from the Reminders board and show tasks due today or overdue.</p>
-                    </div>
-                  </div>
-                  <div class="flex items-center gap-2">
-                    <a
-                      href="#reminders"
-                      class="inline-flex items-center gap-2 rounded-full bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 dark:bg-emerald-500 dark:hover:bg-emerald-400"
-                    >
-                      Open reminders<span aria-hidden="true">→</span>
-                    </a>
-                    <div class="hidden overflow-hidden rounded-full border border-gray-200 dark:border-gray-700 sm:flex" role="group" aria-label="Reorder widget">
-                      <button type="button" class="widget-control-btn" data-widget-action="move-up" aria-label="Move widget up">
-                        <span aria-hidden="true">↑</span>
-                      </button>
-                      <button type="button" class="widget-control-btn" data-widget-action="move-down" aria-label="Move widget down">
-                        <span aria-hidden="true">↓</span>
-                      </button>
-                    </div>
-                    <button type="button" class="widget-control-btn" data-widget-action="collapse" aria-expanded="true" aria-label="Collapse widget">
-                      <span aria-hidden="true" data-icon>−</span>
-                      <span class="sr-only">Collapse widget</span>
-                    </button>
-                    <button type="button" class="widget-control-btn" data-widget-action="hide" aria-label="Hide widget">
-                      <span aria-hidden="true">✕</span>
-                      <span class="sr-only">Hide widget</span>
-                    </button>
-                  </div>
-                </div>
-                <div data-widget-body class="space-y-6 pt-4">
-                  <div>
-                    <div id="dashboard-reminders-skeleton" class="space-y-3 rounded-2xl border border-dashed border-gray-200 bg-white/70 p-4 text-gray-500 dark:text-gray-500 animate-pulse dark:border-gray-700 dark:bg-gray-900/40" aria-hidden="true">
-                      <div class="h-4 w-1/3 rounded bg-gray-200/70 dark:bg-gray-700/70"></div>
-                      <div class="h-16 rounded-2xl bg-gray-100/90 dark:bg-gray-800/60"></div>
-                      <div class="h-4 w-1/2 rounded bg-gray-200/60 dark:bg-gray-700/60"></div>
-                    </div>
-                    <ul id="dashboard-reminders-list" class="hidden space-y-4" aria-live="polite" aria-busy="true"></ul>
-                    <div id="dashboard-reminders-empty" class="hidden"></div>
-                  </div>
-                </div>
-              </section>
-
-              <section
-                id="dashboard-activity-container"
-                data-dashboard-widget="activity"
-                data-widget-title="Recent activity"
-                class="md:col-span-1 lg:col-span-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md"
-                aria-labelledby="activity-heading"
-              >
-                <div
-                  class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 dark:border-gray-700 pb-4"
-                  data-widget-header
-                >
-                  <div class="flex min-w-0 flex-1 items-start gap-3">
-                    <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-blue-100 text-blue-600 text-xl dark:bg-blue-500/10 dark:text-blue-200" aria-hidden="true">🗂️</span>
-                    <div class="min-w-0 space-y-1">
-                      <h2 id="activity-heading" class="text-xl font-semibold text-gray-900 dark:text-gray-100">Recent activity</h2>
-                      <p class="text-sm text-gray-500 dark:text-gray-500">Keep track of updates across lessons, deadlines, and reminders.</p>
-                    </div>
-                  </div>
-                  <div class="flex items-center gap-2">
-                    <div class="hidden overflow-hidden rounded-full border border-gray-200 dark:border-gray-700 sm:flex" role="group" aria-label="Reorder widget">
-                      <button type="button" class="widget-control-btn" data-widget-action="move-up" aria-label="Move widget up">
-                        <span aria-hidden="true">↑</span>
-                      </button>
-                      <button type="button" class="widget-control-btn" data-widget-action="move-down" aria-label="Move widget down">
-                        <span aria-hidden="true">↓</span>
-                      </button>
-                    </div>
-                    <button type="button" class="widget-control-btn" data-widget-action="collapse" aria-expanded="true" aria-label="Collapse widget">
-                      <span aria-hidden="true" data-icon>−</span>
-                      <span class="sr-only">Collapse widget</span>
-                    </button>
-                    <button type="button" class="widget-control-btn" data-widget-action="hide" aria-label="Hide widget">
-                      <span aria-hidden="true">✕</span>
-                      <span class="sr-only">Hide widget</span>
-                    </button>
-                  </div>
-                </div>
-                <div data-widget-body class="space-y-6 pt-4">
-                  <div id="dashboard-activity-loading" class="space-y-3" aria-live="polite">
-                    <div class="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-500">
-                      <span class="inline-flex h-2 w-2 animate-ping rounded-full bg-blue-500"></span>
-                      <span>Preparing your activity feed…</span>
-                    </div>
-                    <div class="rounded-2xl border border-dashed border-gray-200 bg-white/70 p-4 text-gray-500 dark:text-gray-500 animate-pulse dark:border-gray-700 dark:bg-gray-900/40" aria-hidden="true">
-                      <div class="h-3 w-2/3 rounded bg-gray-200/70 dark:bg-gray-700/70"></div>
-                      <div class="mt-2 h-3 w-1/2 rounded bg-gray-200/60 dark:bg-gray-700/60"></div>
-                    </div>
-                  </div>
-                  <div id="dashboard-activity-empty" class="hidden"></div>
-                  <ul id="dashboard-activity-list" class="hidden space-y-3" aria-live="polite" aria-busy="true"></ul>
-                </div>
-              </section>
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              <div class="rounded-lg border-2 border-dashed border-gray-200 bg-white/60 p-6 text-sm text-gray-500 shadow-sm dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-500">
+                Placeholder widget slot
+              </div>
+              <div class="rounded-lg border-2 border-dashed border-gray-200 bg-white/60 p-6 text-sm text-gray-500 shadow-sm dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-500">
+                Placeholder widget slot
+              </div>
+              <div class="rounded-lg border-2 border-dashed border-gray-200 bg-white/60 p-6 text-sm text-gray-500 shadow-sm dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-500">
+                Placeholder widget slot
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- make the reminders widget span the full dashboard width and lead the responsive grid
- update lessons, deadlines, activity, and weather cards to share a consistent two/three-column layout
- add a three-column placeholder grid at the bottom for future widgets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d65266eaac832790b8cb29b7620fc5