### PR TITLE
Add natural language quick add parsing

### DIFF
--- a/js/__tests__/reminders.quick-add.test.js
+++ b/js/__tests__/reminders.quick-add.test.js
@@ -1,0 +1,108 @@
+/** @jest-environment jsdom */
+
+const { beforeEach, afterEach, expect, test } = require('@jest/globals');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadRemindersModule() {
+  const filePath = path.resolve(__dirname, '../reminders.js');
+  let source = fs.readFileSync(filePath, 'utf8');
+  source = source.replace(/export\s+async\s+function\s+initReminders/, 'async function initReminders');
+  source += '\nmodule.exports = { initReminders };\n';
+  const module = { exports: {} };
+  const sandbox = {
+    module,
+    exports: module.exports,
+    require,
+    console,
+    setTimeout,
+    clearTimeout,
+    window,
+    document,
+    localStorage,
+    navigator,
+    Date,
+    fetch: global.fetch,
+    Blob: global.Blob,
+    Response: global.Response,
+    URL: global.URL,
+  };
+  vm.runInNewContext(source, sandbox, { filename: filePath });
+  return module.exports;
+}
+
+function createFirebaseStubs() {
+  return {
+    initializeApp: () => ({}),
+    initializeFirestore: () => ({}),
+    getFirestore: () => ({}),
+    enableMultiTabIndexedDbPersistence: () => Promise.resolve(),
+    enableIndexedDbPersistence: () => Promise.resolve(),
+    doc: () => ({}),
+    setDoc: () => Promise.resolve(),
+    deleteDoc: () => Promise.resolve(),
+    onSnapshot: () => () => {},
+    collection: () => ({}),
+    query: () => ({}),
+    orderBy: () => ({}),
+    persistentLocalCache: () => ({}),
+    serverTimestamp: () => ({}),
+    getAuth: () => ({}),
+    onAuthStateChanged: (_auth, callback) => { callback(null); },
+    GoogleAuthProvider: function GoogleAuthProviderStub() {},
+    signInWithPopup: () => Promise.resolve(),
+    signInWithRedirect: () => Promise.resolve(),
+    getRedirectResult: () => Promise.resolve(),
+    signOut: () => Promise.resolve(),
+  };
+}
+
+let controller;
+
+beforeEach(async () => {
+  jest.useFakeTimers({ now: Date.UTC(2024, 4, 15, 9, 0, 0) });
+  localStorage.clear();
+  document.body.innerHTML = `
+    <div id="status"></div>
+    <div id="remindersWrapper">
+      <div id="emptyState"></div>
+      <ul id="reminderList"></ul>
+    </div>
+    <input id="quickAddInput" />
+  `;
+
+  const { initReminders } = loadRemindersModule();
+  controller = await initReminders({
+    statusSel: '#status',
+    listWrapperSel: '#remindersWrapper',
+    emptyStateSel: '#emptyState',
+    listSel: '#reminderList',
+    firebaseDeps: createFirebaseStubs(),
+  });
+});
+
+afterEach(() => {
+  controller = null;
+  jest.useRealTimers();
+  localStorage.clear();
+  document.body.innerHTML = '';
+});
+
+test('quick add parses natural language time into due date', async () => {
+  const quickInput = document.getElementById('quickAddInput');
+  quickInput.value = 'Call parents tomorrow 1pm';
+
+  await window.memoryCueQuickAddNow();
+
+  const items = controller.__testing.getItems();
+  expect(items).toHaveLength(1);
+  const item = items[0];
+
+  const expected = new Date();
+  expected.setDate(expected.getDate() + 1);
+  expected.setHours(13, 0, 0, 0);
+  const expectedIso = expected.toISOString();
+
+  expect(item.due).toBe(expectedIso);
+});

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -293,10 +293,10 @@ export async function initReminders(sel = {}) {
     typeof document !== 'undefined' ? document.getElementById('quickAddVoiceBtn') : null;
   let stopQuickAddVoiceListening = null;
 
-  function buildQuickReminder(titleText) {
+  function buildQuickReminder(titleText, dueOverride) {
     const now = Date.now();
     const d = loadLastDefaults();
-    const dueIso = null;
+    const dueIso = typeof dueOverride === 'string' && dueOverride ? dueOverride : null;
 
     return {
       id: uid(),
@@ -322,7 +322,18 @@ export async function initReminders(sel = {}) {
     const t = (quickInput.value || '').trim();
     if (!t) return;
 
-    const entry = buildQuickReminder(t);
+    let quickDue = null;
+    try {
+      const parsedWhen = parseQuickWhen(t);
+      if (parsedWhen && parsedWhen.time) {
+        const isoCandidate = new Date(`${parsedWhen.date}T${parsedWhen.time}:00`).toISOString();
+        quickDue = isoCandidate;
+      }
+    } catch {
+      quickDue = null;
+    }
+
+    const entry = buildQuickReminder(t, quickDue);
     items.unshift(entry);
     suppressRenderMemoryEvent = true;
     render();


### PR DESCRIPTION
## Summary
- update the quick add reminder flow to parse natural language times and attach a due timestamp
- ensure the reminder builder accepts an explicit due override so parsed reminders retain scheduling
- add a focused Jest test that exercises the quick add parser while stubbing Firebase and propagating fake timers

## Testing
- npm test -- reminders.quick-add.test.js

------
https://chatgpt.com/codex/tasks/task_e_6905aa38e8bc8324bce954c885f3637a