### PR TITLE
Bold reminder text for better emphasis

### DIFF
--- a/css/teacher.css
+++ b/css/teacher.css
@@ -1328,7 +1328,7 @@ input::placeholder, textarea::placeholder {
 
 .task-title {
   font-size: var(--text-base);
-  font-weight: 500;
+  font-weight: 700;
   margin: 0 0 var(--space-1) 0;
   color: var(--text-primary);
   line-height: 1.4;

--- a/docs/css/teacher.css
+++ b/docs/css/teacher.css
@@ -1328,7 +1328,7 @@ input::placeholder, textarea::placeholder {
 
 .task-title {
   font-size: var(--text-base);
-  font-weight: 500;
+  font-weight: 700;
   margin: 0 0 var(--space-1) 0;
   color: var(--text-primary);
   line-height: 1.4;

--- a/docs/index.html
+++ b/docs/index.html
@@ -272,7 +272,7 @@
               <ol class="space-y-3">
                 <li class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
                   <div class="space-y-1">
-                    <p class="font-medium text-base-content">Send excursion reminder</p>
+                    <p class="font-medium text-base-content"><span class="font-semibold">Send excursion reminder</span></p>
                     <time class="text-sm text-base-content/70" datetime="2024-04-18T09:30">Before 9:30 AM</time>
                   </div>
                   <div class="flex flex-wrap gap-2">
@@ -282,14 +282,14 @@
                 </li>
                 <li class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
                   <div class="space-y-1">
-                    <p class="font-medium text-base-content">Prep science lab</p>
+                    <p class="font-medium text-base-content"><span class="font-semibold">Prep science lab</span></p>
                     <p class="text-sm text-base-content/70">Room 204 &middot; Period 3</p>
                   </div>
                   <span class="badge badge-outline text-primary">Lab</span>
                 </li>
                 <li class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
                   <div class="space-y-1">
-                    <p class="font-medium text-base-content">Call guardians</p>
+                    <p class="font-medium text-base-content"><span class="font-semibold">Call guardians</span></p>
                     <p class="text-sm text-base-content/70">Follow up on field trip slips</p>
                   </div>
                   <span class="badge badge-outline text-error">High</span>
@@ -401,7 +401,7 @@
         <ul class="space-y-3">
           <li class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200/70 p-5 shadow-sm sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <p class="font-medium text-base-content">Submit unit overview</p>
+              <p class="font-medium text-base-content"><span class="font-semibold">Submit unit overview</span></p>
               <p class="text-sm text-base-content/70">Due Friday &middot; Curriculum team</p>
             </div>
             <div class="flex gap-2">
@@ -411,7 +411,7 @@
           </li>
           <li class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200/70 p-5 shadow-sm sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <p class="font-medium text-base-content">Email newsletter blurb</p>
+              <p class="font-medium text-base-content"><span class="font-semibold">Email newsletter blurb</span></p>
               <p class="text-sm text-base-content/70">Add upcoming excursions to the weekly update.</p>
             </div>
             <span class="badge badge-outline text-secondary">This week</span>

--- a/index.html
+++ b/index.html
@@ -272,7 +272,7 @@
               <ol class="space-y-3">
                 <li class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
                   <div class="space-y-1">
-                    <p class="font-medium text-base-content">Send excursion reminder</p>
+                    <p class="font-medium text-base-content"><span class="font-semibold">Send excursion reminder</span></p>
                     <time class="text-sm text-base-content/70" datetime="2024-04-18T09:30">Before 9:30 AM</time>
                   </div>
                   <div class="flex flex-wrap gap-2">
@@ -282,14 +282,14 @@
                 </li>
                 <li class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
                   <div class="space-y-1">
-                    <p class="font-medium text-base-content">Prep science lab</p>
+                    <p class="font-medium text-base-content"><span class="font-semibold">Prep science lab</span></p>
                     <p class="text-sm text-base-content/70">Room 204 &middot; Period 3</p>
                   </div>
                   <span class="badge badge-outline text-primary">Lab</span>
                 </li>
                 <li class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
                   <div class="space-y-1">
-                    <p class="font-medium text-base-content">Call guardians</p>
+                    <p class="font-medium text-base-content"><span class="font-semibold">Call guardians</span></p>
                     <p class="text-sm text-base-content/70">Follow up on field trip slips</p>
                   </div>
                   <span class="badge badge-outline text-error">High</span>
@@ -401,7 +401,7 @@
         <ul class="space-y-3">
           <li class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200/70 p-5 shadow-sm sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <p class="font-medium text-base-content">Submit unit overview</p>
+              <p class="font-medium text-base-content"><span class="font-semibold">Submit unit overview</span></p>
               <p class="text-sm text-base-content/70">Due Friday &middot; Curriculum team</p>
             </div>
             <div class="flex gap-2">
@@ -411,7 +411,7 @@
           </li>
           <li class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200/70 p-5 shadow-sm sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <p class="font-medium text-base-content">Email newsletter blurb</p>
+              <p class="font-medium text-base-content"><span class="font-semibold">Email newsletter blurb</span></p>
               <p class="text-sm text-base-content/70">Add upcoming excursions to the weekly update.</p>
             </div>
             <span class="badge badge-outline text-secondary">This week</span>


### PR DESCRIPTION
## Summary
- increase the font weight used for reminder titles so scheduled cues display in bold
- update static reminder examples to wrap their titles in a bold span for visual emphasis

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690530900e1c8324873336d21ee1ca8d