### PR TITLE
Add glassmorphism styling to navigation surfaces

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -57,6 +57,7 @@
   <link rel="icon" href="./icons/icon-192.svg" type="image/svg+xml" />
   <link rel="stylesheet" href="./styles/tokens.css" />
   <link rel="stylesheet" href="./styles/a11y.css" />
+  <link rel="stylesheet" href="./styles/index.css" />
   <!-- BEGIN GPT CHANGE: styles moved to styles/index.css -->
   <!-- END GPT CHANGE -->
   <link
@@ -79,10 +80,7 @@
 <body id="top" class="bg-base-100 text-base-content antialiased leading-7 min-h-screen">
   <a class="skip-link" href="#mainContent">Skip to main content</a>
   <!-- Modern Navigation -->
-  <nav
-    aria-label="Primary"
-    class="relative fixed top-0 z-50 w-full border-b border-base-200/70 bg-base-100/80 backdrop-blur"
-  >
+  <nav aria-label="Primary" class="relative fixed top-0 z-50 w-full navbar-glass">
     <div class="navbar mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
       <div class="navbar-start gap-2">
         <button
@@ -109,7 +107,7 @@
         <a href="#dashboard" class="btn btn-ghost text-xl font-bold normal-case text-base-content">Memory Cue</a>
       </div>
       <div class="navbar-center nav-desktop hidden lg:flex">
-        <ul class="menu menu-horizontal gap-1 rounded-box bg-base-100/70 p-1 text-sm shadow-sm">
+        <ul class="menu menu-horizontal gap-1 nav-pill-glass text-sm">
           <li>
             <a href="#dashboard" data-route="dashboard" id="nav-dashboard" class="btn btn-sm btn-ghost">Dashboard</a>
           </li>
@@ -217,7 +215,7 @@
       hidden
       class="absolute left-0 right-0 top-full z-40 gap-2 px-4 pb-4 sm:px-6 lg:hidden"
     >
-      <div class="rounded-box border border-base-200 bg-base-100/95 p-3 shadow-lg">
+      <div class="mobile-nav-glass rounded-box p-3">
         <ul class="menu menu-vertical gap-1 text-base-content">
           <li><a href="#dashboard" data-route="dashboard" class="btn btn-ghost justify-start">Dashboard</a></li>
           <li><a href="#reminders" data-route="reminders" class="btn btn-ghost justify-start">Reminders</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,6 +57,7 @@
   <link rel="icon" href="./icons/icon-192.svg" type="image/svg+xml" />
   <link rel="stylesheet" href="./styles/tokens.css" />
   <link rel="stylesheet" href="./styles/a11y.css" />
+  <link rel="stylesheet" href="./styles/index.css" />
   <!-- BEGIN GPT CHANGE: styles moved to styles/index.css -->
   <!-- END GPT CHANGE -->
   <link
@@ -77,10 +78,7 @@
 </head>
 <body id="top" class="bg-base-100 text-base-content antialiased leading-7 min-h-screen">
   <a class="skip-link" href="#mainContent">Skip to main content</a>
-  <nav
-    aria-label="Primary"
-    class="relative fixed top-0 z-50 w-full border-b border-base-200/70 bg-base-100/80 backdrop-blur"
-  >
+  <nav aria-label="Primary" class="relative fixed top-0 z-50 w-full navbar-glass">
     <div class="navbar mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
       <div class="navbar-start gap-2">
         <button
@@ -107,7 +105,7 @@
         <a href="#dashboard" class="btn btn-ghost text-xl font-bold normal-case text-base-content">Memory Cue</a>
       </div>
       <div class="navbar-center nav-desktop hidden lg:flex">
-        <ul class="menu menu-horizontal gap-1 rounded-box bg-base-100/70 p-1 text-sm shadow-sm">
+        <ul class="menu menu-horizontal gap-1 nav-pill-glass text-sm">
           <li>
             <a href="#dashboard" data-nav="dashboard" id="nav-dashboard" class="btn btn-sm btn-ghost">Dashboard</a>
           </li>
@@ -141,7 +139,7 @@
       hidden
       class="absolute left-0 right-0 top-full z-40 gap-2 px-4 pb-4 sm:px-6 lg:hidden"
     >
-      <div class="rounded-box border border-base-200 bg-base-100/95 p-3 shadow-lg">
+      <div class="mobile-nav-glass rounded-box p-3">
         <ul class="menu menu-vertical gap-1 text-base-content">
           <li><a href="#dashboard" data-nav="dashboard" class="btn btn-ghost justify-start">Dashboard</a></li>
           <li><a href="#reminders" data-nav="reminders" class="btn btn-ghost justify-start">Reminders</a></li>

