### PR TITLE
Rework dashboard layout with focus shortcuts

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,43 +239,104 @@
       <div class="view-container">
         <header class="view-header view-header--hero" aria-labelledby="dashboard-heading">
           <div class="hero rounded-2xl border border-base-200/70 bg-base-100/90 shadow-xl">
-            <div class="hero-content w-full flex-col items-start gap-8 lg:flex-row lg:items-center lg:justify-between">
-              <div class="max-w-xl space-y-4">
-                <div class="badge badge-primary badge-outline">Today's overview</div>
-                <h1 id="dashboard-heading" class="text-3xl sm:text-4xl font-bold text-base-content">Your teaching day at a glance</h1>
-                <p id="dashboard-date" class="text-base text-base-content/70"></p>
-                <div class="flex flex-wrap gap-3">
-                  <a href="#planner" class="btn btn-primary btn-sm md:btn-md">Open weekly planner<span aria-hidden="true">→</span></a>
-                  <a href="#reminders" class="btn btn-outline btn-sm md:btn-md">Review reminders<span aria-hidden="true">→</span></a>
+            <div class="hero-content w-full flex-col gap-10 lg:flex-row lg:items-start lg:justify-between">
+              <div class="dashboard-hero-copy">
+                <span class="dashboard-hero-eyebrow">Teacher control centre</span>
+                <h1 id="dashboard-heading" class="dashboard-hero-title">Your teaching day at a glance</h1>
+                <p id="dashboard-date" class="dashboard-hero-date"></p>
+                <p class="dashboard-hero-subtitle">Use quick actions to capture what matters, then move straight into the workspace you need.</p>
+                <div class="dashboard-quick-actions" role="list">
+                  <button type="button" data-quick-action="reminder" class="dashboard-quick-action" role="listitem">
+                    <span class="dashboard-quick-action-icon" aria-hidden="true">🔔</span>
+                    <span class="dashboard-quick-action-content">
+                      <span class="dashboard-quick-action-label">Log a cue</span>
+                      <span class="dashboard-quick-action-help">Open the reminder composer</span>
+                    </span>
+                  </button>
+                  <button type="button" data-quick-action="planner" class="dashboard-quick-action" role="listitem">
+                    <span class="dashboard-quick-action-icon" aria-hidden="true">🗓️</span>
+                    <span class="dashboard-quick-action-content">
+                      <span class="dashboard-quick-action-label">Plan the week</span>
+                      <span class="dashboard-quick-action-help">Jump to your weekly grid</span>
+                    </span>
+                  </button>
+                  <button type="button" data-quick-action="note" class="dashboard-quick-action" role="listitem">
+                    <span class="dashboard-quick-action-icon" aria-hidden="true">📝</span>
+                    <span class="dashboard-quick-action-content">
+                      <span class="dashboard-quick-action-label">Capture a note</span>
+                      <span class="dashboard-quick-action-help">Drop into the scratch pad</span>
+                    </span>
+                  </button>
                 </div>
               </div>
