### PR TITLE
Ensure mobile bundle cache busting and update SW cache version

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -529,7 +529,7 @@
   <!-- When deployed, this should appear in View Source with today’s date. -->
 
   <!-- Load the mobile app bundle (build will rewrite to hashed path) -->
-  <script type="module" src="./mobile.js"></script>
+  <script type="module" src="./mobile.js?v=20251029"></script>
   <script type="module" src="./js/mobile-theme-toggle.js"></script>
   <!-- BEGIN GPT CHANGE: bottom sheet for Create Reminder -->
   <div id="create-sheet" role="dialog" aria-modal="true" aria-labelledby="createSheetTitle" class="sheet hidden" tabindex="-1" data-add-task-dialog>

--- a/service-worker.js
+++ b/service-worker.js
@@ -15,7 +15,7 @@
 
 const APP_PATH = new URL(self.registration.scope).pathname.replace(/\/$/, '/') || '/';
 const CACHE_PREFIX = 'mc-static-';
-const CACHE_VERSION = 'v11'; // bump this to force clients to update
+const CACHE_VERSION = 'v12'; // bump this to force clients to update
 const RUNTIME_CACHE = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
 const SHELL_URLS = [


### PR DESCRIPTION
## Summary
- add a cache-busting query parameter to the mobile bundle script tag
- bump the service worker cache version to invalidate old bundles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_69020cffe6008327a49b92d9e6347d3f