### PR TITLE
Unify the mobile interface

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -293,55 +293,7 @@
     }
   </style>
   <!-- END GPT CHANGE: rhythm -->
-  <style id="voice-add-css">
-    .voice-add-wrap{
-      position: fixed; right: 12px; bottom: 12px; z-index: 50;
-      display: inline-flex; align-items: center; gap: 8px;
-      padding: 6px 8px; border-radius: 9999px; background: var(--fallback-b1,#fff);
-      box-shadow: 0 2px 8px rgba(0,0,0,.15);
-    }
-
-    /* Hide the status text by default */
-    .voice-status { display: none; }
-
-    /* Only show status while actively listening */
-    .voice-add-wrap.listening .voice-status { display: inline; font-size: 12px; opacity: .75; }
-
-  </style>
-  <style id="min-expand-css">
-    /* Expand/collapse behavior */
-    .task-row-min {
-      cursor: pointer;
-      outline: none;
-    }
-    .task-row-min:focus {
-      box-shadow: 0 0 0 2px rgba(0,0,0,.15) inset;
-    }
-    .task-row-min .min-notes {
-      display: none;
-      grid-column: 1 / -1;
-      margin-top: 8px;
-      font-size: 14px;
-      line-height: 1.35;
-      opacity: .95;
-      white-space: pre-wrap;
-    }
-    .task-row-min.expanded .min-notes {
-      display: block;
-    }
-    /* Slightly larger title when expanded */
-    .task-row-min.expanded .title {
-      font-weight: 600;
-    }
-    /* Optional small chevron indicator */
-    .task-row-min::after {
-      content: "▾";
-      justify-self: end;
-      opacity: .5;
-      font-size: 12px;
-    }
-    .task-row-min.expanded::after { transform: rotate(180deg); }
-  </style>
+  
 </head>
 <body class="min-h-screen bg-base-200 text-base-content show-full">
   <a class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-full focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-primary-content" href="#main">Skip to main content</a>
@@ -375,11 +327,6 @@
   </header>
 
   <main id="main" class="max-w-md mx-auto px-4 pb-28 pt-4" tabindex="-1" data-active-view="reminders">
-    <!-- Voice Add Task UI -->
-    <div id="voiceAddWrap" class="voice-add-wrap" aria-live="polite" aria-atomic="true">
-      <button id="voiceAddBtn" class="btn btn-circle btn-ghost" aria-pressed="false" aria-label="Add task by voice">🎤</button>
-      <span id="voiceStatus" class="voice-status" hidden>Tap 🎤 to speak</span>
-    </div>
     <!-- BEGIN GPT CHANGE: create form moved to bottom sheet -->
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: reminders view -->
@@ -394,17 +341,13 @@
                    placeholder="What do you need to remember?"
                    aria-label="Quick add reminder"
                    autocomplete="off" />
-            <button id="quickAddMic"
-                    class="btn btn-circle btn-ghost"
-                    type="button"
-                    aria-label="Add by voice">🎤</button>
             <button id="quickAddSubmit"
                     class="btn btn-primary"
                     type="button"
                     aria-label="Add reminder now">Add</button>
           </div>
           <p class="text-xs text-base-content/60">
-            Tip: Press <kbd>/</kbd> or <kbd>q</kbd> to focus; <kbd>Enter</kbd> to add; <kbd>Alt</kbd>+<kbd>M</kbd> for mic.
+            Tip: Press <kbd>/</kbd> or <kbd>q</kbd> to focus and <kbd>Enter</kbd> to add.
           </p>
         </div>
       </section>
@@ -447,7 +390,7 @@
       <section id="reminderListSection" class="card bg-base-100 border">
         <div class="card-body gap-4 compact" id="remindersWrapper">
           <div id="emptyState" class="hidden text-center text-base-content/60"></div>
-          <ul id="reminderList" class="space-y-3 task-list-min"></ul>
+          <ul id="reminderList" class="space-y-3"></ul>
           <p class="text-xs text-base-content/60">Total reminders: <span id="totalCount">0</span></p>
         </div>
       </section>
@@ -599,6 +542,27 @@
           <div class="flex flex-wrap items-center gap-3">
             <button id="notifBtn" class="btn btn-ghost" type="button">Enable notifications</button>
             <button id="quickAdd" class="btn btn-outline" type="button">Quick add</button>
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <button
+              id="sheetVoiceBtn"
+              class="btn btn-outline justify-center"
+              type="button"
+              aria-pressed="false"
+              aria-label="Dictate reminder"
+            >
+              🎤 Voice input
+            </button>
+            <p
+              id="sheetVoiceStatus"
+              class="text-xs text-base-content/60"
+              role="status"
+              aria-live="polite"
+              hidden
+            >
+              Tap the microphone to start speaking.
+            </p>
           </div>
 
           <div class="card-actions justify-stretch">
@@ -1215,50 +1179,6 @@
       });
     })();
   </script>
