### PR TITLE
Shorten mobile sync status messaging and constrain header pill

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -29,6 +29,16 @@
       color: rgb(15 23 42);
       transition: all 0.2s ease;
     }
+    .navbar .flex-1 {
+      min-width: 0;
+    }
+    .navbar .sync-status {
+      max-width: min(60vw, 14rem);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      flex-shrink: 1;
+    }
     .dark .sync-status {
       border-color: rgba(148, 163, 184, 0.35);
       background: rgba(148, 163, 184, 0.15);
@@ -876,6 +886,24 @@
 
       let currentState = null;
 
+      const DEFAULT_MESSAGES = {
+        checking: 'Checking connection…',
+        syncing: 'Syncing your latest changes…',
+        online: 'Connected. Changes sync automatically.',
+        offline: "You're offline. Changes are saved on this device until you reconnect.",
+        error: "We couldn't sync right now. We'll retry soon.",
+        info: '',
+      };
+
+      const DISPLAY_MESSAGES = {
+        checking: 'Checking…',
+        syncing: 'Syncing…',
+        online: 'Synced. Auto-save on.',
+        offline: 'Offline. Saving locally.',
+        error: 'Sync issue. Retrying.',
+        info: '',
+      };
+
       const setStatus = (state, message) => {
         currentState = state;
         ACTIVE_CLASSES.forEach((cls) => syncStatusEl.classList.remove(cls));
@@ -886,20 +914,30 @@
           syncStatusEl.classList.add('error');
         }
 
-        const defaults = {
-          checking: 'Checking connection…',
-          syncing: 'Syncing your latest changes…',
-          online: 'Connected. Changes sync automatically.',
-          offline: "You're offline. Changes are saved on this device until you reconnect.",
-          error: "We couldn't sync right now. We'll retry soon.",
-          info: '',
-        };
+        const fullText =
+          typeof message === 'string' && message.trim()
+            ? message.trim()
+            : DEFAULT_MESSAGES[state] || '';
 
-        const text = typeof message === 'string' && message.trim() ? message : (defaults[state] || '');
-        if (text) {
-          syncStatusEl.textContent = text;
-        }
+        const displayText =
+          typeof message === 'string' && message.trim()
+            ? message.trim()
+            : DISPLAY_MESSAGES[state] || fullText;
+
+        syncStatusEl.textContent = displayText;
         syncStatusEl.dataset.state = state;
+
+        if (fullText) {
+          syncStatusEl.setAttribute('title', fullText);
+          if (displayText !== fullText) {
+            syncStatusEl.setAttribute('aria-label', fullText);
+          } else {
+            syncStatusEl.removeAttribute('aria-label');
+          }
+        } else {
+          syncStatusEl.removeAttribute('title');
+          syncStatusEl.removeAttribute('aria-label');
+        }
       };
 
       const updateOnlineState = () => {
@@ -1118,7 +1156,7 @@
         const value = (syncUrlInput?.value || '').trim();
         if (!value) {
           persistUrl('');
-          setStatus('info', 'Sync URL cleared. Add a new one to enable syncing.');
+          setStatus('info', 'Sync URL cleared. Add one to enable sync.');
           updateButtonState();
           return;
         }
@@ -1129,7 +1167,7 @@
             throw new Error('Invalid protocol');
           }
         } catch {
-          setStatus('error', 'Enter a valid Apps Script URL before saving.');
+          setStatus('error', 'Enter a valid sync URL before saving.');
           return;
         }
 