-              <div class="stats stats-vertical bg-base-100 shadow-lg md:stats-horizontal">
-                <div class="stat">
-                  <div class="stat-title">Lessons today</div>
-                  <div id="dashboard-lesson-count" class="stat-value text-primary">0</div>
-                  <div id="dashboard-next-lesson" class="stat-desc text-base-content/70"></div>
-                </div>
-                <div class="stat">
-                  <div class="stat-title">Deadlines this week</div>
-                  <div id="dashboard-deadline-count" class="stat-value text-secondary">0</div>
-                  <div class="stat-desc text-base-content/70">Countdowns auto-refresh</div>
-                </div>
-                <div class="stat">
-                  <div class="stat-title">Reminders to action</div>
-                  <div id="dashboard-reminder-count" class="stat-value text-accent">0</div>
-                  <div class="stat-desc text-base-content/70">Due today or overdue</div>
-                </div>
+              <div class="dashboard-hero-summary" role="list" aria-label="Today&#39;s snapshot">
+                <article class="dashboard-hero-card" role="listitem">
+                  <p class="dashboard-hero-card-label">Lessons today</p>
+                  <p id="dashboard-lesson-count" class="dashboard-hero-card-value">0</p>
+                  <p id="dashboard-next-lesson" class="dashboard-hero-card-meta"></p>
+                </article>
+                <article class="dashboard-hero-card" role="listitem">
+                  <p class="dashboard-hero-card-label">Deadlines this week</p>
+                  <p id="dashboard-deadline-count" class="dashboard-hero-card-value">0</p>
+                  <p class="dashboard-hero-card-meta">Countdowns refresh automatically</p>
+                </article>
+                <article class="dashboard-hero-card" role="listitem">
+                  <p class="dashboard-hero-card-label">Reminders to action</p>
+                  <p id="dashboard-reminder-count" class="dashboard-hero-card-value">0</p>
+                  <p class="dashboard-hero-card-meta">Due today or overdue</p>
+                </article>
               </div>
             </div>
           </div>
         </header>
 
-        <div class="view-body space-y-6">
-          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" data-dashboard-area="primary">
+        <div class="view-body space-y-10">
+          <section class="dashboard-focus" aria-labelledby="dashboard-focus-heading">
+            <div class="dashboard-focus-header">
+              <div>
+                <p class="dashboard-focus-eyebrow">Jump to a workspace</p>
+                <h2 id="dashboard-focus-heading">Focus lanes</h2>
+              </div>
+              <p class="dashboard-focus-description">Shortcuts that open the right board or scroll to the panel you need on this page.</p>
+            </div>
+            <div class="dashboard-focus-grid">
+              <a href="#reminders" data-route="reminders" class="dashboard-focus-card" aria-describedby="dashboard-focus-reminders">
+                <span class="dashboard-focus-icon" aria-hidden="true">✅</span>
+                <span class="dashboard-focus-content">
+                  <span class="dashboard-focus-title">Action reminders</span>
+                  <span id="dashboard-focus-reminders" class="dashboard-focus-copy">Open the cues workspace</span>
+                </span>
+              </a>
+              <button type="button" class="dashboard-focus-card" data-scroll-target="#lesson-form" data-focus-target="#lesson-subject">
+                <span class="dashboard-focus-icon" aria-hidden="true">📚</span>
+                <span class="dashboard-focus-content">
+                  <span class="dashboard-focus-title">Log a lesson</span>
+                  <span class="dashboard-focus-copy">Jump to today&#39;s lesson planner</span>
+                </span>
+              </button>
+              <button type="button" class="dashboard-focus-card" data-scroll-target="#dashboard-activity-container">
+                <span class="dashboard-focus-icon" aria-hidden="true">🗂️</span>
+                <span class="dashboard-focus-content">
+                  <span class="dashboard-focus-title">Review activity</span>
+                  <span class="dashboard-focus-copy">Latest changes and sync events</span>
+                </span>
+              </button>
+              <button type="button" class="dashboard-focus-card" data-scroll-target="#widget-outdoor-body">
+                <span class="dashboard-focus-icon" aria-hidden="true">🌦️</span>
+                <span class="dashboard-focus-content">
+                  <span class="dashboard-focus-title">Check weather</span>
+                  <span class="dashboard-focus-copy">Forecast before outdoor sessions</span>
+                </span>
+              </button>
+            </div>
+          </section>
+
+          <div class="dashboard-main-grid">
+            <div class="dashboard-widgets-grid" data-dashboard-area="primary">
               <section
                 data-dashboard-widget="reminders"
                 data-widget-title="Reminders needing attention"
-                class="order-1 md:col-span-2 lg:col-span-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md"
+                class="dashboard-widget dashboard-widget--wide bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md"
                 aria-labelledby="reminders-heading"
               >
                 <div
