### PR TITLE
Ensure reminders save without waiting for Firebase

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -1530,6 +1530,10 @@ export async function initReminders(sel = {}) {
       it.due = due;
       if(details){ it.notes = details.value.trim(); }
       it.updatedAt=Date.now();
+      const canSyncNow = firebaseReady && userId && db && typeof doc === 'function' && typeof setDoc === 'function' && typeof serverTimestamp === 'function';
+      if(!canSyncNow){
+        it.pendingSync = true;
+      }
       saveToFirebase(it);
       tryCalendarSync(it);
       render();


### PR DESCRIPTION
## Summary
- initialize reminder state and offline persistence before attempting to load Firebase modules so UI remains responsive
- attach the save reminder handler before Firebase imports and reuse a shared handler for button, keyboard, and quick-add triggers
- flag edited reminders as pending sync whenever Firebase is unavailable so offline edits persist until migration

## Testing
- npm test -- reminders.offline.test.js

------
https://chatgpt.com/codex/tasks/task_b_6900a2137bd88327a0646adfbb8805bd