### PR TITLE
Improve mobile reminder form submission safety

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -251,21 +251,30 @@ initReminders({
 
 // Ensure Enter/Go on mobile submits the same save path
 (() => {
-  const form = document.getElementById('createReminderForm');
+  const formEl = document.getElementById('createReminderForm');
   const saveBtn = document.getElementById('saveReminder');
-  if (!form || !saveBtn) return;
+  if (!(formEl instanceof HTMLFormElement) || !(saveBtn instanceof HTMLButtonElement)) {
+    return;
+  }
 
-  form.addEventListener('submit', (event) => {
+  formEl.addEventListener('submit', (event) => {
     event.preventDefault();
+    if (saveBtn.matches(':disabled')) return;
     saveBtn.click();
   });
 })();
 
 (() => {
-  const sheet = document.getElementById('create-sheet');
+  const sheetEl = document.getElementById('create-sheet');
+
+  if (!(sheetEl instanceof HTMLElement)) {
+    return;
+  }
 
   function closeSheetIfOpen() {
-    if (!sheet) return;
+    if (sheetEl.classList.contains('hidden')) {
+      return;
+    }
     if (typeof window !== 'undefined' && typeof window.closeAddTask === 'function') {
       window.closeAddTask();
     }


### PR DESCRIPTION
## Summary
- ensure the mobile reminder form submit handler operates on real form and button elements
- prevent keyboard submits from triggering the save flow while the save button is disabled
- only attempt to close the create reminder sheet when it exists and is visible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68fcb1fc2504832780550cac95962cdc