### PR TITLE
Fix mobile stylesheet loading and refresh cache

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2,9 +2,12 @@
 <html lang="en" data-theme="light">
 <head>
   <base href="./" />
+  <!-- Tailwind core -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- daisyUI styles (CSS only) -->
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/daisyui@4.12.10/dist/full.min.css"
+    href="https://cdn.jsdelivr.net/npm/daisyui@4.12.14/dist/full.min.css"
   />
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -14,7 +17,6 @@
   <link rel="icon" href="./icons/icon-192.svg" type="image/svg+xml" />
   <link rel="stylesheet" href="./styles/tokens.css" />
   <link rel="stylesheet" href="./styles/a11y.css" />
-  <link rel="stylesheet" href="./dist/styles.css" />
   <style>
     .sync-status {
       display: inline-flex;
@@ -529,7 +531,7 @@
   <!-- When deployed, this should appear in View Source with today’s date. -->
 
   <!-- Load the mobile app bundle (build will rewrite to hashed path) -->
-  <script type="module" src="./mobile.js?v=20251029"></script>
+  <script type="module" src="./mobile.js?v=2025-10-29-1"></script>
   <script type="module" src="./js/mobile-theme-toggle.js"></script>
   <!-- BEGIN GPT CHANGE: bottom sheet for Create Reminder -->
   <div id="create-sheet" role="dialog" aria-modal="true" aria-labelledby="createSheetTitle" class="sheet hidden" tabindex="-1" data-add-task-dialog>

--- a/service-worker.js
+++ b/service-worker.js
@@ -15,7 +15,7 @@
 
 const APP_PATH = new URL(self.registration.scope).pathname.replace(/\/$/, '/') || '/';
 const CACHE_PREFIX = 'mc-static-';
-const CACHE_VERSION = 'v12'; // bump this to force clients to update
+const CACHE_VERSION = 'v13'; // bump this to force clients to update
 const RUNTIME_CACHE = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
 const SHELL_URLS = [


### PR DESCRIPTION
## Summary
- load Tailwind and the latest daisyUI CSS directly in mobile.html so hidden/sheet styles are available and remove the broken /dist/styles.css reference
- add a cache-busting query to mobile.js and bump the service worker cache version to force clients to fetch the updated assets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_69020fde203c8327a46b50c11d82d52e