### PR TITLE
Adjust mobile header spacing

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -428,7 +428,7 @@
   <a class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-full focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-primary-content" href="#main">Skip to main content</a>
 
   <header class="navbar navbar-glass sticky top-0 z-50 px-3">
-    <div class="flex-1 items-center gap-3">
+    <div class="flex-1 items-center gap-3" style="column-gap: 1rem;">
       <span
         class="inline-flex size-9 items-center justify-center rounded-full bg-primary text-primary-content text-sm font-semibold tracking-tight shadow-sm"
         aria-hidden="true"
@@ -440,6 +440,7 @@
         <span
           id="syncStatus"
           class="sync-status text-xs"
+          style="margin-right: 1.5rem;"
           role="status"
           aria-live="polite"
           aria-atomic="true"
@@ -449,7 +450,7 @@
         </span>
       </div>
     </div>
-    <div class="flex-none flex items-center gap-2">
+    <div class="flex-none flex items-center gap-2" style="margin-left: 1.5rem; column-gap: 1.25rem;">
       <button
         id="inlineQuickAddBtn"
         class="btn btn-circle btn-primary btn-sm"


### PR DESCRIPTION
## Summary
- increase the spacing around the Memory Cue status indicator in the mobile header for improved legibility
- add explicit gaps between the quick add and overflow menu buttons so they are no longer crowded

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_6905d760189083249420329d95046754