### PR TITLE
Simplify mobile filter layout

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -431,52 +431,24 @@
           </p>
         </div>
       </section>
-      <!-- BEGIN GPT CHANGE: sticky filters -->
-      <div id="stickyFilters" style="position:sticky; top:56px; z-index: 10;">
-        <section id="reminderFilters" class="card bg-base-100 border">
-          <div class="card-body gap-4 compact">
-            <div class="flex flex-wrap items-center justify-between gap-3">
-              <div class="flex flex-wrap items-center gap-2" role="group" aria-label="Reminder filters">
-                <button class="btn btn-xs" type="button" data-filter="overdue" aria-pressed="false">Overdue · <span id="overdueCount">0</span></button>
-                <button class="btn btn-xs" type="button" data-filter="all" aria-pressed="true">All · <span id="totalCountBadge">0</span></button>
-                <button class="btn btn-xs" type="button" data-filter="done" aria-pressed="false">Done · <span id="completedCount">0</span></button>
-              </div>
-              <div class="flex flex-1 flex-col gap-2 sm:flex-row sm:items-center sm:justify-end sm:gap-3">
-                <label class="form-control w-full sm:w-auto">
-                  <div class="label hidden sm:flex"><span class="label-text">Sort reminders</span></div>
-                  <select id="sortReminders" class="select select-bordered select-sm">
-                    <option value="due" selected>Due Date (Today first)</option>
-                    <option value="priority">Priority</option>
-                    <option value="category">Category (A–Z)</option>
-                    <option value="recent">Recently Added</option>
-                  </select>
-                </label>
-                <label class="form-control w-full sm:w-auto">
-                  <div class="label hidden sm:flex"><span class="label-text">Category filter</span></div>
-                  <select id="categoryFilter" class="select select-bordered select-sm">
-                    <option value="all" selected>All categories</option>
-                    <option value="General">General</option>
-                    <option value="General Appointments">General Appointments</option>
-                    <option value="Home &amp; Personal">Home &amp; Personal</option>
-                    <option value="School – Appointments/Meetings">School – Appointments/Meetings</option>
-                    <option value="School – Communication &amp; Families">School – Communication &amp; Families</option>
-                    <option value="School – Excursions &amp; Events">School – Excursions &amp; Events</option>
-                    <option value="School – Grading &amp; Assessment">School – Grading &amp; Assessment</option>
-                    <option value="School – Prep &amp; Resources">School – Prep &amp; Resources</option>
-                    <option value="School – To-Do">School – To-Do</option>
-                    <option value="Wellbeing &amp; Support">Wellbeing &amp; Support</option>
-                  </select>
-                </label>
-              </div>
-            </div>
+      <!-- Compact Filters -->
+      <div class="flex flex-col gap-2 mb-2 nonFocusUI nonEssential">
+        <!-- Quick filter tabs -->
+        <div class="tabs tabs-boxed bg-base-200">
+          <button class="tab tab-xs" data-filter="all" aria-pressed="true">
+            All <span class="badge badge-xs ml-1" id="totalCountBadge">0</span>
+          </button>
+          <button class="tab tab-xs" data-filter="today" aria-pressed="false">
+            Today <span class="badge badge-xs ml-1" id="todayCount">0</span>
+          </button>
+          <button class="tab tab-xs" data-filter="overdue" aria-pressed="false">
+            Late <span class="badge badge-xs ml-1" id="overdueCount">0</span>
+          </button>
+        </div>
 
-            <label class="form-control">
-              <input id="searchReminders" type="search" class="input input-bordered" placeholder="Search reminders" aria-label="Search" />
-            </label>
-          </div>
-        </section>
+        <!-- Search input -->
+        <input id="searchReminders" type="search" class="input input-bordered input-sm" placeholder="Search reminders" aria-label="Search" />
       </div>
-      <!-- END GPT CHANGE -->
       <section id="reminderListSection" class="card bg-base-100 border">
         <div class="card-body gap-4 compact" id="remindersWrapper">
           <div id="emptyState" class="hidden text-center text-base-content/60"></div>


### PR DESCRIPTION
## Summary
- replace the bulky sticky filter card on the mobile docs page with a compact tabbed filter row and search input

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905c3f3f0cc8324ab01a318250d620b