### PR TITLE
Fix Tailwind CDN integrity hash

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
   <script
     defer
     src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"
-    integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb"
+    integrity="sha384-5Gd6ZmB6QA0NMG3rwo87IgmzZa+kx0nklBS6vGG/ahHJMsRHi2e19nvMsB3zkL3O"
     crossorigin="anonymous"
   ></script>
   <link


### PR DESCRIPTION
## Summary
- update the Tailwind Play CDN script tag to use the current integrity hash so the resource can load successfully

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ec03a01cd48327a47f323a3e626cbf