### PR TITLE
Disable placeholder action buttons

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -343,7 +343,7 @@
                   </div>
                   <div class="flex flex-wrap gap-2">
                     <button class="btn btn-sm btn-success" type="button">Mark done</button>
-                    <button class="btn btn-sm btn-outline" type="button">Snooze</button>
+                    <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Snooze</button>
                   </div>
                 </li>
                 <li class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
@@ -421,7 +421,7 @@
             <div class="card-body gap-4">
               <div class="flex flex-wrap items-center justify-between gap-3">
                 <h2 class="text-lg font-semibold text-base-content">Pinned notes</h2>
-                <button class="btn btn-sm btn-primary" type="button">New note</button>
+                <button class="btn btn-sm btn-primary" type="button" disabled title="Coming soon">New note</button>
               </div>
               <ul class="space-y-3">
                 <li class="rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm">
@@ -512,8 +512,8 @@
               </div>
               <div class="flex flex-wrap items-center gap-2">
                 <span class="badge badge-outline text-warning">Due soon</span>
-                <button class="btn btn-sm btn-success" type="button">Complete</button>
-                <button class="btn btn-sm btn-outline" type="button">Snooze</button>
+                <button class="btn btn-sm btn-success" type="button" disabled title="Coming soon">Complete</button>
+                <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Snooze</button>
               </div>
             </div>
             <p class="mt-3 text-sm text-base-content/60">Attach the new literacy checkpoints before sending.</p>
@@ -561,8 +561,8 @@
             <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Week 9</button>
           </div>
           <div class="flex flex-wrap items-center gap-2">
-            <button type="button" class="btn btn-sm btn-outline">Duplicate plan</button>
-            <button type="button" class="btn btn-sm btn-primary">New lesson</button>
+            <button type="button" class="btn btn-sm btn-outline" disabled title="Coming soon">Duplicate plan</button>
+            <button type="button" class="btn btn-sm btn-primary" disabled title="Coming soon">New lesson</button>
           </div>
         </div>
         <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
@@ -582,7 +582,7 @@
                   Print small group checklists
                 </li>
               </ul>
-              <button class="btn btn-sm btn-outline" type="button">Add detail</button>
+              <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Add detail</button>
             </div>
           </article>
           <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow">
@@ -601,7 +601,7 @@
                   Collect student reflections in Notes
                 </li>
               </ul>
-              <button class="btn btn-sm btn-outline" type="button">Add detail</button>
+              <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Add detail</button>
             </div>
           </article>
           <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow">
@@ -620,7 +620,7 @@
                   Email timetable to staff
                 </li>
               </ul>
-              <button class="btn btn-sm btn-outline" type="button">Add detail</button>
+              <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Add detail</button>
             </div>
           </article>
           <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow">
@@ -639,7 +639,7 @@
                   Attach planning template
                 </li>
               </ul>
-              <button class="btn btn-sm btn-outline" type="button">Add detail</button>
+              <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Add detail</button>
             </div>
           </article>
         </div>
@@ -657,7 +657,7 @@
             <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Student</button>
             <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Ideas</button>
           </div>
-          <button type="button" class="btn btn-sm btn-primary">New note</button>
+          <button type="button" class="btn btn-sm btn-primary" disabled title="Coming soon">New note</button>
         </div>
         <div class="grid gap-3 md:grid-cols-2">
           <article class="card border border-base-300 bg-base-200/70 shadow-sm">
@@ -668,7 +668,7 @@
               </div>
               <div class="flex flex-wrap items-center gap-2">
                 <span class="badge badge-outline text-primary">Strategy</span>
-                <button class="btn btn-sm btn-outline" type="button">Archive</button>
+                <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Archive</button>
               </div>
             </div>
           </article>
@@ -680,7 +680,7 @@
               </div>
               <div class="flex flex-wrap items-center gap-2">
                 <span class="badge badge-outline text-secondary">Follow up</span>
-                <button class="btn btn-sm btn-outline" type="button">Pin</button>
+                <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Pin</button>
               </div>
             </div>
           </article>
