### PR TITLE
Consolidate mobile add controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -93,7 +93,6 @@ const initialiseReminders = () => {
       syncStatusSel: '#syncStatus',
       voiceBtnSel: '#voiceBtn',
       notifBtnSel: '#notifBtn',
-      addQuickBtnSel: '#quickAdd',
       filterBtnsSel: '[data-filter]',
       categoryFilterSel: '#categoryFilter',
       categoryOptionsSel: '#categorySuggestions',

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -124,118 +124,6 @@ function bindNotificationCleanupHandlers() {
   notificationCleanupBound = true;
 }
 
-let voiceInputInitialized = false;
-
-function initVoiceInput() {
-  if (voiceInputInitialized) {
-    return;
-  }
-  voiceInputInitialized = true;
-
-  if (typeof document === 'undefined') {
-    return;
-  }
-
-  const mic = document.getElementById('voiceAddBtn');
-  const quickMic = document.getElementById('quickAddMic');
-  const status = document.getElementById('voiceStatus');
-  const quickInput = document.getElementById('quickAddInput');
-  const formInput = document.getElementById('reminderText');
-  const defaultInput = quickInput || formInput;
-
-  if (!mic || !defaultInput) {
-    return;
-  }
-
-  if (!('webkitSpeechRecognition' in window || 'SpeechRecognition' in window)) {
-    if (status) {
-      status.textContent = 'Speech not supported';
-      status.hidden = false;
-    }
-    return;
-  }
-
-  const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
-  const recog = new SpeechRecognition();
-  recog.lang = 'en-US';
-  recog.interimResults = false;
-  recog.maxAlternatives = 1;
-
-  let activeInput = defaultInput;
-
-  function resolveInputForButton(btn) {
-    if (!btn) {
-      return defaultInput;
-    }
-    const explicitTargetId = btn.getAttribute?.('data-voice-target');
-    if (explicitTargetId) {
-      const explicitTarget = document.getElementById(explicitTargetId);
-      if (explicitTarget) {
-        return explicitTarget;
-      }
-    }
-    if (btn === quickMic && quickInput) {
-      return quickInput;
-    }
-    if (btn === mic && formInput) {
-      return formInput;
-    }
-    return defaultInput;
-  }
-
-  function beginListeningFor(btn) {
-    const targetInput = resolveInputForButton(btn);
-    if (!targetInput) {
-      return;
-    }
-    activeInput = targetInput;
-    try {
-      if (status) {
-        status.hidden = false;
-        status.textContent = 'Listening…';
-      }
-      recog.start();
-    } catch (err) {
-      console.warn('Speech recognition error:', err);
-    }
-  }
-
-  mic.addEventListener('click', () => beginListeningFor(mic));
-  quickMic?.addEventListener('click', () => beginListeningFor(quickMic));
-
-  recog.addEventListener('result', (e) => {
-    const transcript = e.results?.[0]?.[0]?.transcript?.trim() || '';
-    if (!transcript) {
-      if (status) {
-        status.hidden = true;
-      }
-      return;
-    }
-    const target = activeInput || defaultInput;
-    if (!target) {
-      return;
-    }
-    target.value = transcript;
-    if (status) {
-      status.textContent = 'Added: ' + transcript;
-      status.hidden = true;
-    }
-    if (target && target.id === 'quickAddInput') {
-      try {
-        const globalQuickAdd =
-          typeof window !== 'undefined' ? window.memoryCueQuickAddNow : null;
-        globalQuickAdd?.();
-      } catch {}
-    }
-  });
-
-  recog.addEventListener('end', () => {
-    if (status) {
-      status.hidden = true;
-    }
-  });
-}
-
 function normalizeCategory(value) {
   if (typeof value === 'string') {
     const trimmed = value.replace(/\s+/g, ' ').trim();
@@ -299,7 +187,7 @@ export async function initReminders(sel = {}) {
   const googleAvatar = $(sel.googleAvatarSel);
   const googleUserName = $(sel.googleUserNameSel);
   const dateFeedback = $(sel.dateFeedbackSel);
-  const addQuickBtn = $(sel.addQuickBtnSel);
+  const voiceBtn = $(sel.voiceBtnSel);
   const notifBtn = $(sel.notifBtnSel);
   const moreBtn = $(sel.moreBtnSel);
   const moreMenu = $(sel.moreMenuSel);
@@ -400,8 +288,6 @@ export async function initReminders(sel = {}) {
 
   const quickInput =
     typeof document !== 'undefined' ? document.getElementById('quickAddInput') : null;
-  const quickMic =
-    typeof document !== 'undefined' ? document.getElementById('quickAddMic') : null;
   const quickBtn =
     typeof document !== 'undefined' ? document.getElementById('quickAddSubmit') : null;
 
@@ -483,9 +369,6 @@ export async function initReminders(sel = {}) {
             e.preventDefault();
             quickInput.focus();
           }
-        } else if ((e.key === 'm' || e.key === 'M') && e.altKey) {
-          e.preventDefault();
-          quickMic?.click();
         }
       });
     }
@@ -550,75 +433,6 @@ export async function initReminders(sel = {}) {
     } catch {
       // Ignore environments where CustomEvent construction fails.
     }
-  }
-
-  if (addQuickBtn && title) {
-    addQuickBtn.addEventListener('click', () => {
-      const raw = (title.value || '').trim();
-      if (!raw) {
-        try {
-          title.focus();
-        } catch {}
-        return;
-      }
-
-      const now = Date.now();
-      const hasDate = typeof date?.value === 'string' && date.value;
-      const hasTime = typeof time?.value === 'string' && time.value;
-      let dueValue = null;
-      if (hasDate || hasTime) {
-        dueValue = localDateTimeToISO(
-          hasDate ? date.value : todayISO(),
-          hasTime ? time.value : '09:00',
-        );
-      } else {
-        try {
-          const parsed = parseQuickWhen(raw);
-          if (parsed?.time) {
-            dueValue = new Date(`${parsed.date}T${parsed.time}:00`).toISOString();
-          }
-        } catch {
-          // Ignore parse failures and keep the reminder undated.
-        }
-      }
-
-      const entry = {
-        id: uid(),
-        title: raw,
-        notes: typeof details?.value === 'string' ? details.value.trim() : '',
-        priority: getPriorityInputValue(),
-        category: normalizeCategory(categoryInput?.value || DEFAULT_CATEGORY),
-        done: false,
-        createdAt: now,
-        updatedAt: now,
-        due: dueValue,
-        pendingSync: !userId,
-      };
-
-      items.unshift(entry);
-      suppressRenderMemoryEvent = true;
-      render();
-      persistItems();
-      updateDefaultsFrom(entry);
-      saveToFirebase(entry);
-      tryCalendarSync(entry);
-      scheduleReminder(entry);
-      emitReminderUpdates();
-      dispatchCueEvent('memoryCue:remindersUpdated', { items });
-      closeCreateSheetIfOpen();
-      dispatchCueEvent('cue:close', { reason: 'created' });
-
-      title.value = '';
-      if (typeof details?.value !== 'undefined') {
-        details.value = '';
-      }
-      if (typeof date?.value !== 'undefined') {
-        date.value = '';
-      }
-      if (typeof time?.value !== 'undefined') {
-        time.value = '';
-      }
-    });
   }
 
   if (categoryInput && !categoryInput.value) {
@@ -686,8 +500,142 @@ export async function initReminders(sel = {}) {
     }
   }
 
