### PR TITLE
Simplify mobile interface layout

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -141,80 +141,6 @@
       box-shadow: 0 2px 6px rgba(0,0,0,.15);
     }
   </style>
-  <style id="minimal-mode-unified">
-    /* ============ Minimal Mode: Rules apply when body does NOT have .show-full ============ */
-
-    /* Hide everything marked as non-essential or non-focus UI */
-    body:not(.show-full) .nonEssential,
-    body:not(.show-full) .nonFocusUI {
-      display: none !important;
-    }
-
-    /* Always show these in Minimal Mode */
-    body:not(.show-full) #voiceAddWrap,
-    body:not(.show-full) #reminderList {
-      display: block !important;
-    }
-
-    /* --- FIX: keep Reminders view visible in Minimal Mode ---
-       Without this, the parent container can be display:none due to .nonFocusUI,
-       which hides the list even if #reminderList is forced visible. */
-    body:not(.show-full) [data-view="reminders"] {
-      display: block !important;
-    }
-
-    /* Minimal list presentation */
-    body:not(.show-full) #reminderList.task-list-min {
-      display: grid !important;
-      gap: 8px;
-      padding: 12px;
-      background: transparent;
-    }
-
-    /* Minimal row styling (works with your existing renderers) */
-    body:not(.show-full) #reminderList .task-item {
-      display: grid;
-      grid-template-columns: 1fr auto;
-      align-items: center;
-      gap: 8px;
-      padding: 12px 14px;
-      border-radius: 12px;
-      box-shadow: 0 1px 3px rgba(0,0,0,.06);
-      background: var(--fallback-b1, #fff);
-    }
-    body:not(.show-full) #reminderList .task-item .task-title {
-      font-size: 16px;
-      line-height: 1.2;
-    }
-    body:not(.show-full) #reminderList .task-item .task-meta {
-      justify-self: end;
-    }
-    /* Keep the first meta (usually time/date) subtle; suppress extras */
-    body:not(.show-full) #reminderList .task-item .task-meta-row {
-      display: contents;
-    }
-    body:not(.show-full) #reminderList .task-item .task-meta-row span:first-child {
-      font-size: 13px;
-      opacity: .7;
-    }
-    body:not(.show-full) #reminderList .task-item .task-meta-row span:not(:first-child),
-    body:not(.show-full) #reminderList .task-item .task-actions,
-    body:not(.show-full) #reminderList .task-item input,
-    body:not(.show-full) #reminderList .task-item .task-notes:not(.min-notes) {
-      display: none !important;
-    }
-
-    /* Minimal layout tweaks for the surrounding card */
-    body:not(.show-full) #reminderListSection {
-      background: transparent;
-      border: none;
-      box-shadow: none;
-    }
-    body:not(.show-full) #remindersWrapper {
-      padding: 0;
-      gap: 12px;
-    }
-  </style>
   <!-- BEGIN GPT CHANGE: bottom sheet styles -->
   <style>
     .hidden {
@@ -367,66 +293,6 @@
     }
   </style>
   <!-- END GPT CHANGE: rhythm -->