--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -15,6 +15,7 @@
   <link rel="icon" href="./icons/icon-192.svg" type="image/svg+xml" />
   <link rel="stylesheet" href="./styles/tokens.css" />
   <link rel="stylesheet" href="./styles/a11y.css" />
+  <link rel="stylesheet" href="./styles/index.css" />
   <style>
     .sync-status {
       display: inline-flex;
@@ -369,7 +370,7 @@
 <body class="min-h-screen bg-base-200 text-base-content show-full">
   <a class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-full focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-primary-content" href="#main">Skip to main content</a>
 
-  <header class="navbar bg-base-100 sticky top-0 z-50 border-b">
+  <header class="navbar navbar-glass sticky top-0 z-50">
     <div class="flex-1 items-center gap-2">
       <a class="btn btn-ghost text-lg font-semibold" href="#">Memory Cue</a>
       <span

--- a/docs/styles/index.css
+++ b/docs/styles/index.css
@@ -41,6 +41,85 @@ html {
   backdrop-filter: blur(10px);
 }
 
+.navbar-glass {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.85), rgba(248, 250, 252, 0.65));
+  border-bottom: 1px solid rgba(148, 163, 184, 0.4);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+[data-theme="dark"] .navbar-glass {
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(30, 41, 59, 0.7));
+  border-bottom-color: rgba(148, 163, 184, 0.22);
+  box-shadow: 0 22px 45px rgba(2, 6, 23, 0.55);
+}
+
+.nav-pill-glass {
+  position: relative;
+  border-radius: 9999px;
+  padding: 0.35rem;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.72), rgba(255, 255, 255, 0.3));
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.1);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+
+[data-theme="dark"] .nav-pill-glass {
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.82), rgba(15, 23, 42, 0.6));
+  border-color: rgba(148, 163, 184, 0.22);
+  box-shadow: 0 22px 38px rgba(2, 6, 23, 0.55);
+}
+
+.nav-pill-glass .btn {
+  border-radius: 9999px;
+  color: rgba(30, 41, 59, 0.88);
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+[data-theme="dark"] .nav-pill-glass .btn {
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.nav-pill-glass .btn:hover,
+.nav-pill-glass .btn:focus-visible {
+  background-color: rgba(255, 255, 255, 0.24);
+  color: rgba(15, 23, 42, 0.95);
+}
+
+[data-theme="dark"] .nav-pill-glass .btn:hover,
+[data-theme="dark"] .nav-pill-glass .btn:focus-visible {
+  background-color: rgba(148, 163, 184, 0.18);
+  color: rgba(226, 232, 240, 1);
+}
+
+.nav-pill-glass .btn.btn-active {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.28), rgba(56, 189, 248, 0.22));
+  color: rgb(15 118 110);
+  box-shadow: 0 12px 24px rgba(45, 212, 191, 0.3);
+}
+
+[data-theme="dark"] .nav-pill-glass .btn.btn-active {
+  background: linear-gradient(135deg, rgba(20, 184, 166, 0.35), rgba(56, 189, 248, 0.28));
+  color: rgb(187 247 208);
+  box-shadow: 0 16px 30px rgba(45, 212, 191, 0.32);
+}
+
+.mobile-nav-glass {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 252, 0.7));
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 28px 45px rgba(15, 23, 42, 0.18);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+[data-theme="dark"] .mobile-nav-glass {
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.86), rgba(30, 41, 59, 0.72));
+  border-color: rgba(148, 163, 184, 0.2);
+  box-shadow: 0 26px 48px rgba(2, 6, 23, 0.6);
+}
+
 .glass-effect {
   background: rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(10px);

--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
   <link rel="icon" href="./icons/icon-192.svg" type="image/svg+xml" />
   <link rel="stylesheet" href="./styles/tokens.css" />
   <link rel="stylesheet" href="./styles/a11y.css" />
+  <link rel="stylesheet" href="./styles/index.css" />
   <!-- BEGIN GPT CHANGE: styles moved to styles/index.css -->
   <!-- END GPT CHANGE -->
   <link
@@ -86,10 +87,7 @@
 </head>
 <body id="top" class="bg-base-100 text-base-content antialiased leading-7 min-h-screen">
   <a class="skip-link" href="#mainContent">Skip to main content</a>
-  <nav
-    aria-label="Primary"
-    class="relative fixed top-0 z-50 w-full border-b border-base-200/70 bg-base-100/85 backdrop-blur"
-  >
+  <nav aria-label="Primary" class="relative fixed top-0 z-50 w-full navbar-glass">
     <div class="navbar mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
       <div class="navbar-start gap-3">
         <button
@@ -124,7 +122,7 @@
         </a>
       </div>
       <div class="navbar-center nav-desktop hidden lg:flex">
-        <ul class="menu menu-horizontal gap-1 rounded-full border border-base-200/80 bg-base-100/70 p-1 text-sm shadow-sm">
+        <ul class="menu menu-horizontal gap-1 nav-pill-glass text-sm">
           <li>
             <a href="#dashboard" data-nav="dashboard" id="nav-dashboard" class="btn btn-sm btn-ghost">Dashboard</a>
           </li>
@@ -163,7 +161,7 @@
       hidden
       class="absolute left-0 right-0 top-full z-40 gap-2 px-4 pb-4 sm:px-6 lg:hidden"
     >
-      <div class="rounded-2xl border border-base-200/80 bg-base-100/95 p-4 shadow-xl">
+      <div class="mobile-nav-glass rounded-2xl p-4">
         <div class="mb-3 rounded-xl bg-base-200/80 p-3 text-sm text-base-content/70">
           Set the tone for today and keep your planning in one place.
         </div>

--- a/mobile.html
+++ b/mobile.html
@@ -427,7 +427,7 @@
 <body class="min-h-screen bg-base-200 text-base-content show-full">
   <a class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-full focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-primary-content" href="#main">Skip to main content</a>
 
-  <header class="navbar bg-base-100 sticky top-0 z-50 border-b px-3">
+  <header class="navbar navbar-glass sticky top-0 z-50 px-3">
     <div class="flex-1 items-center gap-3">
       <span
         class="inline-flex size-9 items-center justify-center rounded-full bg-primary text-primary-content text-sm font-semibold tracking-tight shadow-sm"

--- a/styles/index.css
+++ b/styles/index.css
@@ -41,6 +41,85 @@ html {
   backdrop-filter: blur(10px);
 }
 
+.navbar-glass {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.85), rgba(248, 250, 252, 0.65));
+  border-bottom: 1px solid rgba(148, 163, 184, 0.4);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+[data-theme="dark"] .navbar-glass {
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(30, 41, 59, 0.7));
+  border-bottom-color: rgba(148, 163, 184, 0.22);
+  box-shadow: 0 22px 45px rgba(2, 6, 23, 0.55);
+}
+
+.nav-pill-glass {
+  position: relative;
+  border-radius: 9999px;
+  padding: 0.35rem;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.72), rgba(255, 255, 255, 0.3));
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.1);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+
+[data-theme="dark"] .nav-pill-glass {
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.82), rgba(15, 23, 42, 0.6));
+  border-color: rgba(148, 163, 184, 0.22);
+  box-shadow: 0 22px 38px rgba(2, 6, 23, 0.55);
+}
+
+.nav-pill-glass .btn {
+  border-radius: 9999px;
+  color: rgba(30, 41, 59, 0.88);
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+[data-theme="dark"] .nav-pill-glass .btn {
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.nav-pill-glass .btn:hover,
+.nav-pill-glass .btn:focus-visible {
+  background-color: rgba(255, 255, 255, 0.24);
+  color: rgba(15, 23, 42, 0.95);
+}
+
+[data-theme="dark"] .nav-pill-glass .btn:hover,
+[data-theme="dark"] .nav-pill-glass .btn:focus-visible {
+  background-color: rgba(148, 163, 184, 0.18);
+  color: rgba(226, 232, 240, 1);
+}
+
+.nav-pill-glass .btn.btn-active {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.28), rgba(56, 189, 248, 0.22));
+  color: rgb(15 118 110);
+  box-shadow: 0 12px 24px rgba(45, 212, 191, 0.3);
+}
+
+[data-theme="dark"] .nav-pill-glass .btn.btn-active {
+  background: linear-gradient(135deg, rgba(20, 184, 166, 0.35), rgba(56, 189, 248, 0.28));
+  color: rgb(187 247 208);
+  box-shadow: 0 16px 30px rgba(45, 212, 191, 0.32);
+}
+
+.mobile-nav-glass {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 252, 0.7));
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 28px 45px rgba(15, 23, 42, 0.18);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+[data-theme="dark"] .mobile-nav-glass {
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.86), rgba(30, 41, 59, 0.72));
+  border-color: rgba(148, 163, 184, 0.2);
+  box-shadow: 0 26px 48px rgba(2, 6, 23, 0.6);
+}
+
 .glass-effect {
   background: rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(10px);


### PR DESCRIPTION
## Summary
- add reusable glassmorphism utility classes for navigation shells and menus
- apply the glass styling across the main site, docs build, and mobile layout
- ensure built pages load the shared stylesheet that defines the new glass effects

## Testing
- npm test *(fails: existing Jest configuration cannot parse ESM modules)*

------
https://chatgpt.com/codex/tasks/task_e_6905d4a89534832481ae7a9d9d12ebf2