### PR TITLE
Reorganize dashboard overview into modular panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,59 +276,82 @@
             </li>
           </ol>
         </section>
-        <header class="view-header view-header--hero" aria-labelledby="dashboard-heading">
-          <div class="hero rounded-2xl border border-base-200/70 bg-base-100/90 shadow-xl">
-            <!-- BEGIN GPT FIX: widget-density -->
-            <div class="hero-content w-full flex-col gap-6 lg:gap-10 lg:flex-row lg:items-start lg:justify-between">
-              <div class="dashboard-hero-copy">
+        <section class="dashboard-overview" aria-labelledby="dashboard-overview-heading">
+          <div class="dashboard-overview-card">
+            <header class="dashboard-overview-header">
+              <div class="dashboard-overview-title">
                 <span class="dashboard-hero-eyebrow">Teacher control centre</span>
-                <h1 id="dashboard-heading" class="dashboard-hero-title">Your teaching day at a glance</h1>
-                <p id="dashboard-date" class="dashboard-hero-date"></p>
-                <p class="dashboard-hero-subtitle">Use quick actions to capture what matters, then move straight into the workspace you need.</p>
-                <div class="dashboard-quick-actions" role="list">
-                  <button type="button" data-quick-action="reminder" class="dashboard-quick-action" role="listitem">
-                    <span class="dashboard-quick-action-icon" aria-hidden="true">🔔</span>
-                    <span class="dashboard-quick-action-content">
-                      <span class="dashboard-quick-action-label">Log a cue</span>
-                      <span class="dashboard-quick-action-help">Open the reminder composer</span>
-                    </span>
-                  </button>
-                  <button type="button" data-quick-action="planner" class="dashboard-quick-action" role="listitem">
-                    <span class="dashboard-quick-action-icon" aria-hidden="true">🗓️</span>
-                    <span class="dashboard-quick-action-content">
-                      <span class="dashboard-quick-action-label">Plan the week</span>
-                      <span class="dashboard-quick-action-help">Jump to your weekly grid</span>
-                    </span>
-                  </button>
-                  <button type="button" data-quick-action="note" class="dashboard-quick-action" role="listitem">
-                    <span class="dashboard-quick-action-icon" aria-hidden="true">📝</span>
-                    <span class="dashboard-quick-action-content">
-                      <span class="dashboard-quick-action-label">Capture a note</span>
-                      <span class="dashboard-quick-action-help">Drop into the scratch pad</span>
-                    </span>
-                  </button>
+                <h1 id="dashboard-overview-heading" class="dashboard-hero-title">Your teaching day at a glance</h1>
+              </div>
+              <p id="dashboard-date" class="dashboard-overview-date dashboard-hero-date"></p>
+              <p class="dashboard-overview-subtitle dashboard-hero-subtitle">
+                Use the quick capture tools, check the live counts, then jump into the workspace that needs your attention first.
+              </p>
+            </header>
+            <div class="dashboard-overview-grid">
+              <section class="dashboard-overview-panel" aria-labelledby="dashboard-quick-actions-heading">
+                <header class="dashboard-panel-header">
+                  <h2 id="dashboard-quick-actions-heading">Quick capture</h2>
+                  <p class="dashboard-panel-copy">
+                    These shortcuts open the relevant workspace so you can log cues and plans without losing your rhythm.
+                  </p>
+                </header>
+                <ul class="dashboard-quick-actions" role="list">
+                  <li class="dashboard-quick-actions-item">
+                    <button type="button" data-quick-action="reminder" class="dashboard-quick-action">
+                      <span class="dashboard-quick-action-icon" aria-hidden="true">🔔</span>
+                      <span class="dashboard-quick-action-content">
+                        <span class="dashboard-quick-action-label">Log a cue</span>
+                        <span class="dashboard-quick-action-help">Open the reminder composer</span>
+                      </span>
+                    </button>
+                  </li>
+                  <li class="dashboard-quick-actions-item">
+                    <button type="button" data-quick-action="planner" class="dashboard-quick-action">
+                      <span class="dashboard-quick-action-icon" aria-hidden="true">🗓️</span>
+                      <span class="dashboard-quick-action-content">
+                        <span class="dashboard-quick-action-label">Plan the week</span>
+                        <span class="dashboard-quick-action-help">Jump to your weekly grid</span>
+                      </span>
+                    </button>
+                  </li>
+                  <li class="dashboard-quick-actions-item">
+                    <button type="button" data-quick-action="note" class="dashboard-quick-action">
+                      <span class="dashboard-quick-action-icon" aria-hidden="true">📝</span>
+                      <span class="dashboard-quick-action-content">
+                        <span class="dashboard-quick-action-label">Capture a note</span>
+                        <span class="dashboard-quick-action-help">Drop into the scratch pad</span>
+                      </span>
+                    </button>
+                  </li>
+                </ul>
+              </section>
+              <section class="dashboard-overview-panel" aria-labelledby="dashboard-snapshot-heading">
+                <header class="dashboard-panel-header">
+                  <h2 id="dashboard-snapshot-heading">Today&#39;s snapshot</h2>
+                  <p class="dashboard-panel-copy">Live counts refresh as you update reminders, lessons, and notes.</p>
+                </header>
+                <div class="dashboard-hero-summary" role="list" aria-label="Today&#39;s snapshot">
+                  <article class="dashboard-hero-card" role="listitem">
+                    <p class="dashboard-hero-card-label">Lessons today</p>
+                    <p id="dashboard-lesson-count" class="dashboard-hero-card-value">0</p>
+                    <p id="dashboard-next-lesson" class="dashboard-hero-card-meta"></p>
+                  </article>
+                  <article class="dashboard-hero-card" role="listitem">
+                    <p class="dashboard-hero-card-label">Deadlines this week</p>
+                    <p id="dashboard-deadline-count" class="dashboard-hero-card-value">0</p>
+                    <p class="dashboard-hero-card-meta">Countdowns refresh automatically</p>
+                  </article>
+                  <article class="dashboard-hero-card" role="listitem">
+                    <p class="dashboard-hero-card-label">Reminders to action</p>
+                    <p id="dashboard-reminder-count" class="dashboard-hero-card-value">0</p>
+                    <p class="dashboard-hero-card-meta">Due today or overdue</p>
+                  </article>
                 </div>
