### PR TITLE
Extract cue field helpers into dedicated module

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,15 @@
 import { initReminders } from './js/reminders.js';
+import {
+  CUE_FIELD_DEFINITIONS,
+  DEFAULT_CUE_MODAL_TITLE,
+  EDIT_CUE_MODAL_TITLE,
+  getFieldElements,
+  getCueFieldValueFromData,
+  populateCueFormFields,
+  clearCueFormFields,
+  gatherCueFormData,
+  escapeCueText
+} from './js/modules/field-helpers.js';
 
 const cueModal = document.getElementById('cue-modal') ?? document.getElementById('cue_modal');
 const openCueButton = document.getElementById('openCueModal');
@@ -152,8 +163,8 @@ const cuesList = document.getElementById('cues-list');
 const cueForm = document.getElementById('cue-form');
 const cueIdInput = cueForm?.querySelector('#cue-id-input');
 const cueModalTitle = document.getElementById('modal-title');
-const defaultCueModalTitle = cueModalTitle?.textContent?.trim() || '';
-const editCueModalTitle = 'Edit Cue';
+const defaultCueModalTitle = cueModalTitle?.textContent?.trim() || DEFAULT_CUE_MODAL_TITLE;
+const editCueModalTitle = EDIT_CUE_MODAL_TITLE;
 
 const cuesTab = document.getElementById('tab-cues');
 const dailyTab = document.getElementById('tab-daily');
@@ -167,35 +178,7 @@ const dailyTasksContainer = document.getElementById('daily-tasks-container');
 const clearCompletedButton = document.getElementById('clear-completed-btn');
 const dailyListPermissionNotice = document.getElementById('daily-list-permission-notice');
 
