### PR TITLE
Restore mobile filter toggle in header dropdown

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -442,30 +442,65 @@
     </div>
     <div class="flex-none flex flex-col gap-1 text-right">
       <div class="flex justify-end items-center gap-2">
-        <button id="themeToggle" class="btn btn-ghost" type="button">Theme</button>
-        <button id="openSettings" class="btn btn-ghost" type="button">Settings</button>
-        <button
-          id="toggleReminderFilters"
-          class="btn btn-ghost"
-          type="button"
-          aria-controls="reminderFilters"
-          aria-expanded="false"
-        >
-          Sort &amp; filter
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-            class="size-4 opacity-70 sort-filter-icon"
-            aria-hidden="true"
+        <div class="relative">
+          <button
+            id="headerActionsToggle"
+            class="btn btn-ghost"
+            type="button"
+            aria-haspopup="menu"
+            aria-expanded="false"
           >
-            <path
-              fill-rule="evenodd"
-              d="M5.23 7.21a.75.75 0 011.06.02L10 11.17l3.71-3.94a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
-              clip-rule="evenodd"
-            />
-          </svg>
-        </button>
+            Quick actions
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              class="size-4 opacity-70"
+              aria-hidden="true"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M5.23 7.21a.75.75 0 011.06.02L10 11.17l3.71-3.94a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75 0 01.02-1.06z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </button>
+          <div
+            id="headerActionsMenu"
+            class="absolute right-0 mt-3 hidden w-56 rounded-box bg-base-100 p-2 shadow focus:outline-none flex flex-col gap-2 z-50"
+            role="menu"
+          >
+            <button
+              id="toggleReminderFilters"
+              class="btn btn-ghost btn-sm justify-between w-full"
+              type="button"
+              aria-controls="reminderFilters"
+              aria-expanded="false"
+              role="menuitem"
+            >
+              <span>Sort &amp; filter</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                class="size-4 opacity-70 sort-filter-icon"
+                aria-hidden="true"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M5.23 7.21a.75.75 0 011.06.02L10 11.17l3.71-3.94a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75 0 01.02-1.06z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+            </button>
+            <button id="openSettings" class="btn btn-ghost btn-sm justify-start w-full" type="button" role="menuitem">
+              Settings
+            </button>
+            <button id="themeToggle" class="btn btn-ghost btn-sm justify-start w-full" type="button" role="menuitem">
+              Theme
+            </button>
+          </div>
+        </div>
         <button id="googleSignInBtn" class="btn btn-primary" type="button">Sign in</button>
         <button id="googleSignOutBtn" class="btn btn-ghost hidden" type="button">Sign out</button>
       </div>

--- a/mobile.js
+++ b/mobile.js
@@ -305,6 +305,88 @@ if (document.readyState === 'loading') {
 }
 
 (() => {
+  try {
+    const toggle = document.getElementById('headerActionsToggle');
+    const menu = document.getElementById('headerActionsMenu');
+
+    if (!(toggle instanceof HTMLElement) || !(menu instanceof HTMLElement)) {
+      return;
+    }
+
+    const focusSelectors = ['button', '[href]', '[tabindex]:not([tabindex="-1"])'];
+
+    const focusFirstItem = () => {
+      for (const selector of focusSelectors) {
+        const candidate = menu.querySelector(selector);
+        if (candidate instanceof HTMLElement && !candidate.hasAttribute('disabled')) {
+          try {
+            candidate.focus({ preventScroll: true });
+          } catch {
+            candidate.focus();
+          }
+          return;
+        }
+      }
+    };
+
+    const openMenu = () => {
+      menu.classList.remove('hidden');
+      toggle.setAttribute('aria-expanded', 'true');
+      focusFirstItem();
+    };
+
+    const closeMenu = () => {
+      if (menu.classList.contains('hidden')) {
+        return;
+      }
+      menu.classList.add('hidden');
+      toggle.setAttribute('aria-expanded', 'false');
+    };
+
+    toggle.addEventListener('click', (event) => {
+      event.stopPropagation();
+      if (menu.classList.contains('hidden')) {
+        openMenu();
+      } else {
+        closeMenu();
+      }
+    });
+
+    toggle.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closeMenu();
+        toggle.focus({ preventScroll: true });
+      } else if ((event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') && menu.classList.contains('hidden')) {
+        event.preventDefault();
+        openMenu();
+      }
+    });
+
+    menu.addEventListener('click', (event) => {
+      if (event.target instanceof HTMLElement && event.target.closest('button')) {
+        closeMenu();
+      }
+    });
+
+    document.addEventListener('click', (event) => {
+      if (event.target instanceof Node && (menu.contains(event.target) || event.target === toggle)) {
+        return;
+      }
+      closeMenu();
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closeMenu();
+      }
+    });
+  } catch (error) {
+    console.error('[headerActions] init failed', error);
+  }
+})();
+
+
+(() => {
   const toggleBtn = document.getElementById('toggleReminderFilters');
   const filterPanel = document.getElementById('reminderFilters');
 


### PR DESCRIPTION
## Summary
- add a quick actions dropdown to the mobile header that keeps the reminder filter toggle accessible
- preserve the aria-controls/expanded attributes on the toggle so existing mobile.js logic continues to sync the button state

## Testing
- npm test -- --watch=false *(fails: existing Jest config cannot parse ESM imports in mobile.js and js/main.js)*

------
https://chatgpt.com/codex/tasks/task_e_6905980cd9e883248f7c24960ead21e2