### PR TITLE
Add dashboard onboarding section to simplify navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,6 +238,44 @@
   <main id="mainContent" class="app-shell min-h-screen" tabindex="-1">
     <section data-view="dashboard" id="view-dashboard" class="app-view" tabindex="-1">
       <div class="view-container">
+        <section class="dashboard-intro" aria-labelledby="dashboard-intro-heading">
+          <header class="dashboard-intro-header">
+            <div>
+              <p class="dashboard-intro-eyebrow">Welcome to Memory Cue</p>
+              <h2 id="dashboard-intro-heading">How to get organised in three simple steps</h2>
+            </div>
+            <p class="dashboard-intro-copy">
+              Start with the reminders that need your attention, then jump into the planner and notes when you are ready.
+              Each card below opens the right workspace so you never lose track of what to do next.
+            </p>
+          </header>
+          <ol class="dashboard-intro-steps">
+            <li class="dashboard-intro-step">
+              <span class="dashboard-intro-icon" aria-hidden="true">✅</span>
+              <div class="dashboard-intro-content">
+                <h3>Capture urgent cues</h3>
+                <p>Open the reminders board and log any tasks or student follow-ups that cannot wait.</p>
+                <a class="dashboard-intro-action" href="#reminders" data-route="reminders">Go to Reminders</a>
+              </div>
+            </li>
+            <li class="dashboard-intro-step">
+              <span class="dashboard-intro-icon" aria-hidden="true">🗓️</span>
+              <div class="dashboard-intro-content">
+                <h3>Plan your lessons</h3>
+                <p>Block the key sessions for the week, including focus areas and locations, so you can teach with clarity.</p>
+                <a class="dashboard-intro-action" href="#planner" data-route="planner">Open the Planner</a>
+              </div>
+            </li>
+            <li class="dashboard-intro-step">
+              <span class="dashboard-intro-icon" aria-hidden="true">📝</span>
+              <div class="dashboard-intro-content">
+                <h3>Keep quick notes tidy</h3>
+                <p>Use the notes workspace to capture observations and ideas, then pin them to your lessons later.</p>
+                <a class="dashboard-intro-action" href="#notes" data-route="notes">Review Notes</a>
+              </div>
+            </li>
+          </ol>
+        </section>
         <header class="view-header view-header--hero" aria-labelledby="dashboard-heading">
           <div class="hero rounded-2xl border border-base-200/70 bg-base-100/90 shadow-xl">
             <!-- BEGIN GPT FIX: widget-density -->

--- a/styles/index.css
+++ b/styles/index.css
@@ -306,6 +306,178 @@ html {
   outline-offset: 3px;
 }
 
+.dashboard-intro {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 2.5vw, 2.75rem);
+  padding: clamp(1.75rem, 2.5vw, 2.5rem);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(16, 185, 129, 0.08));
+  box-shadow: 0 20px 45px -35px rgba(15, 23, 42, 0.6);
+}
+
+.dark .dashboard-intro {
+  border-color: rgba(148, 163, 184, 0.2);
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.18), rgba(16, 185, 129, 0.12));
+  box-shadow: 0 24px 50px -36px rgba(15, 23, 42, 0.85);
+}
+
+.dashboard-intro-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: clamp(1rem, 3vw, 2rem);
+  flex-wrap: wrap;
+}
+
+.dashboard-intro-eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.dark .dashboard-intro-eyebrow {
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.dashboard-intro-header h2 {
+  font-size: clamp(1.5rem, 1.5vw + 1.2rem, 2rem);
+  font-weight: 700;
+  line-height: 1.2;
+  margin-top: 0.25rem;
+}
+
+.dashboard-intro-copy {
+  max-width: 32rem;
+  font-size: 0.95rem;
+  color: rgba(15, 23, 42, 0.7);
+}
+
+.dark .dashboard-intro-copy {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.dashboard-intro-steps {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(1rem, 2vw, 1.5rem);
+  margin: 0;
+  padding: 0;
+}
+
+@media (max-width: 960px) {
+  .dashboard-intro-steps {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .dashboard-intro-steps {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.dashboard-intro-step {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  padding: clamp(1.25rem, 2vw, 1.75rem);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.dashboard-intro-step:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 12px 22px -20px rgba(15, 23, 42, 0.45);
+  border-color: rgba(59, 130, 246, 0.35);
+}
+
+.dark .dashboard-intro-step {
+  background: rgba(15, 23, 42, 0.85);
+  border-color: rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.08);
+}
+
+.dark .dashboard-intro-step:hover {
+  border-color: rgba(96, 165, 250, 0.4);
+  box-shadow: 0 14px 26px -24px rgba(15, 23, 42, 0.9);
+}
+
+.dashboard-intro-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 9999px;
+  font-size: 1.5rem;
+  background: rgba(59, 130, 246, 0.12);
+}
+
+.dark .dashboard-intro-icon {
+  background: rgba(96, 165, 250, 0.18);
+}
+
+.dashboard-intro-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.dashboard-intro-content h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.dashboard-intro-content p {
+  font-size: 0.9rem;
+  color: rgba(15, 23, 42, 0.7);
+  margin: 0;
+}
+
+.dark .dashboard-intro-content p {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.dashboard-intro-action {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: 0.25rem;
+  padding: 0.55rem 1rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.95), rgba(16, 185, 129, 0.95));
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.dashboard-intro-action::after {
+  content: '→';
+  font-size: 0.9rem;
+}
+
+.dashboard-intro-action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 25px -20px rgba(37, 99, 235, 0.7);
+}
+
+.dashboard-intro-action:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.8);
+  outline-offset: 2px;
+}
+
 .dashboard-hero-copy {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add a guided three-step introduction panel to the dashboard so new users understand the workflow
- create responsive styling for the onboarding panel that works in light and dark themes

## Testing
- npm test -- --runTestsByPath sample.test.js

------
https://chatgpt.com/codex/tasks/task_b_68eb7bfeaa548327af29e2293be8d198