### PR TITLE
Refine mobile header layout

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -34,7 +34,7 @@
     }
     /* Status dot colors */
     .sync-dot {
-      font-size: 20px;
+      font-size: 14px;
       line-height: 1;
       transition: color 0.2s ease;
     }
@@ -409,15 +409,17 @@
   <header class="navbar sticky top-0 z-50 flex items-center justify-between px-4 py-2 bg-base-100/90 backdrop-blur">
     <div class="flex items-center gap-2 min-w-0">
       <a href="#" class="flex items-center min-w-0">
+        <img src="./icons/icon-192.png" alt="Memory Cue" class="h-6 w-6 mr-2" />
         <span class="font-semibold truncate">
-                   <span class="sm:hidden inline">MC</span>
+          <span class="sm:inline hidden">Memory Cue</span>
+          <span class="sm:hidden inline">MC</span>
         </span>
       </a>
+      <span id="mcStatus" class="sync-dot offline" role="status" aria-live="polite" aria-label="Offline">●</span>
+      <span id="mcStatusText" class="sr-only">Offline</span>
     </div>
 
     <div class="flex items-center gap-3">
-      <span id="mcStatus" class="sync-dot offline" role="status" aria-live="polite" aria-label="Offline">●</span>
-      <span id="mcStatusText" class="sr-only">Offline</span>
       <button
         id="addReminderBtn"
         type="button"


### PR DESCRIPTION
## Summary
- adjust the mobile header layout to align the brand and status on the left and action buttons on the right
- update the status indicator styling and add the Memory Cue icon to the header

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6906ab94e9e08324bd4f3b9e4e787761