### PR TITLE
Enable offline reminders on mobile

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -192,6 +192,13 @@ import { initReminders } from './js/reminders.js';
     }
   });
 
+  document.addEventListener('cue:open', () => {
+    openSheet();
+  });
+  document.addEventListener('cue:close', () => {
+    closeSheet();
+  });
+
   if (typeof window !== 'undefined') {
     window.closeAddTask = closeSheet;
   }


### PR DESCRIPTION
## Summary
- persist mobile reminders locally so new reminders can be created without signing in and sync them once authentication succeeds
- keep offline reminder storage updated for edits, imports, deletions, and Firestore updates while rescheduling notifications
- wire the mobile add sheet to cue events so saving or cancelling reliably closes it

## Testing
- npm test -- --runInBand *(fails: Jest cannot parse js/main.js ESM import in existing theme toggle test)*

------
https://chatgpt.com/codex/tasks/task_b_68f4d92a4e088327ae2089fc1e0b2080