### PR TITLE
Allow mobile reminder form submissions

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -720,7 +720,7 @@
           </div>
 
           <div class="card-actions justify-stretch">
-            <button id="saveReminder" class="btn btn-primary w-full" type="button">Save Reminder</button>
+            <button id="saveReminder" class="btn btn-primary w-full" type="submit">Save Reminder</button>
             <button id="cancelEditBtn" class="btn btn-outline w-full hidden" type="button">Cancel</button>
           </div>
           <p id="statusMessage" class="text-sm text-base-content/70" role="status" aria-live="polite"></p>

--- a/mobile.js
+++ b/mobile.js
@@ -249,6 +249,32 @@ initReminders({
   console.error('Failed to initialise reminders:', error);
 });
 
+// Ensure Enter/Go on mobile submits the same save path
+(() => {
+  const form = document.getElementById('createReminderForm');
+  const saveBtn = document.getElementById('saveReminder');
+  if (!form || !saveBtn) return;
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    saveBtn.click();
+  });
+})();
+
+(() => {
+  const sheet = document.getElementById('create-sheet');
+
+  function closeSheetIfOpen() {
+    if (!sheet) return;
+    if (typeof window !== 'undefined' && typeof window.closeAddTask === 'function') {
+      window.closeAddTask();
+    }
+  }
+
+  document.addEventListener('memoryCue:remindersUpdated', closeSheetIfOpen);
+  document.addEventListener('reminders:updated', closeSheetIfOpen);
+})();
+
 document.addEventListener('memoryCue:remindersUpdated', (event) => {
   const totalCountEl = document.getElementById('totalCount');
   if (!totalCountEl) return;


### PR DESCRIPTION
## Summary
- switch the mobile Save Reminder button to submit the form so keyboard actions trigger saves
- delegate form submission to the existing save click handler and close the sheet after reminders update

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68fcae124fc883278578b603b43674d0