### PR TITLE
Restore quick add due parsing fallback

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -513,9 +513,22 @@ export async function initReminders(sel = {}) {
       const now = Date.now();
       const hasDate = typeof date?.value === 'string' && date.value;
       const hasTime = typeof time?.value === 'string' && time.value;
-      const dueValue = hasDate || hasTime
-        ? localDateTimeToISO(hasDate ? date.value : todayISO(), hasTime ? time.value : '09:00')
-        : null;
+      let dueValue = null;
+      if (hasDate || hasTime) {
+        dueValue = localDateTimeToISO(
+          hasDate ? date.value : todayISO(),
+          hasTime ? time.value : '09:00',
+        );
+      } else {
+        try {
+          const parsed = parseQuickWhen(raw);
+          if (parsed?.time) {
+            dueValue = new Date(`${parsed.date}T${parsed.time}:00`).toISOString();
+          }
+        } catch {
+          // Ignore parse failures and keep the reminder undated.
+        }
+      }
 
       const entry = {
         id: uid(),


### PR DESCRIPTION
## Summary
- restore the natural-language due-date fallback when the mobile quick add button creates a reminder
- leave manual date/time entry behavior unchanged while preserving parser failures

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_6901f6c734308327b8f3fc2105dc3562