### PR TITLE
Fix mobile sync controls

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -253,3 +253,373 @@
   });
 })();
 /* END GPT CHANGE */
+
+/* BEGIN GPT CHANGE: sync controls */
+(function () {
+  const syncStatusEl = document.getElementById('syncStatus');
+  const syncUrlInput = document.getElementById('syncUrl');
+  const saveSettingsBtn = document.getElementById('saveSyncSettings');
+  const testSyncBtn = document.getElementById('testSync');
+  const syncAllBtn = document.getElementById('syncAll');
+  const STORAGE_KEY = 'syncUrl';
+
+  if (!syncStatusEl) return;
+
+  const ACTIVE_CLASSES = ['online', 'error'];
+  let currentState = null;
+
+  function setStatus(state, message) {
+    currentState = state;
+    ACTIVE_CLASSES.forEach((cls) => syncStatusEl.classList.remove(cls));
+
+    if (state === 'online') {
+      syncStatusEl.classList.add('online');
+    } else if (state === 'error') {
+      syncStatusEl.classList.add('error');
+    }
+
+    const defaultMessage = {
+      checking: 'Checking connection…',
+      syncing: 'Syncing your latest changes…',
+      online: 'Connected. Changes sync automatically.',
+      offline: "You're offline. Changes are saved on this device until you reconnect.",
+      error: "We couldn't sync right now. We'll retry soon.",
+      info: '',
+    };
+
+    const text = typeof message === 'string' && message.trim() ? message : (defaultMessage[state] || '');
+    if (text) {
+      syncStatusEl.textContent = text;
+    }
+    syncStatusEl.dataset.state = state;
+  }
+
+  function updateOnlineState() {
+    if (currentState === 'syncing') return;
+    if (navigator.onLine) {
+      if (currentState !== 'online') {
+        setStatus('online');
+      }
+    } else {
+      setStatus('offline');
+    }
+  }
+
+  function persistUrl(value) {
+    if (typeof localStorage === 'undefined') return;
+    if (value) {
+      localStorage.setItem(STORAGE_KEY, value);
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }
+
+  function getStoredUrl() {
+    if (typeof localStorage === 'undefined') return '';
+    try {
+      return localStorage.getItem(STORAGE_KEY) || '';
+    } catch {
+      return '';
+    }
+  }
+
+  function normaliseReminder(raw) {
+    if (!raw || typeof raw !== 'object') return null;
+    const id = raw.id || raw.uid || raw.key || raw.slug || raw.uuid;
+    const title = typeof raw.title === 'string' && raw.title.trim()
+      ? raw.title.trim()
+      : (typeof raw.name === 'string' ? raw.name.trim() : '');
+    if (!title) return null;
+
+    const dueIso = typeof raw.dueIso === 'string' && raw.dueIso
+      ? raw.dueIso
+      : (typeof raw.due === 'string' ? raw.due : null);
+
+    const priority = typeof raw.priority === 'string' && raw.priority.trim()
+      ? raw.priority.trim()
+      : (raw.level || raw.importance || 'Medium');
+
+    const category = typeof raw.category === 'string' && raw.category.trim()
+      ? raw.category.trim()
+      : (raw.group || raw.bucket || 'General');
+
+    const done = typeof raw.done === 'boolean'
+      ? raw.done
+      : Boolean(raw.completed || raw.isDone || raw.status === 'done');
+
+    return {
+      id: id || (typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`),
+      title,
+      dueIso: dueIso && dueIso.trim() ? dueIso.trim() : null,
+      priority,
+      category,
+      done,
+    };
+  }
+
+  function collectFromDom() {
+    const elements = Array.from(document.querySelectorAll('[data-reminder]'));
+    if (!elements.length) return [];
+
+    return elements
+      .map((el) => {
+        const dataset = el.dataset || {};
+        let raw = null;
+
+        if (dataset.reminder) {
+          try {
+            raw = JSON.parse(dataset.reminder);
+          } catch {
+            raw = null;
+          }
+        }
+
+        const candidate = raw || {
+          id: dataset.id || dataset.reminderId || el.getAttribute('data-id') || null,
+          title: dataset.title || dataset.reminderTitle || '',
+          dueIso: dataset.due || dataset.reminderDue || el.getAttribute('data-due') || null,
+          priority: dataset.priority || dataset.reminderPriority || el.getAttribute('data-priority') || '',
+          category: dataset.category || dataset.reminderCategory || el.getAttribute('data-category') || '',
+          done: dataset.done === 'true' || dataset.reminderDone === 'true' || el.getAttribute('data-done') === 'true',
+        };
+
+        if (!candidate.title) {
+          const titleEl = el.querySelector('[data-reminder-title], [data-title], h3, h4, strong');
+          if (titleEl) {
+            candidate.title = titleEl.textContent.trim();
+          }
+        }
+
+        if (!candidate.dueIso) {
+          const dueEl = el.querySelector('[data-due], time');
+          if (dueEl) {
+            const attr = dueEl.getAttribute('datetime') || dueEl.getAttribute('data-due');
+            candidate.dueIso = attr || dueEl.textContent.trim();
+          }
+        }
+
+        return normaliseReminder(candidate);
+      })
+      .filter(Boolean);
+  }
+
+  function collectFromStorage() {
+    if (typeof localStorage === 'undefined') return [];
+    const reminders = [];
+    const triedKeys = new Set();
+    const preferredKeys = [
+      'memoryCue.reminders.v1',
+      'memoryCue.reminders',
+      'memoryCueMobile.reminders',
+      'memoryCue.reminders.cache',
+      'reminders',
+    ];
+
+    preferredKeys.forEach((key) => {
+      if (triedKeys.has(key)) return;
+      triedKeys.add(key);
+      try {
+        const value = localStorage.getItem(key);
+        if (!value) return;
+        const parsed = JSON.parse(value);
+        if (Array.isArray(parsed)) {
+          parsed.forEach((item) => reminders.push(item));
+        } else if (parsed && typeof parsed === 'object') {
+          if (Array.isArray(parsed.items)) parsed.items.forEach((item) => reminders.push(item));
+          if (Array.isArray(parsed.reminders)) parsed.reminders.forEach((item) => reminders.push(item));
+        }
+      } catch {
+        // ignore invalid storage entries
+      }
+    });
+
+    if (!reminders.length) {
+      for (let index = 0; index < localStorage.length; index += 1) {
+        const key = localStorage.key(index);
+        if (!key || triedKeys.has(key) || !/remind/i.test(key)) continue;
+        triedKeys.add(key);
+        try {
+          const value = localStorage.getItem(key);
+          if (!value) continue;
+          const parsed = JSON.parse(value);
+          if (Array.isArray(parsed)) {
+            parsed.forEach((item) => reminders.push(item));
+          } else if (parsed && typeof parsed === 'object') {
+            if (Array.isArray(parsed.items)) parsed.items.forEach((item) => reminders.push(item));
+            if (Array.isArray(parsed.reminders)) parsed.reminders.forEach((item) => reminders.push(item));
+          }
+        } catch {
+          // ignore
+        }
+      }
+    }
+
+    return reminders.map(normaliseReminder).filter(Boolean);
+  }
+
+  function collectReminders() {
+    const fromDom = collectFromDom();
+    if (fromDom.length) return fromDom;
+    return collectFromStorage();
+  }
+
+  function toggleBusy(isBusy) {
+    if (isBusy) {
+      syncAllBtn?.setAttribute('aria-busy', 'true');
+      syncAllBtn?.setAttribute('disabled', 'disabled');
+      testSyncBtn?.setAttribute('aria-busy', 'true');
+      testSyncBtn?.setAttribute('disabled', 'disabled');
+    } else {
+      syncAllBtn?.removeAttribute('aria-busy');
+      testSyncBtn?.removeAttribute('aria-busy');
+      updateButtonState();
+    }
+  }
+
+  function updateButtonState() {
+    const hasUrl = Boolean((syncUrlInput?.value || '').trim() || getStoredUrl());
+    if (hasUrl) {
+      syncAllBtn?.removeAttribute('disabled');
+      testSyncBtn?.removeAttribute('disabled');
+    } else {
+      syncAllBtn?.setAttribute('disabled', 'disabled');
+      testSyncBtn?.setAttribute('disabled', 'disabled');
+    }
+  }
+
+  const storedUrl = getStoredUrl();
+  if (syncUrlInput && storedUrl) {
+    syncUrlInput.value = storedUrl;
+  }
+
+  updateButtonState();
+  setStatus(navigator.onLine ? 'online' : 'offline');
+
+  window.addEventListener('online', updateOnlineState);
+  window.addEventListener('offline', updateOnlineState);
+
+  syncUrlInput?.addEventListener('input', updateButtonState);
+
+  saveSettingsBtn?.addEventListener('click', () => {
+    const value = (syncUrlInput?.value || '').trim();
+    if (!value) {
+      persistUrl('');
+      setStatus('info', 'Sync URL cleared. Add a new one to enable syncing.');
+      updateButtonState();
+      return;
+    }
+
+    try {
+      const parsed = new URL(value);
+      if (!/^https?:/.test(parsed.protocol)) {
+        throw new Error('Invalid protocol');
+      }
+    } catch {
+      setStatus('error', 'Enter a valid Apps Script URL before saving.');
+      return;
+    }
+
+    persistUrl(value);
+    setStatus('online', 'Sync settings saved.');
+    updateButtonState();
+  });
+
+  testSyncBtn?.addEventListener('click', async () => {
+    const url = (syncUrlInput?.value || getStoredUrl()).trim();
+    if (!url) {
+      setStatus('error', 'Add your Apps Script URL in Settings first.');
+      return;
+    }
+
+    toggleBusy(true);
+    setStatus('syncing', 'Testing connection…');
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ test: true }),
+      });
+      if (response.ok) {
+        setStatus('online', 'Connection looks good.');
+      } else {
+        setStatus('error', 'Test failed. Please check your Apps Script deployment.');
+      }
+    } catch (error) {
+      console.error('Test sync failed', error);
+      setStatus('error', 'Test failed. Please check your Apps Script deployment.');
+    } finally {
+      toggleBusy(false);
+    }
+  });
+
+  syncAllBtn?.addEventListener('click', async () => {
+    const url = (syncUrlInput?.value || getStoredUrl()).trim();
+    if (!url) {
+      setStatus('error', 'Add your Apps Script URL in Settings first.');
+      return;
+    }
+
+    const reminders = collectReminders();
+    if (!reminders.length) {
+      setStatus('info', 'No reminders to sync right now.');
+      return;
+    }
+
+    toggleBusy(true);
+    setStatus('syncing', `Syncing ${reminders.length} reminder${reminders.length === 1 ? '' : 's'}…`);
+
+    const chunkSize = 20;
+    let okCount = 0;
+    let failCount = 0;
+
+    const makePayload = (reminder) => ({
+      id: reminder.id,
+      title: reminder.title,
+      dueIso: reminder.dueIso || null,
+      priority: reminder.priority || 'Medium',
+      category: reminder.category || 'General',
+      done: Boolean(reminder.done),
+      source: 'memory-cue-mobile',
+    });
+
+    try {
+      for (let index = 0; index < reminders.length; index += chunkSize) {
+        const slice = reminders.slice(index, index + chunkSize);
+        const results = await Promise.allSettled(slice.map((reminder) => (
+          fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(makePayload(reminder)),
+          })
+        )));
+
+        results.forEach((result) => {
+          if (result.status === 'fulfilled' && result.value?.ok) {
+            okCount += 1;
+          } else if (result.status === 'fulfilled') {
+            failCount += 1;
+          } else {
+            failCount += 1;
+          }
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 300));
+      }
+
+      if (!failCount) {
+        setStatus('online', `Sync complete. ${okCount} reminder${okCount === 1 ? '' : 's'} updated.`);
+      } else if (!okCount) {
+        setStatus('error', 'Sync failed. Please check your Apps Script URL and try again.');
+      } else {
+        setStatus('error', `Partial sync: ${okCount} success, ${failCount} failed.`);
+      }
+    } catch (error) {
+      console.error('Sync failed', error);
+      setStatus('error', 'Sync failed. Please try again in a moment.');
+    } finally {
+      toggleBusy(false);
+    }
+  });
+})();
+/* END GPT CHANGE */


### PR DESCRIPTION
## Summary
- add a sync status controller to the mobile experience and wire it to the status badge
- persist the Apps Script URL, enable validation/testing, and stream sync requests in chunks with improved messaging

## Testing
- npm test -- --runTestsByPath sample.test.js

------
https://chatgpt.com/codex/tasks/task_b_68ec1752b0148327a890dcb8c9e478d2