-  <script>
-    (function () {
-      function applyMinimalLayout() {
-        var list = document.getElementById('reminderList');
-        if (!list) return;
-        list.querySelectorAll('.task-item').forEach(function (item) {
-          item.classList.add('task-row-min');
-          var title = item.querySelector('.task-title');
-          if (title) {
-            title.classList.add('title');
-          }
-          var due = item.querySelector('.task-meta-row span');
-          if (due && !due.querySelector('time')) {
-            var text = due.textContent.trim();
-            var timeEl = document.createElement('time');
-            var iso = item.getAttribute('data-due') || (item.dataset ? item.dataset.due : '');
-            if (iso) {
-              timeEl.setAttribute('datetime', iso);
-            }
-            timeEl.textContent = text;
-            due.textContent = '';
-            due.appendChild(timeEl);
-          }
-          var notes = item.querySelector('.task-notes');
-          if (notes) {
-            if (!notes.classList.contains('min-notes')) {
-              notes.classList.add('min-notes');
-            }
-          } else {
-            var content = item.querySelector('.task-content') || item;
-            if (content && !content.querySelector('.min-notes')) {
-              var notesDiv = document.createElement('div');
-              notesDiv.className = 'min-notes';
-              notesDiv.setAttribute('data-source', 'auto');
-              content.appendChild(notesDiv);
-            }
-          }
-        });
-      }
-      document.addEventListener('DOMContentLoaded', applyMinimalLayout);
-      document.addEventListener('reminders:updated', applyMinimalLayout);
-    })();
-  </script>
-  
   <script id="add-task-guard-script">
     (function () {
       const dialog = document.querySelector('[data-add-task-dialog]');
@@ -1469,105 +1389,7 @@
       syncRadiosFromSelect();
     })();
   </script>
