### PR TITLE
Fix Tailwind Play CDN integrity hash

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
   <script
     defer
     src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"
-    integrity="sha384-YJvHoUr6w1FlD9gzD41c9ztiiG5wIJ9fhnawEIqr4iNzJgEpeI++XwO6yjHdcDte"
+    integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb"
     crossorigin="anonymous"
   ></script>
   <link


### PR DESCRIPTION
## Summary
- update the Tailwind Play CDN script tag to use the current SHA-384 integrity value to resolve runtime loading errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ec00b2a7048327891f4a86e12451ad