### PR TITLE
Move reminder filter toggle into header on mobile

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -372,10 +372,10 @@
     details.sort-filter summary::-webkit-details-marker {
       display: none;
     }
-    details.sort-filter .sort-filter-icon {
+    #toggleReminderFilters .sort-filter-icon {
       transition: transform 0.2s ease;
     }
-    details.sort-filter[open] .sort-filter-icon {
+    #toggleReminderFilters[aria-expanded="true"] .sort-filter-icon {
       transform: rotate(180deg);
     }
   </style>
@@ -432,6 +432,28 @@
       <div class="flex justify-end items-center gap-2">
         <button id="themeToggle" class="btn btn-ghost" type="button">Theme</button>
         <button id="openSettings" class="btn btn-ghost" type="button">Settings</button>
+        <button
+          id="toggleReminderFilters"
+          class="btn btn-ghost"
+          type="button"
+          aria-controls="reminderFilters"
+          aria-expanded="false"
+        >
+          Sort &amp; filter
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            class="size-4 opacity-70 sort-filter-icon"
+            aria-hidden="true"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M5.23 7.21a.75.75 0 011.06.02L10 11.17l3.71-3.94a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        </button>
         <button id="googleSignInBtn" class="btn btn-primary" type="button">Sign in</button>
         <button id="googleSignOutBtn" class="btn btn-ghost hidden" type="button">Sign out</button>
       </div>
@@ -450,22 +472,7 @@
         class="card bg-base-100 border sort-filter mb-4"
         aria-label="Sort and filter reminders"
       >
-        <summary class="flex cursor-pointer items-center justify-between gap-2 px-5 py-3 text-sm font-medium text-base-content">
-          <span>Sort &amp; filter reminders</span>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-            class="size-4 opacity-70 sort-filter-icon"
-            aria-hidden="true"
-          >
-            <path
-              fill-rule="evenodd"
-              d="M5.23 7.21a.75.75 0 011.06.02L10 11.17l3.71-3.94a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
-              clip-rule="evenodd"
-            />
-          </svg>
-        </summary>
+        <summary class="sr-only">Sort &amp; filter reminders</summary>
         <div class="card-body gap-4 border-t border-base-300/60 compact">
           <div class="flex flex-wrap items-center gap-3">
             <div class="flex flex-wrap items-center gap-2" role="group" aria-label="Reminder filters">

--- a/mobile.js
+++ b/mobile.js
@@ -302,6 +302,50 @@ if (document.readyState === 'loading') {
 }
 
 (() => {
+  const toggleBtn = document.getElementById('toggleReminderFilters');
+  const filterPanel = document.getElementById('reminderFilters');
+
+  if (!(toggleBtn instanceof HTMLElement) || !(filterPanel instanceof HTMLElement)) {
+    return;
+  }
+
+  const focusSelectors = ['input', 'select', 'button', 'textarea', '[tabindex]:not([tabindex="-1"])'];
+
+  const syncState = () => {
+    const isOpen = filterPanel.hasAttribute('open');
+    toggleBtn.setAttribute('aria-expanded', String(isOpen));
+    toggleBtn.classList.toggle('btn-active', isOpen);
+  };
+
+  const focusFirstControl = () => {
+    for (const selector of focusSelectors) {
+      const control = filterPanel.querySelector(selector);
+      if (control instanceof HTMLElement && !control.hasAttribute('disabled')) {
+        try {
+          control.focus({ preventScroll: true });
+        } catch {
+          control.focus();
+        }
+        return;
+      }
+    }
+  };
+
+  toggleBtn.addEventListener('click', () => {
+    const isOpen = filterPanel.hasAttribute('open');
+    filterPanel.open = !isOpen;
+    if (!isOpen) {
+      focusFirstControl();
+    }
+    syncState();
+  });
+
+  filterPanel.addEventListener('toggle', syncState);
+
+  syncState();
+})();
+
+(() => {
   const sheetEl = document.getElementById('create-sheet');
 
   if (!(sheetEl instanceof HTMLElement)) {


### PR DESCRIPTION
## Summary
- add a compact "Sort & filter" button to the header next to the theme and settings controls
- hide the oversized details summary and hook the new header button up to the reminder filters panel

## Testing
- npm start


------
https://chatgpt.com/codex/tasks/task_e_69053782c4808324bd28268b007058c3