### PR TITLE
Fix mobile page styling regression

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -12,6 +12,13 @@
   <link rel="icon" href="./icons/icon-192.svg" type="image/svg+xml" />
   <link rel="stylesheet" href="./styles/tokens.css" />
   <link rel="stylesheet" href="./styles/a11y.css" />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/daisyui@4.12.10/dist/full.min.css"
+    integrity="sha384-yxrQVVFFRZdq4Z/YbeTDzSYbn1W6VnVonm2vAgnxtxUMehcccE4k2NufOz2tJnOe"
+    crossorigin="anonymous"
+  />
+  <link rel="stylesheet" href="./styles/daisy-themes.css" />
   <style>
     .sync-status {
       display: inline-flex;


### PR DESCRIPTION
## Summary
- load DaisyUI and theme styles on the mobile standalone page to restore styling

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_690514acb9308324bdc3bfe8611149a4