### PR TITLE
Defer local scripts and extract inline CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,9 @@
 <!doctype html>
 <html lang="en" data-theme="caramellatte">
 <head>
+  <!-- BEGIN GPT CHANGE: external styles -->
+  <link rel="stylesheet" href="./styles/index.css">
+  <!-- END GPT CHANGE -->
   <!-- === SUPABASE CONFIG (put before your main JS) === -->
 <!-- BEGIN GPT CHANGE: supabase keys moved to env.js -->
 <!-- END GPT CHANGE -->
@@ -38,18 +41,8 @@
   <link rel="icon" href="./icons/icon-192.svg" type="image/svg+xml" />
   <link rel="stylesheet" href="./styles/tokens.css" />
   <link rel="stylesheet" href="./styles/a11y.css" />
-  <style>
-    /* Example: Make text in the 'dark' theme a light gray instead of pure white */
-    [data-theme="dark"] body {
-      color: #d1d5db; /* Tailwind's gray-300 */
-    }
-
-    /* Example: Make headings in the 'retro' theme a different color */
-    [data-theme="retro"] h1,
-    [data-theme="retro"] h2 {
-      color: #facc15; /* Tailwind's yellow-400, for a retro vibe */
-    }
-  </style>
+  <!-- BEGIN GPT CHANGE: styles moved to styles/index.css -->
+  <!-- END GPT CHANGE -->
   <!-- Tailwind v4 (Play CDN) -->
   <script
     defer
@@ -64,211 +57,12 @@
     crossorigin="anonymous"
   />
   <link rel="stylesheet" href="./styles/daisy-themes.css" />
