### PR TITLE
Add dynamic viewport height handling for mobile layout

### DIFF
--- a/404.html
+++ b/404.html
@@ -70,6 +70,15 @@
   <!-- END GPT CHANGE -->
   <!-- BEGIN GPT FIX: compact-skeleton-style -->
   <style>
+    :root {
+      --vh: 1vh;
+    }
+
+    body,
+    .min-h-screen {
+      min-height: calc(var(--vh, 1vh) * 100);
+    }
+
     .dashboard-widget [aria-hidden="true"].animate-pulse { opacity: .85; }
   </style>
   <!-- END GPT FIX: compact-skeleton-style -->

--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+import { initViewportHeight } from './js/modules/viewport-height.js';
 import { initReminders } from './js/reminders.js';
 import {
   CUE_FIELD_DEFINITIONS,
@@ -11,6 +12,8 @@ import {
   escapeCueText
 } from './js/modules/field-helpers.js';
 import { createModalController } from './js/modules/modal-controller.js';
+
+initViewportHeight();
 
 const titleInput = document.getElementById('title');
 const mobileTitleInput = document.getElementById('reminderText');

--- a/index.html
+++ b/index.html
@@ -69,6 +69,15 @@
   <!-- BEGIN GPT CHANGE: styles moved to styles/index.css -->
   <!-- END GPT CHANGE -->
   <style>
+    :root {
+      --vh: 1vh;
+    }
+
+    body,
+    .min-h-screen {
+      min-height: calc(var(--vh, 1vh) * 100);
+    }
+
     .dashboard-widget [aria-hidden="true"].animate-pulse {
       opacity: .85;
     }

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,8 @@
 
+import { initViewportHeight } from './modules/viewport-height.js';
+
+initViewportHeight();
+
 (function () {
   if (typeof document === 'undefined') {
     return;

--- a/js/modules/viewport-height.js
+++ b/js/modules/viewport-height.js
@@ -1,0 +1,127 @@
+const CSS_VARIABLE = '--vh';
+const CSS_VARIABLE_FALLBACK = '1vh';
+
+let isInitialised = false;
+let activeTeardown = null;
+
+function supportsCssCustomProperties() {
+  if (typeof window === 'undefined') return false;
+  const { CSS } = window;
+  if (!CSS || typeof CSS.supports !== 'function') {
+    return false;
+  }
+  try {
+    return CSS.supports('--fake-var', '1px');
+  } catch (error) {
+    console.warn('Memory Cue: CSS.supports threw while checking custom property support', error);
+    return false;
+  }
+}
+
+function getViewportUnit() {
+  if (typeof window === 'undefined') return null;
+  const height = window.innerHeight;
+  if (typeof height !== 'number' || Number.isNaN(height) || height <= 0) {
+    return null;
+  }
+  return `${height * 0.01}px`;
+}
+
+export function initViewportHeight() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return () => {};
+  }
+
+  const root = document.documentElement;
+  if (!root || root.nodeType !== 1) {
+    return () => {};
+  }
+
+  if (isInitialised) {
+    return activeTeardown || (() => {});
+  }
+
+  const canUseCustomProperties = supportsCssCustomProperties();
+  if (!canUseCustomProperties) {
+    root.style.removeProperty(CSS_VARIABLE);
+    return () => {};
+  }
+
+  let frame = null;
+  const setViewportUnit = () => {
+    const value = getViewportUnit();
+    if (value) {
+      root.style.setProperty(CSS_VARIABLE, value);
+    }
+  };
+
+  const scheduleUpdate = () => {
+    if (frame !== null) {
+      window.cancelAnimationFrame(frame);
+    }
+    frame = window.requestAnimationFrame(() => {
+      frame = null;
+      setViewportUnit();
+    });
+  };
+
+  const onResize = () => scheduleUpdate();
+  const onOrientationChange = () => scheduleUpdate();
+
+  setViewportUnit();
+
+  window.addEventListener('resize', onResize, { passive: true });
+  window.addEventListener('orientationchange', onOrientationChange);
+
+  const visualViewport = window.visualViewport;
+  if (visualViewport) {
+    visualViewport.addEventListener('resize', scheduleUpdate, { passive: true });
+    visualViewport.addEventListener('scroll', scheduleUpdate, { passive: true });
+  }
+
+  const onFocus = () => scheduleUpdate();
+  window.addEventListener('focus', onFocus, true);
+
+  isInitialised = true;
+
+  const teardown = () => {
+    if (frame !== null) {
+      window.cancelAnimationFrame(frame);
+      frame = null;
+    }
+
+    window.removeEventListener('resize', onResize);
+    window.removeEventListener('orientationchange', onOrientationChange);
+    window.removeEventListener('focus', onFocus, true);
+
+    if (visualViewport) {
+      visualViewport.removeEventListener('resize', scheduleUpdate);
+      visualViewport.removeEventListener('scroll', scheduleUpdate);
+    }
+    isInitialised = false;
+    activeTeardown = null;
+  };
+
+  activeTeardown = teardown;
+
+  return teardown;
+}
+
+export function updateViewportHeight() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return;
+  }
+  const root = document.documentElement;
+  if (!root || root.nodeType !== 1) {
+    return;
+  }
+  const value = getViewportUnit();
+  if (value) {
+    root.style.setProperty(CSS_VARIABLE, value);
+  }
+}
+
+export const viewportHeightVariable = {
+  name: CSS_VARIABLE,
+  fallback: CSS_VARIABLE_FALLBACK,
+};

--- a/mobile.html
+++ b/mobile.html
@@ -166,13 +166,24 @@
   </style>
   <!-- BEGIN GPT CHANGE: bottom sheet styles -->
   <style>
+    :root {
+      --vh: 1vh;
+    }
+
+    body,
+    .min-h-screen {
+      min-height: calc(var(--vh, 1vh) * 100);
+    }
+
     .hidden {
       display: none !important;
     }
     .fab {
       position: fixed;
       right: calc(16px + env(safe-area-inset-right));
-      bottom: calc(88px + env(safe-area-inset-bottom));
+      bottom: calc(
+        88px + env(safe-area-inset-bottom) + (100vh - var(--vh, 1vh) * 100)
+      );
       width: 56px;
       height: 56px;
       border-radius: 50%;
@@ -199,6 +210,7 @@
     .sheet {
       position: fixed;
       inset: 0;
+      min-height: calc(var(--vh, 1vh) * 100);
       display: flex;
       flex-direction: column;
       justify-content: flex-end;
@@ -209,7 +221,7 @@
       left: 0;
       right: 0;
       bottom: 0;
-      max-height: 85vh;
+      max-height: calc(var(--vh, 1vh) * 85);
       overflow: auto;
       border-top-left-radius: 16px;
       border-top-right-radius: 16px;

--- a/mobile.js
+++ b/mobile.js
@@ -1,4 +1,7 @@
+import { initViewportHeight } from './js/modules/viewport-height.js';
 import { initReminders } from './js/reminders.js';
+
+initViewportHeight();
 
 /* BEGIN GPT CHANGE: bottom sheet open/close */
 (function () {


### PR DESCRIPTION
## Summary
- add a shared viewport height utility that keeps a --vh custom property in sync with the visual viewport
- initialize the dynamic viewport height calculation in the desktop, mobile, and fallback entry bundles
- update HTML/CSS to rely on var(--vh, 1vh) so floating buttons and sheets respect browser UI changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690593442fcc8324a2d8889a51e3791f