### PR TITLE
Add theme persistence and menuitemradio semantics

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,12 +157,12 @@
                 role="menu"
                 tabindex="0"
               >
-                <li><a href="#" data-theme-name="light" role="menuitem">Light</a></li>
-                <li><a href="#" data-theme-name="dark" role="menuitem">Dark</a></li>
-                <li><a href="#" data-theme-name="dracula" role="menuitem">Dracula</a></li>
-                <li><a href="#" data-theme-name="cupcake" role="menuitem">Cupcake</a></li>
-                <li><a href="#" data-theme-name="caramellatte" role="menuitem">Caramellatte</a></li>
-                <li><a href="#" data-theme-name="synthwave" role="menuitem">Synthwave</a></li>
+                <li><a href="#" data-theme-option="light" role="menuitemradio" aria-checked="false">Light</a></li>
+                <li><a href="#" data-theme-option="dark" role="menuitemradio" aria-checked="false">Dark</a></li>
+                <li><a href="#" data-theme-option="dracula" role="menuitemradio" aria-checked="false">Dracula</a></li>
+                <li><a href="#" data-theme-option="cupcake" role="menuitemradio" aria-checked="false">Cupcake</a></li>
+                <li><a href="#" data-theme-option="caramellatte" role="menuitemradio" aria-checked="false">Caramellatte</a></li>
+                <li><a href="#" data-theme-option="synthwave" role="menuitemradio" aria-checked="false">Synthwave</a></li>
               </ul>
             </div>
             <div

--- a/js/main.js
+++ b/js/main.js
@@ -4606,3 +4606,23 @@ if(noteEl){
 })();
 // === /Activity Ideas Modal ===
 
+/* BEGIN GPT CHANGE: theme persistence */
+(function () {
+  const html = document.documentElement;
+  const saved = localStorage.getItem('theme');
+  if (saved) html.setAttribute('data-theme', saved);
+
+  const items = document.querySelectorAll('[data-theme-option]');
+  items.forEach((el) => {
+    el.setAttribute('role', 'menuitemradio');
+    el.setAttribute('aria-checked', String(html.getAttribute('data-theme') === el.dataset.themeOption));
+    el.addEventListener('click', () => {
+      const theme = el.dataset.themeOption;
+      html.setAttribute('data-theme', theme);
+      localStorage.setItem('theme', theme);
+      items.forEach(i => i.setAttribute('aria-checked', String(i === el)));
+    });
+  });
+})();
+/* END GPT CHANGE */
+


### PR DESCRIPTION
## Summary
- update the theme dropdown options to expose menuitemradio semantics and data-theme-option attributes
- persist the selected theme in localStorage and ensure aria-checked reflects the active theme

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68eb279458908327a90db9361fde2853