### PR TITLE
Fix DaisyUI CDN link on mobile page

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2,7 +2,10 @@
 <html lang="en" data-theme="light">
 <head>
   <base href="./" />
-  <script src="https://cdn.jsdelivr.net/npm/daisyui@latest/dist/full.js"></script>
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/daisyui@4.12.10/dist/full.min.css"
+  />
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Memory Cue (Mobile) — Inline + Edit + Sync All</title>


### PR DESCRIPTION
## Summary
- replace the missing DaisyUI CDN asset on the mobile page with the current CSS bundle to prevent 404s

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_69020461d61c832783fa948f3085a819