-  <script id="min-expand-script">
-(function(){
-  // Find the list container for minimal tasks
-  // Prefer an element with class 'task-list-min'; fallback to common ids.
-  var list = document.querySelector('.task-list-min')
-         || document.getElementById('remindersList')
-         || document.getElementById('tasks')
-         || document.querySelector('[data-list="reminders"]');
-  if (!list) return;
-
-  // Utility: find or create a .min-notes element in a row
-  function ensureNotesEl(row){
-    var el = row.querySelector('.min-notes');
-    if (!el) {
-      el = document.createElement('div');
-      el.className = 'min-notes';
-      el.setAttribute('data-source','auto');
-      row.appendChild(el);
-    }
-    return el;
-  }
-
-  // Utility: get task id/title/notes from dataset or known child selectors
-  function getTaskData(row){
-    // Prefer data attributes if your renderer sets them
-    var id    = row.getAttribute('data-taskid') || row.dataset.taskid;
-    var title = row.querySelector('.title')?.textContent?.trim() || row.getAttribute('data-title') || '';
-    // Try to read an existing notes element if already rendered but hidden
-    var existing = row.querySelector('.notes, .note, [data-notes]');
-    var notes = existing ? (existing.textContent || existing.getAttribute('data-notes') || '').trim() : '';
-
-    // If no notes in DOM, try app hooks (non-breaking)
-    if (!notes && window.getReminderById && id) {
-      try { notes = (window.getReminderById(id)?.notes || '').trim(); } catch(_) {}
-    }
-    return { id, title, notes };
-  }
-
-  // Make rows focusable and togglable
-  function prepareRow(row){
-    if (!row.classList.contains('task-row-min')) return;
-    // ARIA / keyboard
-    row.setAttribute('role','button');
-    row.setAttribute('tabindex','0');
-    row.setAttribute('aria-expanded','false');
-
-    function toggle(){
-      var expanded = row.classList.toggle('expanded');
-      row.setAttribute('aria-expanded', expanded ? 'true' : 'false');
-
-      // Fill notes on first expand if needed
-      if (expanded) {
-        var data = getTaskData(row);
-        var notesEl = ensureNotesEl(row);
-        if (notesEl && !notesEl.textContent.trim()) {
-          // prefer existing notes text if already present
-          if (data.notes) {
-            notesEl.textContent = data.notes;
-          } else {
-            notesEl.textContent = 'No notes';
-            notesEl.style.opacity = '.6';
-          }
-        }
-        // Optionally ensure full title is visible (if row truncates)
-        var titleEl = row.querySelector('.title');
-        if (titleEl) titleEl.title = data.title || titleEl.textContent;
-      }
-    }
-
-    row.addEventListener('click', function(e){
-      // Avoid toggling when clicking links/buttons inside the row
-      if (e.target.closest('a,button,input,textarea,select')) return;
-      toggle();
-    });
-
-    row.addEventListener('keydown', function(e){
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault(); toggle();
-      }
-    });
-  }
-
-  // Prepare existing rows
-  Array.from(list.querySelectorAll('.task-row-min')).forEach(prepareRow);
-
-  // If your list re-renders dynamically, observe and apply to new rows
-  var mo = new MutationObserver(function(muts){
-    for (var m of muts) {
-      m.addedNodes && m.addedNodes.forEach(function(n){
-        if (!(n instanceof Element)) return;
-        if (n.classList && n.classList.contains('task-row-min')) prepareRow(n);
-        // Also catch rows generated within a fragment
-        n.querySelectorAll && n.querySelectorAll('.task-row-min').forEach(prepareRow);
-      });
-    }
-  });
-  mo.observe(list, { childList: true, subtree: true });
-})();
-  </script>
+  
   <script type="module" src="./assets/mobile-D7CLP2NM.js"></script>
 </body>
 </html>

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -136,14 +136,17 @@ function initVoiceInput() {
     return;
   }
 
-  const mic = document.getElementById('voiceAddBtn');
+  const sheetMic = document.getElementById('sheetVoiceBtn');
   const quickMic = document.getElementById('quickAddMic');
-  const status = document.getElementById('voiceStatus');
+  const status = document.getElementById('sheetVoiceStatus');
   const quickInput = document.getElementById('quickAddInput');
   const formInput = document.getElementById('reminderText');
-  const defaultInput = quickInput || formInput;
+  const defaultInput = formInput || quickInput;
+  const isElement = (el) =>
+    Boolean(el) && typeof el === 'object' && typeof el.addEventListener === 'function';
+  const micButtons = [sheetMic, quickMic].filter(isElement);
 
