### PR TITLE
Simplify mobile reminders sorting

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -661,8 +661,11 @@ export async function initReminders(sel = {}) {
   let filter = resolvedDefaultFilter || 'all';
   let categoryFilterValue = categoryFilter?.value || 'all';
   const SORT_STORAGE_KEY = 'memoryCue:sortPreference';
-  const SORT_OPTIONS = new Set(['due', 'priority', 'category', 'recent']);
-  let sortKey = 'due';
+  const SORT_OPTIONS = new Set(['dueDate', 'priority', 'category', 'recent']);
+  const SORT_ALIASES = new Map([
+    ['due', 'dueDate'],
+  ]);
+  let sortKey = 'dueDate';
   let suppressRenderMemoryEvent = false;
   let userId = null;
   let unsubscribe = null;
@@ -673,8 +676,9 @@ export async function initReminders(sel = {}) {
   if (typeof localStorage !== 'undefined') {
     try {
       const storedSort = localStorage.getItem(SORT_STORAGE_KEY);
-      if (storedSort && SORT_OPTIONS.has(storedSort)) {
-        sortKey = storedSort;
+      const normalisedSort = SORT_ALIASES.get(storedSort) || storedSort;
+      if (normalisedSort && SORT_OPTIONS.has(normalisedSort)) {
+        sortKey = normalisedSort;
       }
     } catch {
       // Ignore localStorage access issues (private browsing, etc.).
@@ -683,7 +687,7 @@ export async function initReminders(sel = {}) {
 
   if (sortSel && sortKey) {
     try {
-      sortSel.value = SORT_OPTIONS.has(sortKey) ? sortKey : 'due';
+      sortSel.value = SORT_OPTIONS.has(sortKey) ? sortKey : 'dueDate';
     } catch {
       // Ignore value sync issues if option missing.
     }
@@ -1663,8 +1667,10 @@ export async function initReminders(sel = {}) {
       return (b.updatedAt || 0) - (a.updatedAt || 0);
     };
 
+    const highlightToday = sortKey === 'dueDate';
+
     const compareMap = {
-      due: compareDueDate,
+      dueDate: compareDueDate,
       priority: comparePriority,
       category: compareCategory,
       recent: compareRecent,
@@ -1774,6 +1780,7 @@ export async function initReminders(sel = {}) {
       const dueIsToday = highlightToday && dueDate && dueDate >= t0 && dueDate <= t1;
       if (dueIsToday) {
         div.classList.add('is-today');
+        div.dataset.today = 'true';
       }
       const dueTxt = r.due ? `${fmtTime(new Date(r.due))} • ${fmtDayDate(r.due.slice(0,10))}` : 'No due date';
       const priorityClass = `priority-${(r.priority || 'Medium').toLowerCase()}`;
@@ -2007,9 +2014,10 @@ export async function initReminders(sel = {}) {
   window.addEventListener('load', ()=> title?.focus());
   q?.addEventListener('input', debounce(render,150));
   sortSel?.addEventListener('change', () => {
-    sortKey = sortSel.value || 'due';
+    const selected = sortSel.value;
+    sortKey = SORT_ALIASES.get(selected) || selected || 'dueDate';
     if (!SORT_OPTIONS.has(sortKey)) {
-      sortKey = 'due';
+      sortKey = 'dueDate';
     }
     if (typeof localStorage !== 'undefined') {
       try {

--- a/mobile.html
+++ b/mobile.html
@@ -121,15 +121,21 @@
     .dark .glass-panel {
       background-color: rgba(15, 23, 42, 0.88);
     }
+    .task-item[data-today="true"],
     .task-item.is-today {
+      position: relative;
       border: 1px solid rgba(59, 130, 246, 0.35);
-      box-shadow: 0 6px 12px rgba(59, 130, 246, 0.08);
-      background: rgba(191, 219, 254, 0.22);
+      border-left-width: 4px;
+      border-left-color: rgba(37, 99, 235, 0.7);
+      background: linear-gradient(135deg, rgba(191, 219, 254, 0.28), rgba(191, 219, 254, 0.08));
+      box-shadow: 0 12px 26px -16px rgba(30, 64, 175, 0.55);
     }
+    .dark .task-item[data-today="true"],
     .dark .task-item.is-today {
-      border-color: rgba(96, 165, 250, 0.45);
-      box-shadow: 0 6px 12px rgba(59, 130, 246, 0.28);
-      background: rgba(30, 64, 175, 0.28);
+      border-color: rgba(96, 165, 250, 0.55);
+      border-left-color: rgba(191, 219, 254, 0.85);
+      background: linear-gradient(135deg, rgba(30, 64, 175, 0.5), rgba(30, 58, 138, 0.25));
+      box-shadow: 0 12px 26px -16px rgba(30, 64, 175, 0.7);
     }
   </style>
   <!-- Skip-link CSS: fully hidden until keyboard focus -->
@@ -426,7 +432,7 @@
                 <label class="form-control w-full sm:w-auto">
                   <div class="label hidden sm:flex"><span class="label-text">Sort reminders</span></div>
                   <select id="sortReminders" class="select select-bordered select-sm">
-                    <option value="due" selected>Due Date (Today first)</option>
+                    <option value="dueDate" selected>Due Date (Today first)</option>
                     <option value="priority">Priority</option>
                     <option value="category">Category (A–Z)</option>
                     <option value="recent">Recently Added</option>


### PR DESCRIPTION
## Summary
- update the mobile reminders filter bar to surface a due-date sort option by default and highlight today's items with a subtle accent
- normalise reminder sorting keys to `dueDate` while keeping support for legacy `due` preferences and mark today's tasks via data attributes for styling

## Testing
- npm test -- reminders.categories.test.js

------
https://chatgpt.com/codex/tasks/task_e_6904a3f239b88324a72aa1141e91fd27