### PR TITLE
Fix mobile scripts by loading them as modules

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -423,7 +423,7 @@
     </button>
   </nav>
 
-  <script src="./js/mobile-theme-toggle.js" defer></script>
+  <script type="module" src="./js/mobile-theme-toggle.js"></script>
   <!-- BEGIN GPT CHANGE: bottom sheet for Create Reminder -->
   <div id="create-sheet" role="dialog" aria-modal="true" aria-labelledby="createSheetTitle" class="sheet hidden" tabindex="-1">
     <div class="sheet-panel bg-base-100 border-t border-base-200">
@@ -560,7 +560,7 @@
   <!-- END GPT CHANGE: global FAB -->
 
   <!-- BEGIN GPT CHANGE: include mobile.js -->
-  <script src="mobile.js" defer></script>
+  <script type="module" src="./mobile.js"></script>
   <!-- END GPT CHANGE: include mobile.js -->
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load the mobile theme toggle and main mobile bundle as ES modules so that browsers allow import syntax

## Testing
- npm test -- --runTestsByPath sample.test.js

------
https://chatgpt.com/codex/tasks/task_b_68ec1fa5f5f083278cc64ec7f0de4d4d