### PR TITLE
Fix CSP violations by externalising inline scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,11 +8,7 @@
 <!-- BEGIN GPT CHANGE: supabase keys moved to env.js -->
 <!-- END GPT CHANGE -->
 <!-- BEGIN GPT CHANGE: supabase init via env module -->
-<script type="module">
-  import { ENV } from './js/env.js';
-  import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-  window.supabase = createClient(ENV.SUPABASE_URL, ENV.SUPABASE_ANON_KEY);
-</script>
+<script type="module" src="./js/config-supabase.js" defer></script>
 <!-- END GPT CHANGE -->
 <!-- === /SUPABASE CONFIG === -->
 <!-- BEGIN GPT CHANGE: supabase keys moved to env.js -->
@@ -30,15 +26,17 @@
   <meta name="twitter:card" content="summary_large_image">
   <!-- END GPT CHANGE -->
   <!-- BEGIN GPT CHANGE: basic CSP -->
-  <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self';
-                 img-src 'self' data:;
-                 style-src 'self' 'unsafe-inline';
-                 script-src 'self';
-                 connect-src 'self' https://*.supabase.co;
-                 font-src 'self' data:;
-                 base-uri 'self';
-                 form-action 'self'">
+  <meta
+    http-equiv="Content-Security-Policy"
+    content="default-src 'self';
+             img-src 'self' data:;
+             style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;
+             script-src 'self' https://cdn.jsdelivr.net https://esm.sh https://www.gstatic.com;
+             connect-src 'self' https://*.supabase.co https://api.open-meteo.com https://api.bigdatacloud.net https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://www.googleapis.com;
+             font-src 'self' data:;
+             base-uri 'self';
+             form-action 'self'"
+  >
   <!-- END GPT CHANGE -->
   <meta name="description" content="Memory Cue helps teachers stay organised with integrated dashboards, reminders, planners, and curated resources in one streamlined app." />
   <!-- BEGIN GPT CHANGE: canonical -->
@@ -75,9 +73,7 @@
   <link rel="stylesheet" href="./styles/daisy-themes.css" />
   <!-- BEGIN GPT CHANGE: styles moved to styles/index.css -->
   <!-- END GPT CHANGE -->
-  <script type="module">
-    window.__SUPABASE_ENV__ = typeof import.meta !== 'undefined' && import.meta ? import.meta.env : undefined;
-  </script>
+  <script src="./js/runtime-env-shim.js" defer></script>
   <script type="module" src="./js/main.js" defer></script>
 </head>
 <body id="top" class="bg-base-100 text-base-content antialiased leading-7 min-h-screen">
@@ -1613,31 +1609,9 @@
       </div>
     </div>
   </div>
-  <!-- BEGIN GPT CHANGE: runtime env shim -->
-  <script>
-    window.__ENV = window.__ENV || {};
-    // Optionally, set values via server or dev-only override.
-  </script>
-  <!-- END GPT CHANGE -->
   <script type="module" src="./app.js" defer></script>
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
-  <script>
-    (function registerServiceWorker() {
-      if (!('serviceWorker' in navigator)) return;
-      const register = () => {
-        navigator.serviceWorker
-          .register('./service-worker.js')
-          .catch((err) => console.warn('SW registration failed', err));
-      };
-      if (document.readyState === 'complete') {
-        register();
-      } else {
-        window.addEventListener('load', register, { once: true });
-      }
-    })();
-  </script>
+  <script src="./js/update-footer-year.js" defer></script>
+  <script src="./js/register-service-worker.js" defer></script>
 </body>
 </html>
 <!-- BEGIN GPT FIX: change-summary -->

--- a/js/config-supabase.js
+++ b/js/config-supabase.js
@@ -1,0 +1,5 @@
+import { ENV } from './env.js';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+window.__SUPABASE_ENV__ = typeof import.meta !== 'undefined' && import.meta ? import.meta.env : undefined;
+window.supabase = createClient(ENV.SUPABASE_URL, ENV.SUPABASE_ANON_KEY);

--- a/js/mobile-theme-toggle.js
+++ b/js/mobile-theme-toggle.js
@@ -1,0 +1,10 @@
+(function () {
+  const html = document.documentElement;
+  const stored = localStorage.getItem('theme');
+  if (stored) html.setAttribute('data-theme', stored);
+  document.getElementById('themeToggle')?.addEventListener('click', () => {
+    const next = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    html.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+  });
+})();

--- a/js/register-service-worker.js
+++ b/js/register-service-worker.js
@@ -1,0 +1,15 @@
+(function registerServiceWorker() {
+  if (!('serviceWorker' in navigator)) return;
+
+  const register = () => {
+    navigator.serviceWorker
+      .register('./service-worker.js')
+      .catch((err) => console.warn('SW registration failed', err));
+  };
+
+  if (document.readyState === 'complete') {
+    register();
+  } else {
+    window.addEventListener('load', register, { once: true });
+  }
+})();

--- a/js/runtime-env-shim.js
+++ b/js/runtime-env-shim.js
@@ -1,0 +1,1 @@
+window.__ENV = window.__ENV || {};

--- a/js/update-footer-year.js
+++ b/js/update-footer-year.js
@@ -1,0 +1,4 @@
+const yearElement = document.getElementById('year');
+if (yearElement) {
+  yearElement.textContent = new Date().getFullYear();
+}

--- a/mobile.html
+++ b/mobile.html
@@ -423,18 +423,7 @@
     </button>
   </nav>
 
-  <script>
-    (function () {
-      const html = document.documentElement;
-      const stored = localStorage.getItem('theme');
-      if (stored) html.setAttribute('data-theme', stored);
-      document.getElementById('themeToggle')?.addEventListener('click', () => {
-        const next = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
-        html.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-      });
-    })();
-  </script>
+  <script src="./js/mobile-theme-toggle.js" defer></script>
   <!-- BEGIN GPT CHANGE: bottom sheet for Create Reminder -->
   <div id="create-sheet" role="dialog" aria-modal="true" aria-labelledby="createSheetTitle" class="sheet hidden" tabindex="-1">
     <div class="sheet-panel bg-base-100 border-t border-base-200">


### PR DESCRIPTION
## Summary
- extend the Content Security Policy to allow required CDN scripts, styles, and API endpoints
- move inline Supabase, runtime, footer, and service worker scripts into dedicated modules that comply with CSP rules
- externalise the mobile theme toggle logic so both desktop and mobile pages run without inline scripts

## Testing
- npm test -- --runInBand *(fails: existing Jest suite cannot parse ESM main.js)*

------
https://chatgpt.com/codex/tasks/task_b_68eb6cb042188327bf7ca51608ee6f8f