### PR TITLE
Normalize reminders widget list placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,15 +323,17 @@
                   </div>
                 </div>
                 <div id="widget-reminders-body" data-widget-body class="space-y-6 pt-4">
-                  <div>
-                    <div id="dashboard-reminders-skeleton" class="space-y-3 rounded-2xl border border-dashed border-gray-200 bg-white/70 p-4 text-gray-500 dark:text-gray-500 animate-pulse dark:border-gray-700 dark:bg-gray-900/40" aria-hidden="true">
-                      <div class="h-4 w-1/3 rounded bg-gray-200/70 dark:bg-gray-700/70"></div>
-                      <div class="h-16 rounded-2xl bg-gray-100/90 dark:bg-gray-800/60"></div>
-                      <div class="h-4 w-1/2 rounded bg-gray-200/60 dark:bg-gray-700/60"></div>
-                    </div>
-                    <ul id="dashboard-reminders-list" class="hidden space-y-4" aria-live="polite" aria-busy="true"></ul>
-                    <div id="dashboard-reminders-empty" class="hidden"></div>
+                  <!-- BEGIN GPT FIX: reminders-header-dup -->
+                  <div id="dashboard-reminders-skeleton" class="space-y-3 rounded-2xl border border-dashed border-gray-200 bg-white/70 p-4 text-gray-500 dark:text-gray-500 animate-pulse dark:border-gray-700 dark:bg-gray-900/40" aria-hidden="true">
+                    <div class="h-4 w-1/3 rounded bg-gray-200/70 dark:bg-gray-700/70"></div>
+                    <div class="h-16 rounded-2xl bg-gray-100/90 dark:bg-gray-800/60"></div>
+                    <div class="h-4 w-1/2 rounded bg-gray-200/60 dark:bg-gray-700/60"></div>
                   </div>
+                  <!-- BEGIN GPT FIX: reminders-list-force -->
+                  <ul id="dashboard-reminders-list" class="hidden space-y-4" aria-live="polite" aria-busy="true"></ul>
+                  <!-- END GPT FIX -->
+                  <div id="dashboard-reminders-empty" class="hidden"></div>
+                  <!-- END GPT FIX -->
                 </div>
               </section>
 
@@ -1579,3 +1581,12 @@
   </script>
 </body>
 </html>
+<!-- BEGIN GPT FIX: change-summary -->
+<!--
+CHANGE SUMMARY:
+- Reminders: lifted skeleton/list/empty to the widget body top; verified single reminders list remains.
+- Lessons: single lesson-location field present; no duplicates required removal.
+- Deadlines: header content required no adjustments; skeleton/list/empty already in body.
+- TODOs: none.
+-->
+<!-- END GPT FIX -->


### PR DESCRIPTION
## Summary
- move the reminders skeleton/list/empty directly under the widget body with required fix markers
- refresh the change summary comment to document the updated reminders state

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68eb5045a4a083278bf2c1e86f0e8797