### PR TITLE
Restore full mobile UI visibility after toggle removal

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -253,8 +253,8 @@ export async function initReminders(sel = {}) {
 
   try {
     if (variant === 'mobile' && typeof document !== 'undefined') {
-      // Minimal Mode is the default; let the UI toggle control add/remove 'show-full'
-      // (no body class added here)
+      // Mobile now defaults to the full UI; minimal mode is only enabled when the class is removed elsewhere.
+      document.body.classList.add('show-full');
     }
   } catch {
     /* ignore environments without DOM */

--- a/mobile.html
+++ b/mobile.html
@@ -457,7 +457,7 @@
     .task-row-min.expanded::after { transform: rotate(180deg); }
   </style>
 </head>
-<body class="min-h-screen bg-base-200 text-base-content">
+<body class="min-h-screen bg-base-200 text-base-content show-full">
   <a class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-full focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-primary-content" href="#main">Skip to main content</a>
 
   <header class="navbar bg-base-100 sticky top-0 z-50 border-b nonFocusUI nonEssential">


### PR DESCRIPTION
## Summary
- default the mobile layout to the full UI now that the toggle is gone
- ensure the reminders module adds the show-full class when initializing on mobile

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_6901f31e002483278f6f02a5fa4e47a6