### PR TITLE
Fix reminder dataset metadata for mobile sync

### DIFF
--- a/js/__tests__/reminders.dom-sync.test.js
+++ b/js/__tests__/reminders.dom-sync.test.js
@@ -1,0 +1,175 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const { beforeEach, afterEach, describe, expect, test } = require('@jest/globals');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadRemindersModule() {
+  const filePath = path.resolve(__dirname, '../reminders.js');
+  let source = fs.readFileSync(filePath, 'utf8');
+  source = source.replace(/export\s+async\s+function\s+initReminders/, 'async function initReminders');
+  source += '\nmodule.exports = { initReminders };\n';
+  const module = { exports: {} };
+  const sandbox = {
+    module,
+    exports: module.exports,
+    require,
+    console,
+    setTimeout,
+    clearTimeout,
+    window,
+    document,
+    localStorage,
+    navigator,
+    Notification,
+    CustomEvent: window.CustomEvent,
+    fetch: global.fetch,
+    Blob: global.Blob,
+    Response: global.Response,
+    URL: global.URL,
+  };
+  vm.runInNewContext(source, sandbox, { filename: filePath });
+  return module.exports;
+}
+
+describe('rendered reminders expose dataset metadata', () => {
+  let api;
+
+  class MockNotification {
+    static permission = 'granted';
+    static requestPermission = jest.fn().mockResolvedValue('granted');
+
+    constructor() {
+      this.close = jest.fn();
+    }
+
+    addEventListener() {}
+  }
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    document.body.innerHTML = `
+      <main>
+        <form id="createReminderForm">
+          <input id="reminderText" />
+          <input id="reminderDate" type="date" />
+          <input id="reminderTime" type="time" />
+          <textarea id="reminderDetails"></textarea>
+          <select id="priority">
+            <option value="High">High</option>
+            <option value="Medium" selected>Medium</option>
+            <option value="Low">Low</option>
+          </select>
+          <fieldset id="priorityChips">
+            <label><input type="radio" name="priority" value="High" /></label>
+            <label><input type="radio" name="priority" value="Medium" checked /></label>
+            <label><input type="radio" name="priority" value="Low" /></label>
+          </fieldset>
+          <input id="category" />
+          <button id="saveReminder" type="button">Save</button>
+          <button id="cancelEditBtn" type="button" class="hidden">Cancel</button>
+        </form>
+        <div id="remindersWrapper"><ul id="reminderList"></ul></div>
+        <div id="emptyState" class="hidden"></div>
+        <div id="statusMessage"></div>
+        <div id="syncStatus"></div>
+      </main>
+    `;
+
+    window.scrollTo = jest.fn();
+    window.toast = jest.fn();
+    global.toast = window.toast;
+
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    window.fetch = global.fetch;
+
+    global.Notification = MockNotification;
+    window.Notification = MockNotification;
+
+    navigator.clipboard = navigator.clipboard || { writeText: jest.fn().mockResolvedValue() };
+    navigator.serviceWorker = navigator.serviceWorker || {
+      getRegistration: jest.fn().mockResolvedValue(null),
+      register: jest.fn().mockResolvedValue({}),
+      ready: Promise.resolve({
+        showNotification: jest.fn(),
+        getNotifications: jest.fn().mockResolvedValue([]),
+      }),
+    };
+
+    window.CustomEvent = window.CustomEvent || function CustomEvent(event, params = {}) {
+      const evt = document.createEvent('CustomEvent');
+      evt.initCustomEvent(event, params.bubbles ?? false, params.cancelable ?? false, params.detail);
+      return evt;
+    };
+    global.CustomEvent = window.CustomEvent;
+
+    const { initReminders } = loadRemindersModule();
+    api = await initReminders({
+      variant: 'mobile',
+      titleSel: '#reminderText',
+      dateSel: '#reminderDate',
+      timeSel: '#reminderTime',
+      detailsSel: '#reminderDetails',
+      prioritySel: '#priority',
+      categorySel: '#category',
+      saveBtnSel: '#saveReminder',
+      cancelEditBtnSel: '#cancelEditBtn',
+      listSel: '#reminderList',
+      listWrapperSel: '#remindersWrapper',
+      emptyStateSel: '#emptyState',
+      statusSel: '#statusMessage',
+      syncStatusSel: '#syncStatus',
+      defaultFilter: 'all',
+      importModule: jest.fn(() => Promise.reject(new Error('firebase disabled'))),
+    });
+  });
+
+  afterEach(() => {
+    api?.closeActiveNotifications?.();
+    document.body.innerHTML = '';
+    localStorage.clear();
+    jest.clearAllTimers();
+    delete window.toast;
+    delete global.toast;
+  });
+
+  test('each rendered reminder row includes a serialised dataset payload', () => {
+    const title = document.getElementById('reminderText');
+    const date = document.getElementById('reminderDate');
+    const time = document.getElementById('reminderTime');
+    const save = document.getElementById('saveReminder');
+
+    title.value = 'Call Alex';
+    date.value = '2025-12-24';
+    time.value = '15:45';
+
+    save.click();
+
+    const row = document.querySelector('.task-item');
+    expect(row).toBeTruthy();
+    expect(row.dataset).toBeTruthy();
+
+    const summary = JSON.parse(row.dataset.reminder || '{}');
+
+    expect(summary).toMatchObject({
+      title: 'Call Alex',
+      category: 'General',
+      priority: 'Medium',
+      done: false,
+    });
+    expect(typeof summary.id).toBe('string');
+    expect(summary.id.length).toBeGreaterThan(0);
+    expect(summary.dueIso).toContain('2025-12-24');
+
+    expect(row.dataset.id).toBe(summary.id);
+    expect(row.dataset.title).toBe('Call Alex');
+    expect(row.dataset.category).toBe('General');
+    expect(row.dataset.priority).toBe('Medium');
+    expect(row.dataset.done).toBe('false');
+    expect(row.dataset.due).toContain('2025-12-24');
+  });
+});

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -1742,11 +1742,22 @@ export async function initReminders(sel = {}) {
     const createMobileItem = (r, catName) => {
     const div = document.createElement('div');
     div.className = 'task-item' + (r.done ? ' completed' : '');
+    const summary = {
+      id: r.id,
+      title: r.title,
+      dueIso: r.due || null,
+      priority: r.priority || 'Medium',
+      category: catName,
+      done: Boolean(r.done),
+    };
     div.dataset.category = catName;
     // Make rows discoverable by other modules (e.g., Today view)
-    div.dataset.reminder = '1';
-    div.dataset.id = r.id;
-    if (r.due) div.dataset.due = r.due; // ISO string
+    div.dataset.reminder = JSON.stringify(summary);
+    div.dataset.id = summary.id;
+    div.dataset.title = summary.title;
+    div.dataset.priority = summary.priority;
+    div.dataset.done = String(summary.done);
+    if (summary.dueIso) div.dataset.due = summary.dueIso; // ISO string
       const dueTxt = r.due ? `${fmtTime(new Date(r.due))} • ${fmtDayDate(r.due.slice(0,10))}` : 'No due date';
       const priorityClass = `priority-${(r.priority || 'Medium').toLowerCase()}`;
       const notesHtml = r.notes ? `<div class="task-notes">${notesToHtml(r.notes)}</div>` : '';
@@ -1823,8 +1834,21 @@ export async function initReminders(sel = {}) {
       catRows.forEach(r => {
         if(variant === 'desktop'){
           const itemEl = document.createElement(listIsSemantic ? 'li' : 'div');
-          itemEl.dataset.id = r.id;
-          itemEl.dataset.category = catName;
+          const summary = {
+            id: r.id,
+            title: r.title,
+            dueIso: r.due || null,
+            priority: r.priority || 'Medium',
+            category: catName,
+            done: Boolean(r.done),
+          };
+          itemEl.dataset.id = summary.id;
+          itemEl.dataset.category = summary.category;
+          itemEl.dataset.title = summary.title;
+          itemEl.dataset.priority = summary.priority;
+          itemEl.dataset.done = String(summary.done);
+          if (summary.dueIso) itemEl.dataset.due = summary.dueIso;
+          itemEl.dataset.reminder = JSON.stringify(summary);
           itemEl.className = 'card bg-base-100 shadow-xl w-full lg:w-96 border border-base-200';
           const dueLabel = formatDesktopDue(r);
           const priorityIndicatorClass = desktopPriorityClasses[r.priority] || desktopPriorityClasses.Medium;

--- a/mobile.html
+++ b/mobile.html
@@ -978,7 +978,10 @@
 
             if (dataset.reminder) {
               try {
-                raw = JSON.parse(dataset.reminder);
+                const parsed = JSON.parse(dataset.reminder);
+                if (parsed && typeof parsed === 'object') {
+                  raw = parsed;
+                }
               } catch {
                 raw = null;
               }


### PR DESCRIPTION
## Summary
- embed serialized reminder metadata into rendered reminder rows so sync tooling can reuse DOM data
- harden the mobile sync collector against malformed dataset payloads
- add a regression test ensuring mobile reminder rows expose the expected dataset metadata

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_b_69020acf8068832785fc02104684216e