-  <style>
-    /* Focus Mode toggles */
-    body.focus-mode .nonFocusUI {
-      display: none !important;
-    }
-
-    /* Focus List */
-    .focus-list {
-      display: grid;
-      gap: 8px;
-      padding: 12px;
-    }
-    .focus-list__item {
-      display: grid;
-      grid-template-columns: 1fr auto;
-      align-items: center;
-      padding: 14px 16px;
-      border-radius: 14px;
-      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
-    }
-    .focus-list__title {
-      font-size: 16px;
-      line-height: 1.2;
-    }
-    .focus-list__date {
-      font-size: 13px;
-      opacity: 0.7;
-    }
-    .focus-list__btn {
-      width: 100%;
-      text-align: left;
-    }
-
-    /* Focus Detail */
-    .focus-detail {
-      position: fixed;
-      inset: 0;
-      background: var(--fallback-b1, #fff);
-      display: grid;
-      grid-template-rows: auto 1fr;
-    }
-    .focus-detail__header {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      padding: 10px 12px;
-      border-bottom: 1px solid rgba(0, 0, 0, 0.06);
-    }
-    .focus-detail__body {
-      padding: 12px;
-      display: grid;
-      gap: 12px;
-    }
-
-    /* Safe-area padding */
-    .focus-list,
-    .focus-detail__body {
-      padding-bottom: calc(12px + env(safe-area-inset-bottom));
-    }
-  </style>
   <style id="voice-add-css">
     .voice-add-wrap{
       position: fixed; right: 12px; bottom: 12px; z-index: 50;
@@ -441,8 +307,6 @@
     /* Only show status while actively listening */
     .voice-add-wrap.listening .voice-status { display: inline; font-size: 12px; opacity: .75; }
 
-    /* Keep mic visible even in minimal mode */
-    .nonEssential .voice-add-wrap { display: inline-flex; }
   </style>
   <style id="min-expand-css">
     /* Expand/collapse behavior */
@@ -483,7 +347,7 @@
   <!-- Accessibility: skip link (hidden by default; only shows on :focus-visible) -->
   <a class="skip-link" href="./mobile.html#main">Skip to main content</a>
 
-  <header class="navbar bg-base-100 sticky top-0 z-50 border-b nonFocusUI nonEssential">
+  <header class="navbar bg-base-100 sticky top-0 z-50 border-b">
     <div class="flex-1 items-center gap-2">
       <a class="btn btn-ghost text-lg font-semibold" href="#">Memory Cue</a>
       <span
@@ -517,35 +381,12 @@
       <button id="voiceAddBtn" class="btn btn-circle btn-ghost" aria-pressed="false" aria-label="Add task by voice">🎤</button>
       <span id="voiceStatus" class="voice-status" hidden>Tap 🎤 to speak</span>
     </div>
-    <!-- Removed Full UI toggle; minimalist layout is default -->
-    <!-- Focus List: minimal tasks-only home state -->
-    <section id="focusList" class="focus-list nonEssential" aria-label="Tasks">
-      <!-- populated by JS: renderList() -->
-    </section>
-
-    <!-- Per-task detail surface used when a task is selected -->
-    <section
-      id="focusDetail"
-      class="focus-detail nonEssential"
-      hidden
-      aria-labelledby="focusDetailTitle"
-      role="dialog"
-      aria-modal="true"
-      tabindex="-1"
-    >
-      <header class="focus-detail__header">
-        <button id="focusBackBtn" class="btn btn-ghost" aria-label="Back to task list">← Back</button>
-        <h2 id="focusDetailTitle" class="text-lg font-semibold">Task</h2>
-      </header>
-      <div id="focusDetailBody" class="focus-detail__body"></div>
-    </section>
-
     <!-- BEGIN GPT CHANGE: create form moved to bottom sheet -->
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: reminders view -->
     <section data-view="reminders" id="view-reminders" class="view-panel">
       <!-- BEGIN GPT CHANGE: sticky filters -->
-      <div id="stickyFilters" class="nonFocusUI nonEssential" style="position:sticky; top:56px; z-index: 10;">
+      <div id="stickyFilters" style="position:sticky; top:56px; z-index: 10;">
         <section id="reminderFilters" class="card bg-base-100 border">
           <div class="card-body gap-4 compact">
             <div class="flex flex-wrap items-center justify-between gap-3">
@@ -584,16 +425,16 @@
         <div class="card-body gap-4 compact" id="remindersWrapper">
           <div id="emptyState" class="hidden text-center text-base-content/60"></div>
           <ul id="reminderList" class="space-y-3 task-list-min"></ul>
-          <p class="text-xs text-base-content/60 nonEssential">Total reminders: <span id="totalCount">0</span></p>
+          <p class="text-xs text-base-content/60">Total reminders: <span id="totalCount">0</span></p>
         </div>
       </section>
     </section>
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: today view -->
-    <section data-view="today" id="view-today" class="view-panel hidden nonFocusUI nonEssential"></section>
+    <section data-view="today" id="view-today" class="view-panel hidden"></section>
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: notebook view -->
-    <section data-view="notebook" id="view-notebook" class="view-panel hidden nonFocusUI nonEssential">
+    <section data-view="notebook" id="view-notebook" class="view-panel hidden">
       <section class="card bg-base-100 border">
         <div class="card-body gap-3 compact">
           <div class="flex items-center justify-between gap-2">
@@ -647,7 +488,17 @@
     </section>
     <!-- END GPT CHANGE -->
 </main>
-  <!-- Removed bottom nav; single reminders view only -->
+  <nav class="btm-nav fixed bottom-0 left-0 right-0 bg-base-100 border-t" aria-label="Primary navigation">
+    <button type="button" aria-current="page" class="active">
+      <span class="btm-nav-label">Reminders</span>
+    </button>
+    <button type="button">
+      <span class="btm-nav-label">Today</span>
+    </button>
+    <button type="button">
+      <span class="btm-nav-label">Notebook</span>
+    </button>
+  </nav>
   <script type="module" src="./js/mobile-theme-toggle.js"></script>
   <!-- BEGIN GPT CHANGE: bottom sheet for Create Reminder -->
   <div id="create-sheet" role="dialog" aria-modal="true" aria-labelledby="createSheetTitle" class="sheet hidden" tabindex="-1" data-add-task-dialog>
@@ -783,7 +634,6 @@
   <button id="fabCreate" class="fab" aria-label="Add reminder">＋</button>
   <!-- END GPT CHANGE: global FAB -->
 
-  <script src="app.js" type="module"></script>
   <script id="mobile-enhancements">
     (function () {
       const views = {


### PR DESCRIPTION
## Summary
- remove the legacy minimal/focus mode markup and styles so the mobile UI always shows the full reminder experience
- clean up the reminder view markup, removing hidden-mode classes and the conflicting app.js import
- add a persistent bottom navigation bar while keeping the floating action button as the sole add control

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_69019e753de8832784da265f3e7748f0