### PR TITLE
Remove Google avatar from mobile header

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -184,7 +184,6 @@ export async function initReminders(sel = {}) {
   const countOverdueEl = $(sel.countOverdueSel);
   const countTotalEl = $(sel.countTotalSel);
   const countCompletedEl = $(sel.countCompletedSel);
-  const googleAvatar = $(sel.googleAvatarSel);
   const googleUserName = $(sel.googleUserNameSel);
   const dateFeedback = $(sel.dateFeedbackSel);
   const voiceBtn = $(sel.voiceBtnSel);
@@ -837,10 +836,6 @@ export async function initReminders(sel = {}) {
     }
     googleSignInBtn?.classList.remove('hidden');
     googleSignOutBtn?.classList.add('hidden');
-    if (googleAvatar) {
-      googleAvatar.classList.add('hidden');
-      googleAvatar.src = '';
-    }
     if (googleUserName) {
       googleUserName.textContent = '';
     }
@@ -1358,7 +1353,6 @@ export async function initReminders(sel = {}) {
         if(syncStatus) syncStatus.textContent = 'Online';
         googleSignInBtn?.classList.add('hidden');
         googleSignOutBtn?.classList.remove('hidden');
-        if(googleAvatar){ if(user.photoURL){ googleAvatar.classList.remove('hidden'); googleAvatar.src=user.photoURL; } else { googleAvatar.classList.add('hidden'); googleAvatar.src=''; } }
         if(googleUserName) googleUserName.textContent = user.displayName || user.email || '';
         setupFirestoreSync();
         await migrateOfflineRemindersIfNeeded();

--- a/mobile.html
+++ b/mobile.html
@@ -382,12 +382,6 @@
     </div>
     <div class="flex-none flex flex-col gap-1 text-right">
       <div class="flex justify-end items-center gap-2">
-        <img
-          id="googleAvatar"
-          src=""
-          alt=""
-          class="hidden h-8 w-8 rounded-full border border-base-300"
-        />
         <button id="themeToggle" class="btn btn-ghost" type="button">Theme</button>
         <button id="openSettings" class="btn btn-ghost" type="button">Settings</button>
         <button id="googleSignInBtn" class="btn btn-primary" type="button">Sign in</button>


### PR DESCRIPTION
## Summary
- remove the Google avatar image from the mobile header markup
- stop the reminder auth handlers from trying to show or populate the removed avatar element

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69051ab1951083249fda0f46b3037644