### PR TITLE
Remove signed-in user name from badge

### DIFF
--- a/404.html
+++ b/404.html
@@ -196,7 +196,6 @@
                 class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-primary text-primary-content"
                 aria-hidden="true"
               >T</span>
-              <span id="user-badge-email" class="max-w-[160px] truncate"></span>
             </div>
           </div>
           <div class="flex flex-wrap items-center justify-end gap-2">

--- a/docs/404.html
+++ b/docs/404.html
@@ -185,7 +185,6 @@
                 class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-primary text-primary-content"
                 aria-hidden="true"
               >T</span>
-              <span id="user-badge-email" class="max-w-[160px] truncate"></span>
             </div>
           </div>
           <div class="flex flex-wrap items-center justify-end gap-2">


### PR DESCRIPTION
## Summary
- stop rendering the signed-in user's email within the header badge on the auth views

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905e755cdc883248f20c0f3b947f2c3