### PR TITLE
Revamp Memory Cue dashboard UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,10 +88,10 @@
   <a class="skip-link" href="#mainContent">Skip to main content</a>
   <nav
     aria-label="Primary"
-    class="relative fixed top-0 z-50 w-full border-b border-base-200/70 bg-base-100/80 backdrop-blur"
+    class="relative fixed top-0 z-50 w-full border-b border-base-200/70 bg-base-100/85 backdrop-blur"
   >
     <div class="navbar mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-      <div class="navbar-start gap-2">
+      <div class="navbar-start gap-3">
         <button
           id="mobile-nav-toggle"
           type="button"
@@ -113,10 +113,18 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
           </svg>
         </button>
-        <a href="#dashboard" class="btn btn-ghost text-xl font-bold normal-case text-base-content">Memory Cue</a>
+        <a href="#dashboard" class="btn btn-ghost gap-2 text-left text-lg font-semibold normal-case text-base-content">
+          <span class="inline-flex size-9 items-center justify-center rounded-full bg-primary/15 text-primary">
+            MC
+          </span>
+          <span class="flex flex-col leading-tight">
+            <span>Memory Cue</span>
+            <span class="text-xs font-normal text-base-content/70">Balanced planning for busy teachers</span>
+          </span>
+        </a>
       </div>
       <div class="navbar-center nav-desktop hidden lg:flex">
-        <ul class="menu menu-horizontal gap-1 rounded-box bg-base-100/70 p-1 text-sm shadow-sm">
+        <ul class="menu menu-horizontal gap-1 rounded-full border border-base-200/80 bg-base-100/70 p-1 text-sm shadow-sm">
           <li>
             <a href="#dashboard" data-nav="dashboard" id="nav-dashboard" class="btn btn-sm btn-ghost">Dashboard</a>
           </li>
@@ -140,8 +148,13 @@
           </li>
         </ul>
       </div>
-      <div class="navbar-end">
+      <div class="navbar-end gap-2">
+        <div class="hidden flex-col text-right text-xs font-medium leading-tight text-base-content/60 lg:flex">
+          <span>Next prep window</span>
+          <span class="text-base-content">Today · 3:15 PM</span>
+        </div>
         <button id="theme-toggle" type="button" class="btn btn-sm btn-ghost text-base-content">Toggle theme</button>
+        <a href="#planner" class="btn btn-sm btn-primary hidden sm:inline-flex">Open planner</a>
       </div>
     </div>
     <div
@@ -150,7 +163,10 @@
       hidden
       class="absolute left-0 right-0 top-full z-40 gap-2 px-4 pb-4 sm:px-6 lg:hidden"
     >
-      <div class="rounded-box border border-base-200 bg-base-100/95 p-3 shadow-lg">
+      <div class="rounded-2xl border border-base-200/80 bg-base-100/95 p-4 shadow-xl">
+        <div class="mb-3 rounded-xl bg-base-200/80 p-3 text-sm text-base-content/70">
+          Set the tone for today and keep your planning in one place.
+        </div>
         <ul class="menu menu-vertical gap-1 text-base-content">
           <li><a href="#dashboard" data-nav="dashboard" class="btn btn-ghost justify-start">Dashboard</a></li>
           <li><a href="#reminders" data-nav="reminders" class="btn btn-ghost justify-start">Reminders</a></li>
@@ -160,112 +176,153 @@
           <li><a href="#templates" data-nav="templates" class="btn btn-ghost justify-start">Templates</a></li>
           <li><a href="#settings" data-nav="settings" class="btn btn-ghost justify-start">Settings</a></li>
         </ul>
+        <a href="#planner" class="btn btn-primary btn-sm mt-3 w-full">Jump into planner</a>
       </div>
     </div>
   </nav>
     <main id="mainContent" class="pt-24 min-h-screen" tabindex="-1">
     <div class="mx-auto max-w-6xl px-4 py-6 space-y-8">
-      <section data-route="dashboard" class="space-y-10">
+      <section data-route="dashboard" class="space-y-12">
         <div
-          class="relative overflow-hidden rounded-3xl border border-base-300 bg-gradient-to-br from-primary/10 via-base-100 to-base-200/60 p-8 text-left shadow-sm"
+          class="relative overflow-hidden rounded-3xl border border-base-300 bg-gradient-to-br from-primary/15 via-base-100 to-base-200/70 p-8 shadow-sm"
         >
-          <div class="pointer-events-none absolute -right-16 -top-16 h-48 w-48 rounded-full bg-primary/30 blur-3xl" aria-hidden="true"></div>
-          <div class="pointer-events-none absolute -bottom-20 left-1/3 h-56 w-56 rounded-full bg-secondary/20 blur-3xl" aria-hidden="true"></div>
-          <div class="relative flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
-            <div class="max-w-2xl space-y-5 text-left">
-              <span class="inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary/80">
-                <span aria-hidden="true">📅</span>
-                Today's plan at a glance
+          <div class="pointer-events-none absolute -top-24 left-1/2 h-64 w-64 -translate-x-1/2 rounded-full bg-secondary/20 blur-3xl" aria-hidden="true"></div>
+          <div class="pointer-events-none absolute bottom-[-6rem] right-[-4rem] h-72 w-72 rounded-full bg-primary/30 blur-3xl" aria-hidden="true"></div>
+          <div class="relative grid gap-8 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:items-center">
+            <div class="space-y-6">
+              <span class="inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-primary/80">
+                <span aria-hidden="true">✨</span>
+                A clear start to your day
               </span>
-              <h1 class="text-3xl font-semibold text-base-content sm:text-4xl">Welcome back to Memory Cue</h1>
-              <p class="text-base-content/80">
-                Stay centred on what matters most. Jump straight into your planner, tidy up reminders, and keep resources close without juggling different tabs.
+              <h1 class="text-3xl font-semibold text-base-content sm:text-4xl">
+                Settle into teaching with a focused, organised workspace
+              </h1>
+              <p class="max-w-2xl text-base text-base-content/80">
+                Memory Cue keeps reminders, planning, and quick wins together so you can move from intention to action without searching across tools.
               </p>
               <div class="flex flex-wrap gap-3">
-                <a href="#planner" class="btn btn-primary btn-sm sm:btn-md">Plan the week</a>
+                <a href="#planner" class="btn btn-primary btn-sm sm:btn-md">Start planning</a>
                 <a href="#reminders" class="btn btn-outline btn-sm sm:btn-md">Review reminders</a>
+                <a href="#resources" class="btn btn-ghost btn-sm sm:btn-md">Browse resources</a>
               </div>