-  <style>
-    html { scroll-behavior: smooth; }
-    /* Your existing Tailwind / other styles here */
-    .hidden { display: none; }
-    /* Safe area helper used by header (Tailwind doesn't ship this) */
-    .pt-safe-top { padding-top: env(safe-area-inset-top); }
-
-    /* Custom modern gradients */
-    .card-gradient {
-      background: linear-gradient(135deg, rgba(102, 126, 234, 0.1) 0%, rgba(118, 75, 162, 0.1) 100%);
-      backdrop-filter: blur(10px);
-    }
-
-    .nav-gradient {
-      background: linear-gradient(90deg, rgba(102, 126, 234, 0.9) 0%, rgba(118, 75, 162, 0.9) 100%);
-      backdrop-filter: blur(10px);
-    }
-    
-    .glass-effect {
-      background: rgba(255, 255, 255, 0.1);
-      backdrop-filter: blur(10px);
-      border: 1px solid rgba(255, 255, 255, 0.2);
-    }
-    
-    .dark .glass-effect {
-      background: rgba(15, 23, 42, 0.8);
-      backdrop-filter: blur(10px);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-    }
-    
-    .nav-desktop {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.25rem;
-    }
-
-    .sync-status {
-      transition: all 0.2s ease;
-    }
-
-    .sync-status.online {
-      background: rgba(22, 163, 74, 0.12);
-      color: rgb(22 163 74);
-      border-color: rgba(22, 163, 74, 0.3);
-    }
-
-    .dark .sync-status.online {
-      background: rgba(34, 197, 94, 0.16);
-      color: rgb(187 247 208);
-      border-color: rgba(34, 197, 94, 0.4);
-    }
-
-    .sync-status.error {
-      background: rgba(248, 113, 113, 0.16);
-      color: rgb(220 38 38);
-      border-color: rgba(248, 113, 113, 0.32);
-    }
-
-    .dark .sync-status.error {
-      background: rgba(248, 113, 113, 0.22);
-      color: rgb(254 205 211);
-      border-color: rgba(248, 113, 113, 0.45);
-    }
-
-    @keyframes widget-pop {
-      0% {
-        opacity: 0;
-        transform: translateY(8px) scale(0.98);
-      }
-      60% {
-        opacity: 1;
-        transform: translateY(-2px) scale(1.02);
-      }
-      100% {
-        opacity: 1;
-        transform: translateY(0) scale(1);
-      }
-    }
-
-    @keyframes dashboard-bump {
-      0% {
-        transform: scale(1);
-      }
-      35% {
-        transform: scale(1.08);
-      }
-      100% {
-        transform: scale(1);
-      }
-    }
-
-    @keyframes dashboard-highlight {
-      0% {
-        box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.45);
-      }
-      70% {
-        box-shadow: 0 0 0 12px rgba(59, 130, 246, 0);
-      }
-      100% {
-        box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
-      }
-    }
-
-    .animate-widget-pop {
-      animation: widget-pop 0.38s cubic-bezier(0.16, 1, 0.3, 1);
-    }
-
-    .dashboard-bump {
-      animation: dashboard-bump 0.45s ease;
-    }
-
-    .dashboard-highlight {
-      animation: dashboard-highlight 0.85s ease-out;
-    }
-
-    .quick-action-btn {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 3rem;
-      height: 3rem;
-      border-radius: 9999px;
-      padding: 0;
-      transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
-      box-shadow: 0 14px 30px -20px rgba(76, 29, 149, 0.4);
-      opacity: 0.92;
-    }
-
-    .quick-action-btn span[aria-hidden="true"] {
-      line-height: 1;
-    }
-
-    .quick-action-btn:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 16px 34px -18px rgba(76, 29, 149, 0.45);
-      opacity: 1;
-    }
-
-    .quick-action-btn:focus-visible {
-      outline: 2px solid rgba(99, 102, 241, 0.9);
-      outline-offset: 3px;
-    }
-
-    .widget-control-btn {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 2.25rem;
-      height: 2.25rem;
-      border-radius: 9999px;
-      border: 1px solid rgba(148, 163, 184, 0.35);
-      background: rgba(248, 250, 252, 0.9);
-      color: rgb(100 116 139);
-      font-weight: 600;
-      transition: transform 0.18s ease, box-shadow 0.18s ease, background-color 0.18s ease;
-    }
-
-    .dark .widget-control-btn {
-      background: rgba(15, 23, 42, 0.7);
-      border-color: rgba(71, 85, 105, 0.65);
-      color: rgb(203 213 225);
-    }
-
-    .widget-control-btn:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 16px 35px -20px rgba(30, 64, 175, 0.55);
-    }
-
-    .widget-control-btn:focus-visible {
-      outline: 2px solid rgba(59, 130, 246, 0.85);
-      outline-offset: 2px;
-    }
-
-    .widget-control-btn[disabled] {
-      opacity: 0.4;
-      cursor: not-allowed;
-      transform: none;
-      box-shadow: none;
-    }
-
-    .widget-control-btn span[aria-hidden="true"] {
-      font-size: 1rem;
-      line-height: 1;
-    }
-
-    [data-widget-theme="inverted"] .widget-control-btn {
-      background: rgba(255, 255, 255, 0.18);
-      border-color: rgba(255, 255, 255, 0.35);
-      color: rgba(255, 255, 255, 0.94);
-    }
-
-    [data-widget-theme="inverted"] .widget-control-btn:hover {
-      box-shadow: 0 16px 35px -18px rgba(15, 23, 42, 0.45);
-    }
-
-    .dark [data-widget-theme="inverted"] .widget-control-btn {
-      background: rgba(15, 23, 42, 0.65);
-      border-color: rgba(148, 163, 184, 0.45);
-      color: rgb(226 232 240);
-    }
-  </style>
+  <!-- BEGIN GPT CHANGE: styles moved to styles/index.css -->
+  <!-- END GPT CHANGE -->
   <script type="module">
     window.__SUPABASE_ENV__ = typeof import.meta !== 'undefined' && import.meta ? import.meta.env : undefined;
   </script>
-  <script type="module" src="./js/main.js"></script>
+  <script type="module" src="./js/main.js" defer></script>
 </head>
 <body id="top" class="bg-base-100 text-base-content antialiased leading-7 min-h-screen">
   <a class="skip-link" href="#mainContent">Skip to main content</a>
@@ -1692,7 +1486,7 @@
     // Optionally, set values via server or dev-only override.
   </script>
   <!-- END GPT CHANGE -->
