### PR TITLE
Add live region updates for dashboard widget toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,7 +284,16 @@
                         <span aria-hidden="true">↓</span>
                       </button>
                     </div>
-                    <button type="button" class="widget-control-btn" data-widget-action="collapse" aria-expanded="true" aria-label="Collapse widget">
+                    <button
+                      type="button"
+                      class="widget-control-btn"
+                      data-widget-action="collapse"
+                      data-widget-toggle
+                      data-widget-name="Reminders needing attention"
+                      aria-expanded="true"
+                      aria-controls="widget-reminders-body"
+                      aria-label="Collapse widget"
+                    >
                       <span aria-hidden="true" data-icon>−</span>
                       <span class="sr-only">Collapse widget</span>
                     </button>
@@ -294,7 +303,7 @@
                     </button>
                   </div>
                 </div>
-                <div data-widget-body class="space-y-6 pt-4">
+                <div id="widget-reminders-body" data-widget-body class="space-y-6 pt-4">
                   <div>
                     <div id="dashboard-reminders-skeleton" class="space-y-3 rounded-2xl border border-dashed border-gray-200 bg-white/70 p-4 text-gray-500 dark:text-gray-500 animate-pulse dark:border-gray-700 dark:bg-gray-900/40" aria-hidden="true">
                       <div class="h-4 w-1/3 rounded bg-gray-200/70 dark:bg-gray-700/70"></div>
@@ -347,7 +356,16 @@
                         <span aria-hidden="true">↓</span>
                       </button>
                     </div>
-                    <button type="button" class="widget-control-btn" data-widget-action="collapse" aria-expanded="true" aria-label="Collapse widget">
+                    <button
+                      type="button"
+                      class="widget-control-btn"
+                      data-widget-action="collapse"
+                      data-widget-toggle
+                      data-widget-name="Today's lessons"
+                      aria-expanded="true"
+                      aria-controls="widget-lessons-body"
+                      aria-label="Collapse widget"
+                    >
                       <span aria-hidden="true" data-icon>−</span>
                       <span class="sr-only">Collapse widget</span>
                     </button>
@@ -357,7 +375,7 @@
                     </button>
                   </div>
                 </div>
-                <div data-widget-body class="space-y-6 pt-4">
+                <div id="widget-lessons-body" data-widget-body class="space-y-6 pt-4">
                   <div>
                     <div id="dashboard-lessons-skeleton" class="space-y-3 rounded-2xl bg-white/60 p-4 text-gray-500 dark:bg-gray-900/40 dark:text-gray-500 animate-pulse" aria-hidden="true">
                       <div class="h-4 w-2/3 rounded bg-gray-200/80 dark:bg-gray-700/70"></div>
@@ -419,7 +437,16 @@
                         <span aria-hidden="true">↓</span>
                       </button>
                     </div>
-                    <button type="button" class="widget-control-btn" data-widget-action="collapse" aria-expanded="true" aria-label="Collapse widget">
+                    <button
+                      type="button"
+                      class="widget-control-btn"
+                      data-widget-action="collapse"
+                      data-widget-toggle
+                      data-widget-name="Upcoming deadlines"
+                      aria-expanded="true"
+                      aria-controls="widget-deadlines-body"
+                      aria-label="Collapse widget"
+                    >
                       <span aria-hidden="true" data-icon>−</span>
                       <span class="sr-only">Collapse widget</span>
                     </button>
@@ -429,7 +456,7 @@
                     </button>
                   </div>
                 </div>
-                <div data-widget-body class="space-y-6 pt-4">
+                <div id="widget-deadlines-body" data-widget-body class="space-y-6 pt-4">
                   <div>
                     <div id="dashboard-deadlines-skeleton" class="space-y-3 rounded-2xl border border-dashed border-gray-200 bg-white/70 p-4 text-gray-500 dark:text-gray-500 animate-pulse dark:border-gray-700/70 dark:bg-gray-900/40" aria-hidden="true">
                       <div class="h-4 w-1/2 rounded bg-gray-200/70 dark:bg-gray-700/70"></div>