+              <dl class="grid gap-3 text-sm text-base-content/70 sm:grid-cols-2 xl:grid-cols-3">
+                <div class="rounded-2xl border border-base-200 bg-base-100/80 p-4 shadow-sm">
+                  <dt class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/50">Lessons ready</dt>
+                  <dd class="mt-1 text-base font-semibold text-base-content">4 this week</dd>
+                </div>
+                <div class="rounded-2xl border border-base-200 bg-base-100/80 p-4 shadow-sm">
+                  <dt class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/50">Reminders resolved</dt>
+                  <dd class="mt-1 text-base font-semibold text-base-content">6 cleared</dd>
+                </div>
+                <div class="rounded-2xl border border-base-200 bg-base-100/80 p-4 shadow-sm">
+                  <dt class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/50">Families updated</dt>
+                  <dd class="mt-1 text-base font-semibold text-base-content">2 notes sent</dd>
+                </div>
+              </dl>
             </div>
-            <div class="w-full max-w-sm rounded-2xl border border-base-300 bg-base-100/80 p-6 shadow-sm backdrop-blur">
-              <h2 class="text-sm font-semibold uppercase tracking-wide text-base-content/70">Momentum checklist</h2>
-              <ul class="mt-4 space-y-3 text-sm text-base-content/80">
+            <div class="relative rounded-2xl border border-base-300 bg-base-100/85 p-6 shadow-sm backdrop-blur">
+              <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Daily snapshot</h2>
+              <ul class="mt-5 space-y-4 text-sm text-base-content/80">
                 <li class="flex items-start gap-3">
-                  <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-primary">1</span>
-                  Refresh today's focus and confirm key reminders.
+                  <span class="mt-1 inline-flex h-8 w-8 items-center justify-center rounded-full bg-primary/15 text-sm font-semibold text-primary">
+                    09
+                  </span>
+                  <div>
+                    <p class="font-medium text-base-content">Group reading circles</p>
+                    <p class="text-xs text-base-content/60">Period 2 · Comprehension focus</p>
+                  </div>
                 </li>
                 <li class="flex items-start gap-3">
-                  <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-secondary/15 text-secondary">2</span>
-                  Slot lesson highlights into the planner to spot gaps early.
+                  <span class="mt-1 inline-flex h-8 w-8 items-center justify-center rounded-full bg-secondary/15 text-sm font-semibold text-secondary">
+                    11
+                  </span>
+                  <div>
+                    <p class="font-medium text-base-content">STEM lab check-in</p>
+                    <p class="text-xs text-base-content/60">Confirm robotics kit setup</p>
+                  </div>
                 </li>
                 <li class="flex items-start gap-3">
-                  <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-accent/15 text-accent">3</span>
-                  Pin resources or templates you'll reuse this week.
+                  <span class="mt-1 inline-flex h-8 w-8 items-center justify-center rounded-full bg-accent/15 text-sm font-semibold text-accent">
+                    15
+                  </span>
+                  <div>
+                    <p class="font-medium text-base-content">Family updates</p>
+                    <p class="text-xs text-base-content/60">Send check-in note before home time</p>
+                  </div>
                 </li>
               </ul>
+              <div class="mt-6 rounded-2xl border border-dashed border-base-200 bg-base-200/60 p-4 text-xs text-base-content/70">
+                <p class="font-semibold uppercase tracking-[0.3em] text-base-content/50">Shortcut</p>
+                <p class="mt-1">Press <kbd class="kbd kbd-sm">Shift</kbd><span class="mx-1">+</span><kbd class="kbd kbd-sm">K</kbd> for quick actions anywhere in the app.</p>
+              </div>
             </div>
           </div>
         </div>
 
         <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-          <article class="card border border-base-300 bg-base-200/80 shadow-sm">
+          <article class="card border border-base-300 bg-base-200/80 shadow-sm transition hover:-translate-y-1 hover:shadow">
             <div class="card-body gap-3 p-5">
               <div class="flex items-center justify-between text-base-content/80">
-                <p class="text-xs font-semibold uppercase tracking-[0.2em]">Reminders</p>
+                <p class="text-xs font-semibold uppercase tracking-[0.3em]">Reminders</p>
                 <span aria-hidden="true">🔔</span>
               </div>
-              <p class="text-3xl font-semibold text-base-content">0</p>
-              <p class="text-sm text-base-content/70">Scheduled for today</p>
+              <p class="text-3xl font-semibold text-base-content">3</p>
+              <p class="text-sm text-base-content/70">Due before midday</p>
             </div>
           </article>
-          <article class="card border border-base-300 bg-base-200/80 shadow-sm">
+          <article class="card border border-base-300 bg-base-200/80 shadow-sm transition hover:-translate-y-1 hover:shadow">
             <div class="card-body gap-3 p-5">
               <div class="flex items-center justify-between text-base-content/80">
-                <p class="text-xs font-semibold uppercase tracking-[0.2em]">Lessons</p>
+                <p class="text-xs font-semibold uppercase tracking-[0.3em]">Planner</p>
                 <span aria-hidden="true">🗂️</span>
               </div>
-              <p class="text-3xl font-semibold text-base-content">0</p>
-              <p class="text-sm text-base-content/70">Prepared this week</p>
+              <p class="text-3xl font-semibold text-base-content">5</p>
+              <p class="text-sm text-base-content/70">Lessons ready to go</p>
             </div>
           </article>
-          <article class="card border border-base-300 bg-base-200/80 shadow-sm">
+          <article class="card border border-base-300 bg-base-200/80 shadow-sm transition hover:-translate-y-1 hover:shadow">
             <div class="card-body gap-3 p-5">
               <div class="flex items-center justify-between text-base-content/80">
-                <p class="text-xs font-semibold uppercase tracking-[0.2em]">Resources</p>
+                <p class="text-xs font-semibold uppercase tracking-[0.3em]">Resources</p>
                 <span aria-hidden="true">📁</span>
               </div>
-              <p class="text-3xl font-semibold text-base-content">0</p>
-              <p class="text-sm text-base-content/70">Waiting for review</p>
+              <p class="text-3xl font-semibold text-base-content">12</p>
+              <p class="text-sm text-base-content/70">Tagged for this term</p>
             </div>
           </article>
-          <article class="card border border-base-300 bg-base-200/80 shadow-sm">
+          <article class="card border border-base-300 bg-base-200/80 shadow-sm transition hover:-translate-y-1 hover:shadow">
             <div class="card-body gap-3 p-5">
               <div class="flex items-center justify-between text-base-content/80">
