### PR TITLE
Fix mobile reminder saving workflow and UI wiring

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ const openCueButton = document.getElementById('openCueModal');
 const closeCueButton = document.getElementById('closeCueModal');
 const modalBackdropButton = cueModal?.querySelector('.modal-backdrop button');
 const titleInput = document.getElementById('title');
+const mobileTitleInput = document.getElementById('reminderText');
 
 const focusTitleInput = () => {
   if (!titleInput) return;
@@ -65,32 +66,86 @@ document.addEventListener('cue:close', () => {
   openCueButton?.focus();
 });
 
-initReminders({
-  titleSel: '#title',
-  dateSel: '#date',
-  timeSel: '#time',
-  detailsSel: '#details',
-  prioritySel: '#priority',
-  categorySel: '#category',
-  saveBtnSel: '#saveBtn',
-  cancelEditBtnSel: '#cancelEditBtn',
-  listSel: '#reminderList',
-  statusSel: '#status',
-  syncStatusSel: '#syncStatus',
-  voiceBtnSel: '#voiceBtn',
-  filterBtnsSel: '[data-filter]',
-  sortSel: '#sort',
-  categoryFilterSel: '#categoryFilter',
-  categoryOptionsSel: '#categorySuggestions',
-  defaultFilter: 'today',
-  countTodaySel: '#inlineTodayCount',
-  countOverdueSel: '#inlineOverdueCount',
-  countTotalSel: '#inlineTotalCount',
-  countCompletedSel: '#inlineCompletedCount',
-  emptyStateSel: '#emptyState',
-  listWrapperSel: '#remindersWrapper',
-  dateFeedbackSel: '#dateFeedback',
-  variant: 'desktop'
+const initialiseReminders = () => {
+  const hasDesktopForm = Boolean(titleInput);
+  const hasMobileForm = Boolean(mobileTitleInput);
+
+  if (!hasDesktopForm && !hasMobileForm) {
+    return Promise.resolve();
+  }
+
+  if (hasMobileForm) {
+    return initReminders({
+      variant: 'mobile',
+      qSel: '#searchReminders',
+      titleSel: '#reminderText',
+      dateSel: '#reminderDate',
+      timeSel: '#reminderTime',
+      detailsSel: '#reminderDetails',
+      prioritySel: '#priority',
+      categorySel: '#category',
+      saveBtnSel: '#saveReminder',
+      cancelEditBtnSel: '#cancelEditBtn',
+      listSel: '#reminderList',
+      listWrapperSel: '#remindersWrapper',
+      emptyStateSel: '#emptyState',
+      statusSel: '#statusMessage',
+      syncStatusSel: '#syncStatus',
+      voiceBtnSel: '#voiceBtn',
+      notifBtnSel: '#notifBtn',
+      addQuickBtnSel: '#quickAdd',
+      filterBtnsSel: '[data-filter]',
+      categoryFilterSel: '#categoryFilter',
+      categoryOptionsSel: '#categorySuggestions',
+      defaultFilter: 'all',
+      countTodaySel: '#todayCount',
+      countOverdueSel: '#overdueCount',
+      countTotalSel: '#totalCountBadge',
+      countCompletedSel: '#completedCount',
+      googleSignInBtnSel: '#googleSignInBtn',
+      googleSignOutBtnSel: '#googleSignOutBtn',
+      googleAvatarSel: '#googleAvatar',
+      googleUserNameSel: '#googleUserName',
+      syncAllBtnSel: '#syncAll',
+      syncUrlInputSel: '#syncUrl',
+      saveSettingsSel: '#saveSyncSettings',
+      testSyncSel: '#testSync',
+      openSettingsSel: '#openSettings',
+      dateFeedbackSel: '#dateFeedback'
+    });
+  }
+
+  return initReminders({
+    titleSel: '#title',
+    dateSel: '#date',
+    timeSel: '#time',
+    detailsSel: '#details',
+    prioritySel: '#priority',
+    categorySel: '#category',
+    saveBtnSel: '#saveBtn',
+    cancelEditBtnSel: '#cancelEditBtn',
+    listSel: '#reminderList',
+    statusSel: '#status',
+    syncStatusSel: '#syncStatus',
+    voiceBtnSel: '#voiceBtn',
+    filterBtnsSel: '[data-filter]',
+    sortSel: '#sort',
+    categoryFilterSel: '#categoryFilter',
+    categoryOptionsSel: '#categorySuggestions',
+    defaultFilter: 'today',
+    countTodaySel: '#inlineTodayCount',
+    countOverdueSel: '#inlineOverdueCount',
+    countTotalSel: '#inlineTotalCount',
+    countCompletedSel: '#inlineCompletedCount',
+    emptyStateSel: '#emptyState',
+    listWrapperSel: '#remindersWrapper',
+    dateFeedbackSel: '#dateFeedback',
+    variant: 'desktop'
+  });
+};
+
+initialiseReminders().catch((error) => {
+  console.error('Failed to initialise reminders', error);
 });
 
 const cuesList = document.getElementById('cues-list');

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -206,6 +206,13 @@ export async function initReminders(sel = {}) {
   const categoryFilter = $(sel.categoryFilterSel);
   const categoryDatalist = $(sel.categoryOptionsSel);
   const variant = sel.variant || 'mobile';
+  try {
+    if (variant === 'mobile' && typeof document !== 'undefined') {
+      document.body?.classList?.add('show-full');
+    }
+  } catch {
+    /* ignore environments without DOM */
+  }
   const emptyInitialText = sel.emptyStateInitialText || 'Create your first reminder to keep important tasks in view.';
   const emptyFilteredText = sel.emptyStateFilteredText || 'No reminders match the current filter. Adjust your filters or add a new cue.';
   const sharedEmptyStateMount = (typeof window !== 'undefined' && typeof window.memoryCueMountEmptyState === 'function') ? window.memoryCueMountEmptyState : null;

--- a/mobile.html
+++ b/mobile.html
@@ -795,10 +795,573 @@
   <button id="fabCreate" class="fab nonFocusUI nonEssential" aria-label="Add reminder">＋</button>
   <!-- END GPT CHANGE: global FAB -->
 
-  <!-- BEGIN GPT CHANGE: include mobile.js -->
-  <script type="module" src="./mobile.js"></script>
-  <!-- END GPT CHANGE: include mobile.js -->
   <script src="app.js" type="module"></script>
+  <script id="mobile-enhancements">
+    (function () {
+      const views = {
+        reminders: document.querySelector('[data-view="reminders"]'),
+        today: document.querySelector('[data-view="today"]'),
+        notebook: document.querySelector('[data-view="notebook"]'),
+      };
+      const nav = document.querySelector('.btm-nav');
+      if (!nav) return;
+
+      const buttons = Array.from(nav.querySelectorAll('button')).slice(0, 3);
+      const order = ['reminders', 'today', 'notebook'];
+
+      if (!buttons.length || order.some((key) => !views[key])) {
+        return;
+      }
+
+      const reduceMotion = typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+        ? window.matchMedia('(prefers-reduced-motion: reduce)')
+        : null;
+
+      const setActiveView = (target) => {
+        if (!order.includes(target)) return;
+
+        order.forEach((key, index) => {
+          const view = views[key];
+          const button = buttons[index];
+          const isActive = key === target;
+
+          if (view) {
+            view.classList.toggle('hidden', !isActive);
+            view.setAttribute('aria-hidden', String(!isActive));
+          }
+
+          if (button) {
+            button.setAttribute('aria-current', isActive ? 'page' : 'false');
+            button.classList.toggle('active', Boolean(isActive));
+          }
+        });
+
+        const skipLink = document.querySelector('a[href="#main"]');
+        const main = document.getElementById('main') || document.querySelector('main');
+        if (main) {
+          main.setAttribute('data-active-view', target);
+        }
+        if (skipLink && main) {
+          const behaviour = reduceMotion?.matches ? 'auto' : 'smooth';
+          try {
+            window.scrollTo({ top: 0, behavior: behaviour });
+          } catch {
+            window.scrollTo(0, 0);
+          }
+        }
+      };
+
+      buttons.forEach((button, index) => {
+        button.addEventListener('click', () => {
+          setActiveView(order[index]);
+        });
+      });
+
+      document.querySelectorAll('[data-jump-view]').forEach((control) => {
+        control.addEventListener('click', () => {
+          const target = control.getAttribute('data-jump-view');
+          if (target) {
+            setActiveView(target);
+          }
+        });
+      });
+
+      document.querySelectorAll('[data-scroll-target]').forEach((control) => {
+        control.addEventListener('click', () => {
+          const targetId = control.getAttribute('data-scroll-target');
+          if (!targetId) return;
+          const el = document.getElementById(targetId);
+          if (!el) return;
+          try {
+            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          } catch {
+            el.scrollIntoView(true);
+          }
+        });
+      });
+
+      setActiveView('reminders');
+    })();
+
+    (function () {
+      const todayView = document.querySelector('[data-view="today"]');
+      const list = document.getElementById('reminderList');
+      if (!todayView || !list) return;
+
+      const isToday = (dateStr) => {
+        const d = new Date(dateStr);
+        if (Number.isNaN(d.getTime())) return false;
+        const now = new Date();
+        return d.getFullYear() === now.getFullYear() &&
+          d.getMonth() === now.getMonth() &&
+          d.getDate() === now.getDate();
+      };
+
+      const renderToday = () => {
+        const items = Array.from(list.querySelectorAll('[data-reminder]'));
+        const todaysItems = items.filter((item) => {
+          const direct = item.getAttribute('data-due');
+          const nested = item.querySelector('[data-due]');
+          const when = direct || (nested ? nested.textContent : '') || '';
+          return isToday(when.trim());
+        });
+
+        todayView.innerHTML = '';
+        const heading = document.createElement('h2');
+        heading.textContent = 'Today';
+        todayView.appendChild(heading);
+
+        if (!todaysItems.length) {
+          const empty = document.createElement('p');
+          empty.textContent = 'No reminders due today.';
+          todayView.appendChild(empty);
+          return;
+        }
+
+        todaysItems.forEach((item) => {
+          todayView.appendChild(item.cloneNode(true));
+        });
+      };
+
+      document.addEventListener('DOMContentLoaded', renderToday);
+      document.addEventListener('reminders:updated', renderToday);
+      document.addEventListener('memoryCue:remindersUpdated', renderToday);
+    })();
+
+    (function () {
+      const list = document.getElementById('reminderList');
+      if (!list) return;
+
+      const allChildren = Array.from(list.children);
+      if (allChildren.length <= 30) return;
+
+      const PAGE_SIZE = 20;
+      list.innerHTML = '';
+      let index = 0;
+
+      const appendPage = () => {
+        const slice = allChildren.slice(index, index + PAGE_SIZE);
+        slice.forEach((node) => list.appendChild(node));
+        index += slice.length;
+      };
+
+      appendPage();
+
+      const sentinel = document.createElement('div');
+      sentinel.id = 'listSentinel';
+      list.appendChild(sentinel);
+
+      const observer = new IntersectionObserver((entries) => {
+        if (entries.some((entry) => entry.isIntersecting) && index < allChildren.length) {
+          appendPage();
+          if (index >= allChildren.length) {
+            observer.disconnect();
+          }
+        }
+      });
+
+      observer.observe(sentinel);
+    })();
+
+    (function () {
+      const openBtn = document.querySelector('[data-open="settings"]') || document.getElementById('openSettings');
+      const modal = document.getElementById('settingsModal');
+      const closeBtn = document.getElementById('closeSettings');
+      if (!openBtn || !modal || !closeBtn) return;
+
+      const open = () => {
+        modal.classList.remove('hidden');
+      };
+
+      const close = () => {
+        modal.classList.add('hidden');
+      };
+
+      openBtn.addEventListener('click', open);
+      closeBtn.addEventListener('click', close);
+      modal.addEventListener('click', (event) => {
+        if (event.target instanceof HTMLElement && event.target.matches('[data-close]')) {
+          close();
+        }
+      });
+      modal.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          close();
+        }
+      });
+    })();
+
+    (function () {
+      const syncStatusEl = document.getElementById('syncStatus');
+      if (!syncStatusEl) return;
+
+      const syncUrlInput = document.getElementById('syncUrl');
+      const saveSettingsBtn = document.getElementById('saveSyncSettings');
+      const testSyncBtn = document.getElementById('testSync');
+      const syncAllBtn = document.getElementById('syncAll');
+      const STORAGE_KEY = 'syncUrl';
+      const ACTIVE_CLASSES = ['online', 'error'];
+
+      let currentState = null;
+
+      const setStatus = (state, message) => {
+        currentState = state;
+        ACTIVE_CLASSES.forEach((cls) => syncStatusEl.classList.remove(cls));
+
+        if (state === 'online') {
+          syncStatusEl.classList.add('online');
+        } else if (state === 'error') {
+          syncStatusEl.classList.add('error');
+        }
+
+        const defaults = {
+          checking: 'Checking connection…',
+          syncing: 'Syncing your latest changes…',
+          online: 'Connected. Changes sync automatically.',
+          offline: "You're offline. Changes are saved on this device until you reconnect.",
+          error: "We couldn't sync right now. We'll retry soon.",
+          info: '',
+        };
+
+        const text = typeof message === 'string' && message.trim() ? message : (defaults[state] || '');
+        if (text) {
+          syncStatusEl.textContent = text;
+        }
+        syncStatusEl.dataset.state = state;
+      };
+
+      const updateOnlineState = () => {
+        if (currentState === 'syncing') return;
+        if (navigator.onLine) {
+          if (currentState !== 'online') setStatus('online');
+        } else {
+          setStatus('offline');
+        }
+      };
+
+      const persistUrl = (value) => {
+        if (typeof localStorage === 'undefined') return;
+        if (value) {
+          localStorage.setItem(STORAGE_KEY, value);
+        } else {
+          localStorage.removeItem(STORAGE_KEY);
+        }
+      };
+
+      const getStoredUrl = () => {
+        if (typeof localStorage === 'undefined') return '';
+        try {
+          return localStorage.getItem(STORAGE_KEY) || '';
+        } catch {
+          return '';
+        }
+      };
+
+      const normaliseReminder = (raw) => {
+        if (!raw || typeof raw !== 'object') return null;
+        const id = raw.id || raw.uid || raw.key || raw.slug || raw.uuid;
+        let title = typeof raw.title === 'string' ? raw.title.trim() : '';
+        if (!title && typeof raw.name === 'string') {
+          title = raw.name.trim();
+        }
+        if (!title) return null;
+
+        const dueIso = typeof raw.dueIso === 'string' && raw.dueIso
+          ? raw.dueIso
+          : (typeof raw.due === 'string' ? raw.due : null);
+
+        const priority = typeof raw.priority === 'string' && raw.priority.trim()
+          ? raw.priority.trim()
+          : (raw.level || raw.importance || 'Medium');
+
+        const category = typeof raw.category === 'string' && raw.category.trim()
+          ? raw.category.trim()
+          : (raw.group || raw.bucket || 'General');
+
+        const done = typeof raw.done === 'boolean'
+          ? raw.done
+          : Boolean(raw.completed || raw.isDone || raw.status === 'done');
+
+        const ensuredId = id || (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+          ? crypto.randomUUID()
+          : `${Date.now()}-${Math.random()}`);
+
+        return {
+          id: ensuredId,
+          title,
+          dueIso: dueIso && dueIso.trim() ? dueIso.trim() : null,
+          priority,
+          category,
+          done,
+        };
+      };
+
+      const collectFromDom = () => {
+        const elements = Array.from(document.querySelectorAll('[data-reminder]'));
+        if (!elements.length) return [];
+
+        return elements
+          .map((el) => {
+            const dataset = el.dataset || {};
+            let raw = null;
+
+            if (dataset.reminder) {
+              try {
+                raw = JSON.parse(dataset.reminder);
+              } catch {
+                raw = null;
+              }
+            }
+
+            const candidate = raw || {
+              id: dataset.id || dataset.reminderId || el.getAttribute('data-id') || null,
+              title: dataset.title || dataset.reminderTitle || '',
+              dueIso: dataset.due || dataset.reminderDue || el.getAttribute('data-due') || null,
+              priority: dataset.priority || dataset.reminderPriority || el.getAttribute('data-priority') || '',
+              category: dataset.category || dataset.reminderCategory || el.getAttribute('data-category') || '',
+              done: dataset.done === 'true' || dataset.reminderDone === 'true' || el.getAttribute('data-done') === 'true',
+            };
+
+            if (!candidate.title) {
+              const titleEl = el.querySelector('[data-reminder-title], [data-title], h3, h4, strong');
+              if (titleEl) {
+                candidate.title = titleEl.textContent.trim();
+              }
+            }
+
+            if (!candidate.dueIso) {
+              const dueEl = el.querySelector('[data-due], time');
+              if (dueEl) {
+                const attr = dueEl.getAttribute('datetime') || dueEl.getAttribute('data-due');
+                candidate.dueIso = attr || dueEl.textContent.trim();
+              }
+            }
+
+            return normaliseReminder(candidate);
+          })
+          .filter(Boolean);
+      };
+
+      const collectFromStorage = () => {
+        if (typeof localStorage === 'undefined') return [];
+        const reminders = [];
+        const triedKeys = new Set();
+        const preferredKeys = [
+          'memoryCue.reminders.v1',
+          'memoryCue.reminders',
+          'memoryCueMobile.reminders',
+          'memoryCue.reminders.cache',
+          'reminders',
+        ];
+
+        preferredKeys.forEach((key) => {
+          if (triedKeys.has(key)) return;
+          triedKeys.add(key);
+          try {
+            const value = localStorage.getItem(key);
+            if (!value) return;
+            const parsed = JSON.parse(value);
+            if (Array.isArray(parsed)) {
+              parsed.forEach((item) => reminders.push(item));
+            } else if (parsed && typeof parsed === 'object') {
+              if (Array.isArray(parsed.items)) parsed.items.forEach((item) => reminders.push(item));
+              if (Array.isArray(parsed.reminders)) parsed.reminders.forEach((item) => reminders.push(item));
+            }
+          } catch {
+            // ignore invalid storage entries
+          }
+        });
+
+        if (!reminders.length) {
+          for (let index = 0; index < localStorage.length; index += 1) {
+            const key = localStorage.key(index);
+            if (!key || triedKeys.has(key) || !/remind/i.test(key)) continue;
+            triedKeys.add(key);
+            try {
+              const value = localStorage.getItem(key);
+              if (!value) continue;
+              const parsed = JSON.parse(value);
+              if (Array.isArray(parsed)) {
+                parsed.forEach((item) => reminders.push(item));
+              } else if (parsed && typeof parsed === 'object') {
+                if (Array.isArray(parsed.items)) parsed.items.forEach((item) => reminders.push(item));
+                if (Array.isArray(parsed.reminders)) parsed.reminders.forEach((item) => reminders.push(item));
+              }
+            } catch {
+              // ignore
+            }
+          }
+        }
+
+        return reminders.map(normaliseReminder).filter(Boolean);
+      };
+
+      const collectReminders = () => {
+        const fromDom = collectFromDom();
+        if (fromDom.length) return fromDom;
+        return collectFromStorage();
+      };
+
+      const toggleBusy = (isBusy) => {
+        if (isBusy) {
+          syncAllBtn?.setAttribute('aria-busy', 'true');
+          syncAllBtn?.setAttribute('disabled', 'disabled');
+          testSyncBtn?.setAttribute('aria-busy', 'true');
+          testSyncBtn?.setAttribute('disabled', 'disabled');
+        } else {
+          syncAllBtn?.removeAttribute('aria-busy');
+          testSyncBtn?.removeAttribute('aria-busy');
+          updateButtonState();
+        }
+      };
+
+      const updateButtonState = () => {
+        const hasUrl = Boolean((syncUrlInput?.value || '').trim() || getStoredUrl());
+        if (hasUrl) {
+          syncAllBtn?.removeAttribute('disabled');
+          testSyncBtn?.removeAttribute('disabled');
+        } else {
+          syncAllBtn?.setAttribute('disabled', 'disabled');
+          testSyncBtn?.setAttribute('disabled', 'disabled');
+        }
+      };
+
+      const storedUrl = getStoredUrl();
+      if (syncUrlInput && storedUrl) {
+        syncUrlInput.value = storedUrl;
+      }
+
+      updateButtonState();
+      setStatus(navigator.onLine ? 'online' : 'offline');
+
+      window.addEventListener('online', updateOnlineState);
+      window.addEventListener('offline', updateOnlineState);
+
+      syncUrlInput?.addEventListener('input', updateButtonState);
+
+      saveSettingsBtn?.addEventListener('click', () => {
+        const value = (syncUrlInput?.value || '').trim();
+        if (!value) {
+          persistUrl('');
+          setStatus('info', 'Sync URL cleared. Add a new one to enable syncing.');
+          updateButtonState();
+          return;
+        }
+
+        try {
+          const parsed = new URL(value);
+          if (!/^https?:/.test(parsed.protocol)) {
+            throw new Error('Invalid protocol');
+          }
+        } catch {
+          setStatus('error', 'Enter a valid Apps Script URL before saving.');
+          return;
+        }
+
+        persistUrl(value);
+        setStatus('online', 'Sync settings saved.');
+        updateButtonState();
+      });
+
+      testSyncBtn?.addEventListener('click', async () => {
+        const url = (syncUrlInput?.value || getStoredUrl()).trim();
+        if (!url) {
+          setStatus('error', 'Add your Apps Script URL in Settings first.');
+          return;
+        }
+
+        toggleBusy(true);
+        setStatus('syncing', 'Testing connection…');
+
+        try {
+          const response = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ test: true }),
+          });
+          if (response.ok) {
+            setStatus('online', 'Connection looks good.');
+          } else {
+            setStatus('error', 'Test failed. Please check your Apps Script deployment.');
+          }
+        } catch (error) {
+          console.error('Test sync failed', error);
+          setStatus('error', 'Test failed. Please check your Apps Script deployment.');
+        } finally {
+          toggleBusy(false);
+        }
+      });
+
+      syncAllBtn?.addEventListener('click', async () => {
+        const url = (syncUrlInput?.value || getStoredUrl()).trim();
+        if (!url) {
+          setStatus('error', 'Add your Apps Script URL in Settings first.');
+          return;
+        }
+
+        const reminders = collectReminders();
+        if (!reminders.length) {
+          setStatus('info', 'No reminders to sync right now.');
+          return;
+        }
+
+        toggleBusy(true);
+        setStatus('syncing', `Syncing ${reminders.length} reminder${reminders.length === 1 ? '' : 's'}…`);
+
+        const chunkSize = 20;
+        let okCount = 0;
+        let failCount = 0;
+
+        const makePayload = (reminder) => ({
+          id: reminder.id,
+          title: reminder.title,
+          dueIso: reminder.dueIso || null,
+          priority: reminder.priority || 'Medium',
+          category: reminder.category || 'General',
+          done: Boolean(reminder.done),
+          source: 'memory-cue-mobile',
+        });
+
+        try {
+          for (let index = 0; index < reminders.length; index += chunkSize) {
+            const slice = reminders.slice(index, index + chunkSize);
+            const results = await Promise.allSettled(slice.map((reminder) => (
+              fetch(url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(makePayload(reminder)),
+              })
+            )));
+
+            results.forEach((result) => {
+              if (result.status === 'fulfilled' && result.value?.ok) {
+                okCount += 1;
+              } else if (result.status === 'fulfilled') {
+                failCount += 1;
+              } else {
+                failCount += 1;
+              }
+            });
+
+            await new Promise((resolve) => setTimeout(resolve, 300));
+          }
+
+          if (!failCount) {
+            setStatus('online', `Sync complete. ${okCount} reminder${okCount === 1 ? '' : 's'} updated.`);
+          } else if (!okCount) {
+            setStatus('error', 'Sync failed. Please check your Apps Script URL and try again.');
+          } else {
+            setStatus('error', `Partial sync: ${okCount} success, ${failCount} failed.`);
+          }
+        } catch (error) {
+          console.error('Sync failed', error);
+          setStatus('error', 'Sync failed. Please try again in a moment.');
+        } finally {
+          toggleBusy(false);
+        }
+      });
+    })();
+  </script>
   <script>
     (function () {
       var btn = document.getElementById('toggleUiBtn');
@@ -968,38 +1531,211 @@
     })();
   </script>
   <script id="add-task-guard-script">
