### PR TITLE
Extract modal management into dedicated controller

### DIFF
--- a/js/modules/modal-controller.js
+++ b/js/modules/modal-controller.js
@@ -1,0 +1,439 @@
+/**
+ * @fileoverview Provides a reusable, accessible modal controller with focus management,
+ * keyboard support, and event lifecycle hooks.
+ */
+
+/**
+ * @typedef {Object} ModalControllerEvents
+ * @property {string} [prepare]
+ * @property {string} [openRequest]
+ * @property {string} [closeRequest]
+ * @property {string} [cancelled]
+ * @property {string} [shown]
+ * @property {string} [hidden]
+ */
+
+/**
+ * @typedef {Object} ModalControllerAnimationHooks
+ * @property {(controller: ModalController) => void | Promise<void>} [onBeforeShow]
+ * @property {(controller: ModalController) => void | Promise<void>} [onAfterShow]
+ * @property {(controller: ModalController) => void | Promise<void>} [onBeforeHide]
+ * @property {(controller: ModalController) => void | Promise<void>} [onAfterHide]
+ */
+
+/**
+ * @typedef {Object} ModalControllerOptions
+ * @property {HTMLDialogElement | HTMLElement | null} [modalElement]
+ * @property {HTMLElement | null} [openButton]
+ * @property {HTMLElement | null} [closeButton]
+ * @property {HTMLElement | null} [backdropButton]
+ * @property {HTMLElement | null} [titleInput]
+ * @property {HTMLElement | null} [modalTitle]
+ * @property {string} [defaultTitle]
+ * @property {string} [editTitle]
+ * @property {boolean} [manageAria]
+ * @property {boolean} [focusTrap]
+ * @property {boolean} [autoFocus]
+ * @property {EventTarget} [eventTarget]
+ * @property {ModalControllerEvents} [events]
+ * @property {ModalControllerAnimationHooks} [animationHooks]
+ * @property {boolean} [enableStacking]
+ */
+
+const FOCUSABLE_SELECTORS = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])'
+].join(',');
+
+const DEFAULT_EVENTS = {
+  prepare: 'cue:prepare',
+  openRequest: 'cue:open',
+  closeRequest: 'cue:close',
+  cancelled: 'cue:cancelled',
+  shown: 'cue:shown',
+  hidden: 'cue:hidden'
+};
+
+/**
+ * Controls modal behaviour including focus management, keyboard handling, and custom events.
+ */
+export class ModalController {
+  /** @type {ModalController[]} */
+  static activeStack = [];
+
+  /**
+   * @param {ModalControllerOptions} [options]
+   */
+  constructor(options = {}) {
+    this.modal = options.modalElement ?? null;
+    this.openButton = options.openButton ?? null;
+    this.closeButton = options.closeButton ?? null;
+    this.backdropButton = options.backdropButton ?? null;
+    this.titleInput = options.titleInput ?? null;
+    this.modalTitle = options.modalTitle ?? null;
+    this.defaultTitle = options.defaultTitle ?? '';
+    this.editTitle = options.editTitle ?? options.defaultTitle ?? '';
+    this.isOpen = false;
+    this.isDestroyed = false;
+    this.manageAria = options.manageAria !== false;
+    this.enableFocusTrap = options.focusTrap !== false;
+    this.shouldAutoFocus = options.autoFocus !== false;
+    this.eventTarget = options.eventTarget ?? document;
+    this.events = { ...DEFAULT_EVENTS, ...(options.events || {}) };
+    this.animationHooks = options.animationHooks ?? {};
+    this.enableStacking = options.enableStacking !== false;
+    this.isDisabled = false;
+
+    this.previouslyFocusedElement = null;
+    this.boundHandlers = {
+      handleOpenClick: this.handleOpenClick.bind(this),
+      handleCloseClick: this.handleCloseClick.bind(this),
+      handleBackdropClick: this.handleBackdropClick.bind(this),
+      handleCancel: this.handleCancel.bind(this),
+      handleKeydown: this.handleKeydown.bind(this),
+      handleDocumentOpenRequest: this.handleDocumentOpenRequest.bind(this),
+      handleDocumentCloseRequest: this.handleDocumentCloseRequest.bind(this)
+    };
+
+    this.init();
+  }
+
+  /** Initialise the controller and wire listeners. */
+  init() {
+    if (!this.validateModal()) {
+      this.isDisabled = true;
+      return;
+    }
+    if (this.manageAria) {
+      this.applyAriaAttributes();
+    }
+    this.setupEventListeners();
+  }
+
+  /** Validate modal element. */
+  validateModal() {
+    if (!this.modal || !(this.modal instanceof HTMLElement)) {
+      console.warn('[ModalController] Modal element is not provided or invalid.');
+      return false;
+    }
+    if (typeof this.modal.showModal !== 'function') {
+      this.modal.showModal = this.modal.showModal || (() => {
+        this.modal?.setAttribute('open', '');
+      });
+    }
+    if (typeof this.modal.close !== 'function') {
+      this.modal.close = this.modal.close || (() => {
+        this.modal?.removeAttribute('open');
+      });
+    }
+    if (!this.modal.hasAttribute('tabindex')) {
+      this.modal.tabIndex = -1;
+    }
+    return true;
+  }
+
+  /** Apply ARIA attributes for accessibility. */
+  applyAriaAttributes() {
+    if (!this.modal) return;
+    this.modal.setAttribute('role', this.modal.getAttribute('role') || 'dialog');
+    this.modal.setAttribute('aria-modal', 'true');
+    if (this.modalTitle && this.modalTitle.id) {
+      this.modal.setAttribute('aria-labelledby', this.modalTitle.id);
+    }
+    if (this.titleInput && this.titleInput.id) {
+      this.modal.setAttribute('aria-describedby', this.titleInput.id);
+    }
+    this.modal.setAttribute('aria-hidden', 'true');
+  }
+
+  /** Show the modal. */
+  async show(detail = {}) {
+    if (!this.modal || this.isDestroyed || this.isDisabled) return;
+    if (this.isOpen) {
+      if (this.shouldAutoFocus) {
+        this.focusTitleInput();
+      }
+      return;
+    }
+    await this.runHook('onBeforeShow');
+    this.previouslyFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    if (this.enableStacking) {
+      this.addToStack();
+    }
+    if (typeof this.modal.showModal === 'function' && !this.modal.open) {
+      this.modal.showModal();
+    } else {
+      this.modal.setAttribute('open', '');
+    }
+    this.modal.setAttribute('aria-hidden', 'false');
+    this.isOpen = true;
+    if (this.shouldAutoFocus) {
+      this.focusTitleInput();
+    }
+    this.dispatchEvent('shown', { controller: this, ...detail });
+    await this.runHook('onAfterShow');
+  }
+
+  /** Hide the modal. */
+  async hide(detail = {}) {
+    if (!this.modal || this.isDestroyed || this.isDisabled || !this.isOpen) return;
+    await this.runHook('onBeforeHide');
+    if (typeof this.modal.close === 'function' && this.modal.open) {
+      this.modal.close();
+    } else {
+      this.modal.removeAttribute('open');
+    }
+    this.modal.setAttribute('aria-hidden', 'true');
+    this.isOpen = false;
+    this.removeFromStack();
+    await this.restoreFocus();
+    this.dispatchEvent('hidden', { controller: this, ...detail });
+    await this.runHook('onAfterHide');
+  }
+
+  /** Focuses the title input field when present. */
+  focusTitleInput() {
+    const target = this.titleInput || this.modal?.querySelector('[autofocus]');
+    if (!target || typeof target.focus !== 'function') {
+      return;
+    }
+    window.setTimeout(() => {
+      try {
+        target.focus({ preventScroll: true });
+      } catch {
+        target.focus();
+      }
+    }, 50);
+  }
+
+  /** Restore focus to previous element. */
+  async restoreFocus() {
+    const target = this.previouslyFocusedElement || this.openButton;
+    if (target && typeof target.focus === 'function') {
+      try {
+        target.focus({ preventScroll: true });
+      } catch {
+        target.focus();
+      }
+    }
+    this.previouslyFocusedElement = null;
+  }
+
+  /** Setup all required event listeners. */
+  setupEventListeners() {
+    if (!this.modal) return;
+    if (this.openButton) {
+      this.openButton.addEventListener('click', this.boundHandlers.handleOpenClick);
+    }
+    if (this.closeButton) {
+      this.closeButton.addEventListener('click', this.boundHandlers.handleCloseClick);
+    }
+    if (this.backdropButton) {
+      this.backdropButton.addEventListener('click', this.boundHandlers.handleBackdropClick);
+    }
+    this.modal.addEventListener('cancel', this.boundHandlers.handleCancel);
+    this.modal.addEventListener('keydown', this.boundHandlers.handleKeydown);
+    if (this.eventTarget) {
+      this.eventTarget.addEventListener(this.events.openRequest, this.boundHandlers.handleDocumentOpenRequest);
+      this.eventTarget.addEventListener(this.events.closeRequest, this.boundHandlers.handleDocumentCloseRequest);
+    }
+  }
+
+  /** Remove all listeners. */
+  cleanup() {
+    if (!this.modal) return;
+    if (this.openButton) {
+      this.openButton.removeEventListener('click', this.boundHandlers.handleOpenClick);
+    }
+    if (this.closeButton) {
+      this.closeButton.removeEventListener('click', this.boundHandlers.handleCloseClick);
+    }
+    if (this.backdropButton) {
+      this.backdropButton.removeEventListener('click', this.boundHandlers.handleBackdropClick);
+    }
+    this.modal.removeEventListener('cancel', this.boundHandlers.handleCancel);
+    this.modal.removeEventListener('keydown', this.boundHandlers.handleKeydown);
+    if (this.eventTarget) {
+      this.eventTarget.removeEventListener(this.events.openRequest, this.boundHandlers.handleDocumentOpenRequest);
+      this.eventTarget.removeEventListener(this.events.closeRequest, this.boundHandlers.handleDocumentCloseRequest);
+    }
+  }
+
+  /** Destroy controller and cleanup listeners. */
+  async destroy(detail = {}) {
+    if (this.isDestroyed) return;
+    await this.hide(detail);
+    this.cleanup();
+    this.isDestroyed = true;
+  }
+
+  /** Toggle edit mode state. */
+  setEditMode(isEdit = false) {
+    if (this.modalTitle) {
+      this.modalTitle.textContent = isEdit ? this.editTitle : this.defaultTitle;
+    }
+    if (this.modal) {
+      this.modal.setAttribute('data-mode', isEdit ? 'edit' : 'create');
+    }
+    this.currentMode = isEdit ? 'edit' : 'create';
+  }
+
+  /** Handle open button click. */
+  handleOpenClick(event) {
+    event.preventDefault();
+    this.dispatchEvent('prepare', { mode: 'create', controller: this });
+    this.setEditMode(false);
+    this.show({ reason: 'open-button' });
+  }
+
+  /** Handle close button click. */
+  handleCloseClick(event) {
+    event.preventDefault();
+    this.requestClose('user-dismissed');
+  }
+
+  /** Handle backdrop click. */
+  handleBackdropClick(event) {
+    event.preventDefault();
+    this.requestClose('backdrop');
+  }
+
+  /** Handle cancel event (keyboard). */
+  handleCancel(event) {
+    event.preventDefault();
+    this.requestClose('keyboard');
+  }
+
+  /** Handle keydown for focus trap and escape. */
+  handleKeydown(event) {
+    if (this.enableFocusTrap && event.key === 'Tab') {
+      this.maintainFocus(event);
+    }
+    if (event.key === 'Escape') {
+      this.requestClose('keyboard');
+    }
+  }
+
+  /** Maintain focus within modal. */
+  maintainFocus(event) {
+    if (!this.modal) return;
+    const focusable = this.getFocusableElements();
+    if (focusable.length === 0) {
+      event.preventDefault();
+      this.modal.focus();
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+    if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  /** Get focusable elements inside modal. */
+  getFocusableElements() {
+    if (!this.modal) return [];
+    return Array.from(this.modal.querySelectorAll(FOCUSABLE_SELECTORS)).filter((el) => {
+      if (!(el instanceof HTMLElement)) return false;
+      if (el.hasAttribute('disabled')) return false;
+      const ariaHidden = el.getAttribute('aria-hidden');
+      return ariaHidden !== 'true';
+    });
+  }
+
+  /** Handle global open request events. */
+  handleDocumentOpenRequest(event) {
+    if (!event || (event.detail && event.detail.controller && event.detail.controller !== this)) {
+      return;
+    }
+    const isEdit = Boolean(event?.detail?.mode === 'edit');
+    this.setEditMode(isEdit);
+    this.show({ reason: event?.detail?.reason || 'external-open', mode: event?.detail?.mode });
+  }
+
+  /** Handle global close request events. */
+  handleDocumentCloseRequest(event) {
+    if (!event) return;
+    if (event.detail?.controller && event.detail.controller !== this) {
+      return;
+    }
+    if (event.detail?.initiatedBy === 'controller') {
+      return;
+    }
+    const reason = event.detail?.reason || 'external-close';
+    this.hide({ reason });
+  }
+
+  /** Dispatch a custom event. */
+  dispatchEvent(name, detail = {}) {
+    const eventName = this.events[name];
+    if (!eventName || !this.eventTarget || typeof this.eventTarget.dispatchEvent !== 'function') {
+      return;
+    }
+    const customEvent = new CustomEvent(eventName, {
+      detail,
+      bubbles: false,
+      cancelable: true
+    });
+    this.eventTarget.dispatchEvent(customEvent);
+  }
+
+  /** Initiate a close request with events. */
+  requestClose(reason) {
+    const detail = { reason, controller: this };
+    this.dispatchEvent('cancelled', detail);
+    this.dispatchEvent('closeRequest', { ...detail, initiatedBy: 'controller' });
+    this.hide({ reason });
+  }
+
+  /** Run animation hook if provided. */
+  async runHook(hookName) {
+    const hook = this.animationHooks?.[hookName];
+    if (typeof hook === 'function') {
+      await hook(this);
+    }
+  }
+
+  /** Add controller to active stack. */
+  addToStack() {
+    const stack = ModalController.activeStack;
+    const existingIndex = stack.indexOf(this);
+    if (existingIndex !== -1) {
+      stack.splice(existingIndex, 1);
+    }
+    stack.push(this);
+    this.stackIndex = stack.length - 1;
+    this.modal?.setAttribute('data-stack-index', String(this.stackIndex));
+  }
+
+  /** Remove controller from stack. */
+  removeFromStack() {
+    const stack = ModalController.activeStack;
+    const index = stack.indexOf(this);
+    if (index !== -1) {
+      stack.splice(index, 1);
+    }
+    this.stackIndex = undefined;
+    if (this.modal) {
+      this.modal.removeAttribute('data-stack-index');
+    }
+  }
+}
+
+/**
+ * Factory for creating modal controllers.
+ * @param {ModalControllerOptions} options
+ * @returns {ModalController}
+ */
+export function createModalController(options) {
+  return new ModalController(options);
+}

--- a/js/tests/modal-controller.test.js
+++ b/js/tests/modal-controller.test.js
@@ -1,0 +1,455 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const { describe, it, expect, beforeEach, beforeAll, afterEach } = require('@jest/globals');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let ModalController;
+let createModalController;
+
+function loadModalControllerModule() {
+  const filePath = path.resolve(__dirname, '../modules/modal-controller.js');
+  let source = fs.readFileSync(filePath, 'utf8');
+  source = source
+    .replace(/export\s+class\s+ModalController/g, 'class ModalController')
+    .replace(/export\s+function\s+createModalController/g, 'function createModalController');
+  source += `\nmodule.exports = { ModalController, createModalController };\n`;
+  const module = { exports: {} };
+  const sandbox = {
+    module,
+    exports: module.exports,
+    require,
+    console,
+    document,
+    window,
+    CustomEvent,
+    HTMLElement
+  };
+  vm.runInNewContext(source, sandbox, { filename: filePath });
+  return module.exports;
+}
+
+function setupModalDom() {
+  document.body.innerHTML = `
+    <button id="openCueModal">Open</button>
+    <div id="cue-modal" role="dialog">
+      <div class="modal-backdrop"><button type="button">Backdrop</button></div>
+      <h2 id="modal-title">Create Cue</h2>
+      <input id="title" />
+      <input id="secondary" />
+      <button id="closeCueModal" type="button">Close</button>
+      <button id="saveBtn" type="button">Save</button>
+    </div>
+  `;
+  const modalElement = document.getElementById('cue-modal');
+  modalElement.showModal = jest.fn(() => {
+    modalElement.open = true;
+    modalElement.setAttribute('open', '');
+  });
+  modalElement.close = jest.fn(() => {
+    modalElement.open = false;
+    modalElement.removeAttribute('open');
+  });
+  return {
+    modalElement,
+    openButton: document.getElementById('openCueModal'),
+    closeButton: document.getElementById('closeCueModal'),
+    backdropButton: modalElement.querySelector('.modal-backdrop button'),
+    titleInput: document.getElementById('title'),
+    modalTitle: document.getElementById('modal-title'),
+    secondaryInput: document.getElementById('secondary')
+  };
+}
+
+beforeAll(() => {
+  ({ ModalController, createModalController } = loadModalControllerModule());
+});
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  ModalController.activeStack = [];
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('ModalController', () => {
+  it('shows the modal and focuses the title input', async () => {
+    const {
+      modalElement,
+      openButton,
+      closeButton,
+      backdropButton,
+      titleInput,
+      modalTitle
+    } = setupModalDom();
+    titleInput.focus = jest.fn();
+    const controller = createModalController({
+      modalElement,
+      openButton,
+      closeButton,
+      backdropButton,
+      titleInput,
+      modalTitle,
+      defaultTitle: 'Create Cue',
+      editTitle: 'Edit Cue'
+    });
+
+    jest.useFakeTimers();
+    await controller.show();
+    jest.runAllTimers();
+
+    expect(modalElement.showModal).toHaveBeenCalledTimes(1);
+    expect(titleInput.focus).toHaveBeenCalled();
+    expect(controller.isOpen).toBe(true);
+    expect(modalElement.getAttribute('aria-hidden')).toBe('false');
+    expect(modalElement.getAttribute('aria-modal')).toBe('true');
+    expect(modalElement.getAttribute('role')).toBe('dialog');
+    expect(modalElement.getAttribute('aria-labelledby')).toBe('modal-title');
+  });
+
+  it('hides the modal and restores focus', async () => {
+    const {
+      modalElement,
+      openButton,
+      closeButton,
+      backdropButton,
+      titleInput,
+      modalTitle
+    } = setupModalDom();
+    openButton.focus = jest.fn(() => {
+      document.activeElement = openButton;
+    });
+    titleInput.focus = jest.fn();
+    const controller = createModalController({
+      modalElement,
+      openButton,
+      closeButton,
+      backdropButton,
+      titleInput,
+      modalTitle,
+      defaultTitle: 'Create Cue',
+      editTitle: 'Edit Cue'
+    });
+
+    jest.useFakeTimers();
+    openButton.focus();
+    await controller.show();
+    jest.runAllTimers();
+    await controller.hide();
+
+    expect(modalElement.close).toHaveBeenCalledTimes(1);
+    expect(openButton.focus).toHaveBeenCalled();
+    expect(controller.isOpen).toBe(false);
+    expect(modalElement.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('dispatches custom events when closing via button', async () => {
+    const {
+      modalElement,
+      openButton,
+      closeButton,
+      backdropButton,
+      titleInput,
+      modalTitle
+    } = setupModalDom();
+    const controller = createModalController({
+      modalElement,
+      openButton,
+      closeButton,
+      backdropButton,
+      titleInput,
+      modalTitle,
+      defaultTitle: 'Create Cue',
+      editTitle: 'Edit Cue'
+    });
+
+    const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
+
+    jest.useFakeTimers();
+    await controller.show();
+    jest.runAllTimers();
+    closeButton.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    jest.runAllTimers();
+
+    const eventTypes = dispatchSpy.mock.calls.map(([event]) => event.type);
+    expect(eventTypes).toContain('cue:cancelled');
+    expect(eventTypes).toContain('cue:close');
+
+    const cancelledEvent = dispatchSpy.mock.calls.find(([event]) => event.type === 'cue:cancelled')[0];
+    expect(cancelledEvent.detail.reason).toBe('user-dismissed');
+
+    dispatchSpy.mockRestore();
+  });
+
+  it('supports backdrop and escape key cancellation', async () => {
+    const {
+      modalElement,
+      openButton,
+      closeButton,
+      backdropButton,
+      titleInput,
+      modalTitle
+    } = setupModalDom();
+    const controller = createModalController({
+      modalElement,
+      openButton,
+      closeButton,
+      backdropButton,
+      titleInput,
+      modalTitle,
+      defaultTitle: 'Create Cue',
+      editTitle: 'Edit Cue'
+    });
+
+    const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
+
+    jest.useFakeTimers();
+    await controller.show();
+    jest.runAllTimers();
+
+    backdropButton.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    const backdropEvent = dispatchSpy.mock.calls.find(([event]) => event.type === 'cue:cancelled');
+    expect(backdropEvent[0].detail.reason).toBe('backdrop');
+
+    dispatchSpy.mockClear();
+    controller.handleKeydown({ key: 'Escape', preventDefault: jest.fn() });
+    const keyboardEvent = dispatchSpy.mock.calls.find(([event]) => event.type === 'cue:cancelled');
+    expect(keyboardEvent[0].detail.reason).toBe('keyboard');
+
+    dispatchSpy.mockRestore();
+  });
+
+  it('maintains a focus trap with tab navigation', async () => {
+    const {
+      modalElement,
+      openButton,
+      closeButton,
+      backdropButton,
+      titleInput,
+      modalTitle,
+      secondaryInput
+    } = setupModalDom();
+    const controller = createModalController({
+      modalElement,
+      openButton,
+      closeButton,
+      backdropButton,
+      titleInput,
+      modalTitle,
+      defaultTitle: 'Create Cue',
+      editTitle: 'Edit Cue'
+    });
+
+    jest.useFakeTimers();
+    await controller.show();
+    jest.runAllTimers();
+
+    const focusable = controller.getFocusableElements();
+    expect(focusable.length).toBeGreaterThan(1);
+    focusable.forEach((el) => {
+      el.focus = jest.fn(() => {
+      });
+    });
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    const originalActiveDescriptor = Object.getOwnPropertyDescriptor(document, 'activeElement');
+    let activeEl = last;
+    Object.defineProperty(document, 'activeElement', {
+      configurable: true,
+      get: () => activeEl
+    });
+
+    const preventNext = jest.fn();
+    controller.handleKeydown({ key: 'Tab', preventDefault: preventNext, shiftKey: false });
+    expect(first.focus).toHaveBeenCalled();
+    expect(preventNext).toHaveBeenCalled();
+
+    first.focus.mockClear();
+    const preventPrev = jest.fn();
+    activeEl = first;
+    controller.handleKeydown({ key: 'Tab', preventDefault: preventPrev, shiftKey: true });
+    expect(last.focus).toHaveBeenCalled();
+    expect(preventPrev).toHaveBeenCalled();
+
+    if (originalActiveDescriptor) {
+      Object.defineProperty(document, 'activeElement', originalActiveDescriptor);
+    }
+  });
+
+  it('toggles edit mode and updates titles', () => {
+    const {
+      modalElement,
+      openButton,
+      closeButton,
+      backdropButton,
+      titleInput,
+      modalTitle
+    } = setupModalDom();
+    const controller = createModalController({
+      modalElement,
+      openButton,
+      closeButton,
+      backdropButton,
+      titleInput,
+      modalTitle,
+      defaultTitle: 'Create Cue',
+      editTitle: 'Edit Cue'
+    });
+
+    controller.setEditMode(true);
+    expect(modalTitle.textContent).toBe('Edit Cue');
+    expect(modalElement.getAttribute('data-mode')).toBe('edit');
+
+    controller.setEditMode(false);
+    expect(modalTitle.textContent).toBe('Create Cue');
+    expect(modalElement.getAttribute('data-mode')).toBe('create');
+  });
+
+  it('cleans up listeners and supports destroy()', async () => {
+    const {
+      modalElement,
+      openButton,
+      closeButton,
+      backdropButton,
+      titleInput,
+      modalTitle
+    } = setupModalDom();
+    const controller = createModalController({
+      modalElement,
+      openButton,
+      closeButton,
+      backdropButton,
+      titleInput,
+      modalTitle,
+      defaultTitle: 'Create Cue',
+      editTitle: 'Edit Cue'
+    });
+
+    const removeOpenSpy = jest.spyOn(openButton, 'removeEventListener');
+    const removeDocumentSpy = jest.spyOn(document, 'removeEventListener');
+
+    await controller.destroy();
+
+    expect(removeOpenSpy).toHaveBeenCalledWith('click', controller.boundHandlers.handleOpenClick);
+    expect(removeDocumentSpy).toHaveBeenCalledWith('cue:open', controller.boundHandlers.handleDocumentOpenRequest);
+    expect(controller.isDestroyed).toBe(true);
+    expect(ModalController.activeStack.includes(controller)).toBe(false);
+
+    removeOpenSpy.mockRestore();
+    removeDocumentSpy.mockRestore();
+  });
+
+  it('handles missing modal elements safely', async () => {
+    const controller = createModalController({ modalElement: null });
+    await expect(controller.show()).resolves.toBeUndefined();
+    await expect(controller.hide()).resolves.toBeUndefined();
+    expect(controller.isDisabled).toBe(true);
+  });
+
+  it('responds to global open and close requests', async () => {
+    const {
+      modalElement,
+      openButton,
+      closeButton,
+      backdropButton,
+      titleInput,
+      modalTitle
+    } = setupModalDom();
+    const controller = createModalController({
+      modalElement,
+      openButton,
+      closeButton,
+      backdropButton,
+      titleInput,
+      modalTitle,
+      defaultTitle: 'Create Cue',
+      editTitle: 'Edit Cue'
+    });
+
+    jest.useFakeTimers();
+    document.dispatchEvent(new CustomEvent('cue:open', { detail: { mode: 'edit' } }));
+    await Promise.resolve();
+    jest.runAllTimers();
+    expect(controller.isOpen).toBe(true);
+    expect(modalElement.getAttribute('data-mode')).toBe('edit');
+
+    document.dispatchEvent(new CustomEvent('cue:close', { detail: { reason: 'external' } }));
+    await Promise.resolve();
+    jest.runAllTimers();
+    expect(controller.isOpen).toBe(false);
+  });
+
+  it('dispatches lifecycle events for show and hide', async () => {
+    const {
+      modalElement,
+      openButton,
+      closeButton,
+      backdropButton,
+      titleInput,
+      modalTitle
+    } = setupModalDom();
+    const controller = createModalController({
+      modalElement,
+      openButton,
+      closeButton,
+      backdropButton,
+      titleInput,
+      modalTitle,
+      defaultTitle: 'Create Cue',
+      editTitle: 'Edit Cue'
+    });
+
+    const shownListener = jest.fn();
+    const hiddenListener = jest.fn();
+    document.addEventListener('cue:shown', shownListener);
+    document.addEventListener('cue:hidden', hiddenListener);
+
+    jest.useFakeTimers();
+    await controller.show();
+    jest.runAllTimers();
+    expect(shownListener).toHaveBeenCalled();
+
+    await controller.hide();
+    jest.runAllTimers();
+    expect(hiddenListener).toHaveBeenCalled();
+
+    document.removeEventListener('cue:shown', shownListener);
+    document.removeEventListener('cue:hidden', hiddenListener);
+  });
+
+  it('supports stacking multiple modals', async () => {
+    const modalA = document.createElement('div');
+    modalA.id = 'modal-a';
+    const modalB = document.createElement('div');
+    modalB.id = 'modal-b';
+    document.body.append(modalA, modalB);
+
+    [modalA, modalB].forEach((modal) => {
+      modal.showModal = function () {
+        modal.open = true;
+      };
+      modal.close = function () {
+        modal.open = false;
+      };
+    });
+
+    const controllerA = createModalController({ modalElement: modalA, defaultTitle: 'A', editTitle: 'A Edit' });
+    const controllerB = createModalController({ modalElement: modalB, defaultTitle: 'B', editTitle: 'B Edit' });
+
+    await controllerA.show();
+    await controllerB.show();
+
+    expect(ModalController.activeStack[ModalController.activeStack.length - 1]).toBe(controllerB);
+    expect(modalB.getAttribute('data-stack-index')).toBe(String(ModalController.activeStack.length - 1));
+
+    await controllerB.hide();
+    expect(ModalController.activeStack.includes(controllerB)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable modal controller module with accessibility, keyboard, focus trapping, and stacking support
- refactor app.js to initialise and interact with the modal through the controller
- cover the modal controller behaviours with dedicated Jest tests

## Testing
- npx jest js/tests/modal-controller.test.js

------
https://chatgpt.com/codex/tasks/task_e_6904a5438f2c83248d5130bf8c595246