-                <p class="text-xs font-semibold uppercase tracking-[0.2em]">Templates</p>
+                <p class="text-xs font-semibold uppercase tracking-[0.3em]">Templates</p>
                 <span aria-hidden="true">🧩</span>
               </div>
-              <p class="text-3xl font-semibold text-base-content">0</p>
-              <p class="text-sm text-base-content/70">Ready to reuse</p>
+              <p class="text-3xl font-semibold text-base-content">8</p>
+              <p class="text-sm text-base-content/70">Pinned for quick reuse</p>
             </div>
           </article>
         </div>
 
-        <div class="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1.2fr)]">
+        <div class="grid gap-6 xl:grid-cols-[minmax(0,1.8fr)_minmax(0,1.1fr)]">
           <section class="card border border-base-300 bg-base-200/70 shadow-sm">
-            <div class="card-body gap-5">
+            <div class="card-body gap-6">
               <div class="flex flex-wrap items-start justify-between gap-4">
-                <div class="space-y-2">
+                <div class="space-y-3">
                   <h2 class="text-lg font-semibold text-base-content">Today's focus</h2>
                   <p class="text-sm text-base-content/70">
-                    Group reading circles with comprehension checkpoints to spot early wins and quick supports.
+                    Keep literacy collaborative, celebrate small wins, and capture anything that needs follow up before the afternoon rush.
                   </p>
-                  <dl class="flex flex-wrap gap-4 text-xs text-base-content/60">
+                  <dl class="flex flex-wrap gap-3 text-xs text-base-content/60">
                     <div class="flex items-center gap-2">
-                      <dt class="font-semibold uppercase tracking-widest">Focus area</dt>
-                      <dd class="rounded-full bg-base-100 px-3 py-1 text-base-content/80">Literacy collaboration</dd>
+                      <dt class="font-semibold uppercase tracking-[0.3em]">Focus area</dt>
+                      <dd class="rounded-full bg-base-100 px-3 py-1 text-base-content/80">Literacy workshops</dd>
                     </div>
                     <div class="flex items-center gap-2">
-                      <dt class="font-semibold uppercase tracking-widest">Time block</dt>
-                      <dd class="rounded-full bg-base-100 px-3 py-1 text-base-content/80">Period 2 &middot; 45 mins</dd>
+                      <dt class="font-semibold uppercase tracking-[0.3em]">Time block</dt>
+                      <dd class="rounded-full bg-base-100 px-3 py-1 text-base-content/80">Period 2 · 45 mins</dd>
+                    </div>
+                    <div class="flex items-center gap-2">
+                      <dt class="font-semibold uppercase tracking-[0.3em]">Support</dt>
+                      <dd class="rounded-full bg-base-100 px-3 py-1 text-base-content/80">Co-teach with Mia</dd>
                     </div>
                   </dl>
                 </div>
@@ -281,8 +338,10 @@
               <ol class="space-y-3">
                 <li class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
                   <div class="space-y-1">
-                    <p class="font-medium text-base-content"><span class="font-semibold">Send excursion reminder</span></p>
-                    <time class="text-sm text-base-content/70" datetime="2024-04-18T09:30">Before 9:30 AM</time>
+                    <p class="font-medium text-base-content">
+                      <span class="font-semibold">Send excursion reminder</span>
+                    </p>
+                    <time class="text-sm text-base-content/70" datetime="2024-04-18T09:30">Before 9:30 AM · Families group</time>
                   </div>
                   <div class="flex flex-wrap gap-2">
                     <button class="btn btn-sm btn-success" type="button">Mark done</button>
@@ -291,14 +350,18 @@
                 </li>
                 <li class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
                   <div class="space-y-1">
-                    <p class="font-medium text-base-content"><span class="font-semibold">Prep science lab</span></p>
-                    <p class="text-sm text-base-content/70">Room 204 &middot; Period 3</p>
+                    <p class="font-medium text-base-content">
+                      <span class="font-semibold">Prep science lab</span>
+                    </p>
+                    <p class="text-sm text-base-content/70">Room 204 · Check goggles + robotics sets</p>
                   </div>
                   <span class="badge badge-outline text-primary">Lab</span>
                 </li>
                 <li class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
                   <div class="space-y-1">
-                    <p class="font-medium text-base-content"><span class="font-semibold">Call guardians</span></p>
+                    <p class="font-medium text-base-content">
+                      <span class="font-semibold">Call guardians</span>
+                    </p>
                     <p class="text-sm text-base-content/70">Follow up on field trip slips</p>
                   </div>
                   <span class="badge badge-outline text-error">High</span>
@@ -308,122 +371,182 @@
           </section>
 
           <section class="card h-full border border-base-300 bg-base-200/70 shadow-sm">
-            <div class="card-body gap-4">
+            <div class="card-body gap-5">
               <div class="flex flex-wrap items-center justify-between gap-3">
-                <h2 class="text-lg font-semibold text-base-content">This week</h2>
+                <h2 class="text-lg font-semibold text-base-content">Week at a glance</h2>
                 <div class="join">
                   <button class="btn btn-sm join-item" type="button">Prev</button>
                   <button class="btn btn-sm btn-primary join-item" type="button">Today</button>
                   <button class="btn btn-sm join-item" type="button">Next</button>
                 </div>
               </div>
-              <ul class="space-y-3">
-                <li class="flex flex-col gap-2 rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm">
-                  <div class="flex items-center justify-between gap-3">
-                    <p class="font-medium text-base-content">Mon</p>
-                    <span class="badge badge-outline text-primary">Ready</span>
+              <ol class="relative space-y-4 before:absolute before:left-4 before:top-2 before:h-[calc(100%-1rem)] before:w-px before:bg-base-300/60">
+                <li class="relative flex gap-4 rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm">
+                  <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary">Mon</span>
+                  <div class="space-y-1 text-sm">
+                    <p class="font-semibold text-base-content">Stage rehearsal</p>
+                    <p class="text-base-content/70">Auditorium · Checklist ready</p>
+                    <span class="badge badge-outline badge-sm text-primary">Ready</span>
                   </div>
-                  <p class="text-sm text-base-content/70">Stage rehearsal &middot; Auditorium</p>
                 </li>
-                <li class="flex flex-col gap-2 rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm">
-                  <div class="flex items-center justify-between gap-3">
-                    <p class="font-medium text-base-content">Tue</p>
-                    <span class="badge badge-outline text-secondary">In prep</span>
+                <li class="relative flex gap-4 rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm">
+                  <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-secondary/15 text-xs font-semibold text-secondary">Tue</span>
+                  <div class="space-y-1 text-sm">
+                    <p class="font-semibold text-base-content">STEM lab rotations</p>
+                    <p class="text-base-content/70">Robotics challenges</p>
+                    <span class="badge badge-outline badge-sm text-secondary">In prep</span>
                   </div>
