### PR TITLE
Fix mobile page init & default Minimal Mode

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -208,7 +208,8 @@ export async function initReminders(sel = {}) {
   const variant = sel.variant || 'mobile';
   try {
     if (variant === 'mobile' && typeof document !== 'undefined') {
-      document.body?.classList?.add('show-full');
+      // Minimal Mode is the default; let the UI toggle control add/remove 'show-full'
+      // (no body class added here)
     }
   } catch {
     /* ignore environments without DOM */

--- a/mobile.html
+++ b/mobile.html
@@ -1837,5 +1837,6 @@
   mo.observe(list, { childList: true, subtree: true });
 })();
   </script>
+  <script type="module" src="./mobile.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load the mobile initialization script on mobile.html so the page boots correctly
- let the UI toggle manage the `.show-full` class so Minimal Mode is the default on mobile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ffc98171808327ace9996cab399d53