### PR TITLE
Remove visible header name from navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
             MC
           </span>
           <span class="flex flex-col leading-tight">
-            <span>Memory Cue</span>
+            <span class="sr-only">Memory Cue</span>
             <span class="text-xs font-normal text-base-content/70">Balanced planning for busy teachers</span>
           </span>
         </a>


### PR DESCRIPTION
## Summary
- hide the Memory Cue brand text in the main navigation while retaining the tagline
- keep the brand name accessible to assistive technology via a visually hidden label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905d6bc67488324a80f05d6f8ed16bc