+  function setupVoiceEnhancement() {
+    if (
+      typeof HTMLElement === 'undefined' ||
+      !(voiceBtn instanceof HTMLElement)
+    ) {
+      return;
+    }
+
+    const isInputElement =
+      typeof HTMLInputElement !== 'undefined' &&
+      title instanceof HTMLInputElement;
+    const isTextareaElement =
+      typeof HTMLTextAreaElement !== 'undefined' &&
+      title instanceof HTMLTextAreaElement;
+
+    if (!isInputElement && !isTextareaElement) {
+      return;
+    }
+
+    if (voiceBtn.dataset.voiceBound === 'true') {
+      return;
+    }
+    voiceBtn.dataset.voiceBound = 'true';
+
+    if (typeof window === 'undefined') {
+      voiceBtn.setAttribute('disabled', 'true');
+      voiceBtn.setAttribute('aria-disabled', 'true');
+      return;
+    }
+
+    const SpeechRecognitionCtor =
+      window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (typeof SpeechRecognitionCtor !== 'function') {
+      voiceBtn.setAttribute('disabled', 'true');
+      voiceBtn.setAttribute('aria-disabled', 'true');
+      if (!voiceBtn.getAttribute('title')) {
+        voiceBtn.title = 'Voice input is not supported in this browser.';
+      }
+      return;
+    }
+
+    let recognition = null;
+    let listening = false;
+
+    const updateListening = (state) => {
+      listening = state;
+      voiceBtn.setAttribute('aria-pressed', state ? 'true' : 'false');
+      voiceBtn.dataset.listening = state ? 'true' : 'false';
+      voiceBtn.classList.toggle('is-listening', state);
+    };
+
+    const ensureRecognition = () => {
+      if (recognition) {
+        return recognition;
+      }
+      recognition = new SpeechRecognitionCtor();
+      recognition.lang = 'en-US';
+      recognition.interimResults = false;
+      recognition.maxAlternatives = 1;
+
+      recognition.addEventListener('result', (event) => {
+        const transcript = event.results?.[0]?.[0]?.transcript?.trim() || '';
+        if (!transcript) {
+          return;
+        }
+        title.value = transcript;
+        try {
+          title.focus({ preventScroll: true });
+        } catch {
+          try {
+            title.focus();
+          } catch {}
+        }
+        try {
+          const length = title.value.length;
+          if (typeof title.setSelectionRange === 'function') {
+            title.setSelectionRange(length, length);
+          }
+        } catch {}
+        emitActivity({ action: 'dictated', label: `Voice input captured · ${transcript}` });
+      });
+
+      const resetState = () => {
+        updateListening(false);
+      };
+
+      recognition.addEventListener('end', resetState);
+      recognition.addEventListener('error', resetState);
+
+      return recognition;
+    };
+
+    const stopListening = () => {
+      if (!listening || !recognition) {
+        return;
+      }
+      try {
+        recognition.stop();
+      } catch {}
+      updateListening(false);
+    };
+
+    voiceBtn.addEventListener('click', () => {
+      const recog = ensureRecognition();
+      if (!recog) {
+        return;
+      }
+
+      if (listening) {
+        stopListening();
+        return;
+      }
+
+      try {
+        recog.start();
+        updateListening(true);
+      } catch (error) {
+        console.warn('Speech recognition error:', error);
+        updateListening(false);
+      }
+    });
+
+    const handleClose = () => {
+      stopListening();
+    };
+
+    if (typeof document !== 'undefined') {
+      document.addEventListener('cue:close', handleClose);
+      document.addEventListener('reminders:updated', handleClose);
+    }
+
+    updateListening(false);
+  }
+
   bindNotificationCleanupHandlers();
