### PR TITLE
Ensure mobile.html loads mobile bundle reliably

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -525,6 +525,9 @@
       <span class="btm-nav-label">Notebook</span>
     </button>
   </nav>
+  <!-- build-marker: mobile.html / runs mobile.js / EXPECTED LIVE -->
+  <!-- When deployed, this should appear in View Source with today’s date. -->
+
   <!-- Load the mobile app bundle (build will rewrite to hashed path) -->
   <script type="module" src="./mobile.js"></script>
   <script type="module" src="./js/mobile-theme-toggle.js"></script>
@@ -1583,6 +1586,5 @@
   mo.observe(list, { childList: true, subtree: true });
 })();
   </script>
-  <script type="module" src="./mobile.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a deployment build marker above the mobile bundle include in `mobile.html`
- ensure the page loads `mobile.js` in the intended location and remove the duplicate script tag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_6902083646e083278ade3244f7a54b69