-                  <p class="text-sm text-base-content/70">STEM lab rotations</p>
                 </li>
-                <li class="flex flex-col gap-2 rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm">
-                  <div class="flex items-center justify-between gap-3">
-                    <p class="font-medium text-base-content">Wed</p>
-                    <span class="badge badge-outline text-warning">Confirm</span>
+                <li class="relative flex gap-4 rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm">
+                  <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-warning/15 text-xs font-semibold text-warning">Wed</span>
+                  <div class="space-y-1 text-sm">
+                    <p class="font-semibold text-base-content">Parent interviews</p>
+                    <p class="text-base-content/70">3:00 – 6:00 PM · Prep student snapshots</p>
+                    <span class="badge badge-outline badge-sm text-warning">Confirm</span>
                   </div>
-                  <p class="text-sm text-base-content/70">Parent interviews (3-6 PM)</p>
                 </li>
-                <li class="flex flex-col gap-2 rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm">
-                  <div class="flex items-center justify-between gap-3">
-                    <p class="font-medium text-base-content">Thu</p>
-                    <span class="badge badge-outline text-accent">Shared</span>
+                <li class="relative flex gap-4 rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm">
+                  <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-accent/15 text-xs font-semibold text-accent">Thu</span>
+                  <div class="space-y-1 text-sm">
+                    <p class="font-semibold text-base-content">Lesson study</p>
+                    <p class="text-base-content/70">Staffroom · Shared facilitation</p>
+                    <span class="badge badge-outline badge-sm text-accent">Shared</span>
                   </div>
-                  <p class="text-sm text-base-content/70">Lesson study &middot; Staffroom</p>
                 </li>
-              </ul>
+              </ol>
             </div>
           </section>
         </div>
 
-        <section class="card border border-base-300 bg-base-200/70 shadow-sm">
-          <div class="card-body gap-3">
-            <div class="flex flex-wrap items-center justify-between gap-3">
-              <h2 class="text-lg font-semibold text-base-content">Pinned notes</h2>
-              <button class="btn btn-sm btn-primary" type="button">New note</button>
+        <div class="grid gap-6 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
+          <section class="card border border-base-300 bg-base-200/70 shadow-sm">
+            <div class="card-body gap-4">
+              <div class="flex flex-wrap items-center justify-between gap-3">
+                <h2 class="text-lg font-semibold text-base-content">Pinned notes</h2>
+                <button class="btn btn-sm btn-primary" type="button">New note</button>
+              </div>
+              <ul class="space-y-3">
+                <li class="rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm">
+                  <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div class="space-y-1">
+                      <p class="font-medium text-base-content">Year 8 group goals</p>
+                      <p class="text-sm text-base-content/70">Focus on inquiry questions for Friday.</p>
+                    </div>
+                    <div class="flex flex-wrap gap-2">
+                      <button class="btn btn-sm btn-outline" type="button">Open</button>
+                      <button class="btn btn-sm btn-ghost" type="button">Share</button>
+                    </div>
+                  </div>
+                </li>
+                <li class="rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm">
+                  <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div class="space-y-1">
+                      <p class="font-medium text-base-content">Camps &amp; excursions</p>
+                      <p class="text-sm text-base-content/70">Confirm transport numbers with admin.</p>
+                    </div>
+                    <div class="flex flex-wrap gap-2">
+                      <button class="btn btn-sm btn-outline" type="button">Pin</button>
+                      <button class="btn btn-sm btn-ghost" type="button">Archive</button>
+                    </div>
+                  </div>
+                </li>
+              </ul>
             </div>
-            <ul class="space-y-3">
-              <li class="rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm">
-                <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                  <div>
-                    <p class="font-medium text-base-content">Year 8 group goals</p>
-                    <p class="text-sm text-base-content/70">Focus on inquiry questions for Friday.</p>
-                  </div>
-                  <button class="btn btn-sm btn-outline" type="button">Open</button>
-                </div>
-              </li>
-              <li class="rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm">
-                <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                  <div>
-                    <p class="font-medium text-base-content">Camps &amp; excursions</p>
-                    <p class="text-sm text-base-content/70">Confirm transport numbers with admin.</p>
-                  </div>
-                  <button class="btn btn-sm btn-outline" type="button">Pin</button>
-                </div>
-              </li>
-            </ul>
-          </div>
-        </section>
+          </section>
 
-        <section class="card border border-base-300 bg-base-200/70 shadow-sm">
-          <div class="card-body gap-4">
-            <div class="flex flex-wrap items-center justify-between gap-2">
-              <h2 class="text-lg font-semibold text-base-content">Quick links</h2>
-              <span class="text-xs uppercase tracking-[0.3em] text-base-content/50">Jump back in</span>
+          <section class="card border border-base-300 bg-base-200/70 shadow-sm">
+            <div class="card-body gap-5">
+              <div class="flex flex-wrap items-center justify-between gap-2">
+                <h2 class="text-lg font-semibold text-base-content">Action shortcuts</h2>
+                <span class="text-xs uppercase tracking-[0.3em] text-base-content/50">Jump back in</span>
+              </div>
+              <div class="grid gap-2 sm:grid-cols-2">
+                <a href="#reminders" class="btn btn-sm btn-outline justify-start gap-2" data-nav="reminders">
+                  <span aria-hidden="true">🔔</span>
+                  Open reminders
+                </a>
+                <a href="#planner" class="btn btn-sm btn-outline justify-start gap-2" data-nav="planner">
+                  <span aria-hidden="true">🗓️</span>
+                  Weekly planner
+                </a>
+                <a href="#notes" class="btn btn-sm btn-outline justify-start gap-2" data-nav="notes">
+                  <span aria-hidden="true">📝</span>
+                  Daily notes
+                </a>
+                <a href="#resources" class="btn btn-sm btn-outline justify-start gap-2" data-nav="resources">
+                  <span aria-hidden="true">📚</span>
+                  Resource library
+                </a>
+              </div>
+              <div class="rounded-2xl border border-dashed border-base-300 bg-base-100/70 p-4 text-sm text-base-content/80">
+                <p class="font-medium text-base-content">Need inspiration?</p>
+                <p class="mt-1">
+                  Open the activity ideas modal from the quick action toolbar to gather ready-to-run activities tailored to your class context.
+                </p>
+              </div>
             </div>