-  <script type="module" src="./app.js"></script>
+  <script type="module" src="./app.js" defer></script>
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,0 +1,213 @@
+[data-theme="dark"] body {
+  color: #d1d5db;
+}
+
+[data-theme="retro"] h1,
+[data-theme="retro"] h2 {
+  color: #facc15;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+.hidden {
+  display: none;
+}
+
+.pt-safe-top {
+  padding-top: env(safe-area-inset-top);
+}
+
+.card-gradient {
+  background: linear-gradient(135deg, rgba(102, 126, 234, 0.1) 0%, rgba(118, 75, 162, 0.1) 100%);
+  backdrop-filter: blur(10px);
+}
+
+.nav-gradient {
+  background: linear-gradient(90deg, rgba(102, 126, 234, 0.9) 0%, rgba(118, 75, 162, 0.9) 100%);
+  backdrop-filter: blur(10px);
+}
+
+.glass-effect {
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.dark .glass-effect {
+  background: rgba(15, 23, 42, 0.8);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.nav-desktop {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.sync-status {
+  transition: all 0.2s ease;
+}
+
+.sync-status.online {
+  background: rgba(22, 163, 74, 0.12);
+  color: rgb(22 163 74);
+  border-color: rgba(22, 163, 74, 0.3);
+}
+
+.dark .sync-status.online {
+  background: rgba(34, 197, 94, 0.16);
+  color: rgb(187 247 208);
+  border-color: rgba(34, 197, 94, 0.4);
+}
+
+.sync-status.error {
+  background: rgba(248, 113, 113, 0.16);
+  color: rgb(220 38 38);
+  border-color: rgba(248, 113, 113, 0.32);
+}
+
+.dark .sync-status.error {
+  background: rgba(248, 113, 113, 0.22);
+  color: rgb(254 205 211);
+  border-color: rgba(248, 113, 113, 0.45);
+}
+
+@keyframes widget-pop {
+  0% {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+  }
+  60% {
+    opacity: 1;
+    transform: translateY(-2px) scale(1.02);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes dashboard-bump {
+  0% {
+    transform: scale(1);
+  }
+  35% {
+    transform: scale(1.08);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes dashboard-highlight {
+  0% {
+    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.45);
+  }
+  70% {
+    box-shadow: 0 0 0 12px rgba(59, 130, 246, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
+  }
+}
+
+.animate-widget-pop {
+  animation: widget-pop 0.38s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.dashboard-bump {
+  animation: dashboard-bump 0.45s ease;
+}
+
+.dashboard-highlight {
+  animation: dashboard-highlight 0.85s ease-out;
+}
+
+.quick-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 9999px;
+  padding: 0;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  box-shadow: 0 14px 30px -20px rgba(76, 29, 149, 0.4);
+  opacity: 0.92;
+}
+
+.quick-action-btn span[aria-hidden="true"] {
+  line-height: 1;
+}
+
+.quick-action-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 34px -18px rgba(76, 29, 149, 0.45);
+  opacity: 1;
+}
+
+.quick-action-btn:focus-visible {
+  outline: 2px solid rgba(99, 102, 241, 0.9);
+  outline-offset: 3px;
+}
+
+.widget-control-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(248, 250, 252, 0.9);
+  color: rgb(100 116 139);
+  font-weight: 600;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background-color 0.18s ease;
+}
+
+.dark .widget-control-btn {
+  background: rgba(15, 23, 42, 0.7);
+  border-color: rgba(71, 85, 105, 0.65);
+  color: rgb(203 213 225);
+}
+
+.widget-control-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 35px -20px rgba(30, 64, 175, 0.55);
+}
+
+.widget-control-btn:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.85);
+  outline-offset: 2px;
+}
+
+.widget-control-btn[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.widget-control-btn span[aria-hidden="true"] {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+[data-widget-theme="inverted"] .widget-control-btn {
+  background: rgba(255, 255, 255, 0.18);
+  border-color: rgba(255, 255, 255, 0.35);
+  color: rgba(255, 255, 255, 0.94);
+}
+
+[data-widget-theme="inverted"] .widget-control-btn:hover {
+  box-shadow: 0 16px 35px -18px rgba(15, 23, 42, 0.45);
+}
+
+.dark [data-widget-theme="inverted"] .widget-control-btn {
+  background: rgba(15, 23, 42, 0.65);
+  border-color: rgba(148, 163, 184, 0.45);
+  color: rgb(226 232 240);
+}


### PR DESCRIPTION
## Summary
- move the large inline style blocks in `index.html` into a new `styles/index.css`
- add a dedicated stylesheet link so the extracted rules load with the page
- mark local module scripts with `defer` to avoid blocking HTML parsing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68eb217625008327a008d4c525c45a72