@@ -692,7 +692,7 @@
               </div>
               <div class="flex flex-wrap items-center gap-2">
                 <span class="badge badge-outline text-accent">Idea</span>
-                <button class="btn btn-sm btn-outline" type="button">Convert to template</button>
+                <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Convert to template</button>
               </div>
             </div>
           </article>
@@ -711,7 +711,7 @@
             <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Family</button>
             <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Admin</button>
           </div>
-          <button type="button" class="btn btn-sm btn-outline">Upload resource</button>
+          <button type="button" class="btn btn-sm btn-outline" disabled title="Coming soon">Upload resource</button>
         </div>
         <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           <article class="card border border-base-300 bg-base-200/70 shadow-sm">
@@ -723,7 +723,7 @@
               </div>
               <div class="flex flex-wrap gap-2">
                 <a class="btn btn-sm btn-outline" href="#">Open</a>
-                <button class="btn btn-sm btn-ghost" type="button">Copy link</button>
+                <button class="btn btn-sm btn-ghost" type="button" disabled title="Coming soon">Copy link</button>
               </div>
             </div>
           </article>
@@ -736,7 +736,7 @@
               </div>
               <div class="flex flex-wrap gap-2">
                 <a class="btn btn-sm btn-outline" href="#">Open</a>
-                <button class="btn btn-sm btn-ghost" type="button">Add to planner</button>
+                <button class="btn btn-sm btn-ghost" type="button" disabled title="Coming soon">Add to planner</button>
               </div>
             </div>
           </article>
@@ -749,7 +749,7 @@
               </div>
               <div class="flex flex-wrap gap-2">
                 <a class="btn btn-sm btn-outline" href="#">Open</a>
-                <button class="btn btn-sm btn-ghost" type="button">Duplicate</button>
+                <button class="btn btn-sm btn-ghost" type="button" disabled title="Coming soon">Duplicate</button>
               </div>
             </div>
           </article>

--- a/index.html
+++ b/index.html
@@ -343,7 +343,7 @@
                   </div>
                   <div class="flex flex-wrap gap-2">
                     <button class="btn btn-sm btn-success" type="button">Mark done</button>
-                    <button class="btn btn-sm btn-outline" type="button">Snooze</button>
+                    <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Snooze</button>
                   </div>
                 </li>
                 <li class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
@@ -421,7 +421,7 @@
             <div class="card-body gap-4">
               <div class="flex flex-wrap items-center justify-between gap-3">
                 <h2 class="text-lg font-semibold text-base-content">Pinned notes</h2>
-                <button class="btn btn-sm btn-primary" type="button">New note</button>
+                <button class="btn btn-sm btn-primary" type="button" disabled title="Coming soon">New note</button>
               </div>
               <ul class="space-y-3">
                 <li class="rounded-2xl border border-base-300 bg-base-100/80 p-4 shadow-sm">
@@ -512,8 +512,8 @@
               </div>
               <div class="flex flex-wrap items-center gap-2">
                 <span class="badge badge-outline text-warning">Due soon</span>
-                <button class="btn btn-sm btn-success" type="button">Complete</button>
-                <button class="btn btn-sm btn-outline" type="button">Snooze</button>
+                <button class="btn btn-sm btn-success" type="button" disabled title="Coming soon">Complete</button>
+                <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Snooze</button>
               </div>
             </div>
             <p class="mt-3 text-sm text-base-content/60">Attach the new literacy checkpoints before sending.</p>
@@ -561,8 +561,8 @@
             <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Week 9</button>
           </div>
           <div class="flex flex-wrap items-center gap-2">
-            <button type="button" class="btn btn-sm btn-outline">Duplicate plan</button>
-            <button type="button" class="btn btn-sm btn-primary">New lesson</button>
+            <button type="button" class="btn btn-sm btn-outline" disabled title="Coming soon">Duplicate plan</button>
+            <button type="button" class="btn btn-sm btn-primary" disabled title="Coming soon">New lesson</button>
           </div>
         </div>
         <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
@@ -582,7 +582,7 @@
                   Print small group checklists
                 </li>
               </ul>