@@ -1141,7 +1179,7 @@
       testSyncBtn?.addEventListener('click', async () => {
         const url = (syncUrlInput?.value || getStoredUrl()).trim();
         if (!url) {
-          setStatus('error', 'Add your Apps Script URL in Settings first.');
+          setStatus('error', 'Add your sync URL in Settings first.');
           return;
         }
 
@@ -1157,11 +1195,11 @@
           if (response.ok) {
             setStatus('online', 'Connection looks good.');
           } else {
-            setStatus('error', 'Test failed. Please check your Apps Script deployment.');
+            setStatus('error', 'Test failed. Check your Apps Script deployment.');
           }
         } catch (error) {
           console.error('Test sync failed', error);
-          setStatus('error', 'Test failed. Please check your Apps Script deployment.');
+          setStatus('error', 'Test failed. Check your Apps Script deployment.');
         } finally {
           toggleBusy(false);
         }
@@ -1170,13 +1208,13 @@
       syncAllBtn?.addEventListener('click', async () => {
         const url = (syncUrlInput?.value || getStoredUrl()).trim();
         if (!url) {
-          setStatus('error', 'Add your Apps Script URL in Settings first.');
+          setStatus('error', 'Add your sync URL in Settings first.');
           return;
         }
 
         const reminders = collectReminders();
         if (!reminders.length) {
-          setStatus('info', 'No reminders to sync right now.');
+          setStatus('info', 'Nothing to sync right now.');
           return;
         }
 
@@ -1222,15 +1260,15 @@
           }
 
           if (!failCount) {
-            setStatus('online', `Sync complete. ${okCount} reminder${okCount === 1 ? '' : 's'} updated.`);
+            setStatus('online', `Sync complete. ${okCount} updated.`);
           } else if (!okCount) {
-            setStatus('error', 'Sync failed. Please check your Apps Script URL and try again.');
+            setStatus('error', 'Sync failed. Check your sync URL and retry.');
           } else {
             setStatus('error', `Partial sync: ${okCount} success, ${failCount} failed.`);
           }
         } catch (error) {
           console.error('Sync failed', error);
-          setStatus('error', 'Sync failed. Please try again in a moment.');
+          setStatus('error', 'Sync failed. Try again soon.');
         } finally {
           toggleBusy(false);
         }

--- a/mobile.html
+++ b/mobile.html
@@ -33,6 +33,16 @@
       color: rgb(15 23 42);
       transition: all 0.2s ease;
     }
+    .navbar .flex-1 {
+      min-width: 0;
+    }
+    .navbar .sync-status {
+      max-width: min(60vw, 14rem);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      flex-shrink: 1;
+    }
     .dark .sync-status {
       border-color: rgba(148, 163, 184, 0.35);
       background: rgba(148, 163, 184, 0.15);
@@ -1047,6 +1057,24 @@
 
       let currentState = null;
 
+      const DEFAULT_MESSAGES = {
+        checking: 'Checking connection…',
+        syncing: 'Syncing your latest changes…',
+        online: 'Connected. Changes sync automatically.',
+        offline: "You're offline. Changes are saved on this device until you reconnect.",
+        error: "We couldn't sync right now. We'll retry soon.",
+        info: '',
+      };
+
+      const DISPLAY_MESSAGES = {
+        checking: 'Checking…',
+        syncing: 'Syncing…',
+        online: 'Synced. Auto-save on.',
+        offline: 'Offline. Saving locally.',
+        error: 'Sync issue. Retrying.',
+        info: '',
+      };
+
       const setStatus = (state, message) => {
         currentState = state;
         ACTIVE_CLASSES.forEach((cls) => syncStatusEl.classList.remove(cls));
@@ -1057,20 +1085,30 @@
           syncStatusEl.classList.add('error');
         }
 
-        const defaults = {
-          checking: 'Checking connection…',
-          syncing: 'Syncing your latest changes…',
-          online: 'Connected. Changes sync automatically.',
-          offline: "You're offline. Changes are saved on this device until you reconnect.",
-          error: "We couldn't sync right now. We'll retry soon.",
-          info: '',
-        };
+        const fullText =
+          typeof message === 'string' && message.trim()
+            ? message.trim()
+            : DEFAULT_MESSAGES[state] || '';
 
-        const text = typeof message === 'string' && message.trim() ? message : (defaults[state] || '');
-        if (text) {
-          syncStatusEl.textContent = text;
-        }
+        const displayText =
+          typeof message === 'string' && message.trim()
+            ? message.trim()
+            : DISPLAY_MESSAGES[state] || fullText;
+
+        syncStatusEl.textContent = displayText;
         syncStatusEl.dataset.state = state;
+
+        if (fullText) {
+          syncStatusEl.setAttribute('title', fullText);
+          if (displayText !== fullText) {
+            syncStatusEl.setAttribute('aria-label', fullText);
+          } else {
+            syncStatusEl.removeAttribute('aria-label');
+          }
+        } else {
+          syncStatusEl.removeAttribute('title');
+          syncStatusEl.removeAttribute('aria-label');
+        }
       };
 
       const updateOnlineState = () => {
@@ -1289,7 +1327,7 @@
         const value = (syncUrlInput?.value || '').trim();
         if (!value) {
           persistUrl('');
-          setStatus('info', 'Sync URL cleared. Add a new one to enable syncing.');
+          setStatus('info', 'Sync URL cleared. Add one to enable sync.');
           updateButtonState();
           return;
         }
@@ -1300,7 +1338,7 @@
             throw new Error('Invalid protocol');
           }
         } catch {
-          setStatus('error', 'Enter a valid Apps Script URL before saving.');
+          setStatus('error', 'Enter a valid sync URL before saving.');
           return;
         }
 
