### PR TITLE
Fix skip link lookup in mobile view switcher

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -674,7 +674,9 @@
           }
         });
 
-        const skipLink = document.querySelector('a[href="#main"]');
+        const skipLink =
+          document.querySelector('.skip-link') ||
+          document.querySelector('a[href$="#main"]');
         const main = document.getElementById('main') || document.querySelector('main');
         if (main) {
           main.setAttribute('data-active-view', target);


### PR DESCRIPTION
## Summary
- update the mobile view switcher to look up the skip link by class or href suffix so scroll-to-top triggers when tabs change

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_6901acd636a48327b60556dc7be8cb9b