### PR TITLE
Add base href for GitHub Pages deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en" data-theme="caramellatte">
 <head>
+  <base href="/memory-cue/">
   <!-- BEGIN GPT CHANGE: external styles -->
   <link rel="stylesheet" href="./styles/index.css">
   <!-- END GPT CHANGE -->


### PR DESCRIPTION
## Summary
- add a base href pointing to /memory-cue/ so asset URLs resolve when hosted on GitHub Pages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68f61a0c00588327b812200ec0aaad63