### PR TITLE
Address Codex feedback for mobile reminder save handler

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -207,93 +207,6 @@ export async function initReminders(sel = {}) {
   const categoryDatalist = $(sel.categoryOptionsSel);
   const variant = sel.variant || 'mobile';
 
-  // === BEGIN: Save handler (add inside initReminders, after element selections & helper fns exist) ===
-
-  // Prefer priority “chips” if present; fallback to the (hidden) select#priority
-  function getPriorityValue() {
-    const chip = document.querySelector('fieldset#priorityChips input[name="priority"]:checked');
-    if (chip && chip.value) return chip.value;
-    return (priority?.value || 'Medium');
-  }
-
-  // Build ISO from date/time as used elsewhere in this module
-  function toDueIso(dateInput, timeInput) {
-    const d = (dateInput?.value || '').trim();
-    if (!d) return null;
-    const t = (timeInput?.value || '').trim();
-    if (t) {
-      // Leverage existing helper if present; otherwise construct standard ISO
-      try {
-        return typeof localDateTimeToISO === 'function'
-          ? localDateTimeToISO(d, t)
-          : new Date(`${d}T${t}:00`).toISOString();
-      } catch {
-        return new Date(`${d}T${t}:00`).toISOString();
-      }
-    }
-    return new Date(`${d}T00:00:00`).toISOString();
-  }
-
-  async function onSaveClick() {
-    const titleVal = (title?.value || '').trim();
-    if (!titleVal) {
-      // Optional: show non-blocking feedback if a toast/status helper exists
-      try { toast?.('Enter a title'); } catch {}
-      return;
-    }
-
-    const entry = {
-      id: uid(),
-      title: titleVal,
-      priority: getPriorityValue(),
-      category: normalizeCategory(categoryInput?.value || 'General'),
-      notes: (details?.value || '').trim(),
-      done: false,
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-      due: toDueIso(date, time),
-      pendingSync: !userId,
-    };
-
-    // Update in-memory list and persist offline
-    items.unshift(entry);
-    persistItems();
-    render();
-    rescheduleAllReminders();
-
-    // Best-effort cloud save if user is signed in (if saveToFirebase exists)
-    try {
-      if (userId && typeof saveToFirebase === 'function') {
-        await saveToFirebase(entry);
-        entry.pendingSync = false;
-        persistItems();
-      }
-    } catch {
-      // keep offline; pendingSync remains true
-    }
-
-    // Notify listeners so mobile sheet/metrics close & refresh
-    document.dispatchEvent(new CustomEvent('reminders:updated', { detail: { items } }));
-    dispatchCueEvent('memoryCue:remindersUpdated', { items });
-
-    // (Optional) Clear inputs after save
-    try {
-      if (title) title.value = '';
-      if (details) details.value = '';
-      if (date) date.value = '';
-      if (time) time.value = '';
-      if (categoryInput) categoryInput.value = 'General';
-      if (priority) priority.value = 'Medium';
-    } catch {}
-  }
-
-  // Bind the handler once
-  if (saveBtn && !saveBtn.__mcBound) {
-    saveBtn.addEventListener('click', onSaveClick);
-    saveBtn.__mcBound = true;
-  }
-  // === END: Save handler ===
-
   try {
     if (variant === 'mobile' && typeof document !== 'undefined') {
       // Minimal Mode is the default; let the UI toggle control add/remove 'show-full'
@@ -650,6 +563,32 @@ export async function initReminders(sel = {}) {
   let editingId = null;
   const reminderTimers = {};
   let scheduledReminders = {};
+
+  function notifyRemindersUpdated() {
+    const detail = { items };
+    if (typeof document !== 'undefined') {
+      try {
+        document.dispatchEvent(new CustomEvent('reminders:updated', { detail }));
+      } catch {
+        try {
+          if (document.createEvent) {
+            const evt = document.createEvent('CustomEvent');
+            if (evt && typeof evt.initCustomEvent === 'function') {
+              evt.initCustomEvent('reminders:updated', false, false, detail);
+              document.dispatchEvent(evt);
+            }
+          }
+        } catch {
+          // Ignore older browser dispatch issues
+        }
+      }
+    }
+    try {
+      dispatchCueEvent('memoryCue:remindersUpdated', detail);
+    } catch {
+      // Ignore dispatch errors so reminders continue to function
+    }
+  }
 
   function applySignedOutState() {
     userId = null;
@@ -1025,13 +964,26 @@ export async function initReminders(sel = {}) {
     items = [item, ...items];
     render();
     persistItems();
-    saveToFirebase(item);
+    const syncPromise = saveToFirebase(item);
+    if (syncPromise && typeof syncPromise.then === 'function') {
+      syncPromise
+        .then(() => {
+          if (userId && item.pendingSync) {
+            item.pendingSync = false;
+            persistItems();
+          }
+        })
+        .catch(() => {
+          // keep offline when sync fails; pendingSync remains true
+        });
+    }
     tryCalendarSync(item);
     scheduleReminder(item);
     emitActivity({
       action: 'created',
       label: `Reminder added · ${item.title}`,
     });
+    notifyRemindersUpdated();
     return item;
   }
   function addNoteToReminder(id, noteText){
@@ -1603,7 +1555,21 @@ export async function initReminders(sel = {}) {
   });
   document.addEventListener('DOMContentLoaded', () => { settingsSection?.classList.add('hidden'); });
 
+  function getSelectedPriorityValue() {
+    if (typeof document !== 'undefined') {
+      const chip = document.querySelector('fieldset#priorityChips input[name="priority"]:checked');
+      if (chip && typeof chip.value === 'string' && chip.value) {
+        return chip.value;
+      }
+    }
+    if (priority && typeof priority.value === 'string' && priority.value) {
+      return priority.value;
+    }
+    return 'Medium';
+  }
+
   saveBtn?.addEventListener('click', () => {
+    const priorityValue = getSelectedPriorityValue();
     if(editingId){
       const it = items.find(x=>x.id===editingId);
       if(!it){ resetForm(); return; }
@@ -1612,17 +1578,30 @@ export async function initReminders(sel = {}) {
       if(date.value || time.value){ const d=(date.value || todayISO()); const tm=(time.value || '09:00'); due = localDateTimeToISO(d,tm); }
       else { const p=parseQuickWhen(tNew); if(p.time){ due = new Date(`${p.date}T${p.time}:00`).toISOString(); } }
       it.title = tNew;
-      it.priority=priority.value;
+      it.priority=priorityValue;
       if(categoryInput){ it.category = normalizeCategory(categoryInput.value); }
       it.due = due;
       if(details){ it.notes = details.value.trim(); }
       it.updatedAt=Date.now();
-      saveToFirebase(it);
+      const updatePromise = saveToFirebase(it);
+      if (updatePromise && typeof updatePromise.then === 'function') {
+        updatePromise
+          .then(() => {
+            if (userId && it.pendingSync) {
+              it.pendingSync = false;
+              persistItems();
+            }
+          })
+          .catch(() => {
+            // keep offline; pendingSync remains true
+          });
+      }
       tryCalendarSync(it);
       render();
       scheduleReminder(it);
       persistItems();
       emitActivity({ action: 'updated', label: `Reminder updated · ${it.title}` });
+      notifyRemindersUpdated();
       resetForm();
       toast('Reminder updated');
       dispatchCueEvent('cue:close', { reason: 'updated' });
@@ -1633,8 +1612,8 @@ export async function initReminders(sel = {}) {
     let due=null;
     if(date.value || time.value){ const d=(date.value || todayISO()); const tm=(time.value || '09:00'); due = localDateTimeToISO(d,tm); }
     else { const p=parseQuickWhen(t); if(p.time){ due=new Date(`${p.date}T${p.time}:00`).toISOString(); } }
-    addItem({ title:t, priority:priority.value, category: categoryInput ? categoryInput.value : '', due, notes: noteText });
-    title.value=''; time.value=''; if(details) details.value='';
+    addItem({ title:t, priority:priorityValue, category: categoryInput ? categoryInput.value : '', due, notes: noteText });
+    resetForm();
     dispatchCueEvent('cue:close', { reason: 'created' });
   });
   title?.addEventListener('keydown', (e)=>{ if(e.key==='Enter') saveBtn.click(); });


### PR DESCRIPTION
## Summary
- remove the temporary mobile save listener and update the existing handler to cover both create and edit flows
- notify listeners after reminder mutations and clear pending sync flags when cloud writes succeed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_6900a21d205c8327b77e975d5eb5ab0c