### PR TITLE
Add import map for three-mesh-bvh CDN resolution

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,16 @@
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="stylesheet" href="./styles/tokens.css" />
   <link rel="stylesheet" href="./styles/a11y.css" />
+  <!-- Map bare module imports used by 3D helper modules to CDN builds -->
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js",
+        "three/examples/": "https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/",
+        "three-mesh-bvh": "https://cdn.jsdelivr.net/npm/three-mesh-bvh@0.7.5/build/index.module.js"
+      }
+    }
+  </script>
   <style>
     /* Example: Make text in the 'dark' theme a light gray instead of pure white */
     [data-theme="dark"] body {

--- a/mobile.html
+++ b/mobile.html
@@ -9,6 +9,16 @@
   <link rel="stylesheet" href="./styles/tokens.css" />
   <link rel="stylesheet" href="./styles/a11y.css" />
   <link rel="stylesheet" href="dist/styles.css" />
+  <!-- Map bare module imports used by 3D helper modules to CDN builds -->
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js",
+        "three/examples/": "https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/",
+        "three-mesh-bvh": "https://cdn.jsdelivr.net/npm/three-mesh-bvh@0.7.5/build/index.module.js"
+      }
+    }
+  </script>
 </head>
 <body class="min-h-screen bg-base-200 text-base-content">
   <a class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-full focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-primary-content" href="#mainContent">Skip to main content</a>


### PR DESCRIPTION
## Summary
- add an import map in the main and mobile HTML shells to map three.js and three-mesh-bvh to CDN modules so bare imports work in the browser
- document the purpose of the import map to clarify why the mapping exists

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68eaea6c7bf083279e6172380764958b