### PR TITLE
Shrink create sheet add trigger

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -451,9 +451,11 @@
     <div class="flex-none flex items-center gap-2">
       <button
         id="inlineQuickAddBtn"
-        class="btn btn-primary btn-sm gap-1"
+        class="btn btn-circle btn-primary btn-sm"
         type="button"
         data-open-add-task
+        aria-label="Add reminder"
+        title="Add reminder"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -469,7 +471,7 @@
           <path d="M12 5v14" />
           <path d="M5 12h14" />
         </svg>
-        <span class="text-sm font-semibold">Quick add</span>
+        <span class="sr-only">Quick add</span>
       </button>
       <div class="relative">
         <button


### PR DESCRIPTION
## Summary
- shrink the mobile header quick add button that opens the create reminder sheet so it matches the other controls
- add accessible labelling to the icon-only button to preserve screen reader support

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6905d1c749508324851170a4b13d37be