-  if (!mic || !defaultInput) {
+  if (!micButtons.length || !defaultInput) {
     return;
   }
 
@@ -162,6 +165,7 @@ function initVoiceInput() {
   recog.maxAlternatives = 1;
 
   let activeInput = defaultInput;
+  let listeningButton = null;
 
   function resolveInputForButton(btn) {
     if (!btn) {
@@ -177,7 +181,7 @@ function initVoiceInput() {
     if (btn === quickMic && quickInput) {
       return quickInput;
     }
-    if (btn === mic && formInput) {
+    if (btn === sheetMic && formInput) {
       return formInput;
     }
     return defaultInput;
@@ -189,6 +193,10 @@ function initVoiceInput() {
       return;
     }
     activeInput = targetInput;
+    listeningButton = isElement(btn) ? btn : null;
+    if (listeningButton) {
+      listeningButton.setAttribute('aria-pressed', 'true');
+    }
     try {
       if (status) {
         status.hidden = false;
@@ -200,8 +208,9 @@ function initVoiceInput() {
     }
   }
 
-  mic.addEventListener('click', () => beginListeningFor(mic));
-  quickMic?.addEventListener('click', () => beginListeningFor(quickMic));
+  micButtons.forEach((btn) => {
+    btn.addEventListener('click', () => beginListeningFor(btn));
+  });
 
   recog.addEventListener('result', (e) => {
     const transcript = e.results?.[0]?.[0]?.transcript?.trim() || '';
@@ -230,6 +239,10 @@ function initVoiceInput() {
   });
 
   recog.addEventListener('end', () => {
+    if (listeningButton) {
+      listeningButton.setAttribute('aria-pressed', 'false');
+      listeningButton = null;
+    }
     if (status) {
       status.hidden = true;
     }
@@ -1748,16 +1761,7 @@ export async function initReminders(sel = {}) {
     const frag = document.createDocumentFragment();
     const listIsSemantic = list.tagName === 'UL' || list.tagName === 'OL';
 
-    const isMinimalLayout = (() => {
-      if (typeof document === 'undefined') return false;
-      const body = document.body;
-      if (!body || typeof body.classList?.contains !== 'function') return false;
-      return !body.classList.contains('show-full');
-    })();
-    const shouldGroupCategories =
-      variant === 'desktop' ||
-      !isMinimalLayout ||
-      (!listIsSemantic && variant !== 'desktop');
+    const shouldGroupCategories = true;
 
     const createMobileItem = (r, catName) => {
     const div = document.createElement('div');

--- a/mobile.html
+++ b/mobile.html
@@ -296,55 +296,7 @@
     }
   </style>
   <!-- END GPT CHANGE: rhythm -->
-  <style id="voice-add-css">
-    .voice-add-wrap{
-      position: fixed; right: 12px; bottom: 12px; z-index: 50;
-      display: inline-flex; align-items: center; gap: 8px;
-      padding: 6px 8px; border-radius: 9999px; background: var(--fallback-b1,#fff);
-      box-shadow: 0 2px 8px rgba(0,0,0,.15);
-    }
-
-    /* Hide the status text by default */
-    .voice-status { display: none; }
-
-    /* Only show status while actively listening */
-    .voice-add-wrap.listening .voice-status { display: inline; font-size: 12px; opacity: .75; }
-
-  </style>
-  <style id="min-expand-css">
-    /* Expand/collapse behavior */
-    .task-row-min {
-      cursor: pointer;
-      outline: none;
-    }
-    .task-row-min:focus {
-      box-shadow: 0 0 0 2px rgba(0,0,0,.15) inset;
-    }
-    .task-row-min .min-notes {
-      display: none;
-      grid-column: 1 / -1;
-      margin-top: 8px;
-      font-size: 14px;
-      line-height: 1.35;
-      opacity: .95;
-      white-space: pre-wrap;
-    }
-    .task-row-min.expanded .min-notes {
-      display: block;
-    }
-    /* Slightly larger title when expanded */
-    .task-row-min.expanded .title {
-      font-weight: 600;
-    }
-    /* Optional small chevron indicator */
-    .task-row-min::after {
-      content: "▾";
-      justify-self: end;
-      opacity: .5;
-      font-size: 12px;
-    }
-    .task-row-min.expanded::after { transform: rotate(180deg); }
-  </style>
+  
 </head>
 <body class="min-h-screen bg-base-200 text-base-content show-full">
   <a class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-full focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-primary-content" href="#main">Skip to main content</a>
@@ -378,11 +330,6 @@
   </header>
 
   <main id="main" class="max-w-md mx-auto px-4 pb-28 pt-4" tabindex="-1" data-active-view="reminders">
-    <!-- Voice Add Task UI -->
-    <div id="voiceAddWrap" class="voice-add-wrap" aria-live="polite" aria-atomic="true">
-      <button id="voiceAddBtn" class="btn btn-circle btn-ghost" aria-pressed="false" aria-label="Add task by voice">🎤</button>
-      <span id="voiceStatus" class="voice-status" hidden>Tap 🎤 to speak</span>
-    </div>
     <!-- BEGIN GPT CHANGE: create form moved to bottom sheet -->
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: reminders view -->
@@ -397,17 +344,13 @@
                    placeholder="What do you need to remember?"
                    aria-label="Quick add reminder"
                    autocomplete="off" />
-            <button id="quickAddMic"
-                    class="btn btn-circle btn-ghost"
-                    type="button"
-                    aria-label="Add by voice">🎤</button>
             <button id="quickAddSubmit"
                     class="btn btn-primary"
                     type="button"
                     aria-label="Add reminder now">Add</button>
           </div>
           <p class="text-xs text-base-content/60">
-            Tip: Press <kbd>/</kbd> or <kbd>q</kbd> to focus; <kbd>Enter</kbd> to add; <kbd>Alt</kbd>+<kbd>M</kbd> for mic.
+            Tip: Press <kbd>/</kbd> or <kbd>q</kbd> to focus and <kbd>Enter</kbd> to add.
           </p>
         </div>
       </section>
@@ -450,7 +393,7 @@
       <section id="reminderListSection" class="card bg-base-100 border">
         <div class="card-body gap-4 compact" id="remindersWrapper">
           <div id="emptyState" class="hidden text-center text-base-content/60"></div>
-          <ul id="reminderList" class="space-y-3 task-list-min"></ul>
+          <ul id="reminderList" class="space-y-3"></ul>
           <p class="text-xs text-base-content/60">Total reminders: <span id="totalCount">0</span></p>
         </div>
       </section>
@@ -607,6 +550,27 @@
           <div class="flex flex-wrap items-center gap-3">
             <button id="notifBtn" class="btn btn-ghost" type="button">Enable notifications</button>
             <button id="quickAdd" class="btn btn-outline" type="button">Quick add</button>
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <button
+              id="sheetVoiceBtn"
+              class="btn btn-outline justify-center"
+              type="button"
+              aria-pressed="false"
+              aria-label="Dictate reminder"
+            >
+              🎤 Voice input
+            </button>
+            <p
+              id="sheetVoiceStatus"
+              class="text-xs text-base-content/60"
+              role="status"
+              aria-live="polite"
+              hidden
+            >
+              Tap the microphone to start speaking.
+            </p>
           </div>
 
           <div class="card-actions justify-stretch">
@@ -1226,50 +1190,6 @@
       });
     })();
   </script>
-  <script>
-    (function () {
-      function applyMinimalLayout() {
-        var list = document.getElementById('reminderList');
-        if (!list) return;
-        list.querySelectorAll('.task-item').forEach(function (item) {
-          item.classList.add('task-row-min');
-          var title = item.querySelector('.task-title');
-          if (title) {
-            title.classList.add('title');
-          }
-          var due = item.querySelector('.task-meta-row span');
-          if (due && !due.querySelector('time')) {
-            var text = due.textContent.trim();
-            var timeEl = document.createElement('time');
-            var iso = item.getAttribute('data-due') || (item.dataset ? item.dataset.due : '');
-            if (iso) {
-              timeEl.setAttribute('datetime', iso);
-            }
-            timeEl.textContent = text;
-            due.textContent = '';
-            due.appendChild(timeEl);
-          }
-          var notes = item.querySelector('.task-notes');
-          if (notes) {
-            if (!notes.classList.contains('min-notes')) {
-              notes.classList.add('min-notes');
-            }
-          } else {
-            var content = item.querySelector('.task-content') || item;
-            if (content && !content.querySelector('.min-notes')) {
-              var notesDiv = document.createElement('div');
-              notesDiv.className = 'min-notes';
-              notesDiv.setAttribute('data-source', 'auto');
-              content.appendChild(notesDiv);
-            }
-          }
-        });
-      }
-      document.addEventListener('DOMContentLoaded', applyMinimalLayout);
-      document.addEventListener('reminders:updated', applyMinimalLayout);
-    })();
-  </script>
-  
   <script id="add-task-guard-script">
     (function () {
       const dialog = document.querySelector('[data-add-task-dialog]');
@@ -1773,104 +1693,6 @@
       });
     })();
   </script>
-  <script id="min-expand-script">
-(function(){
-  // Find the list container for minimal tasks
-  // Prefer an element with class 'task-list-min'; fallback to common ids.
-  var list = document.querySelector('.task-list-min')
-         || document.getElementById('remindersList')
-         || document.getElementById('tasks')
-         || document.querySelector('[data-list="reminders"]');
-  if (!list) return;
-
-  // Utility: find or create a .min-notes element in a row
-  function ensureNotesEl(row){
-    var el = row.querySelector('.min-notes');
-    if (!el) {
-      el = document.createElement('div');
-      el.className = 'min-notes';
-      el.setAttribute('data-source','auto');
-      row.appendChild(el);
-    }
-    return el;
-  }
-
-  // Utility: get task id/title/notes from dataset or known child selectors
-  function getTaskData(row){
-    // Prefer data attributes if your renderer sets them
-    var id    = row.getAttribute('data-taskid') || row.dataset.taskid;
-    var title = row.querySelector('.title')?.textContent?.trim() || row.getAttribute('data-title') || '';
-    // Try to read an existing notes element if already rendered but hidden
-    var existing = row.querySelector('.notes, .note, [data-notes]');
-    var notes = existing ? (existing.textContent || existing.getAttribute('data-notes') || '').trim() : '';
-
-    // If no notes in DOM, try app hooks (non-breaking)
-    if (!notes && window.getReminderById && id) {
-      try { notes = (window.getReminderById(id)?.notes || '').trim(); } catch(_) {}
-    }
-    return { id, title, notes };
-  }
-
-  // Make rows focusable and togglable
-  function prepareRow(row){
-    if (!row.classList.contains('task-row-min')) return;
-    // ARIA / keyboard
-    row.setAttribute('role','button');
-    row.setAttribute('tabindex','0');
-    row.setAttribute('aria-expanded','false');
-
-    function toggle(){
-      var expanded = row.classList.toggle('expanded');
-      row.setAttribute('aria-expanded', expanded ? 'true' : 'false');
-
-      // Fill notes on first expand if needed
-      if (expanded) {
-        var data = getTaskData(row);
-        var notesEl = ensureNotesEl(row);
-        if (notesEl && !notesEl.textContent.trim()) {
-          // prefer existing notes text if already present
-          if (data.notes) {
-            notesEl.textContent = data.notes;
-          } else {
-            notesEl.textContent = 'No notes';
-            notesEl.style.opacity = '.6';
-          }
-        }
-        // Optionally ensure full title is visible (if row truncates)
-        var titleEl = row.querySelector('.title');
-        if (titleEl) titleEl.title = data.title || titleEl.textContent;
-      }
-    }
-
-    row.addEventListener('click', function(e){
-      // Avoid toggling when clicking links/buttons inside the row
-      if (e.target.closest('a,button,input,textarea,select')) return;
-      toggle();
-    });
-
-    row.addEventListener('keydown', function(e){
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault(); toggle();
-      }
-    });
-  }
-
-  // Prepare existing rows
-  Array.from(list.querySelectorAll('.task-row-min')).forEach(prepareRow);
-
-  // If your list re-renders dynamically, observe and apply to new rows
-  var mo = new MutationObserver(function(muts){
-    for (var m of muts) {
-      m.addedNodes && m.addedNodes.forEach(function(n){
-        if (!(n instanceof Element)) return;
-        if (n.classList && n.classList.contains('task-row-min')) prepareRow(n);
-        // Also catch rows generated within a fragment
-        n.querySelectorAll && n.querySelectorAll('.task-row-min').forEach(prepareRow);
-      });
-    }
-  });
-  mo.observe(list, { childList: true, subtree: true });
-})();
-  </script>
+  
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove the floating minimal-mode voice UI and related scripts from the mobile layout
- add a dedicated voice input control inside the bottom-sheet form and update copy across the HTML sources
- simplify reminder rendering by assuming the full interface layout at all times

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_69049b1f497083249a496f0c051add8d