### PR TITLE
Fix mobile reminder list default filter

### DIFF
--- a/app.js
+++ b/app.js
@@ -82,6 +82,7 @@ initReminders({
   sortSel: '#sort',
   categoryFilterSel: '#categoryFilter',
   categoryOptionsSel: '#categorySuggestions',
+  defaultFilter: 'today',
   countTodaySel: '#inlineTodayCount',
   countOverdueSel: '#inlineOverdueCount',
   countTotalSel: '#inlineTotalCount',

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -165,6 +165,20 @@ export async function initReminders(sel = {}) {
   const loadNotesBtn = $(sel.loadNotesBtnSel);
   const sortSel = $(sel.sortSel);
   const filterBtns = $$(sel.filterBtnsSel);
+  const normaliseFilterValue = (value) =>
+    typeof value === 'string' ? value.trim().toLowerCase() : '';
+  const filterLookup = new Map();
+  filterBtns.forEach((btn) => {
+    const raw = btn?.getAttribute('data-filter');
+    const normalised = normaliseFilterValue(raw);
+    if (normalised && !filterLookup.has(normalised)) {
+      filterLookup.set(normalised, raw);
+    }
+  });
+  const providedDefaultFilter = normaliseFilterValue(sel.defaultFilter);
+  const resolvedDefaultFilter =
+    (providedDefaultFilter && filterLookup.get(providedDefaultFilter)) ||
+    (providedDefaultFilter && !filterLookup.size ? providedDefaultFilter : null);
   const countTodayEl = $(sel.countTodaySel);
   const countWeekEl = $(sel.countWeekSel);
   const countOverdueEl = $(sel.countOverdueSel);
@@ -529,7 +543,7 @@ export async function initReminders(sel = {}) {
 
   // State
   let items = [];
-  let filter = filterBtns.length ? 'today' : 'all';
+  let filter = resolvedDefaultFilter || (filterBtns.length ? 'today' : 'all');
   let categoryFilterValue = categoryFilter?.value || 'all';
   let sortKey = 'smart';
   let listening = false;

--- a/mobile.html
+++ b/mobile.html
@@ -499,10 +499,10 @@
           <div class="card-body gap-4 compact">
             <div class="flex flex-wrap items-center justify-between gap-3">
               <div class="flex flex-wrap items-center gap-2" role="group" aria-label="Reminder filters">
-                <button class="btn btn-xs" type="button" data-filter="today" aria-pressed="true">Today · <span id="todayCount">0</span></button>
-                <button class="btn btn-xs" type="button" data-filter="overdue">Overdue · <span id="overdueCount">0</span></button>
-                <button class="btn btn-xs" type="button" data-filter="all">All · <span id="totalCountBadge">0</span></button>
-                <button class="btn btn-xs" type="button" data-filter="done">Done · <span id="completedCount">0</span></button>
+                <button class="btn btn-xs" type="button" data-filter="today" aria-pressed="false">Today · <span id="todayCount">0</span></button>
+                <button class="btn btn-xs" type="button" data-filter="overdue" aria-pressed="false">Overdue · <span id="overdueCount">0</span></button>
+                <button class="btn btn-xs" type="button" data-filter="all" aria-pressed="true">All · <span id="totalCountBadge">0</span></button>
+                <button class="btn btn-xs" type="button" data-filter="done" aria-pressed="false">Done · <span id="completedCount">0</span></button>
               </div>
               <label class="form-control w-full sm:w-auto">
                 <div class="label hidden sm:flex"><span class="label-text">Category filter</span></div>

--- a/mobile.js
+++ b/mobile.js
@@ -228,6 +228,7 @@ initReminders({
   countOverdueSel: '#overdueCount',
   countTotalSel: '#totalCountBadge, #totalCount',
   countCompletedSel: '#completedCount',
+  defaultFilter: 'all',
   googleSignInBtnSel: '#googleSignInBtn',
   googleSignOutBtnSel: '#googleSignOutBtn',
   googleAvatarSel: '#googleAvatar',


### PR DESCRIPTION
## Summary
- allow the reminders initialiser to honour a configured default filter
- default the mobile reminder view to the "all" filter so newly saved cues appear immediately
- align the mobile filter button states and keep the desktop default filter explicit

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68fc617ef3f8832784bc0e318748e8d4