@@ -1312,7 +1350,7 @@
       testSyncBtn?.addEventListener('click', async () => {
         const url = (syncUrlInput?.value || getStoredUrl()).trim();
         if (!url) {
-          setStatus('error', 'Add your Apps Script URL in Settings first.');
+          setStatus('error', 'Add your sync URL in Settings first.');
           return;
         }
 
@@ -1328,11 +1366,11 @@
           if (response.ok) {
             setStatus('online', 'Connection looks good.');
           } else {
-            setStatus('error', 'Test failed. Please check your Apps Script deployment.');
+            setStatus('error', 'Test failed. Check your Apps Script deployment.');
           }
         } catch (error) {
           console.error('Test sync failed', error);
-          setStatus('error', 'Test failed. Please check your Apps Script deployment.');
+          setStatus('error', 'Test failed. Check your Apps Script deployment.');
         } finally {
           toggleBusy(false);
         }
@@ -1341,13 +1379,13 @@
       syncAllBtn?.addEventListener('click', async () => {
         const url = (syncUrlInput?.value || getStoredUrl()).trim();
         if (!url) {
-          setStatus('error', 'Add your Apps Script URL in Settings first.');
+          setStatus('error', 'Add your sync URL in Settings first.');
           return;
         }
 
         const reminders = collectReminders();
         if (!reminders.length) {
-          setStatus('info', 'No reminders to sync right now.');
+          setStatus('info', 'Nothing to sync right now.');
           return;
         }
 
@@ -1393,15 +1431,15 @@
           }
 
           if (!failCount) {
-            setStatus('online', `Sync complete. ${okCount} reminder${okCount === 1 ? '' : 's'} updated.`);
+            setStatus('online', `Sync complete. ${okCount} updated.`);
           } else if (!okCount) {
-            setStatus('error', 'Sync failed. Please check your Apps Script URL and try again.');
+            setStatus('error', 'Sync failed. Check your sync URL and retry.');
           } else {
             setStatus('error', `Partial sync: ${okCount} success, ${failCount} failed.`);
           }
         } catch (error) {
           console.error('Sync failed', error);
-          setStatus('error', 'Sync failed. Please try again in a moment.');
+          setStatus('error', 'Sync failed. Try again soon.');
         } finally {
           toggleBusy(false);
         }

--- a/mobile.js
+++ b/mobile.js
@@ -557,6 +557,25 @@ document.addEventListener('click', (ev) => {
   if (!syncStatusEl) return;
 
   const ACTIVE_CLASSES = ['online', 'error'];
+  const DEFAULT_MESSAGES = {
+    checking: 'Checking connection…',
+    syncing: 'Syncing your latest changes…',
+    online: 'Connected. Changes sync automatically.',
+    offline:
+      "You're offline. Changes are saved on this device until you reconnect.",
+    error: "We couldn't sync right now. We'll retry soon.",
+    info: '',
+  };
+
+  const DISPLAY_MESSAGES = {
+    checking: 'Checking…',
+    syncing: 'Syncing…',
+    online: 'Synced. Auto-save on.',
+    offline: 'Offline. Saving locally.',
+    error: 'Sync issue. Retrying.',
+    info: '',
+  };
+
   let currentState = null;
 
   function setStatus(state, message) {
@@ -569,19 +588,30 @@ document.addEventListener('click', (ev) => {
       syncStatusEl.classList.add('error');
     }
 
-    const defaultMessage = {
-      checking: 'Checking connection…',
-      syncing: 'Syncing your latest changes…',
-      online: 'Connected. Changes sync automatically.',
-      offline: "You're offline. Changes are saved on this device until you reconnect.",
-      error: "We couldn't sync right now. We'll retry soon.",
-      info: '',
-    };
+    const fullText =
+      typeof message === 'string' && message.trim()
+        ? message.trim()
+        : DEFAULT_MESSAGES[state] || '';
 
-    const text = typeof message === 'string' && message.trim() ? message : (defaultMessage[state] || '');
-    if (text) {
-      syncStatusEl.textContent = text;
+    const displayText =
+      typeof message === 'string' && message.trim()
+        ? message.trim()
+        : DISPLAY_MESSAGES[state] || fullText;
+
+    syncStatusEl.textContent = displayText;
+
+    if (fullText) {
+      syncStatusEl.setAttribute('title', fullText);
+      if (displayText !== fullText) {
+        syncStatusEl.setAttribute('aria-label', fullText);
+      } else {
+        syncStatusEl.removeAttribute('aria-label');
+      }
+    } else {
+      syncStatusEl.removeAttribute('title');
+      syncStatusEl.removeAttribute('aria-label');
     }
+
     syncStatusEl.dataset.state = state;
   }
 
@@ -795,7 +825,7 @@ document.addEventListener('click', (ev) => {
     const value = (syncUrlInput?.value || '').trim();
     if (!value) {
       persistUrl('');
-      setStatus('info', 'Sync URL cleared. Add a new one to enable syncing.');
+      setStatus('info', 'Sync URL cleared. Add one to enable sync.');
       updateButtonState();
       return;
     }
@@ -806,7 +836,7 @@ document.addEventListener('click', (ev) => {
         throw new Error('Invalid protocol');
       }
     } catch {
-      setStatus('error', 'Enter a valid Apps Script URL before saving.');
+      setStatus('error', 'Enter a valid sync URL before saving.');
       return;
     }
 
@@ -818,7 +848,7 @@ document.addEventListener('click', (ev) => {
   testSyncBtn?.addEventListener('click', async () => {
     const url = (syncUrlInput?.value || getStoredUrl()).trim();
     if (!url) {
-      setStatus('error', 'Add your Apps Script URL in Settings first.');
+      setStatus('error', 'Add your sync URL in Settings first.');
       return;
     }
 
@@ -834,11 +864,11 @@ document.addEventListener('click', (ev) => {
       if (response.ok) {
         setStatus('online', 'Connection looks good.');
       } else {
-        setStatus('error', 'Test failed. Please check your Apps Script deployment.');
+        setStatus('error', 'Test failed. Check your Apps Script deployment.');
       }
     } catch (error) {
       console.error('Test sync failed', error);
-      setStatus('error', 'Test failed. Please check your Apps Script deployment.');
+      setStatus('error', 'Test failed. Check your Apps Script deployment.');
     } finally {
       toggleBusy(false);
     }
@@ -847,13 +877,13 @@ document.addEventListener('click', (ev) => {
   syncAllBtn?.addEventListener('click', async () => {
     const url = (syncUrlInput?.value || getStoredUrl()).trim();
     if (!url) {
-      setStatus('error', 'Add your Apps Script URL in Settings first.');
+      setStatus('error', 'Add your sync URL in Settings first.');
       return;
     }
 
     const reminders = collectReminders();
     if (!reminders.length) {
-      setStatus('info', 'No reminders to sync right now.');
+      setStatus('info', 'Nothing to sync right now.');
       return;
     }
 
@@ -899,15 +929,15 @@ document.addEventListener('click', (ev) => {
       }
 
       if (!failCount) {
-        setStatus('online', `Sync complete. ${okCount} reminder${okCount === 1 ? '' : 's'} updated.`);
+        setStatus('online', `Sync complete. ${okCount} updated.`);
       } else if (!okCount) {
-        setStatus('error', 'Sync failed. Please check your Apps Script URL and try again.');
+        setStatus('error', 'Sync failed. Check your sync URL and retry.');
       } else {
         setStatus('error', `Partial sync: ${okCount} success, ${failCount} failed.`);
       }
     } catch (error) {
       console.error('Sync failed', error);
-      setStatus('error', 'Sync failed. Please try again in a moment.');
+      setStatus('error', 'Sync failed. Try again soon.');
     } finally {
       toggleBusy(false);
     }

--- a/styles/index.css
+++ b/styles/index.css
@@ -63,6 +63,18 @@ html {
   transition: all 0.2s ease;
 }
 
+.navbar .flex-1 {
+  min-width: 0;
+}
+
+.navbar .sync-status {
+  max-width: min(60vw, 14rem);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 1;
+}
+
 .sync-status.online {
   background: rgba(22, 163, 74, 0.12);
   color: rgb(22 163 74);


### PR DESCRIPTION
## Summary
- shorten the mobile sync status defaults while keeping the full copy available for assistive tech
- mirror the shorter messaging across the inline mobile demo scripts
- cap the navbar status pill width so long messages truncate instead of stretching the header

## Testing
- npm test -- --runTestsByPath sample.test.js

------
https://chatgpt.com/codex/tasks/task_e_6905a7850e688324b72ffa9fcdcf6f81