### PR TITLE
Enhance auth form progressive enhancement

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@
             </div>
           </div>
           <div class="flex flex-wrap items-center justify-end gap-2">
-            <form id="auth-form" class="flex flex-wrap items-center justify-end gap-2">
+            <form id="auth-form" class="flex flex-wrap items-center justify-end gap-2" hidden>
               <label for="auth-email" class="sr-only">Email address</label>
               <input
                 id="auth-email"
@@ -192,7 +192,9 @@
             </form>
             <button id="sign-out-btn" type="button" class="btn btn-sm btn-error hidden">Sign out</button>
           </div>
-          <p id="auth-feedback" class="hidden text-xs font-medium text-base-content" role="status" aria-live="polite"></p>
+          <!-- BEGIN GPT CHANGE: auth feedback -->
+          <div id="auth-feedback" role="status" aria-live="polite" hidden></div>
+          <!-- END GPT CHANGE -->
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- hide the authentication form until JavaScript enhances it and provide a dedicated live region for feedback
- refactor Supabase email sign-in handling to expose a reusable function and update feedback toggling to use the hidden attribute
- add a progressive enhancement wrapper that manages busy states, disables the submit button, and surfaces user-facing status messages during auth

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68eb29738cb083278c3902ab22631ccb