-    (function(){
-      var dialog = document.querySelector('[data-add-task-dialog]');
-      if (!dialog) return;
-
-      var content = dialog.querySelector('[data-dialog-content]') || dialog;
-      var backdrop = dialog.querySelector('.backdrop') || dialog;
-
-      content.addEventListener('click', function(e){
-        e.stopPropagation();
-      }, true);
-
-      backdrop.addEventListener('click', function(e){
-        if (e.target !== backdrop) return;
-        if (typeof window.closeAddTask === 'function') return window.closeAddTask();
-
-        if (dialog.hasAttribute('open')) dialog.removeAttribute('open');
-        else dialog.hidden = true;
-      });
-
-      function focusFirst(){
-        var first = dialog.querySelector('input, textarea, [contenteditable="true"]');
-        if (first) setTimeout(function(){ try { first.focus(); } catch(_){} }, 0);
+    (function () {
+      const dialog = document.querySelector('[data-add-task-dialog]');
+      if (!(dialog instanceof HTMLElement)) {
+        return;
       }
 
-      var openers = document.querySelectorAll('[data-open-add-task], #addReminderFab, #fabCreate, [aria-controls="createReminderModal"]');
-      openers.forEach(function(btn){
-        btn.addEventListener('click', function(){
-          dialog.hidden = false;
-          dialog.setAttribute('open','');
-          focusFirst();
+      const content = dialog.querySelector('[data-dialog-content]') || dialog.querySelector('.sheet-panel') || dialog;
+      const backdrop = dialog.querySelector('.sheet-backdrop') || dialog.querySelector('.backdrop');
+      const closeBtn = document.getElementById('closeCreateSheet');
+      const fab = document.getElementById('fabCreate');
+      const form = document.getElementById('createReminderForm');
+      const saveBtn = document.getElementById('saveReminder');
+      const prioritySelect = document.getElementById('priority');
+      const priorityChips = document.getElementById('priorityChips');
+      const totalBadge = document.getElementById('totalCountBadge');
+      const totalCount = document.getElementById('totalCount');
+
+      let lastTrigger = null;
+      let pendingSave = false;
+
+      const ensureHidden = () => {
+        dialog.classList.add('hidden');
+        dialog.hidden = true;
+        dialog.removeAttribute('open');
+        dialog.setAttribute('aria-hidden', 'true');
+      };
+
+      const isOpen = () => !dialog.classList.contains('hidden');
+
+      const focusFirstField = () => {
+        const target = dialog.querySelector('input, textarea, select, button, [contenteditable="true"]');
+        if (target && typeof target.focus === 'function') {
+          setTimeout(() => {
+            try { target.focus(); } catch { /* ignore focus failures */ }
+          }, 0);
+        }
+      };
+
+      const openSheet = (trigger) => {
+        lastTrigger = trigger instanceof HTMLElement ? trigger : null;
+        dialog.classList.remove('hidden');
+        dialog.hidden = false;
+        dialog.setAttribute('open', '');
+        dialog.setAttribute('aria-hidden', 'false');
+        focusFirstField();
+        document.dispatchEvent(new CustomEvent('reminder:sheet-opened', { detail: { trigger: lastTrigger } }));
+      };
+
+      const closeSheet = (reason = 'dismissed') => {
+        if (!isOpen()) {
+          ensureHidden();
+          lastTrigger = null;
+          return;
+        }
+
+        ensureHidden();
+
+        const focusTarget = (lastTrigger && document.body.contains(lastTrigger)) ? lastTrigger : fab;
+        if (focusTarget && typeof focusTarget.focus === 'function') {
+          try { focusTarget.focus(); } catch { /* ignore focus issues */ }
+        }
+        lastTrigger = null;
+
+        document.dispatchEvent(new CustomEvent('reminder:sheet-closed', { detail: { reason } }));
+      };
+
+      ensureHidden();
+
+      if (content && content !== dialog) {
+        content.addEventListener('click', (event) => event.stopPropagation(), true);
+      }
+
+      if (backdrop instanceof HTMLElement) {
+        backdrop.addEventListener('click', (event) => {
+          if (event.target !== backdrop) return;
+          closeSheet('backdrop');
+        });
+      }
+
+      closeBtn?.addEventListener('click', (event) => {
+        event.preventDefault();
+        closeSheet('close-button');
+      });
+
+      dialog.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          event.stopPropagation();
+          closeSheet('escape');
+        }
+      });
+
+      const openerSelectors = [
+        '[data-open-add-task]',
+        '#addReminderFab',
+        '#fabCreate',
+        '[aria-controls="createReminderModal"]'
+      ];
+      const openerElements = new Set();
+      openerSelectors.forEach((selector) => {
+        document.querySelectorAll(selector).forEach((el) => openerElements.add(el));
+      });
+
+      openerElements.forEach((trigger) => {
+        if (!(trigger instanceof HTMLElement)) return;
+        trigger.addEventListener('click', (event) => {
+          event.preventDefault();
+          openSheet(trigger);
         });
       });
+
+      window.closeAddTask = closeSheet;
+
+      if (form instanceof HTMLFormElement && saveBtn instanceof HTMLElement) {
+        form.addEventListener('submit', (event) => {
+          event.preventDefault();
+          if (!saveBtn.matches(':disabled')) {
+            saveBtn.click();
+          }
+        });
+      }
+
+      if (saveBtn instanceof HTMLElement) {
+        saveBtn.addEventListener('click', () => {
+          pendingSave = true;
+          document.dispatchEvent(
+            new CustomEvent('reminder:save', {
+              detail: { form: form instanceof HTMLFormElement ? form : null, trigger: saveBtn }
+            })
+          );
+        }, { capture: true });
+      }
+
+      const updateTotalCounts = (items) => {
+        const total = Array.isArray(items) ? items.length : (typeof items === 'number' ? items : 0);
+        const value = String(total);
+        if (totalBadge) totalBadge.textContent = value;
+        if (totalCount) totalCount.textContent = value;
+      };
+
+      const handleRemindersUpdated = (event) => {
+        updateTotalCounts(event?.detail?.items);
+      };
+
+      document.addEventListener('memoryCue:remindersUpdated', handleRemindersUpdated);
+      document.addEventListener('reminders:updated', handleRemindersUpdated);
+
+      const priorityRadios = priorityChips
+        ? Array.from(priorityChips.querySelectorAll('input[name="priority"]'))
+        : [];
+
+      const syncRadiosFromSelect = () => {
+        const value = prioritySelect?.value || 'Medium';
+        priorityRadios.forEach((radio) => {
+          const isChecked = radio.value === value;
+          radio.checked = isChecked;
+          radio.setAttribute('aria-checked', isChecked ? 'true' : 'false');
+        });
+      };
+
+      const setPriorityValue = (value) => {
+        if (!prioritySelect) return;
+        if (prioritySelect.value !== value) {
+          prioritySelect.value = value;
+          prioritySelect.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+        syncRadiosFromSelect();
+      };
+
+      priorityRadios.forEach((radio) => {
+        radio.addEventListener('change', () => {
+          if (radio.checked) {
+            setPriorityValue(radio.value);
+          }
+        });
+      });
+
+      prioritySelect?.addEventListener('change', syncRadiosFromSelect);
+
+      document.addEventListener('cue:prepare', () => {
+        pendingSave = false;
+        syncRadiosFromSelect();
+      });
+
+      document.addEventListener('cue:open', () => {
+        pendingSave = false;
+        syncRadiosFromSelect();
+        openSheet();
+      });
+
+      document.addEventListener('cue:close', (event) => {
+        const reason = event?.detail?.reason || 'cue-close';
+        if (reason === 'created' || reason === 'updated') {
+          document.dispatchEvent(new CustomEvent('reminder:saved', { detail: { reason } }));
+        }
+        pendingSave = false;
+        syncRadiosFromSelect();
+        closeSheet(reason);
+      });
+
+      document.addEventListener('cue:cancelled', () => {
+        pendingSave = false;
+        closeSheet('cue-cancelled');
+      });
+
+      syncRadiosFromSelect();
     })();
   </script>
   <script id="min-expand-script">


### PR DESCRIPTION
## Summary
- update the shared reminder bootstrap to detect the mobile form and initialise it with the correct selectors
- move the mobile-specific interactions (sheet open/close, priority chips, navigation, sync controls) inline so the save flow closes the sheet and updates counts
- ensure the mobile variant defaults to the full layout so category groupings render and reminder totals stay in sync

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ff4a1a87188324ae9178451105a0cb