### PR TITLE
Ensure new mobile reminders render bold titles

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -1917,7 +1917,7 @@ export async function initReminders(sel = {}) {
       div.innerHTML = `
         <input type="checkbox" ${r.done ? 'checked' : ''} aria-label="Mark complete" />
         <div class="task-content">
-          <div class="task-title">${escapeHtml(r.title)}</div>
+          <div class="task-title"><strong>${escapeHtml(r.title)}</strong></div>
           <div class="task-meta">
             <div class="task-meta-row" style="gap:8px; flex-wrap:wrap;">
               <span>${dueTxt}</span>


### PR DESCRIPTION
## Summary
- wrap the mobile reminder title in a strong tag so newly added reminders are bolded

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69053d4b9270832493ffe5f3d668ac0d