### PR TITLE
Fix mobile reminder save on mobile page

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -675,7 +675,26 @@ export async function initReminders(sel = {}) {
   }
 
   // Formatting helpers
-  const navigatorLocale = typeof navigator !== 'undefined' && navigator.language ? navigator.language : '';
+  function sanitizeLocaleTag(tag) {
+    if (typeof tag !== 'string') return '';
+    let value = tag.trim();
+    if (!value) return '';
+    const atIndex = value.indexOf('@');
+    if (atIndex >= 0) {
+      value = value.slice(0, atIndex);
+    }
+    value = value.replace(/_/g, '-');
+    try {
+      // Validate via Intl API – throws if the tag is invalid.
+      new Intl.DateTimeFormat(value);
+      return value;
+    } catch {
+      return '';
+    }
+  }
+
+  const navigatorLocaleRaw = typeof navigator !== 'undefined' && navigator.language ? navigator.language : '';
+  const navigatorLocale = sanitizeLocaleTag(navigatorLocaleRaw);
   let locale = navigatorLocale || 'en-US';
   let TZ = 'UTC';
   try {

--- a/mobile.html
+++ b/mobile.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-theme="light">
 <head>
-  <base href="/memory-cue/" />
+  <base href="./" />
   <script src="https://cdn.jsdelivr.net/npm/daisyui@latest/dist/full.js"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
## Summary
- update the mobile page base href so bundled scripts load when the app is served from different base paths
- sanitize browser locale values before using Intl APIs so initialization succeeds in environments that report non-standard tags

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68fc16ecf33c832798bce384efcd84c6