### PR TITLE
Fix mobile sheet closing + production CSS (no CDN)

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -522,22 +522,25 @@ export async function initReminders(sel = {}) {
       return;
     }
 
-    const wasOpen = sheet.classList?.contains('open') || !sheet.classList?.contains('hidden');
-    if (!wasOpen) {
-      return;
-    }
-
+    sheet.classList?.remove('open');
     sheet.classList?.add('hidden');
     sheet.setAttribute('hidden', '');
     sheet.setAttribute('aria-hidden', 'true');
     sheet.removeAttribute('open');
-    sheet.classList?.remove('open');
 
     const backdrop = sheet.querySelector('.sheet-backdrop, .backdrop');
     if (backdrop instanceof HTMLElement) {
       backdrop.classList.add('hidden');
       backdrop.setAttribute('hidden', '');
       backdrop.setAttribute('aria-hidden', 'true');
+    }
+
+    try {
+      document.dispatchEvent(
+        new CustomEvent('cue:close', { detail: { reason: 'save' } }),
+      );
+    } catch {
+      /* ignore CustomEvent issues */
     }
   }
 

--- a/mobile.html
+++ b/mobile.html
@@ -2,13 +2,8 @@
 <html lang="en" data-theme="light">
 <head>
   <base href="./" />
-  <!-- Tailwind core -->
-  <script src="https://cdn.tailwindcss.com"></script>
-  <!-- daisyUI styles (CSS only) -->
-  <link
-    rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/daisyui@4.12.14/dist/full.min.css"
-  />
+  <!-- Production CSS: compiled via Tailwind/PostCSS; build rewrites this to a hashed asset -->
+  <link rel="stylesheet" href="./dist/styles.css" />
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Memory Cue (Mobile) — Inline + Edit + Sync All</title>

--- a/service-worker.js
+++ b/service-worker.js
@@ -15,7 +15,7 @@
 
 const APP_PATH = new URL(self.registration.scope).pathname.replace(/\/$/, '/') || '/';
 const CACHE_PREFIX = 'mc-static-';
-const CACHE_VERSION = 'v13'; // bump this to force clients to update
+const CACHE_VERSION = 'v14'; // bump this to force clients to update
 const RUNTIME_CACHE = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
 const SHELL_URLS = [
@@ -27,7 +27,6 @@ const SHELL_URLS = [
   // Add your real icons below if present; missing files are skipped.
   `${APP_PATH}icons/icon-192.svg`,
   `${APP_PATH}icons/icon-512.svg`,
-  'https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4',
 ];
 
 // File extensions treated as static assets for SWR caching


### PR DESCRIPTION
## Summary
- Remove Tailwind/DaisyUI CDN from `mobile.html` and rely on the compiled `./dist/styles.css` asset.
- Force-close the create reminder sheet directly from `reminders.js`, ensuring the UI hides immediately and broadcasting a `cue:close` event.
- Bump the service worker cache to `v14` and drop the Tailwind CDN URL from the precache list so clients pick up new assets.

## Testing
- npm ci
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_b_6902d383591083278b1840aedf2e1be5