### PR TITLE
Remove legacy floating controls from mobile layout

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -208,33 +208,6 @@
     .hidden {
       display: none !important;
     }
-    .fab {
-      position: fixed;
-      right: calc(16px + env(safe-area-inset-right));
-      bottom: calc(88px + env(safe-area-inset-bottom) + (var(--vh, 1vh) * 2));
-      width: 56px;
-      height: 56px;
-      border-radius: 50%;
-      font-size: 28px;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      background: var(--fallback-p, #2563eb);
-      color: var(--fallback-pc, #fff);
-      box-shadow: 0 10px 25px rgba(15, 23, 42, 0.2);
-      border: none;
-      cursor: pointer;
-      z-index: 80;
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
-    }
-    .fab:focus-visible {
-      outline: 2px solid currentColor;
-      outline-offset: 2px;
-    }
-    .fab:active {
-      transform: scale(0.96);
-      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.25);
-    }
     .sheet {
       position: fixed;
       inset: 0;
@@ -1092,20 +1065,6 @@
     <div class="modal-backdrop" data-close></div>
   </div>
   <!-- END GPT CHANGE: settings modal -->
-
-  <!-- BEGIN GPT CHANGE: global FAB -->
-  <button
-    id="fabCreate"
-    class="fab"
-    type="button"
-    aria-label="Add reminder"
-    aria-haspopup="dialog"
-    aria-controls="create-sheet"
-    aria-expanded="false"
-  >
-    ＋
-  </button>
-  <!-- END GPT CHANGE: global FAB -->
 
   <script id="mobile-enhancements">
     (function () {

--- a/mobile.js
+++ b/mobile.js
@@ -26,7 +26,6 @@ initViewportHeight();
 
     const sheetContent = sheet.querySelector('[data-dialog-content]');
     const backdrop = sheet.querySelector('.sheet-backdrop');
-    const fab = document.getElementById('fabCreate');
     const form = document.getElementById('createReminderForm');
     const saveBtn = document.getElementById('saveReminder');
     const prioritySelect = document.getElementById('priority');
@@ -36,7 +35,6 @@ initViewportHeight();
       : [];
 
     const openerSet = new Set([
-      ...(fab ? [fab] : []),
       ...Array.from(document.querySelectorAll('[data-open-add-task]')),
       ...Array.from(document.querySelectorAll('[aria-controls="createReminderModal"]')),
       ...Array.from(document.querySelectorAll('#addReminderFab')),
@@ -45,6 +43,7 @@ initViewportHeight();
     const openers = Array.from(openerSet).filter((button) =>
       button instanceof HTMLElement
     );
+    const defaultOpener = openers[0] || null;
 
     const ensureHidden = () => {
       sheet.classList.add('hidden');
@@ -118,10 +117,7 @@ initViewportHeight();
       sheet.setAttribute('open', '');
       sheet.classList.add('open');
 
-      if (fab) {
-        fab.setAttribute('aria-expanded', 'true');
-      }
-      if (lastTrigger && lastTrigger !== fab) {
+      if (lastTrigger) {
         lastTrigger.setAttribute('aria-expanded', 'true');
       }
 
@@ -135,15 +131,13 @@ initViewportHeight();
       const wasOpen = !sheet.classList.contains('hidden');
       ensureHidden();
 
-      if (fab) {
-        fab.setAttribute('aria-expanded', 'false');
-      }
-      if (lastTrigger && lastTrigger !== fab) {
+      if (lastTrigger) {
         lastTrigger.setAttribute('aria-expanded', 'false');
       }
 
       const focusTarget =
-        (lastTrigger && document.body.contains(lastTrigger) && lastTrigger) || fab;
+        (lastTrigger && document.body.contains(lastTrigger) && lastTrigger) ||
+        defaultOpener;
       if (focusTarget && typeof focusTarget.focus === 'function') {
         try {
           focusTarget.focus();


### PR DESCRIPTION
## Summary
- remove the old floating action button markup and styling from `mobile.html`
- update the sheet controller logic so focus management works without the floating button

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6905c5740c8483248fbb5baf442d13ab