### PR TITLE
Mobile/minimal: remove duplicate Add button + ensure Save works; expose data-due for Today view

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -1336,9 +1336,13 @@ export async function initReminders(sel = {}) {
     const shouldGroupCategories = variant === 'desktop' || !isMinimalLayout;
 
     const createMobileItem = (r, catName) => {
-      const div = document.createElement('div');
-      div.className = 'task-item' + (r.done ? ' completed' : '');
-      div.dataset.category = catName;
+    const div = document.createElement('div');
+    div.className = 'task-item' + (r.done ? ' completed' : '');
+    div.dataset.category = catName;
+    // Make rows discoverable by other modules (e.g., Today view)
+    div.dataset.reminder = '1';
+    div.dataset.id = r.id;
+    if (r.due) div.dataset.due = r.due; // ISO string
       const dueTxt = r.due ? `${fmtTime(new Date(r.due))} • ${fmtDayDate(r.due.slice(0,10))}` : 'No due date';
       const priorityClass = `priority-${(r.priority || 'Medium').toLowerCase()}`;
       const notesHtml = r.notes ? `<div class="task-notes">${notesToHtml(r.notes)}</div>` : '';

--- a/mobile.html
+++ b/mobile.html
@@ -453,16 +453,6 @@
   <main id="main" class="max-w-md mx-auto px-4 pb-28 pt-4" tabindex="-1" data-active-view="reminders">
     <!-- Voice Add Task UI -->
     <div id="voiceAddWrap" class="voice-add-wrap" aria-live="polite" aria-atomic="true">
-      <button
-        id="quickAddMinimal"
-        class="btn btn-circle btn-primary"
-        type="button"
-        data-open-add-task
-        aria-label="Quick add reminder"
-        title="Quick add reminder"
-      >
-        ＋
-      </button>
       <button id="voiceAddBtn" class="btn btn-circle btn-ghost" aria-pressed="false" aria-label="Add task by voice">🎤</button>
       <span id="voiceStatus" class="voice-status" hidden>Tap 🎤 to speak</span>
     </div>
@@ -720,7 +710,7 @@
           </div>
 
           <div class="card-actions justify-stretch">
-            <button id="saveReminder" class="btn btn-primary w-full" type="submit">Save Reminder</button>
+            <button id="saveReminder" class="btn btn-primary w-full" type="button">Save Reminder</button>
             <button id="cancelEditBtn" class="btn btn-outline w-full hidden" type="button">Cancel</button>
           </div>
           <p id="statusMessage" class="text-sm text-base-content/70" role="status" aria-live="polite"></p>

--- a/mobile.js
+++ b/mobile.js
@@ -206,6 +206,7 @@ import { initReminders } from './js/reminders.js';
 /* END GPT CHANGE */
 
 initReminders({
+  variant: 'mobile',
   qSel: '#searchReminders',
   titleSel: '#reminderText',
   dateSel: '#reminderDate',
@@ -216,6 +217,8 @@ initReminders({
   saveBtnSel: '#saveReminder',
   cancelEditBtnSel: '#cancelEditBtn',
   listSel: '#reminderList',
+  listWrapperSel: '#remindersWrapper',
+  emptyStateSel: '#emptyState',
   statusSel: '#statusMessage',
   syncStatusSel: '#syncStatus',
   voiceBtnSel: '#voiceBtn',
@@ -238,13 +241,10 @@ initReminders({
   saveSettingsSel: '#saveSyncSettings',
   testSyncSel: '#testSync',
   openSettingsSel: '#openSettings',
-  emptyStateSel: '#emptyState',
-  listWrapperSel: '#remindersWrapper',
   notesSel: '#notes',
   saveNotesBtnSel: '#saveNotes',
   loadNotesBtnSel: '#loadNotes',
   dateFeedbackSel: '#dateFeedback',
-  variant: 'mobile',
 }).catch((error) => {
   console.error('Failed to initialise reminders:', error);
 });
@@ -253,9 +253,7 @@ initReminders({
 (() => {
   const formEl = document.getElementById('createReminderForm');
   const saveBtn = document.getElementById('saveReminder');
-  if (!(formEl instanceof HTMLFormElement) || !(saveBtn instanceof HTMLButtonElement)) {
-    return;
-  }
+  if (!(formEl instanceof HTMLFormElement) || !(saveBtn instanceof HTMLButtonElement)) return;
 
   formEl.addEventListener('submit', (event) => {
     event.preventDefault();


### PR DESCRIPTION
## Summary
- remove the extra inline quick add button from the mobile voice toolbar while keeping the FAB
- adjust the save reminder control so the bottom sheet save path does not trigger a full page reload
- expose data-reminder, data-id, and data-due attributes on rendered reminders so the Today view can detect them

## Testing
- Hard refresh mobile.html
- Tap the floating + → type a title → tap Save Reminder
- Verify the new reminder appears in the list and the page didn’t reload
- If you set date/time for today, switch to Today tab and verify it appears there
- Confirm only one “+” button is visible


------
https://chatgpt.com/codex/tasks/task_e_68ff4549cb88832497ca3d067881c195