### PR TITLE
Remove Stay organised card from notebook view

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -498,16 +498,6 @@
         </div>
       </section>
 
-      <section class="card bg-base-100 border">
-        <div class="card-body gap-3 compact">
-          <h2 class="card-title text-base">Stay organised</h2>
-          <p class="text-sm text-base-content/70">Use columns to create side-by-side checklists, or switch back to a single column for longer thoughts. Notes are saved locally so you can revisit them anytime.</p>
-          <div class="flex flex-wrap gap-2">
-            <button type="button" class="btn btn-outline btn-sm" data-scroll-target="notes">Jump to editor</button>
-            <button type="button" class="btn btn-ghost btn-sm" data-jump-view="reminders">Create a reminder instead</button>
-          </div>
-        </div>
-      </section>
     </section>
     <!-- END GPT CHANGE -->
 </main>

--- a/mobile.html
+++ b/mobile.html
@@ -501,16 +501,6 @@
         </div>
       </section>
 
-      <section class="card bg-base-100 border">
-        <div class="card-body gap-3 compact">
-          <h2 class="card-title text-base">Stay organised</h2>
-          <p class="text-sm text-base-content/70">Use columns to create side-by-side checklists, or switch back to a single column for longer thoughts. Notes are saved locally so you can revisit them anytime.</p>
-          <div class="flex flex-wrap gap-2">
-            <button type="button" class="btn btn-outline btn-sm" data-scroll-target="notes">Jump to editor</button>
-            <button type="button" class="btn btn-ghost btn-sm" data-jump-view="reminders">Create a reminder instead</button>
-          </div>
-        </div>
-      </section>
     </section>
     <!-- END GPT CHANGE -->
 </main>


### PR DESCRIPTION
## Summary
- remove the Stay organised guidance card from the notebook view to reduce clutter
- mirror the removal in the prebuilt docs version of the mobile page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690498d9b9f08324a7216a2d3132e2ee