### PR TITLE
Fix PWA manifest paths for subdirectory hosting

### DIFF
--- a/404.html
+++ b/404.html
@@ -23,7 +23,7 @@
     content="Memory Cue helps teachers stay organised with integrated dashboards, reminders, planners, and curated resources in one streamlined app."
   >
   <meta property="og:type" content="website">
-  <meta property="og:image" content="/icons/og-image.png">
+  <meta property="og:image" content="./icons/og-image.png">
   <meta name="twitter:card" content="summary_large_image">
   <!-- END GPT CHANGE -->
   <!-- BEGIN GPT CHANGE: basic CSP -->
@@ -49,9 +49,9 @@
   <!-- BEGIN GPT CHANGE: head cleanup -->
   <!-- END GPT CHANGE -->
   <!-- PWA manifest -->
-  <link rel="manifest" href="manifest.webmanifest" />
+  <link rel="manifest" href="./manifest.webmanifest" />
   <!-- BEGIN GPT CHANGE: apple icon -->
-  <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png">
+  <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png">
   <!-- END GPT CHANGE -->
   <link rel="icon" href="./icons/icon-192.svg" type="image/svg+xml" />
   <link rel="stylesheet" href="./styles/tokens.css" />

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     content="Memory Cue helps teachers stay organised with integrated dashboards, reminders, planners, and curated resources in one streamlined app."
   >
   <meta property="og:type" content="website">
-  <meta property="og:image" content="/icons/og-image.png">
+  <meta property="og:image" content="./icons/og-image.png">
   <meta name="twitter:card" content="summary_large_image">
   <!-- END GPT CHANGE -->
   <!-- BEGIN GPT CHANGE: basic CSP -->
@@ -49,9 +49,9 @@
   <!-- BEGIN GPT CHANGE: head cleanup -->
   <!-- END GPT CHANGE -->
   <!-- PWA manifest -->
-  <link rel="manifest" href="manifest.webmanifest" />
+  <link rel="manifest" href="./manifest.webmanifest" />
   <!-- BEGIN GPT CHANGE: apple icon -->
-  <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png">
+  <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png">
   <!-- END GPT CHANGE -->
   <link rel="icon" href="./icons/icon-192.svg" type="image/svg+xml" />
   <link rel="stylesheet" href="./styles/tokens.css" />

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -8,9 +8,9 @@
   "background_color": "#0f172a",
   "description": "Offline-friendly reminder app with local notifications, smart sort, voice quick-add, and optional Google Apps Script sync.",
   "icons": [
-    { "src": "icons/icon-192.svg", "sizes": "192x192", "type": "image/svg+xml" },
-    { "src": "icons/icon-512.svg", "sizes": "512x512", "type": "image/svg+xml" },
-    { "src": "icons/maskable-192.svg", "sizes": "192x192", "type": "image/svg+xml", "purpose": "maskable any" },
-    { "src": "icons/maskable-512.svg", "sizes": "512x512", "type": "image/svg+xml", "purpose": "maskable any" }
+    { "src": "./icons/icon-192.svg", "sizes": "192x192", "type": "image/svg+xml" },
+    { "src": "./icons/icon-512.svg", "sizes": "512x512", "type": "image/svg+xml" },
+    { "src": "./icons/maskable-192.svg", "sizes": "192x192", "type": "image/svg+xml", "purpose": "maskable any" },
+    { "src": "./icons/maskable-512.svg", "sizes": "512x512", "type": "image/svg+xml", "purpose": "maskable any" }
   ]
 }

--- a/mobile.html
+++ b/mobile.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Memory Cue (Mobile) — Inline + Edit + Sync All</title>
   <meta name="theme-color" content="#0f172a" />
-  <link rel="manifest" href="manifest.webmanifest" id="manifestLink" />
+  <link rel="manifest" href="./manifest.webmanifest" id="manifestLink" />
   <link rel="icon" href="./icons/icon-192.svg" type="image/svg+xml" />
   <link rel="stylesheet" href="./styles/tokens.css" />
   <link rel="stylesheet" href="./styles/a11y.css" />


### PR DESCRIPTION
## Summary
- point PWA manifest link tags to a relative path so they work with the /memory-cue/ base href
- switch apple touch and Open Graph icons to relative URLs that resolve when hosted in a subdirectory
- update manifest icon entries to use relative paths compatible with subdirectory hosting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f69796cc1483279268ab3732ccfe77