-            <div class="flex flex-wrap gap-2">
-              <a href="#reminders" class="btn btn-sm btn-outline" data-nav="reminders">Open reminders</a>
-              <a href="#planner" class="btn btn-sm btn-outline" data-nav="planner">Weekly planner</a>
-              <a href="#notes" class="btn btn-sm btn-outline" data-nav="notes">Daily notes</a>
-              <a href="#resources" class="btn btn-sm btn-outline" data-nav="resources">Resource library</a>
-            </div>
-            <div class="rounded-2xl border border-dashed border-base-300 bg-base-100/60 p-4 text-sm text-base-content/80">
-              <p class="font-medium text-base-content">Need inspiration?</p>
-              <p class="mt-1">
-                Open the activity ideas modal from the quick actions to gather ready-to-run activities tailored to your class.
-              </p>
-            </div>
-          </div>
-        </section>
+          </section>
+        </div>
       </section>
 
       <section data-route="reminders" class="space-y-6" style="display: none;">
         <header class="space-y-2">
           <h1 class="text-2xl font-semibold text-base-content">Reminders</h1>
-          <p class="text-base-content/70">Keep track of tasks, parent follow-ups, and quick wins.</p>
+          <p class="text-base-content/70">Keep track of tasks, family updates, and prep work in one organised list.</p>
         </header>
+        <div class="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-200/70 p-4 shadow-sm">
+          <div class="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">
+            <span class="rounded-full bg-base-100 px-3 py-1 text-base-content/70">All</span>
+            <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Today</button>
+            <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">This week</button>
+            <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Later</button>
+          </div>
+          <button type="button" class="btn btn-sm btn-outline">Add reminder</button>
+        </div>
         <ul class="space-y-3">
-          <li class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200/70 p-5 shadow-sm sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <p class="font-medium text-base-content"><span class="font-semibold">Submit unit overview</span></p>
-              <p class="text-sm text-base-content/70">Due Friday &middot; Curriculum team</p>
+          <li class="rounded-2xl border border-base-300 bg-base-200/70 p-5 shadow-sm">
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div class="space-y-1">
+                <p class="font-medium text-base-content">
+                  <span class="font-semibold">Submit unit overview</span>
+                </p>
+                <p class="text-sm text-base-content/70">Due Friday · Curriculum team</p>
+              </div>
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="badge badge-outline text-warning">Due soon</span>
+                <button class="btn btn-sm btn-success" type="button">Complete</button>
+                <button class="btn btn-sm btn-outline" type="button">Snooze</button>
+              </div>
             </div>
-            <div class="flex gap-2">
-              <button class="btn btn-sm btn-success" type="button">Complete</button>
-              <button class="btn btn-sm btn-outline" type="button">Snooze</button>
+            <p class="mt-3 text-sm text-base-content/60">Attach the new literacy checkpoints before sending.</p>
+          </li>
+          <li class="rounded-2xl border border-base-300 bg-base-200/70 p-5 shadow-sm">
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div class="space-y-1">
+                <p class="font-medium text-base-content">
+                  <span class="font-semibold">Email newsletter blurb</span>
+                </p>
+                <p class="text-sm text-base-content/70">Add upcoming excursions to the weekly update.</p>
+              </div>
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="badge badge-outline text-secondary">This week</span>
+                <button class="btn btn-sm btn-outline" type="button">Open notes</button>
+              </div>
             </div>
           </li>
-          <li class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200/70 p-5 shadow-sm sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <p class="font-medium text-base-content"><span class="font-semibold">Email newsletter blurb</span></p>
-              <p class="text-sm text-base-content/70">Add upcoming excursions to the weekly update.</p>
+          <li class="rounded-2xl border border-base-300 bg-base-200/70 p-5 shadow-sm">
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div class="space-y-1">
+                <p class="font-medium text-base-content">
+                  <span class="font-semibold">Call guardians</span>
+                </p>
+                <p class="text-sm text-base-content/70">Follow up on field trip permissions · Family liaison</p>
+              </div>
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="badge badge-outline text-error">High priority</span>
+                <button class="btn btn-sm btn-outline" type="button">Log call</button>
+              </div>
             </div>
-            <span class="badge badge-outline text-secondary">This week</span>
           </li>
         </ul>
       </section>
@@ -431,27 +554,93 @@
       <section data-route="planner" class="space-y-6" style="display: none;">
         <header class="space-y-2">
           <h1 class="text-2xl font-semibold text-base-content">Weekly planner</h1>
-          <p class="text-base-content/70">Draft the key lessons and checkpoints for your classes.</p>
+          <p class="text-base-content/70">Draft the key lessons, checkpoints, and resources your classes need this week.</p>
         </header>
+        <div class="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-200/70 p-4 shadow-sm">
+          <div class="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">
+            <span class="rounded-full bg-base-100 px-3 py-1 text-base-content/70">Week 7</span>
+            <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Week 8</button>
+            <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Week 9</button>
+          </div>
+          <div class="flex flex-wrap items-center gap-2">
+            <button type="button" class="btn btn-sm btn-outline">Duplicate plan</button>
+            <button type="button" class="btn btn-sm btn-primary">New lesson</button>
+          </div>
+        </div>
         <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-          <article class="card border border-base-300 bg-base-200/70 shadow-sm">
-            <div class="card-body gap-3">
-              <h2 class="text-lg font-semibold text-base-content">Monday</h2>
-              <p class="text-sm text-base-content/70">Co-teach literacy rotations with Mia. Collect exit slips.</p>
-            <button class="btn btn-sm btn-outline" type="button">Add detail</button>
-            </div>
-          </article>
-          <article class="card border border-base-300 bg-base-200/70 shadow-sm">
-            <div class="card-body gap-3">
-              <h2 class="text-lg font-semibold text-base-content">Tuesday</h2>
-              <p class="text-sm text-base-content/70">STEM lab &ndash; robotics challenges for groups A &amp; B.</p>
+          <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow">
+            <div class="card-body gap-4">
+              <div>
+                <h2 class="text-lg font-semibold text-base-content">Monday</h2>
+                <p class="text-sm text-base-content/70">Co-teach literacy rotations with Mia. Collect exit slips.</p>
+              </div>
+              <ul class="space-y-2 text-sm text-base-content/70">
+                <li class="flex items-center gap-2">
+                  <span class="badge badge-outline badge-sm text-primary">Workshop</span>
+                  Shared reading focus · 45 mins
+                </li>
+                <li class="flex items-center gap-2">
+                  <span class="badge badge-outline badge-sm text-secondary">Prep</span>
+                  Print small group checklists
+                </li>
+              </ul>
               <button class="btn btn-sm btn-outline" type="button">Add detail</button>
             </div>
           </article>
