### PR TITLE
Improve accessibility skip link and sync status announcements

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -15,6 +15,18 @@ html {
   display: none;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .pt-safe-top {
   padding-top: env(safe-area-inset-top);
 }


### PR DESCRIPTION
## Summary
- focus the main content region when the skip link is used and expose a reusable sync status controller for announcements
- integrate the sync status updates with Supabase initialisation, online/offline events, and resource refreshes
- add a shared `.sr-only` utility class for assistive-only text

## Testing
- npm test -- --runTestsByPath sample.test.js

------
https://chatgpt.com/codex/tasks/task_b_68eb2ff3e7008327a9001b7a1660d151