@@ -487,7 +514,16 @@
                         <span aria-hidden="true">↓</span>
                       </button>
                     </div>
-                    <button type="button" class="widget-control-btn" data-widget-action="collapse" aria-expanded="true" aria-label="Collapse widget">
+                    <button
+                      type="button"
+                      class="widget-control-btn"
+                      data-widget-action="collapse"
+                      data-widget-toggle
+                      data-widget-name="Recent activity"
+                      aria-expanded="true"
+                      aria-controls="widget-activity-body"
+                      aria-label="Collapse widget"
+                    >
                       <span aria-hidden="true" data-icon>−</span>
                       <span class="sr-only">Collapse widget</span>
                     </button>
@@ -497,7 +533,7 @@
                     </button>
                   </div>
                 </div>
-                <div data-widget-body class="space-y-6 pt-4">
+                <div id="widget-activity-body" data-widget-body class="space-y-6 pt-4">
                   <div id="dashboard-activity-loading" class="space-y-3" aria-live="polite">
                     <div class="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-500">
                       <span class="inline-flex h-2 w-2 animate-ping rounded-full bg-blue-500"></span>
@@ -540,7 +576,16 @@
                         <span aria-hidden="true">↓</span>
                       </button>
                     </div>
-                    <button type="button" class="widget-control-btn" data-widget-action="collapse" aria-expanded="true" aria-label="Collapse widget">
+                    <button
+                      type="button"
+                      class="widget-control-btn"
+                      data-widget-action="collapse"
+                      data-widget-toggle
+                      data-widget-name="Outdoor planning"
+                      aria-expanded="true"
+                      aria-controls="widget-outdoor-body"
+                      aria-label="Collapse widget"
+                    >
                       <span aria-hidden="true" data-icon>−</span>
                       <span class="sr-only">Collapse widget</span>
                     </button>
@@ -550,7 +595,7 @@
                     </button>
                   </div>
                 </div>
-                <div data-widget-body class="space-y-6 pt-4" aria-live="polite">
+                <div id="widget-outdoor-body" data-widget-body class="space-y-6 pt-4" aria-live="polite">
                   <div class="flex flex-wrap items-center justify-between gap-3">
                     <p id="weather-status" class="text-sm text-white/80" role="status" aria-live="polite" aria-atomic="true">Finding your forecast…</p>
                     <button
@@ -1349,6 +1394,9 @@
       </div>
     </section>
   </main>
+  <!-- BEGIN GPT CHANGE: live region -->
+  <div id="live-status" class="sr-only" aria-live="polite" role="status"></div>
+  <!-- END GPT CHANGE -->
   <nav
     id="quick-action-toolbar"
     aria-label="Quick actions"

--- a/js/main.js
+++ b/js/main.js
@@ -39,6 +39,23 @@ const navButtons = [...document.querySelectorAll('.nav-desktop [data-route]')];
 })();
 /* END GPT CHANGE */
 
+/* BEGIN GPT CHANGE: widget a11y state */
+(function () {
+  const live = document.getElementById('live-status');
+  if (!live) return;
+  document.addEventListener('click', (e) => {
+    const btn = e.target.closest('[data-widget-toggle]');
+    if (!btn) return;
+    const panel = document.getElementById(btn.getAttribute('aria-controls'));
+    if (!panel) return;
+    const expanded = btn.getAttribute('aria-expanded') === 'true';
+    btn.setAttribute('aria-expanded', String(!expanded));
+    panel.hidden = expanded;
+    live.textContent = `${btn.getAttribute('data-widget-name') || 'Section'} ${expanded ? 'collapsed' : 'expanded'}.`;
+  }, true);
+})();
+/* END GPT CHANGE */
+
 // Routing
 const views = [...document.querySelectorAll('[data-view]')];
 const viewMap = new Map(views.map(v => [v.dataset.view, v]));


### PR DESCRIPTION
## Summary
- mark each dashboard widget collapse control with aria-expanded, aria-controls, and widget labels
- add a shared sr-only live region to announce widget collapse and expansion
- update widget toggle handling to sync aria-expanded state, panel visibility, and live announcements

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68eb25e2e728832786ebacbb66acf780