### PR TITLE
Add reminder modal for reminder button

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,6 +15,117 @@ import { createModalController } from './js/modules/modal-controller.js';
 
 initViewportHeight();
 
+function initReminderModalUI() {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const modal = document.getElementById('reminder-modal');
+  const form = document.getElementById('reminder-form');
+  const titleField = document.getElementById('reminder-title');
+
+  if (!modal || !form || !titleField) {
+    return;
+  }
+
+  const openButtons = document.querySelectorAll('[data-open-reminder-modal]');
+
+  if (!openButtons.length) {
+    return;
+  }
+
+  const backdrop = modal.querySelector('[data-reminder-modal-backdrop]');
+  const closeButtons = modal.querySelectorAll('[data-close-modal]');
+  const mainContent = document.getElementById('mainContent');
+  const primaryNav = document.querySelector('nav[aria-label="Primary"]');
+  const backgroundTargets = [mainContent, primaryNav];
+  let lastActiveElement = null;
+
+  const setBackgroundInert = (shouldInert) => {
+    backgroundTargets.forEach((node) => {
+      if (!node) {
+        return;
+      }
+      if (shouldInert) {
+        node.setAttribute('inert', '');
+      } else {
+        node.removeAttribute('inert');
+      }
+    });
+  };
+
+  const closeModal = () => {
+    modal.classList.add('hidden');
+    modal.setAttribute('aria-hidden', 'true');
+    modal.setAttribute('inert', '');
+    setBackgroundInert(false);
+    document.removeEventListener('keydown', handleEscape, true);
+    if (lastActiveElement && typeof lastActiveElement.focus === 'function') {
+      lastActiveElement.focus();
+    }
+  };
+
+  const handleEscape = (event) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeModal();
+    }
+  };
+
+  const openModal = () => {
+    lastActiveElement = document.activeElement;
+    modal.classList.remove('hidden');
+    modal.removeAttribute('aria-hidden');
+    modal.removeAttribute('inert');
+    setBackgroundInert(true);
+    document.addEventListener('keydown', handleEscape, true);
+    window.requestAnimationFrame(() => {
+      titleField.focus();
+    });
+  };
+
+  openButtons.forEach((button) => {
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      openModal();
+    });
+  });
+
+  closeButtons.forEach((button) => {
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      closeModal();
+    });
+  });
+
+  modal.addEventListener('click', (event) => {
+    if (event.target === modal) {
+      closeModal();
+    }
+  });
+
+  backdrop?.addEventListener('click', (event) => {
+    if (event.target === backdrop) {
+      closeModal();
+    }
+  });
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const reminder = {
+      title: titleField.value.trim(),
+      date: document.getElementById('reminder-date')?.value || '',
+      priority: document.getElementById('reminder-priority')?.value || '',
+      notes: document.getElementById('reminder-notes')?.value || ''
+    };
+    console.log('New Reminder:', reminder);
+    form.reset();
+    closeModal();
+  });
+}
+
+initReminderModalUI();
+
 const titleInput = document.getElementById('title');
 const mobileTitleInput = document.getElementById('reminderText');
 

--- a/index.html
+++ b/index.html
@@ -325,7 +325,15 @@
                   </dl>
                 </div>
                 <div class="flex flex-wrap items-center gap-2">
-                  <button class="btn btn-primary btn-sm sm:btn-md" type="button">Add reminder</button>
+                  <button
+                    class="btn btn-primary btn-sm sm:btn-md"
+                    type="button"
+                    data-open-reminder-modal
+                    aria-haspopup="dialog"
+                    aria-controls="reminder-modal"
+                  >
+                    Add reminder
+                  </button>
                   <div class="join hidden sm:inline-flex">
                     <button class="btn btn-sm join-item btn-outline" type="button">Low</button>
                     <button class="btn btn-sm join-item btn-outline" type="button">Medium</button>
@@ -499,7 +507,15 @@
             <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">This week</button>
             <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Later</button>
           </div>
-          <button type="button" class="btn btn-sm btn-outline">Add reminder</button>
+          <button
+            type="button"
+            class="btn btn-sm btn-outline"
+            data-open-reminder-modal
+            aria-haspopup="dialog"
+            aria-controls="reminder-modal"
+          >
+            Add reminder
+          </button>
         </div>
         <ul class="space-y-3">
           <li class="rounded-2xl border border-base-300 bg-base-200/70 p-5 shadow-sm">
@@ -931,6 +947,60 @@
       </div>
     </div>
   </footer>
+  <div id="reminder-modal" class="fixed inset-0 z-50 hidden" aria-hidden="true" inert>
+    <div class="min-h-dvh w-full bg-black/50 flex items-center justify-center px-4" data-reminder-modal-backdrop>
+      <div
+        class="w-full max-w-md rounded-2xl bg-white p-6 shadow-lg dark:bg-gray-900"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="reminder-modal-title"
+      >
+        <div class="flex items-center justify-between gap-4">
+          <h3 id="reminder-modal-title" class="text-lg font-semibold text-base-content">Add new reminder</h3>
+          <button
+            type="button"
+            id="closeReminderModal"
+            data-close-modal
+            class="rounded px-2 py-1 text-gray-600 transition hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-300 dark:text-gray-400 dark:hover:bg-gray-800"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+        <form id="reminder-form" class="mt-4 space-y-4">
+          <label class="block">
+            <span class="font-medium text-base-content">Title</span>
+            <input
+              id="reminder-title"
+              type="text"
+              class="input input-bordered mt-1 w-full"
+              required
+            />
+          </label>
+          <label class="block">
+            <span class="font-medium text-base-content">Due date</span>
+            <input id="reminder-date" type="date" class="input input-bordered mt-1 w-full" />
+          </label>
+          <label class="block">
+            <span class="font-medium text-base-content">Priority</span>
+            <select id="reminder-priority" class="select select-bordered mt-1 w-full">
+              <option>Low</option>
+              <option>Medium</option>
+              <option>High</option>
+            </select>
+          </label>
+          <label class="block">
+            <span class="font-medium text-base-content">Notes</span>
+            <textarea id="reminder-notes" class="textarea textarea-bordered mt-1 w-full" rows="3"></textarea>
+          </label>
+          <div class="flex justify-end gap-3 pt-2">
+            <button type="button" class="btn" data-close-modal>Cancel</button>
+            <button type="submit" class="btn btn-primary">Save</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
   <div id="activity-ideas-modal" class="fixed inset-0 z-50 hidden" aria-hidden="true" inert>
     <div class="min-h-dvh w-full bg-black/50 flex items-center justify-center">
       <div


### PR DESCRIPTION
## Summary
- add a dedicated reminder modal with form fields and accessibility attributes
- wire existing "Add reminder" buttons to open and close the modal
- log reminder details on submit, reset the form, and restore page focus when closing

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_6906f889601c8324bcfa12f9a89cbaf4