-  initVoiceInput();
+  setupVoiceEnhancement();
 
   // Placeholder for Firebase modules loaded later
   let initializeApp, getFirestore, enableMultiTabIndexedDbPersistence,

--- a/mobile.html
+++ b/mobile.html
@@ -161,8 +161,8 @@
     }
     .fab {
       position: fixed;
-      right: 16px;
-      bottom: 88px;
+      right: calc(16px + env(safe-area-inset-right));
+      bottom: calc(88px + env(safe-area-inset-bottom));
       width: 56px;
       height: 56px;
       border-radius: 50%;
@@ -175,11 +175,16 @@
       box-shadow: 0 10px 25px rgba(15, 23, 42, 0.2);
       border: none;
       cursor: pointer;
-      z-index: 60;
+      z-index: 80;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
     }
     .fab:focus-visible {
       outline: 2px solid currentColor;
       outline-offset: 2px;
+    }
+    .fab:active {
+      transform: scale(0.96);
+      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.25);
     }
     .sheet {
       position: fixed;
@@ -187,7 +192,7 @@
       display: flex;
       flex-direction: column;
       justify-content: flex-end;
-      z-index: 70;
+      z-index: 90;
     }
     .sheet-panel {
       position: relative;
@@ -211,6 +216,16 @@
       align-items: center;
       justify-content: space-between;
       padding-bottom: 12px;
+      gap: 12px;
+    }
+    .sheet-header-actions {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .sheet-header-actions .btn.is-listening {
+      background: var(--fallback-p, #2563eb);
+      color: var(--fallback-pc, #fff);
     }
     .sheet-backdrop {
       position: absolute;
@@ -306,21 +321,6 @@
     }
   </style>
   <!-- END GPT CHANGE: rhythm -->
-  <style id="voice-add-css">
-    .voice-add-wrap{
-      position: fixed; right: 12px; bottom: 12px; z-index: 50;
-      display: inline-flex; align-items: center; gap: 8px;
-      padding: 6px 8px; border-radius: 9999px; background: var(--fallback-b1,#fff);
-      box-shadow: 0 2px 8px rgba(0,0,0,.15);
-    }
-
-    /* Hide the status text by default */
-    .voice-status { display: none; }
-
-    /* Only show status while actively listening */
-    .voice-add-wrap.listening .voice-status { display: inline; font-size: 12px; opacity: .75; }
-
-  </style>
   <style id="min-expand-css">
     /* Expand/collapse behavior */
     .task-row-min {
@@ -388,11 +388,6 @@
   </header>
 
   <main id="main" class="max-w-md mx-auto px-4 pb-28 pt-4" tabindex="-1" data-active-view="reminders">
-    <!-- Voice Add Task UI -->
-    <div id="voiceAddWrap" class="voice-add-wrap" aria-live="polite" aria-atomic="true">
-      <button id="voiceAddBtn" class="btn btn-circle btn-ghost" aria-pressed="false" aria-label="Add task by voice">🎤</button>
-      <span id="voiceStatus" class="voice-status" hidden>Tap 🎤 to speak</span>
-    </div>
     <!-- BEGIN GPT CHANGE: create form moved to bottom sheet -->
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: reminders view -->
@@ -407,17 +402,13 @@
                    placeholder="What do you need to remember?"
                    aria-label="Quick add reminder"
                    autocomplete="off" />
-            <button id="quickAddMic"
-                    class="btn btn-circle btn-ghost"
-                    type="button"
-                    aria-label="Add by voice">🎤</button>
             <button id="quickAddSubmit"
                     class="btn btn-primary"
                     type="button"
                     aria-label="Add reminder now">Add</button>
           </div>
           <p class="text-xs text-base-content/60">
-            Tip: Press <kbd>/</kbd> or <kbd>q</kbd> to focus; <kbd>Enter</kbd> to add; <kbd>Alt</kbd>+<kbd>M</kbd> for mic.
+            Tip: Press <kbd>/</kbd> or <kbd>q</kbd> to focus; press <kbd>Enter</kbd> to add instantly.
           </p>
         </div>
       </section>
@@ -540,7 +531,20 @@
     <div class="sheet-panel bg-base-100 border-t border-base-200" data-dialog-content>
       <header class="sheet-header">
         <h2 id="createSheetTitle">Create Reminder</h2>
-        <button type="button" id="closeCreateSheet" aria-label="Close">✕</button>
+        <div class="sheet-header-actions">
+          <button
+            id="voiceBtn"
+            type="button"
+            class="btn btn-circle btn-ghost"
+            aria-label="Start voice input"
+            aria-pressed="false"
+            title="Fill reminder using your voice"
+          >
+            <span aria-hidden="true">🎙️</span>
+            <span class="sr-only">Start voice input</span>
+          </button>
+          <button type="button" id="closeCreateSheet" aria-label="Close">✕</button>
+        </div>
       </header>
       <form id="createReminderForm" class="inputs-compact">
         <div class="card-body gap-4 compact">
@@ -620,7 +624,6 @@
 
           <div class="flex flex-wrap items-center gap-3">
             <button id="notifBtn" class="btn btn-ghost" type="button">Enable notifications</button>
-            <button id="quickAdd" class="btn btn-outline" type="button">Quick add</button>
           </div>
 
           <div class="card-actions justify-stretch">
@@ -666,7 +669,17 @@
   <!-- END GPT CHANGE: settings modal -->
 
   <!-- BEGIN GPT CHANGE: global FAB -->
-  <button id="fabCreate" class="fab" aria-label="Add reminder">＋</button>
+  <button
+    id="fabCreate"
+    class="fab"
+    type="button"
+    aria-label="Add reminder"
+    aria-haspopup="dialog"
+    aria-controls="create-sheet"
+    aria-expanded="false"
+  >
+    ＋
+  </button>
   <!-- END GPT CHANGE: global FAB -->
 
   <script id="mobile-enhancements">

--- a/mobile.js
+++ b/mobile.js
@@ -74,6 +74,12 @@ import { initReminders } from './js/reminders.js';
     sheet.setAttribute('aria-hidden', 'false');
     sheet.setAttribute('open', '');
     sheet.classList.add('open');
+    if (fab) {
+      fab.setAttribute('aria-expanded', 'true');
+    }
+    if (trigger instanceof HTMLElement && trigger !== fab) {
+      trigger.setAttribute('aria-expanded', 'true');
+    }
     const firstInput = sheet.querySelector('input,select,textarea,button');
     if (firstInput instanceof HTMLElement) {
       firstInput.focus();
@@ -87,6 +93,12 @@ import { initReminders } from './js/reminders.js';
     sheet.setAttribute('aria-hidden', 'true');
     sheet.removeAttribute('open');
     sheet.classList.remove('open');
+    if (fab) {
+      fab.setAttribute('aria-expanded', 'false');
+    }
+    if (lastTrigger instanceof HTMLElement && lastTrigger !== fab) {
+      lastTrigger.setAttribute('aria-expanded', 'false');
+    }
     const focusTarget =
       (lastTrigger && document.body.contains(lastTrigger) && lastTrigger) || fab;
     if (focusTarget && typeof focusTarget.focus === 'function') {
@@ -148,7 +160,6 @@ initReminders({
   statusSel: '#statusMessage',
   syncStatusSel: '#syncStatus',
   notifBtnSel: '#notifBtn',
-  addQuickBtnSel: '#quickAdd',
   filterBtnsSel: '[data-filter]',
   sortSel: '#sortReminders',
   categoryFilterSel: '#categoryFilter',


### PR DESCRIPTION
## Summary
- remove redundant floating voice/quick-add controls from the mobile layout and dedicate the FAB as the single entry point
- add a voice enhancement button inside the creation sheet with updated styling, accessibility, and consistent FAB positioning
- simplify reminders initialisation logic to drop quick add button wiring and bind the new in-sheet voice recognition helper

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_69049d1889d88324a3f791be149efcf5