-          <article class="card border border-base-300 bg-base-200/70 shadow-sm">
-            <div class="card-body gap-3">
-              <h2 class="text-lg font-semibold text-base-content">Wednesday</h2>
-              <p class="text-sm text-base-content/70">Parent interviews from 3 PM. Prepare student snapshots.</p>
+          <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow">
+            <div class="card-body gap-4">
+              <div>
+                <h2 class="text-lg font-semibold text-base-content">Tuesday</h2>
+                <p class="text-sm text-base-content/70">STEM lab – robotics challenges for groups A &amp; B.</p>
+              </div>
+              <ul class="space-y-2 text-sm text-base-content/70">
+                <li class="flex items-center gap-2">
+                  <span class="badge badge-outline badge-sm text-accent">Lab</span>
+                  Calibrate sensors before class
+                </li>
+                <li class="flex items-center gap-2">
+                  <span class="badge badge-outline badge-sm text-warning">Check-in</span>
+                  Collect student reflections in Notes
+                </li>
+              </ul>
+              <button class="btn btn-sm btn-outline" type="button">Add detail</button>
+            </div>
+          </article>
+          <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow">
+            <div class="card-body gap-4">
+              <div>
+                <h2 class="text-lg font-semibold text-base-content">Wednesday</h2>
+                <p class="text-sm text-base-content/70">Parent interviews from 3 PM. Prepare student snapshots.</p>
+              </div>
+              <ul class="space-y-2 text-sm text-base-content/70">
+                <li class="flex items-center gap-2">
+                  <span class="badge badge-outline badge-sm text-secondary">Families</span>
+                  Finalise progress highlights
+                </li>
+                <li class="flex items-center gap-2">
+                  <span class="badge badge-outline badge-sm text-primary">Reminder</span>
+                  Email timetable to staff
+                </li>
+              </ul>
+              <button class="btn btn-sm btn-outline" type="button">Add detail</button>
+            </div>
+          </article>
+          <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow">
+            <div class="card-body gap-4">
+              <div>
+                <h2 class="text-lg font-semibold text-base-content">Thursday</h2>
+                <p class="text-sm text-base-content/70">Lesson study · co-design inquiry prompts with team.</p>
+              </div>
+              <ul class="space-y-2 text-sm text-base-content/70">
+                <li class="flex items-center gap-2">
+                  <span class="badge badge-outline badge-sm text-success">Collab</span>
+                  Align goals with team rubric
+                </li>
+                <li class="flex items-center gap-2">
+                  <span class="badge badge-outline badge-sm text-info">Resource</span>
+                  Attach planning template
+                </li>
+              </ul>
               <button class="btn btn-sm btn-outline" type="button">Add detail</button>
             </div>
           </article>
@@ -461,91 +650,213 @@
       <section data-route="notes" class="space-y-6" style="display: none;">
         <header class="space-y-2">
           <h1 class="text-2xl font-semibold text-base-content">Notes</h1>
-          <p class="text-base-content/70">Capture observations and quick wins to revisit later.</p>
+          <p class="text-base-content/70">Capture observations, behaviour wins, and quick reflections to revisit later.</p>
         </header>
-        <div class="space-y-3">
+        <div class="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-200/70 p-4 shadow-sm">
+          <div class="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">
+            <span class="rounded-full bg-base-100 px-3 py-1 text-base-content/70">Pinned</span>
+            <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Class</button>
+            <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Student</button>
+            <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Ideas</button>
+          </div>
+          <button type="button" class="btn btn-sm btn-primary">New note</button>
+        </div>
+        <div class="grid gap-3 md:grid-cols-2">
           <article class="card border border-base-300 bg-base-200/70 shadow-sm">
-            <div class="card-body gap-3">
-              <h2 class="text-lg font-semibold text-base-content">Maths group reflection</h2>
-              <p class="text-sm text-base-content/70">Students responded well to manipulatives; revisit fractions model next week.</p>
-              <button class="btn btn-sm btn-outline self-start" type="button">Archive</button>
+            <div class="card-body gap-4">
+              <div class="space-y-2">
+                <h2 class="text-lg font-semibold text-base-content">Maths group reflection</h2>
+                <p class="text-sm text-base-content/70">Students responded well to manipulatives; revisit fractions model next week.</p>
+              </div>
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="badge badge-outline text-primary">Strategy</span>
+                <button class="btn btn-sm btn-outline" type="button">Archive</button>
+              </div>
             </div>
           </article>
           <article class="card border border-base-300 bg-base-200/70 shadow-sm">
-            <div class="card-body gap-3">
-              <h2 class="text-lg font-semibold text-base-content">Student wellbeing</h2>
-              <p class="text-sm text-base-content/70">Check in with Aidan about new seating plan and group expectations.</p>
-              <button class="btn btn-sm btn-outline self-start" type="button">Pin</button>
+            <div class="card-body gap-4">
+              <div class="space-y-2">
+                <h2 class="text-lg font-semibold text-base-content">Student wellbeing</h2>
+                <p class="text-sm text-base-content/70">Check in with Aidan about new seating plan and group expectations.</p>
+              </div>
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="badge badge-outline text-secondary">Follow up</span>
+                <button class="btn btn-sm btn-outline" type="button">Pin</button>
+              </div>
+            </div>
+          </article>
+          <article class="card border border-base-300 bg-base-200/70 shadow-sm md:col-span-2">
+            <div class="card-body gap-4">
+              <div class="space-y-2">
+                <h2 class="text-lg font-semibold text-base-content">Ideas for next assembly</h2>
+                <p class="text-sm text-base-content/70">Collect short student shout-outs and share quick wellbeing wins from the week.</p>
+              </div>
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="badge badge-outline text-accent">Idea</span>
+                <button class="btn btn-sm btn-outline" type="button">Convert to template</button>
+              </div>
             </div>
           </article>
         </div>
       </section>
 
       <section data-route="resources" class="space-y-6" style="display: none;">
