### PR TITLE
Fix manifest path for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
   <link rel="dns-prefetch" href="https://www.gstatic.com">
   <!-- PWA manifest -->
   <link rel="manifest" href="manifest.webmanifest" />
+  <link rel="icon" href="./icons/icon-192.svg" type="image/svg+xml" />
   <link rel="stylesheet" href="./styles/tokens.css" />
   <link rel="stylesheet" href="./styles/a11y.css" />
   <style>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,8 +1,8 @@
 {
   "name": "Memory Cue — Reminders",
   "short_name": "Memory Cue",
-  "start_url": "/",
-  "scope": "/",
+  "start_url": "./",
+  "scope": "./",
   "display": "standalone",
   "theme_color": "#0f172a",
   "background_color": "#0f172a",

--- a/mobile.html
+++ b/mobile.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Memory Cue (Mobile) — Inline + Edit + Sync All</title>
   <meta name="theme-color" content="#0f172a" />
-  <link rel="manifest" href="/manifest.webmanifest" id="manifestLink" />
+  <link rel="manifest" href="manifest.webmanifest" id="manifestLink" />
+  <link rel="icon" href="./icons/icon-192.svg" type="image/svg+xml" />
   <link rel="stylesheet" href="./styles/tokens.css" />
   <link rel="stylesheet" href="./styles/a11y.css" />
   <link rel="stylesheet" href="dist/styles.css" />


### PR DESCRIPTION
## Summary
- update the PWA manifest scope/start URL so installs stay scoped to the deployed subdirectory
- point mobile manifest reference at the relative file and add a favicon link for both entry points

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_b_68eb16afd5cc83278fb18e445e24e013