-              <button class="btn btn-sm btn-outline" type="button">Add detail</button>
+              <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Add detail</button>
             </div>
           </article>
           <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow">
@@ -601,7 +601,7 @@
                   Collect student reflections in Notes
                 </li>
               </ul>
-              <button class="btn btn-sm btn-outline" type="button">Add detail</button>
+              <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Add detail</button>
             </div>
           </article>
           <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow">
@@ -620,7 +620,7 @@
                   Email timetable to staff
                 </li>
               </ul>
-              <button class="btn btn-sm btn-outline" type="button">Add detail</button>
+              <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Add detail</button>
             </div>
           </article>
           <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow">
@@ -639,7 +639,7 @@
                   Attach planning template
                 </li>
               </ul>
-              <button class="btn btn-sm btn-outline" type="button">Add detail</button>
+              <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Add detail</button>
             </div>
           </article>
         </div>
@@ -657,7 +657,7 @@
             <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Student</button>
             <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Ideas</button>
           </div>
-          <button type="button" class="btn btn-sm btn-primary">New note</button>
+          <button type="button" class="btn btn-sm btn-primary" disabled title="Coming soon">New note</button>
         </div>
         <div class="grid gap-3 md:grid-cols-2">
           <article class="card border border-base-300 bg-base-200/70 shadow-sm">
@@ -668,7 +668,7 @@
               </div>
               <div class="flex flex-wrap items-center gap-2">
                 <span class="badge badge-outline text-primary">Strategy</span>
-                <button class="btn btn-sm btn-outline" type="button">Archive</button>
+                <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Archive</button>
               </div>
             </div>
           </article>
@@ -680,7 +680,7 @@
               </div>
               <div class="flex flex-wrap items-center gap-2">
                 <span class="badge badge-outline text-secondary">Follow up</span>
-                <button class="btn btn-sm btn-outline" type="button">Pin</button>
+                <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Pin</button>
               </div>
             </div>
           </article>
@@ -692,7 +692,7 @@
               </div>
               <div class="flex flex-wrap items-center gap-2">
                 <span class="badge badge-outline text-accent">Idea</span>
-                <button class="btn btn-sm btn-outline" type="button">Convert to template</button>
+                <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Convert to template</button>
               </div>
             </div>
           </article>
@@ -711,7 +711,7 @@
             <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Family</button>
             <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Admin</button>
           </div>
-          <button type="button" class="btn btn-sm btn-outline">Upload resource</button>
+          <button type="button" class="btn btn-sm btn-outline" disabled title="Coming soon">Upload resource</button>
         </div>
         <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           <article class="card border border-base-300 bg-base-200/70 shadow-sm">
@@ -723,7 +723,7 @@
               </div>
               <div class="flex flex-wrap gap-2">
                 <a class="btn btn-sm btn-outline" href="#">Open</a>
-                <button class="btn btn-sm btn-ghost" type="button">Copy link</button>
+                <button class="btn btn-sm btn-ghost" type="button" disabled title="Coming soon">Copy link</button>
               </div>
             </div>
           </article>
@@ -736,7 +736,7 @@
               </div>
               <div class="flex flex-wrap gap-2">
                 <a class="btn btn-sm btn-outline" href="#">Open</a>
-                <button class="btn btn-sm btn-ghost" type="button">Add to planner</button>
+                <button class="btn btn-sm btn-ghost" type="button" disabled title="Coming soon">Add to planner</button>
               </div>
             </div>
           </article>
@@ -749,7 +749,7 @@
               </div>
               <div class="flex flex-wrap gap-2">
                 <a class="btn btn-sm btn-outline" href="#">Open</a>
-                <button class="btn btn-sm btn-ghost" type="button">Duplicate</button>
+                <button class="btn btn-sm btn-ghost" type="button" disabled title="Coming soon">Duplicate</button>
               </div>
             </div>
           </article>


### PR DESCRIPTION
## Summary
- disable placeholder action buttons across reminders, notes, planner, and resource cards
- add a "Coming soon" tooltip to clarify why the controls are inactive

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6906febc21608324a56c8536b8a35b85