@@ -324,24 +385,20 @@
                   </div>
                 </div>
                 <div id="widget-reminders-body" data-widget-body class="space-y-6 pt-4">
-                  <!-- BEGIN GPT FIX: reminders-header-dup -->
                   <div id="dashboard-reminders-skeleton" class="space-y-3 rounded-2xl border border-dashed border-gray-200 bg-white/70 p-4 text-gray-500 dark:text-gray-500 animate-pulse dark:border-gray-700 dark:bg-gray-900/40" aria-hidden="true">
                     <div class="h-4 w-1/3 rounded bg-gray-200/70 dark:bg-gray-700/70"></div>
                     <div class="h-16 rounded-2xl bg-gray-100/90 dark:bg-gray-800/60"></div>
                     <div class="h-4 w-1/2 rounded bg-gray-200/60 dark:bg-gray-700/60"></div>
                   </div>
-                  <!-- BEGIN GPT FIX: reminders-list-force -->
                   <ul id="dashboard-reminders-list" class="hidden space-y-4" aria-live="polite" aria-busy="true"></ul>
-                  <!-- END GPT FIX -->
                   <div id="dashboard-reminders-empty" class="hidden"></div>
-                  <!-- END GPT FIX -->
                 </div>
               </section>
 
               <section
                 data-dashboard-widget="lessons"
-                data-widget-title="Today's lessons"
-                class="order-2 md:col-span-1 lg:col-span-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md"
+                data-widget-title="Today&#39;s lessons"
+                class="dashboard-widget dashboard-widget--primary bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md"
                 aria-labelledby="lessons-heading"
               >
                 <div
@@ -355,7 +412,7 @@
                     >📘</span>
                     <div class="min-w-0 space-y-1">
                       <div class="flex flex-wrap items-center gap-2">
-                        <h2 id="lessons-heading" class="text-xl font-semibold text-gray-900 dark:text-gray-100">Today's lessons</h2>
+                        <h2 id="lessons-heading" class="text-xl font-semibold text-gray-900 dark:text-gray-100">Today&#39;s lessons</h2>
                         <span
                           id="dashboard-lesson-status"
                           class="hidden rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-600 dark:bg-blue-500/10 dark:text-blue-200"
@@ -383,7 +440,7 @@
                       class="widget-control-btn"
                       data-widget-action="collapse"
                       data-widget-toggle
-                      data-widget-name="Today's lessons"
+                      data-widget-name="Today&#39;s lessons"
                       aria-expanded="true"
                       aria-controls="widget-lessons-body"
                       aria-label="Collapse widget"
@@ -424,9 +481,6 @@
                       <label for="lesson-location" class="block text-sm font-medium text-gray-600 dark:text-gray-400">Location</label>
                       <input id="lesson-location" name="lesson-location" type="text" placeholder="e.g. Lab 2" class="mt-1 w-full rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
                     </div>
-                    <!-- BEGIN GPT FIX: lessons-location-dedup -->
-                    <!-- TODO: selector not found -->
-                    <!-- END GPT FIX -->
                     <div class="flex items-end">
                       <button type="submit" class="inline-flex w-full items-center justify-center rounded-xl bg-blue-600 px-4 py-2.5 font-semibold text-white shadow transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500">Add lesson</button>
                     </div>
@@ -438,7 +492,7 @@
               <section
                 data-dashboard-widget="deadlines"
                 data-widget-title="Upcoming deadlines"
-                class="order-2 md:col-span-1 lg:col-span-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md"
+                class="dashboard-widget dashboard-widget--primary bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md"
                 aria-labelledby="deadlines-heading"
               >
                 <div
@@ -516,7 +570,7 @@
                 id="dashboard-activity-container"
                 data-dashboard-widget="activity"
                 data-widget-title="Recent activity"