-              </div>
-              <div class="dashboard-hero-summary" role="list" aria-label="Today&#39;s snapshot">
-                <article class="dashboard-hero-card" role="listitem">
-                  <p class="dashboard-hero-card-label">Lessons today</p>
-                  <p id="dashboard-lesson-count" class="dashboard-hero-card-value">0</p>
-                  <p id="dashboard-next-lesson" class="dashboard-hero-card-meta"></p>
-                </article>
-                <article class="dashboard-hero-card" role="listitem">
-                  <p class="dashboard-hero-card-label">Deadlines this week</p>
-                  <p id="dashboard-deadline-count" class="dashboard-hero-card-value">0</p>
-                  <p class="dashboard-hero-card-meta">Countdowns refresh automatically</p>
-                </article>
-                <article class="dashboard-hero-card" role="listitem">
-                  <p class="dashboard-hero-card-label">Reminders to action</p>
-                  <p id="dashboard-reminder-count" class="dashboard-hero-card-value">0</p>
-                  <p class="dashboard-hero-card-meta">Due today or overdue</p>
-                </article>
-              </div>
+              </section>
             </div>
           </div>
-        </header>
+        </section>
 
         <div class="view-body space-y-10">
           <section class="dashboard-focus" aria-labelledby="dashboard-focus-heading">

--- a/styles/index.css
+++ b/styles/index.css
@@ -478,6 +478,119 @@ html {
   outline-offset: 2px;
 }
 
+.dashboard-overview {
+  margin-top: clamp(2rem, 3vw, 3rem);
+}
+
+.dashboard-overview-card {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 2vw, 2.25rem);
+  padding: clamp(1.75rem, 2vw + 1rem, 2.75rem);
+  border-radius: 1.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: linear-gradient(140deg, rgba(248, 250, 252, 0.92), rgba(241, 245, 249, 0.85));
+  box-shadow: 0 40px 60px -45px rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(4px);
+}
+
+.dark .dashboard-overview-card {
+  background: linear-gradient(140deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.9));
+  border-color: rgba(71, 85, 105, 0.55);
+  box-shadow: 0 45px 70px -55px rgba(15, 23, 42, 0.85);
+}
+
+.dashboard-overview-header {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.dashboard-overview-title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.dashboard-overview-date {
+  font-weight: 500;
+}
+
+.dashboard-overview-subtitle {
+  max-width: 40rem;
+}
+
+@media (min-width: 768px) {
+  .dashboard-overview-header {
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .dashboard-overview-date {
+    justify-self: end;
+  }
+
+  .dashboard-overview-subtitle {
+    grid-column: 1 / -1;
+  }
+}
+
+.dashboard-overview-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .dashboard-overview-grid {
+    gap: 1.75rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .dashboard-overview-grid {
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+    align-items: stretch;
+  }
+}
+
+.dashboard-overview-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.5rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  backdrop-filter: blur(6px);
+  min-height: 100%;
+}
+
+.dark .dashboard-overview-panel {
+  background: rgba(15, 23, 42, 0.78);
+  border-color: rgba(71, 85, 105, 0.55);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.12);
+}
+
+.dashboard-panel-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.dashboard-panel-header h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.dashboard-panel-copy {
+  font-size: 0.9rem;
+  color: rgba(71, 85, 105, 0.85);
+}
+
+.dark .dashboard-panel-copy {
+  color: rgba(148, 163, 184, 0.85);
+}
+
 .dashboard-hero-copy {
   display: flex;
   flex-direction: column;
@@ -527,6 +640,13 @@ html {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.dashboard-quick-actions-item {
+  display: flex;
 }
 
 .dashboard-quick-action {


### PR DESCRIPTION
## Summary
- replace the dashboard hero block with a reorganised overview section that groups quick capture actions and the live snapshot
- add supporting styles for the new overview panels and list-based quick actions

## Testing
- npm test -- --runInBand *(fails: Jest cannot parse js/main.js as it uses ESM imports)*

------
https://chatgpt.com/codex/tasks/task_b_68eb850f0bf083279bd3bd7bcd686cd2