-const cueFieldDefinitions = [
-  { key: 'title', ids: ['cue-title', 'title'] },
-  { key: 'details', ids: ['cue-details', 'details', 'cue-description'] },
-  { key: 'date', ids: ['cue-date', 'date'] },
-  { key: 'time', ids: ['cue-time', 'time'] },
-  { key: 'priority', ids: ['cue-priority', 'priority'] },
-  { key: 'category', ids: ['cue-category', 'category'] }
-];
-
-const cueFieldAliases = {
-  title: ['title', 'name'],
-  details: ['details', 'description', 'notes', 'body'],
-  date: ['date', 'dueDate', 'due_date'],
-  time: ['time', 'dueTime', 'due_time'],
-  priority: ['priority', 'level'],
-  category: ['category', 'tag']
-};
-
-const cueFieldElements = cueFieldDefinitions
-  .map(({ key, ids }) => {
-    for (const id of ids) {
-      const el = id ? document.getElementById(id) : null;
-      if (el) {
-        return { key, element: el };
-      }
-    }
-    return null;
-  })
-  .filter((entry) => entry && entry.element);
+const cueFieldElements = getFieldElements(CUE_FIELD_DEFINITIONS);
 
 const firebaseCueConfig = {
   apiKey: 'AIzaSyAmAMiz0zG3dAhZJhOy1DYj8fKVDObL36c',
@@ -208,114 +191,6 @@ const firebaseCueConfig = {
 };
 
 let firestoreCueContextPromise = null;
-
-function getCueFieldValueFromData(data, key) {
-  if (!data || typeof data !== 'object') {
-    return '';
-  }
-  const possibleKeys = cueFieldAliases[key] || [key];
-  for (const field of possibleKeys) {
-    if (Object.prototype.hasOwnProperty.call(data, field)) {
-      const value = data[field];
-      if (value === null || value === undefined) {
-        return '';
-      }
-      return typeof value === 'string' ? value : String(value);
-    }
-  }
-  return '';
-}
-
-function setCueFieldValue(element, value) {
-  const normalised = value === undefined || value === null ? '' : value;
-  if (element instanceof HTMLInputElement) {
-    if (element.type === 'checkbox') {
-      element.checked = Boolean(normalised);
-    } else {
-      element.value = typeof normalised === 'string' ? normalised : String(normalised);
-    }
-    return;
-  }
-  if (element instanceof HTMLTextAreaElement || element instanceof HTMLSelectElement) {
-    element.value = typeof normalised === 'string' ? normalised : String(normalised);
-  }
-}
-
-function readCueFieldValue(element) {
-  if (element instanceof HTMLInputElement) {
-    if (element.type === 'checkbox') {
-      return element.checked;
-    }
-    return element.value;
-  }
-  if (element instanceof HTMLTextAreaElement || element instanceof HTMLSelectElement) {
-    return element.value;
-  }
-  return '';
-}
-
-function populateCueFormFields(cue) {
-  cueFieldElements.forEach(({ key, element }) => {
-    const value = cue && typeof cue === 'object' ? getCueFieldValueFromData(cue, key) : '';
-    setCueFieldValue(element, value);
-  });
-}
-
-function clearCueFormFields() {
-  cueFieldElements.forEach(({ element }) => {
-    if (element instanceof HTMLInputElement) {
-      if (['checkbox', 'radio'].includes(element.type)) {
-        element.checked = false;
-      } else {
-        element.value = '';
-      }
-    } else if (element instanceof HTMLTextAreaElement || element instanceof HTMLSelectElement) {
-      element.value = '';
-    }
-  });
-  if (cueIdInput) {
-    cueIdInput.value = '';
-  }
-  if (cueModalTitle) {
-    cueModalTitle.textContent = defaultCueModalTitle;
-  }
-}
-
-function gatherCueFormData() {
-  const result = {};
-  cueFieldElements.forEach(({ key, element }) => {
-    const raw = readCueFieldValue(element);
-    if (typeof raw === 'boolean') {
-      result[key] = raw;
-      return;
-    }
-    const trimmed = typeof raw === 'string' ? raw.trim() : raw;
-    result[key] = trimmed === undefined || trimmed === null ? '' : trimmed;
-  });
-  return result;
-}
-
-function escapeCueText(value) {
-  if (value === null || value === undefined) {
-    return '';
-  }
-  return String(value).replace(/[&<>'"]/g, (char) => {
-    switch (char) {
-      case '&':
-        return '&amp;';
-      case '<':
-        return '&lt;';
-      case '>':
-        return '&gt;';
-      case '"':
-        return '&quot;';
-      case "'":
-        return '&#39;';
-      default:
-        return char;
-    }
-  });
-}
 
 function renderCueList(cues) {
   if (!cuesList) {
@@ -476,7 +351,7 @@ function enterCueEditMode(cue) {
   if (!cueForm || !cueIdInput) {
     return;
   }
-  populateCueFormFields(cue);
+  populateCueFormFields(cue, cueFieldElements);
   cueIdInput.value = cue?.id || '';
   if (cueModalTitle) {
     cueModalTitle.textContent = editCueModalTitle;
@@ -511,7 +386,7 @@ async function handleCueFormSubmit(event) {
     return;
   }
   const cueId = cueIdInput.value.trim();
-  const data = gatherCueFormData();
+  const data = gatherCueFormData(cueFieldElements);
   try {
     const firestore = await ensureCueFirestore();
     const { db, doc, addDoc, updateDoc, cuesCollection, serverTimestamp } = firestore;
@@ -532,7 +407,7 @@ async function handleCueFormSubmit(event) {
       await addDoc(cuesCollection, payload);
     }
     await refreshCueList();
-    clearCueFormFields();
+    clearCueFormFields(cueFieldElements, cueIdInput, cueModalTitle, defaultCueModalTitle);
     hideCueModal();
   } catch (error) {
     console.error('Failed to save cue', error);

--- a/js/modules/field-helpers.js
+++ b/js/modules/field-helpers.js
@@ -1,0 +1,254 @@
+/**
+ * Field helper utilities for cue forms.
+ * @module field-helpers
+ */
+
+/**
+ * Definitions for cue fields and their associated DOM element IDs.
+ * @type {Array<{key: string, ids: string[]}>}
+ */
+export const CUE_FIELD_DEFINITIONS = [
+  { key: 'title', ids: ['cue-title', 'title'] },
+  { key: 'details', ids: ['cue-details', 'details', 'cue-description'] },
+  { key: 'date', ids: ['cue-date', 'date'] },
+  { key: 'time', ids: ['cue-time', 'time'] },
+  { key: 'priority', ids: ['cue-priority', 'priority'] },
+  { key: 'category', ids: ['cue-category', 'category'] }
+];
+
+/**
+ * Aliases for cue fields to support various data shapes.
+ * @type {Record<string, string[]>}
+ */
+export const CUE_FIELD_ALIASES = {
+  title: ['title', 'name'],
+  details: ['details', 'description', 'notes', 'body'],
+  date: ['date', 'dueDate', 'due_date'],
+  time: ['time', 'dueTime', 'due_time'],
+  priority: ['priority', 'level'],
+  category: ['category', 'tag']
+};
+
+/** Default modal title when creating a cue. */
+export const DEFAULT_CUE_MODAL_TITLE = 'Create Cue';
+
+/** Modal title when editing an existing cue. */
+export const EDIT_CUE_MODAL_TITLE = 'Edit Cue';
+
+/**
+ * Finds the field elements based on the provided definitions.
+ *
+ * @param {Array<{key: string, ids: string[]}>} definitions - Field definitions to resolve.
+ * @param {Document} [doc=document] - Document instance used to look up elements.
+ * @returns {Array<{key: string, element: HTMLElement}>} Resolved field elements.
+ */
+export function getFieldElements(definitions, doc = document) {
+  if (!Array.isArray(definitions) || !doc || typeof doc.getElementById !== 'function') {
+    return [];
+  }
+
+  return definitions
+    .map(({ key, ids }) => {
+      if (!Array.isArray(ids)) {
+        return null;
+      }
+      for (const id of ids) {
+        if (typeof id !== 'string' || !id) {
+          continue;
+        }
+        const element = doc.getElementById(id);
+        if (element) {
+          return { key, element };
+        }
+      }
+      return null;
+    })
+    .filter((entry) => Boolean(entry && entry.element));
+}
+
+/**
+ * Retrieves a cue field value from a generic data object.
+ *
+ * @param {Record<string, unknown>|null|undefined} data - The source data.
+ * @param {string} key - The cue field key to resolve.
+ * @returns {string} The resolved field value as a string.
+ */
+export function getCueFieldValueFromData(data, key) {
+  if (!data || typeof data !== 'object') {
+    return '';
+  }
+
+  const possibleKeys = CUE_FIELD_ALIASES[key] || [key];
+  for (const field of possibleKeys) {
+    if (Object.prototype.hasOwnProperty.call(data, field)) {
+      const value = data[field];
+      if (value === null || value === undefined) {
+        return '';
+      }
+      return typeof value === 'string' ? value : String(value);
+    }
+  }
+
+  return '';
+}
+
+/**
+ * Sets the value of a cue field element.
+ *
+ * @param {HTMLElement|null|undefined} element - The target field element.
+ * @param {unknown} value - The value to apply.
+ * @returns {void}
+ */
+export function setCueFieldValue(element, value) {
+  if (!element) {
+    return;
+  }
+
+  const normalised = value === undefined || value === null ? '' : value;
+
+  if (element instanceof HTMLInputElement) {
+    if (element.type === 'checkbox') {
+      element.checked = Boolean(normalised);
+    } else {
+      element.value = typeof normalised === 'string' ? normalised : String(normalised);
+    }
+    return;
+  }
+
+  if (element instanceof HTMLTextAreaElement || element instanceof HTMLSelectElement) {
+    element.value = typeof normalised === 'string' ? normalised : String(normalised);
+  }
+}
+
+/**
+ * Reads the value from a cue field element.
+ *
+ * @param {HTMLElement|null|undefined} element - The target field element.
+ * @returns {string|boolean} The field value.
+ */
+export function readCueFieldValue(element) {
+  if (!element) {
+    return '';
+  }
+
+  if (element instanceof HTMLInputElement) {
+    if (element.type === 'checkbox') {
+      return element.checked;
+    }
+    return element.value;
+  }
+
+  if (element instanceof HTMLTextAreaElement || element instanceof HTMLSelectElement) {
+    return element.value;
+  }
+
+  return '';
+}
+
+/**
+ * Populates cue form fields from a cue object.
+ *
+ * @param {Record<string, unknown>|null|undefined} cue - The cue data.
+ * @param {Array<{key: string, element: HTMLElement}>} fieldElements - Resolved field elements.
+ * @returns {void}
+ */
+export function populateCueFormFields(cue, fieldElements) {
+  if (!Array.isArray(fieldElements)) {
+    return;
+  }
+
+  fieldElements.forEach(({ key, element }) => {
+    const value = cue && typeof cue === 'object' ? getCueFieldValueFromData(cue, key) : '';
+    setCueFieldValue(element, value);
+  });
+}
+
+/**
+ * Clears cue form fields and related metadata inputs.
+ *
+ * @param {Array<{element: HTMLElement}>} fieldElements - Resolved field elements.
+ * @param {HTMLInputElement|null|undefined} cueIdInput - The cue ID input element.
+ * @param {HTMLElement|null|undefined} cueModalTitle - The modal title element.
+ * @param {string} defaultTitle - Default title text to restore.
+ * @returns {void}
+ */
+export function clearCueFormFields(fieldElements, cueIdInput, cueModalTitle, defaultTitle) {
+  if (Array.isArray(fieldElements)) {
+    fieldElements.forEach(({ element }) => {
+      if (element instanceof HTMLInputElement) {
+        if (['checkbox', 'radio'].includes(element.type)) {
+          element.checked = false;
+        } else {
+          element.value = '';
+        }
+      } else if (element instanceof HTMLTextAreaElement || element instanceof HTMLSelectElement) {
+        element.value = '';
+      }
+    });
+  }
+
+  if (cueIdInput) {
+    cueIdInput.value = '';
+  }
+
+  if (cueModalTitle) {
+    cueModalTitle.textContent = defaultTitle;
+  }
+}
+
+/**
+ * Gathers cue form field data into a plain object.
+ *
+ * @param {Array<{key: string, element: HTMLElement}>} fieldElements - Resolved field elements.
+ * @returns {Record<string, string|boolean>} Cue data derived from the form.
+ */
+export function gatherCueFormData(fieldElements) {
+  const result = {};
+
+  if (!Array.isArray(fieldElements)) {
+    return result;
+  }
+
+  fieldElements.forEach(({ key, element }) => {
+    const raw = readCueFieldValue(element);
+
+    if (typeof raw === 'boolean') {
+      result[key] = raw;
+      return;
+    }
+
+    const trimmed = typeof raw === 'string' ? raw.trim() : raw;
+    result[key] = trimmed === undefined || trimmed === null ? '' : trimmed;
+  });
+
+  return result;
+}
+
+/**
+ * Escapes cue text content for safe HTML rendering.
+ *
+ * @param {unknown} value - The value to escape.
+ * @returns {string} Escaped string value.
+ */
+export function escapeCueText(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  return String(value).replace(/[&<>'"]/g, (char) => {
+    switch (char) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case "'":
+        return '&#39;';
+      default:
+        return char;
+    }
+  });
+}

--- a/js/tests/field-helpers.test.js
+++ b/js/tests/field-helpers.test.js
@@ -1,0 +1,230 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const { describe, it, expect, beforeAll, beforeEach } = require('@jest/globals');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let fieldHelpers;
+let CUE_FIELD_DEFINITIONS;
+let CUE_FIELD_ALIASES;
+let DEFAULT_CUE_MODAL_TITLE;
+let EDIT_CUE_MODAL_TITLE;
+let getFieldElements;
+let getCueFieldValueFromData;
+let setCueFieldValue;
+let readCueFieldValue;
+let populateCueFormFields;
+let clearCueFormFields;
+let gatherCueFormData;
+let escapeCueText;
+
+function loadFieldHelpersModule() {
+  const filePath = path.resolve(__dirname, '../modules/field-helpers.js');
+  let source = fs.readFileSync(filePath, 'utf8');
+  source = source
+    .replace(/export\s+const/g, 'const')
+    .replace(/export\s+function/g, 'function');
+  source += `\nmodule.exports = {\n  CUE_FIELD_DEFINITIONS,\n  CUE_FIELD_ALIASES,\n  DEFAULT_CUE_MODAL_TITLE,\n  EDIT_CUE_MODAL_TITLE,\n  getFieldElements,\n  getCueFieldValueFromData,\n  setCueFieldValue,\n  readCueFieldValue,\n  populateCueFormFields,\n  clearCueFormFields,\n  gatherCueFormData,\n  escapeCueText\n};\n`;
+  const module = { exports: {} };
+  const sandbox = {
+    module,
+    exports: module.exports,
+    require,
+    console,
+    document,
+    window,
+    HTMLInputElement,
+    HTMLTextAreaElement,
+    HTMLSelectElement
+  };
+  vm.runInNewContext(source, sandbox, { filename: filePath });
+  return module.exports;
+}
+
+beforeAll(() => {
+  fieldHelpers = loadFieldHelpersModule();
+  ({
+    CUE_FIELD_DEFINITIONS,
+    CUE_FIELD_ALIASES,
+    DEFAULT_CUE_MODAL_TITLE,
+    EDIT_CUE_MODAL_TITLE,
+    getFieldElements,
+    getCueFieldValueFromData,
+    setCueFieldValue,
+    readCueFieldValue,
+    populateCueFormFields,
+    clearCueFormFields,
+    gatherCueFormData,
+    escapeCueText
+  } = fieldHelpers);
+});
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('constants', () => {
+  it('exports cue field definitions and aliases', () => {
+    expect(Array.isArray(CUE_FIELD_DEFINITIONS)).toBe(true);
+    expect(CUE_FIELD_DEFINITIONS.length).toBeGreaterThan(0);
+    expect(CUE_FIELD_ALIASES).toHaveProperty('title');
+  });
+
+  it('provides modal title constants', () => {
+    expect(DEFAULT_CUE_MODAL_TITLE).toBe('Create Cue');
+    expect(EDIT_CUE_MODAL_TITLE).toBe('Edit Cue');
+  });
+});
+
+describe('getFieldElements', () => {
+  it('locates elements based on the provided definitions', () => {
+    document.body.innerHTML = `
+      <input id="cue-title" />
+      <textarea id="details"></textarea>
+      <input id="cue-date" />
+    `;
+
+    const elements = getFieldElements(CUE_FIELD_DEFINITIONS);
+    const keys = elements.map((entry) => entry.key);
+
+    expect(elements.length).toBeGreaterThanOrEqual(3);
+    expect(keys).toContain('title');
+    expect(keys).toContain('details');
+  });
+
+  it('returns an empty array when no definitions are provided', () => {
+    expect(getFieldElements(null)).toEqual([]);
+    expect(getFieldElements(undefined)).toEqual([]);
+  });
+});
+
+describe('getCueFieldValueFromData', () => {
+  it('resolves values using aliases', () => {
+    const data = { name: 'Alias Title', description: 'Details text' };
+    expect(getCueFieldValueFromData(data, 'title')).toBe('Alias Title');
+    expect(getCueFieldValueFromData(data, 'details')).toBe('Details text');
+  });
+
+  it('normalises non-string values to strings', () => {
+    const data = { priority: 5 };
+    expect(getCueFieldValueFromData(data, 'priority')).toBe('5');
+  });
+
+  it('returns an empty string for missing values', () => {
+    expect(getCueFieldValueFromData(null, 'title')).toBe('');
+    expect(getCueFieldValueFromData({}, 'unknown')).toBe('');
+  });
+});
+
+describe('setCueFieldValue and readCueFieldValue', () => {
+  it('supports text inputs, textareas, selects, and checkboxes', () => {
+    const textInput = document.createElement('input');
+    textInput.type = 'text';
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    const textarea = document.createElement('textarea');
+    const select = document.createElement('select');
+    const option = document.createElement('option');
+    option.value = 'Option';
+    select.append(option);
+
+    setCueFieldValue(textInput, 'Hello');
+    setCueFieldValue(checkbox, true);
+    setCueFieldValue(textarea, 'Notes');
+    setCueFieldValue(select, 'Option');
+
+    expect(readCueFieldValue(textInput)).toBe('Hello');
+    expect(readCueFieldValue(checkbox)).toBe(true);
+    expect(readCueFieldValue(textarea)).toBe('Notes');
+    expect(readCueFieldValue(select)).toBe('Option');
+  });
+
+  it('handles null or undefined elements gracefully', () => {
+    expect(readCueFieldValue(null)).toBe('');
+    expect(() => setCueFieldValue(null, 'value')).not.toThrow();
+  });
+});
+
+describe('populateCueFormFields', () => {
+  it('applies cue data to the resolved fields', () => {
+    document.body.innerHTML = `
+      <input id="cue-title" />
+      <textarea id="cue-details"></textarea>
+    `;
+    const elements = getFieldElements([
+      { key: 'title', ids: ['cue-title'] },
+      { key: 'details', ids: ['cue-details'] }
+    ]);
+
+    populateCueFormFields({ title: 'My Cue', details: 'Remember this' }, elements);
+
+    expect(readCueFieldValue(elements[0].element)).toBe('My Cue');
+    expect(readCueFieldValue(elements[1].element)).toBe('Remember this');
+  });
+
+  it('clears fields when cue data is not provided', () => {
+    document.body.innerHTML = `<input id="cue-title" value="Existing" />`;
+    const elements = getFieldElements([{ key: 'title', ids: ['cue-title'] }]);
+
+    populateCueFormFields(null, elements);
+
+    expect(readCueFieldValue(elements[0].element)).toBe('');
+  });
+});
+
+describe('clearCueFormFields', () => {
+  it('resets field values and metadata elements', () => {
+    document.body.innerHTML = `
+      <input id="cue-title" value="Existing" />
+      <input id="cue-id-input" value="123" />
+      <h2 id="modal-title">Edit Cue</h2>
+    `;
+    const elements = getFieldElements([{ key: 'title', ids: ['cue-title'] }]);
+    const cueIdInput = document.getElementById('cue-id-input');
+    const cueModalTitle = document.getElementById('modal-title');
+
+    clearCueFormFields(elements, cueIdInput, cueModalTitle, DEFAULT_CUE_MODAL_TITLE);
+
+    expect(readCueFieldValue(elements[0].element)).toBe('');
+    expect(cueIdInput.value).toBe('');
+    expect(cueModalTitle.textContent).toBe(DEFAULT_CUE_MODAL_TITLE);
+  });
+});
+
+describe('gatherCueFormData', () => {
+  it('collects trimmed values and booleans', () => {
+    document.body.innerHTML = `
+      <input id="cue-title" value="  My Cue  " />
+      <textarea id="cue-details"> Note </textarea>
+      <input id="cue-priority" type="checkbox" checked />
+    `;
+    const elements = getFieldElements([
+      { key: 'title', ids: ['cue-title'] },
+      { key: 'details', ids: ['cue-details'] },
+      { key: 'priority', ids: ['cue-priority'] }
+    ]);
+
+    const data = gatherCueFormData(elements);
+
+    expect(data).toEqual({ title: 'My Cue', details: 'Note', priority: true });
+  });
+
+  it('returns an empty object when elements are not provided', () => {
+    expect(gatherCueFormData(null)).toEqual({});
+  });
+});
+
+describe('escapeCueText', () => {
+  it('escapes HTML special characters', () => {
+    const escaped = escapeCueText("<div>&\"'</div>");
+    expect(escaped).toBe('&lt;div&gt;&amp;&quot;&#39;&lt;/div&gt;');
+  });
+
+  it('returns an empty string for nullish values', () => {
+    expect(escapeCueText(null)).toBe('');
+    expect(escapeCueText(undefined)).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- move cue field constants and DOM utility logic from `app.js` into `js/modules/field-helpers.js`
- update `app.js` to consume the shared helper functions and modal title defaults while preserving behaviour
- add `js/tests/field-helpers.test.js` with coverage for helper data handling and DOM interactions

## Testing
- npx jest js/tests/field-helpers.test.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_69049f427e648324a28bb4f73574d939