-                class="order-3 md:col-span-2 lg:col-span-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md"
+                class="dashboard-widget dashboard-widget--wide bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md"
                 aria-labelledby="activity-heading"
               >
                 <div
@@ -578,7 +632,7 @@
                 data-dashboard-widget="weather"
                 data-widget-title="Outdoor planning"
                 data-widget-theme="inverted"
-                class="order-3 md:col-span-1 lg:col-span-1 bg-gradient-to-br from-sky-500 via-indigo-500 to-emerald-500 text-white rounded-lg shadow-sm border border-white/40 p-6 transition-shadow duration-200 hover:shadow-md"
+                class="dashboard-widget dashboard-widget--secondary bg-gradient-to-br from-sky-500 via-indigo-500 to-emerald-500 text-white rounded-lg shadow-sm border border-white/40 p-6 transition-shadow duration-200 hover:shadow-md"
                 aria-labelledby="weather-heading"
               >
                 <div
@@ -678,38 +732,28 @@
               </section>
             </div>
 
-            <aside
-              id="dashboard-hidden-tray"
-              class="hidden rounded-lg border border-dashed border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-6 py-5 shadow-sm"
-            >
-              <div class="flex flex-wrap items-center gap-3">
-                <p class="text-sm font-semibold text-gray-600 dark:text-gray-400">Hidden dashboard widgets</p>
-                <div id="dashboard-hidden-list" class="flex flex-wrap gap-2"></div>
-                <button
-                  type="button"
-                  id="dashboard-show-all"
-                  class="hidden inline-flex items-center gap-2 rounded-full bg-gray-900/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white/85 dark:text-gray-900 dark:text-gray-100 dark:hover:bg-white"
-                >
-                  <span aria-hidden="true">↺</span>
-                  Restore all
-                </button>
-              </div>
-              <p class="mt-3 text-xs text-gray-500 dark:text-gray-500">
-                Use the widget chrome to collapse, hide, or reorder cards. Restore any hidden widgets here.
-              </p>
+            <aside class="dashboard-secondary">
+              <section
+                id="dashboard-hidden-tray"
+                class="dashboard-widget-tray hidden rounded-lg border border-dashed border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-6 py-5 shadow-sm"
+              >
+                <div class="flex flex-wrap items-center gap-3">
+                  <p class="text-sm font-semibold text-gray-600 dark:text-gray-400">Hidden dashboard widgets</p>
+                  <div id="dashboard-hidden-list" class="flex flex-wrap gap-2"></div>
+                  <button
+                    type="button"
+                    id="dashboard-show-all"
+                    class="hidden inline-flex items-center gap-2 rounded-full bg-gray-900/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white/85 dark:text-gray-900 dark:text-gray-100 dark:hover:bg-white"
+                  >
+                    <span aria-hidden="true">↺</span>
+                    Restore all
+                  </button>
+                </div>
+                <p class="mt-3 text-xs text-gray-500 dark:text-gray-500">
+                  Use the widget controls to collapse, hide, or reorder cards. Restore any hidden widgets here.
+                </p>
+              </section>
             </aside>
-
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              <div class="rounded-lg border-2 border-dashed border-gray-200 bg-white/60 p-6 text-sm text-gray-500 shadow-sm dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-500">
-                Placeholder widget slot
-              </div>
-              <div class="rounded-lg border-2 border-dashed border-gray-200 bg-white/60 p-6 text-sm text-gray-500 shadow-sm dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-500">
-                Placeholder widget slot
-              </div>
-              <div class="rounded-lg border-2 border-dashed border-gray-200 bg-white/60 p-6 text-sm text-gray-500 shadow-sm dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-500">
-                Placeholder widget slot
-              </div>
-            </div>
           </div>
         </div>
       </div>

--- a/js/main.js
+++ b/js/main.js
@@ -476,6 +476,39 @@ quickActionButtons.forEach((button) => {
   });
 });
 
