### PR TITLE
Fix collapse icon scaling for dashboard widgets

### DIFF
--- a/index.html
+++ b/index.html
@@ -377,7 +377,25 @@
                       aria-controls="widget-reminders-body"
                       aria-label="Collapse widget"
                     >
-                      <span aria-hidden="true" data-icon>−</span>
+                      <span aria-hidden="true" data-icon class="widget-control-icon">
+                        <svg
+                          data-icon-minus
+                          viewBox="0 0 16 16"
+                          aria-hidden="true"
+                          focusable="false"
+                        >
+                          <path d="M3 7.25h10v1.5H3z" fill="currentColor" />
+                        </svg>
+                        <svg
+                          data-icon-plus
+                          viewBox="0 0 16 16"
+                          aria-hidden="true"
+                          focusable="false"
+                          hidden
+                        >
+                          <path d="M7.25 3v4.25H3v1.5h4.25V13h1.5V8.75H13v-1.5H8.75V3z" fill="currentColor" />
+                        </svg>
+                      </span>
                       <span class="sr-only">Collapse widget</span>
                     </button>
                     <button type="button" class="widget-control-btn" data-widget-action="hide" aria-label="Hide widget">
@@ -447,7 +465,25 @@
                       aria-controls="widget-lessons-body"
                       aria-label="Collapse widget"
                     >
-                      <span aria-hidden="true" data-icon>−</span>
+                      <span aria-hidden="true" data-icon class="widget-control-icon">
+                        <svg
+                          data-icon-minus
+                          viewBox="0 0 16 16"
+                          aria-hidden="true"
+                          focusable="false"
+                        >
+                          <path d="M3 7.25h10v1.5H3z" fill="currentColor" />
+                        </svg>
+                        <svg
+                          data-icon-plus
+                          viewBox="0 0 16 16"
+                          aria-hidden="true"
+                          focusable="false"
+                          hidden
+                        >
+                          <path d="M7.25 3v4.25H3v1.5h4.25V13h1.5V8.75H13v-1.5H8.75V3z" fill="currentColor" />
+                        </svg>
+                      </span>
                       <span class="sr-only">Collapse widget</span>
                     </button>
                     <button type="button" class="widget-control-btn" data-widget-action="hide" aria-label="Hide widget">
@@ -528,7 +564,25 @@
                       aria-controls="widget-deadlines-body"
                       aria-label="Collapse widget"
                     >
-                      <span aria-hidden="true" data-icon>−</span>
+                      <span aria-hidden="true" data-icon class="widget-control-icon">
+                        <svg
+                          data-icon-minus
+                          viewBox="0 0 16 16"
+                          aria-hidden="true"
+                          focusable="false"
+                        >
+                          <path d="M3 7.25h10v1.5H3z" fill="currentColor" />
+                        </svg>
+                        <svg
+                          data-icon-plus
+                          viewBox="0 0 16 16"
+                          aria-hidden="true"
+                          focusable="false"
+                          hidden
+                        >
+                          <path d="M7.25 3v4.25H3v1.5h4.25V13h1.5V8.75H13v-1.5H8.75V3z" fill="currentColor" />
+                        </svg>
+                      </span>
                       <span class="sr-only">Collapse widget</span>
                     </button>
                     <button type="button" class="widget-control-btn" data-widget-action="hide" aria-label="Hide widget">
@@ -606,7 +660,25 @@
                       aria-controls="widget-activity-body"
                       aria-label="Collapse widget"
                     >
-                      <span aria-hidden="true" data-icon>−</span>
+                      <span aria-hidden="true" data-icon class="widget-control-icon">
+                        <svg
+                          data-icon-minus
+                          viewBox="0 0 16 16"
+                          aria-hidden="true"
+                          focusable="false"
+                        >
+                          <path d="M3 7.25h10v1.5H3z" fill="currentColor" />
+                        </svg>
+                        <svg
+                          data-icon-plus
+                          viewBox="0 0 16 16"
+                          aria-hidden="true"
+                          focusable="false"
+                          hidden
+                        >
+                          <path d="M7.25 3v4.25H3v1.5h4.25V13h1.5V8.75H13v-1.5H8.75V3z" fill="currentColor" />
+                        </svg>
+                      </span>
                       <span class="sr-only">Collapse widget</span>
                     </button>
                     <button type="button" class="widget-control-btn" data-widget-action="hide" aria-label="Hide widget">
@@ -668,7 +740,25 @@
                       aria-controls="widget-outdoor-body"
                       aria-label="Collapse widget"
                     >
-                      <span aria-hidden="true" data-icon>−</span>
+                      <span aria-hidden="true" data-icon class="widget-control-icon">
+                        <svg
+                          data-icon-minus
+                          viewBox="0 0 16 16"
+                          aria-hidden="true"
+                          focusable="false"
+                        >
+                          <path d="M3 7.25h10v1.5H3z" fill="currentColor" />
+                        </svg>
+                        <svg
+                          data-icon-plus
+                          viewBox="0 0 16 16"
+                          aria-hidden="true"
+                          focusable="false"
+                          hidden
+                        >
+                          <path d="M7.25 3v4.25H3v1.5h4.25V13h1.5V8.75H13v-1.5H8.75V3z" fill="currentColor" />
+                        </svg>
+                      </span>
                       <span class="sr-only">Collapse widget</span>
                     </button>
                     <button type="button" class="widget-control-btn" data-widget-action="hide" aria-label="Hide widget">

--- a/js/main.js
+++ b/js/main.js
@@ -1531,7 +1531,16 @@ const dashboardController = (() => {
     if (collapseBtn) {
       collapseBtn.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
       const icon = collapseBtn.querySelector('[data-icon]');
-      if (icon) icon.textContent = collapsed ? '+' : '−';
+      if (icon) {
+        const minusIcon = icon.querySelector('[data-icon-minus]');
+        const plusIcon = icon.querySelector('[data-icon-plus]');
+        if (minusIcon && plusIcon) {
+          minusIcon.hidden = collapsed;
+          plusIcon.hidden = !collapsed;
+        } else {
+          icon.textContent = collapsed ? '+' : '−';
+        }
+      }
       const sr = collapseBtn.querySelector('.sr-only');
       if (sr) sr.textContent = collapsed ? 'Expand widget' : 'Collapse widget';
       collapseBtn.setAttribute('title', collapsed ? 'Expand widget' : 'Collapse widget');

--- a/styles/index.css
+++ b/styles/index.css
@@ -707,6 +707,17 @@ html {
   line-height: 1;
 }
 
+.widget-control-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.widget-control-icon svg {
+  width: 1rem;
+  height: 1rem;
+}
+
 [data-widget-theme="inverted"] .widget-control-btn {
   background: rgba(255, 255, 255, 0.18);
   border-color: rgba(255, 255, 255, 0.35);


### PR DESCRIPTION
## Summary
- replace the text glyphs in the dashboard collapse buttons with dedicated SVG plus/minus icons to avoid oversized symbols
- add styles that keep the new widget control icons sized and centered consistently
- update the widget state controller to toggle the correct icon without affecting screen reader text

## Testing
- npm test -- --runTestsByPath theme-toggle.test.js service-worker.test.js reminders.categories.test.js sample.test.js *(fails: SyntaxError: Cannot use import statement outside a module in theme-toggle.test.js)*

------
https://chatgpt.com/codex/tasks/task_b_68eb7871329883279fff169dd40f82f2