-        <h2 class="text-lg font-semibold text-base-content">Resources</h2>
-        <ul class="space-y-3">
-          <li class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200/70 p-5 shadow-sm sm:flex-row sm:items-start sm:justify-between">
-            <div>
-              <p class="font-medium text-base-content">Project-based learning toolkit</p>
-              <p class="text-sm text-base-content/70 line-clamp-2">Templates, rubrics, and launch ideas for interdisciplinary projects.</p>
+        <header class="space-y-2">
+          <h1 class="text-2xl font-semibold text-base-content">Resources</h1>
+          <p class="text-base-content/70">Curated templates, routines, and downloads to keep your planning moving.</p>
+        </header>
+        <div class="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-200/70 p-4 shadow-sm">
+          <div class="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">
+            <span class="rounded-full bg-base-100 px-3 py-1 text-base-content/70">All</span>
+            <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Lesson</button>
+            <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Family</button>
+            <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Admin</button>
+          </div>
+          <button type="button" class="btn btn-sm btn-outline">Upload resource</button>
+        </div>
+        <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          <article class="card border border-base-300 bg-base-200/70 shadow-sm">
+            <div class="card-body gap-4">
+              <div class="space-y-2">
+                <p class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Project-based learning</p>
+                <h2 class="text-lg font-semibold text-base-content">Project-based learning toolkit</h2>
+                <p class="text-sm text-base-content/70">Templates, rubrics, and launch ideas for interdisciplinary projects.</p>
+              </div>
+              <div class="flex flex-wrap gap-2">
+                <a class="btn btn-sm btn-outline" href="#">Open</a>
+                <button class="btn btn-sm btn-ghost" type="button">Copy link</button>
+              </div>
             </div>
-            <div class="flex shrink-0 gap-2">
-              <a class="btn btn-sm btn-outline" href="#">Open</a>
-              <button class="btn btn-sm btn-outline" type="button">Copy</button>
+          </article>
+          <article class="card border border-base-300 bg-base-200/70 shadow-sm">
+            <div class="card-body gap-4">
+              <div class="space-y-2">
+                <p class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Wellbeing</p>
+                <h2 class="text-lg font-semibold text-base-content">Wellbeing conversation starters</h2>
+                <p class="text-sm text-base-content/70">Prompts and check-in activities to support SEL routines.</p>
+              </div>
+              <div class="flex flex-wrap gap-2">
+                <a class="btn btn-sm btn-outline" href="#">Open</a>
+                <button class="btn btn-sm btn-ghost" type="button">Add to planner</button>
+              </div>
             </div>
-          </li>
-          <li class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200/70 p-5 shadow-sm sm:flex-row sm:items-start sm:justify-between">
-            <div>
-              <p class="font-medium text-base-content">Wellbeing conversation starters</p>
-              <p class="text-sm text-base-content/70 line-clamp-2">Prompts and check-in activities to support SEL routines.</p>
+          </article>
+          <article class="card border border-base-300 bg-base-200/70 shadow-sm">
+            <div class="card-body gap-4">
+              <div class="space-y-2">
+                <p class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Excursions</p>
+                <h2 class="text-lg font-semibold text-base-content">Excursion planning checklist</h2>
+                <p class="text-sm text-base-content/70">Stay on top of permissions, transport, and risk assessments.</p>
+              </div>
+              <div class="flex flex-wrap gap-2">
+                <a class="btn btn-sm btn-outline" href="#">Open</a>
+                <button class="btn btn-sm btn-ghost" type="button">Duplicate</button>
+              </div>
             </div>
-            <div class="flex shrink-0 gap-2">
-              <a class="btn btn-sm btn-outline" href="#">Open</a>
-              <button class="btn btn-sm btn-outline" type="button">Copy</button>
+          </article>
+          <article class="card border border-base-300 bg-base-200/70 shadow-sm md:col-span-2 xl:col-span-3">
+            <div class="card-body gap-4 md:flex md:items-center md:justify-between">
+              <div class="space-y-2">
+                <p class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">New</p>
+                <h2 class="text-lg font-semibold text-base-content">Activity idea generator</h2>
+                <p class="text-sm text-base-content/70">Use the quick action toolbar to open AI-assisted ideas tailored to your subject and lesson phase.</p>
+              </div>
+              <button type="button" class="btn btn-primary btn-sm">Launch ideas modal</button>
             </div>
-          </li>
-          <li class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200/70 p-5 shadow-sm sm:flex-row sm:items-start sm:justify-between">
-            <div>
-              <p class="font-medium text-base-content">Excursion planning checklist</p>
-              <p class="text-sm text-base-content/70 line-clamp-2">Stay on top of permissions, transport, and risk assessments.</p>
-            </div>
-            <div class="flex shrink-0 gap-2">
-              <a class="btn btn-sm btn-outline" href="#">Open</a>
-              <button class="btn btn-sm btn-outline" type="button">Copy</button>
-            </div>
-          </li>
-        </ul>
-      </section>
-
-      <section data-route="templates" class="space-y-4" style="display: none;">
-        <h2 class="text-lg font-semibold text-base-content">Templates</h2>
-        <div class="flex flex-wrap gap-2">
-          <button class="btn btn-sm btn-outline" type="button">Daily Note</button>
-          <button class="btn btn-sm btn-outline" type="button">Weekly Plan</button>
-          <button class="btn btn-sm btn-outline" type="button">Project Brief</button>
-          <button class="btn btn-sm btn-outline" type="button">Parent Update</button>
+          </article>
         </div>
       </section>
 
-      <section data-route="settings" class="space-y-4" style="display: none;">
-        <header class="space-y-1">
-          <h1 class="text-2xl font-semibold text-base-content">Settings</h1>
-          <p class="text-base-content/70">Personalise Memory Cue for your daily workflow.</p>
+      <section data-route="templates" class="space-y-6" style="display: none;">
+        <header class="space-y-2">
+          <h1 class="text-2xl font-semibold text-base-content">Templates</h1>
+          <p class="text-base-content/70">Quick-start layouts to speed up planning, reflection, and family communication.</p>
         </header>