+document.addEventListener('click', (event) => {
+  const trigger = event.target.closest('[data-scroll-target], [data-focus-target]');
+  if (!trigger) return;
+
+  const scrollSelector = trigger.dataset.scrollTarget;
+  const focusSelector = trigger.dataset.focusTarget || scrollSelector;
+
+  const preventDefault = () => {
+    if (event.type === 'click') {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
+  preventDefault();
+
+  if (scrollSelector) {
+    const scrollTarget = document.querySelector(scrollSelector);
+    if (scrollTarget && typeof scrollTarget.scrollIntoView === 'function') {
+      scrollTarget.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }
+
+  if (focusSelector) {
+    window.setTimeout(() => {
+      const focusTarget = resolveFocusTarget(focusSelector);
+      if (focusTarget) {
+        focusElementWithHighlight(focusTarget);
+      }
+    }, 180);
+  }
+});
+
 function normalizeActivityPayload(entry){
   if (!entry || typeof entry !== 'object') return null;
   const label = typeof entry.label === 'string' ? entry.label.trim() : '';

--- a/styles/index.css
+++ b/styles/index.css
@@ -306,6 +306,365 @@ html {
   outline-offset: 3px;
 }
 
+.dashboard-hero-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 32rem;
+}
+
+.dashboard-hero-eyebrow {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.dark .dashboard-hero-eyebrow {
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.dashboard-hero-title {
+  font-size: clamp(2rem, 2vw + 1.2rem, 2.75rem);
+  line-height: 1.05;
+  font-weight: 700;
+  color: inherit;
+}
+
+.dashboard-hero-date {
+  font-size: 0.95rem;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.dark .dashboard-hero-date {
+  color: rgba(203, 213, 225, 0.75);
+}
+
+.dashboard-hero-subtitle {
+  font-size: 0.95rem;
+  color: rgba(15, 23, 42, 0.7);
+  max-width: 30rem;
+}
+
+.dark .dashboard-hero-subtitle {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.dashboard-quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.dashboard-quick-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(248, 250, 252, 0.9);
+  color: rgb(15, 23, 42);
+  box-shadow: 0 10px 25px -20px rgba(15, 23, 42, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+  cursor: pointer;
+}
+
+.dashboard-quick-action:hover {
+  transform: translateY(-2px);
+  border-color: rgba(59, 130, 246, 0.45);
+  box-shadow: 0 16px 35px -18px rgba(37, 99, 235, 0.35);
+}
+
+.dashboard-quick-action:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.8);
+  outline-offset: 3px;
+}
+
+.dark .dashboard-quick-action {
+  background: rgba(15, 23, 42, 0.8);
+  color: rgba(226, 232, 240, 0.92);
+  border-color: rgba(148, 163, 184, 0.3);
+  box-shadow: 0 12px 30px -24px rgba(30, 64, 175, 0.55);
+}
+
+.dashboard-quick-action-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.9rem;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(16, 185, 129, 0.15));
+  font-size: 1.25rem;
+}
+
+.dashboard-quick-action-content {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+}
+
+.dashboard-quick-action-label {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.dashboard-quick-action-help {
+  font-size: 0.75rem;
+  color: rgba(71, 85, 105, 0.85);
+}
+
+.dark .dashboard-quick-action-help {
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.dashboard-hero-summary {
+  display: grid;
+  gap: 1rem;
+  width: min(100%, 28rem);
+}
+
+@media (min-width: 1024px) {
+  .dashboard-hero-summary {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.dashboard-hero-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1.15rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: linear-gradient(145deg, rgba(248, 250, 252, 0.95), rgba(241, 245, 249, 0.85));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 18px 35px -30px rgba(15, 23, 42, 0.45);
+}
+
+.dark .dashboard-hero-card {
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.85), rgba(15, 23, 42, 0.88));
+  border-color: rgba(148, 163, 184, 0.25);
+}
+
+.dashboard-hero-card-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(71, 85, 105, 0.85);
+}
+
+.dark .dashboard-hero-card-label {
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.dashboard-hero-card-value {
+  font-size: clamp(1.75rem, 2.5vw + 0.75rem, 2.35rem);
+  font-weight: 700;
+  color: rgb(15, 23, 42);
+}
+
+.dark .dashboard-hero-card-value {
+  color: rgba(226, 232, 240, 0.98);
+}
+
+.dashboard-hero-card-meta {
+  font-size: 0.85rem;
+  color: rgba(71, 85, 105, 0.85);
+}
+
+.dark .dashboard-hero-card-meta {
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.dashboard-focus {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.dashboard-focus-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.dashboard-focus-eyebrow {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(100, 116, 139, 0.85);
+}
+
+.dark .dashboard-focus-eyebrow {
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.dashboard-focus-header h2 {
+  font-size: clamp(1.35rem, 1.3vw + 0.85rem, 1.75rem);
+  font-weight: 700;
+}
+
+.dashboard-focus-description {
+  font-size: 0.9rem;
+  color: rgba(71, 85, 105, 0.85);
+  max-width: 32rem;
+}
+
+.dark .dashboard-focus-description {
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.dashboard-focus-grid {
+  display: grid;
+  gap: 0.85rem;
+}
+
+@media (min-width: 640px) {
+  .dashboard-focus-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .dashboard-focus-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+.dashboard-focus-card {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.9rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(248, 250, 252, 0.85);
+  color: inherit;
+  text-align: left;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+  cursor: pointer;
+}
+
+.dashboard-focus-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(59, 130, 246, 0.4);
+  box-shadow: 0 16px 32px -24px rgba(15, 23, 42, 0.35);
+}
+
+.dashboard-focus-card:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.8);
+  outline-offset: 3px;
+}
+
+.dark .dashboard-focus-card {
+  background: rgba(15, 23, 42, 0.75);
+  border-color: rgba(148, 163, 184, 0.28);
+}
+
+.dashboard-focus-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.9rem;
+  background: rgba(59, 130, 246, 0.12);
+}
+
+.dashboard-focus-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.dashboard-focus-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.dashboard-focus-copy {
+  font-size: 0.8rem;
+  color: rgba(71, 85, 105, 0.85);
+}
+
+.dark .dashboard-focus-copy {
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.dashboard-main-grid {
+  display: grid;
+  gap: clamp(1.75rem, 3vw, 2.75rem);
+}
+
+@media (min-width: 1024px) {
+  .dashboard-main-grid {
+    grid-template-columns: minmax(0, 2.35fr) minmax(0, 1fr);
+  }
+}
+
+.dashboard-widgets-grid {
+  display: grid;
+  gap: clamp(1.5rem, 2vw, 2.25rem);
+}
+
+@media (min-width: 768px) {
+  .dashboard-widgets-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .dashboard-widgets-grid {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+}
+
+.dashboard-widget {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+@media (min-width: 1024px) {
+  .dashboard-widget--wide {
+    grid-column: span 6;
+  }
+
+  .dashboard-widget--primary {
+    grid-column: span 3;
+  }
+
+  .dashboard-widget--secondary {
+    grid-column: span 3;
+  }
+}
+
+.dashboard-secondary {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.dashboard-widget-tray {
+  position: sticky;
+  top: 6.5rem;
+}
+
+@media (max-width: 1024px) {
+  .dashboard-widget-tray {
+    position: static;
+    top: auto;
+  }
+}
+
 .widget-control-btn {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- refresh the dashboard hero with guided quick actions and a concise daily snapshot
- add focus-lane shortcuts plus a reorganised widget grid to make reminders, lessons, activity and weather easier to reach
- expand the stylesheet and interaction logic to support the new layout and smooth scroll/focus helpers

## Testing
- npm test *(fails: Jest cannot parse the ESM main.js module in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68eb60fead9883278075eaf87b82e45b