-        <form class="space-y-4 max-w-xl">
-          <label class="flex flex-col gap-2">
-            <span class="text-sm font-medium text-base-content/80">Display name</span>
-            <input type="text" class="input input-bordered" placeholder="Your name" />
-          </label>
-          <label class="flex flex-col gap-2">
-            <span class="text-sm font-medium text-base-content/80">Notifications</span>
-            <select class="select select-bordered">
-              <option>Send summaries each morning</option>
-              <option>Send summaries each Friday</option>
-              <option>Mute reminders</option>
-            </select>
-          </label>
-          <button class="btn btn-primary" type="button">Save changes</button>
+        <div class="grid gap-4 md:grid-cols-2">
+          <article class="card border border-base-300 bg-base-200/70 shadow-sm">
+            <div class="card-body gap-3">
+              <div class="flex items-start justify-between gap-2">
+                <h2 class="text-lg font-semibold text-base-content">Daily note</h2>
+                <span class="badge badge-outline text-primary">Popular</span>
+              </div>
+              <p class="text-sm text-base-content/70">Capture daily highlights, celebrations, and quick interventions.</p>
+              <button class="btn btn-sm btn-outline" type="button">Use template</button>
+            </div>
+          </article>
+          <article class="card border border-base-300 bg-base-200/70 shadow-sm">
+            <div class="card-body gap-3">
+              <h2 class="text-lg font-semibold text-base-content">Weekly plan</h2>
+              <p class="text-sm text-base-content/70">Map out focus areas, resources, and success criteria for the week.</p>
+              <button class="btn btn-sm btn-outline" type="button">Use template</button>
+            </div>
+          </article>
+          <article class="card border border-base-300 bg-base-200/70 shadow-sm">
+            <div class="card-body gap-3">
+              <h2 class="text-lg font-semibold text-base-content">Project brief</h2>
+              <p class="text-sm text-base-content/70">Share timelines, checkpoints, and collaboration tips with colleagues.</p>
+              <button class="btn btn-sm btn-outline" type="button">Use template</button>
+            </div>
+          </article>
+          <article class="card border border-base-300 bg-base-200/70 shadow-sm">
+            <div class="card-body gap-3">
+              <h2 class="text-lg font-semibold text-base-content">Parent update</h2>
+              <p class="text-sm text-base-content/70">Send a quick snapshot of class progress and upcoming events.</p>
+              <button class="btn btn-sm btn-outline" type="button">Use template</button>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section data-route="settings" class="space-y-6" style="display: none;">
+        <header class="space-y-2">
+          <h1 class="text-2xl font-semibold text-base-content">Settings</h1>
+          <p class="text-base-content/70">Personalise Memory Cue so it fits how you plan, communicate, and capture the day.</p>
+        </header>
+        <form class="grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
+          <div class="space-y-4">
+            <div class="rounded-2xl border border-base-300 bg-base-200/70 p-4 shadow-sm">
+              <h2 class="text-sm font-semibold uppercase tracking-[0.3em] text-base-content/60">Profile</h2>
+              <label class="mt-3 flex flex-col gap-2">
+                <span class="text-sm font-medium text-base-content/80">Display name</span>
+                <input type="text" class="input input-bordered" placeholder="Your name" />
+              </label>
+              <label class="mt-3 flex flex-col gap-2">
+                <span class="text-sm font-medium text-base-content/80">Role</span>
+                <select class="select select-bordered">
+                  <option>Classroom teacher</option>
+                  <option>Year level lead</option>
+                  <option>Specialist teacher</option>
+                </select>
+              </label>
+            </div>
+            <div class="rounded-2xl border border-base-300 bg-base-200/70 p-4 shadow-sm">
+              <h2 class="text-sm font-semibold uppercase tracking-[0.3em] text-base-content/60">Notifications</h2>
+              <label class="mt-3 flex flex-col gap-2">
+                <span class="text-sm font-medium text-base-content/80">Digest frequency</span>
+                <select class="select select-bordered">
+                  <option>Send summaries each morning</option>
+                  <option>Send summaries each Friday</option>
+                  <option>Mute reminders</option>
+                </select>
+              </label>
+              <label class="mt-3 flex items-center gap-3 text-sm text-base-content/80">
+                <input type="checkbox" class="checkbox checkbox-sm" checked />
+                Notify me when resources are shared with my class
+              </label>
+            </div>
+            <div class="flex justify-end">
+              <button class="btn btn-primary" type="button">Save changes</button>
+            </div>
+          </div>
+          <aside class="rounded-2xl border border-dashed border-base-300 bg-base-100/70 p-4 text-sm text-base-content/80">
+            <h2 class="text-sm font-semibold uppercase tracking-[0.3em] text-base-content/60">Tips</h2>
+            <ul class="mt-3 space-y-2">
+              <li>Adjust digest frequency to match your planning rhythm.</li>
+              <li>Toggle quick action prompts if you prefer a quieter workspace.</li>
+              <li>Use templates to share consistent updates with families.</li>
+            </ul>
+          </aside>
         </form>
       </section>
     </div>
@@ -589,13 +900,37 @@
       <span class="sr-only">New lesson plan</span>
     </button>
   </nav>
-  <footer class="border-t border-base-300 bg-base-200/70 py-8">
-    <div class="mx-auto flex max-w-7xl flex-col gap-4 px-4 text-sm text-base-content/80 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8">
-      <p>© <span id="year"></span> Memory Cue. All rights reserved.</p>
-      <div class="flex flex-wrap gap-4">
-        <a href="#" class="hover:text-base-content">Privacy</a>
-        <a href="#" class="hover:text-base-content">Terms</a>
-        <a href="#" class="hover:text-base-content">Support</a>
+  <footer class="border-t border-base-300 bg-base-200/80 py-10">
+    <div class="mx-auto flex max-w-7xl flex-col gap-6 px-4 text-sm text-base-content/80 sm:px-6 lg:px-8">
+      <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div class="max-w-lg space-y-2">
+          <p class="text-base font-semibold text-base-content">Memory Cue</p>
+          <p>Designed to help teachers stay organised, communicate clearly, and celebrate daily wins.</p>
+        </div>
+        <div class="grid gap-4 text-sm sm:grid-cols-3">
+          <div class="space-y-2">
+            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Product</p>
+            <a href="#dashboard" class="block hover:text-base-content">Dashboard</a>
+            <a href="#planner" class="block hover:text-base-content">Planner</a>
+            <a href="#resources" class="block hover:text-base-content">Resources</a>
+          </div>
+          <div class="space-y-2">
+            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Support</p>
+            <a href="#notes" class="block hover:text-base-content">Guides</a>
+            <a href="#templates" class="block hover:text-base-content">Templates</a>
+            <a href="#" class="block hover:text-base-content">Contact</a>
+          </div>
+          <div class="space-y-2">
+            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Company</p>
+            <a href="#" class="block hover:text-base-content">Privacy</a>
+            <a href="#" class="block hover:text-base-content">Terms</a>
+            <a href="#" class="block hover:text-base-content">Support</a>
+          </div>
+        </div>
+      </div>
+      <div class="flex flex-col gap-2 border-t border-base-300/60 pt-4 text-xs text-base-content/60 sm:flex-row sm:items-center sm:justify-between">
+        <p>© <span id="year"></span> Memory Cue. All rights reserved.</p>
+        <p>Crafted with care for classrooms everywhere.</p>
       </div>
     </div>
   </footer>


### PR DESCRIPTION
## Summary
- redesign the main navigation and hero to emphasise quick planning actions and context
- refresh dashboard widgets, supporting sections, and footer with organised cards and shortcut panels
- update reminders, planner, notes, resources, templates, and settings views with consistent layouts and helpful filters

## Testing
- npm test -- --runInBand *(fails: existing jest configuration cannot parse ESM imports in mobile.js and js/main.js)*

------
https://chatgpt.com/codex/tasks/task_e_6905d2c6530883249ea3bd96aaca2e08