### PR TITLE
Add accent stripes and chips to task reminders

### DIFF
--- a/css/teacher.css
+++ b/css/teacher.css
@@ -1301,20 +1301,68 @@ input::placeholder, textarea::placeholder {
 }
 
 .task-item {
+  --task-accent: var(--accent);
+  --task-chip-bg: color-mix(in srgb, var(--task-accent) 20%, transparent);
+  --task-chip-color: color-mix(in srgb, var(--text-primary) 80%, var(--task-accent) 20%);
+  --task-priority-chip-bg: color-mix(in srgb, var(--task-accent) 32%, transparent);
+  --task-priority-chip-color: color-mix(in srgb, var(--text-primary) 60%, var(--task-accent) 40%);
+  position: relative;
   display: grid;
   grid-template-columns: auto 1fr auto;
   gap: var(--space-4);
   align-items: center;
   padding: var(--space-4);
+  padding-left: calc(var(--space-4) + 4px);
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg-tertiary) 88%, var(--task-accent) 12%);
+  border: 1px solid color-mix(in srgb, var(--border) 80%, var(--task-accent) 20%);
   border-radius: var(--radius-md);
+  overflow: hidden;
   transition: all 0.2s ease;
+}
+
+.task-item::before {
+  content: '';
+  position: absolute;
+  inset: var(--space-2) auto var(--space-2) 0;
+  width: 4px;
+  border-radius: var(--radius-md) 0 0 var(--radius-md);
+  background: var(--task-accent);
 }
 
 .task-item:hover {
   border-color: var(--border-light);
+  border-color: color-mix(in srgb, var(--border-light) 80%, var(--task-accent) 20%);
   box-shadow: var(--shadow-md);
+}
+
+.task-item[data-priority="High"] {
+  --task-accent: var(--danger);
+  --task-chip-bg: color-mix(in srgb, var(--danger) 20%, transparent);
+  --task-chip-color: color-mix(in srgb, var(--text-primary) 80%, var(--danger) 20%);
+  --task-priority-chip-bg: color-mix(in srgb, var(--danger) 40%, transparent);
+  --task-priority-chip-color: color-mix(in srgb, var(--text-primary) 60%, var(--danger) 40%);
+}
+
+.task-item[data-priority="Medium"] {
+  --task-accent: var(--warning);
+  --task-chip-bg: color-mix(in srgb, var(--warning) 20%, transparent);
+  --task-chip-color: color-mix(in srgb, var(--text-primary) 80%, var(--warning) 20%);
+  --task-priority-chip-bg: color-mix(in srgb, var(--warning) 34%, transparent);
+  --task-priority-chip-color: color-mix(in srgb, var(--text-primary) 75%, var(--warning) 25%);
+}
+
+.task-item[data-priority="Low"] {
+  --task-accent: var(--success);
+  --task-chip-bg: color-mix(in srgb, var(--success) 20%, transparent);
+  --task-chip-color: color-mix(in srgb, var(--text-primary) 80%, var(--success) 20%);
+  --task-priority-chip-bg: color-mix(in srgb, var(--success) 32%, transparent);
+  --task-priority-chip-color: color-mix(in srgb, var(--text-primary) 65%, var(--success) 35%);
+}
+
+.task-item:not([data-priority]) {
+  --task-accent: var(--accent);
 }
 
 .task-item.completed .task-title {
@@ -1331,6 +1379,7 @@ input::placeholder, textarea::placeholder {
   font-weight: 700;
   margin: 0 0 var(--space-1) 0;
   color: var(--text-primary);
+  color: color-mix(in srgb, var(--text-primary) 88%, var(--task-accent) 12%);
   line-height: 1.4;
 }
 
@@ -1340,7 +1389,28 @@ input::placeholder, textarea::placeholder {
   align-items: center;
   flex-wrap: wrap;
   font-size: var(--text-xs);
-  color: var(--text-muted);
+  color: var(--text-secondary);
+  color: color-mix(in srgb, var(--text-secondary) 85%, var(--task-accent) 15%);
+}
+
+.task-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--task-chip-bg, rgba(148, 163, 184, 0.2));
+  color: var(--task-chip-color, var(--text-secondary));
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  line-height: 1.4;
+}
+
+.task-chip[data-chip="priority"] {
+  background: var(--task-priority-chip-bg, var(--task-chip-bg));
+  color: var(--task-priority-chip-color, var(--task-chip-color));
 }
 
 .task-actions {

--- a/docs/css/teacher.css
+++ b/docs/css/teacher.css
@@ -1301,20 +1301,68 @@ input::placeholder, textarea::placeholder {
 }
 
 .task-item {
+  --task-accent: var(--accent);
+  --task-chip-bg: color-mix(in srgb, var(--task-accent) 20%, transparent);
+  --task-chip-color: color-mix(in srgb, var(--text-primary) 80%, var(--task-accent) 20%);
+  --task-priority-chip-bg: color-mix(in srgb, var(--task-accent) 32%, transparent);
+  --task-priority-chip-color: color-mix(in srgb, var(--text-primary) 60%, var(--task-accent) 40%);
+  position: relative;
   display: grid;
   grid-template-columns: auto 1fr auto;
   gap: var(--space-4);
   align-items: center;
   padding: var(--space-4);
+  padding-left: calc(var(--space-4) + 4px);
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg-tertiary) 88%, var(--task-accent) 12%);
+  border: 1px solid color-mix(in srgb, var(--border) 80%, var(--task-accent) 20%);
   border-radius: var(--radius-md);
+  overflow: hidden;
   transition: all 0.2s ease;
+}
+
+.task-item::before {
+  content: '';
+  position: absolute;
+  inset: var(--space-2) auto var(--space-2) 0;
+  width: 4px;
+  border-radius: var(--radius-md) 0 0 var(--radius-md);
+  background: var(--task-accent);
 }
 
 .task-item:hover {
   border-color: var(--border-light);
+  border-color: color-mix(in srgb, var(--border-light) 80%, var(--task-accent) 20%);
   box-shadow: var(--shadow-md);
+}
+
+.task-item[data-priority="High"] {
+  --task-accent: var(--danger);
+  --task-chip-bg: color-mix(in srgb, var(--danger) 20%, transparent);
+  --task-chip-color: color-mix(in srgb, var(--text-primary) 80%, var(--danger) 20%);
+  --task-priority-chip-bg: color-mix(in srgb, var(--danger) 40%, transparent);
+  --task-priority-chip-color: color-mix(in srgb, var(--text-primary) 60%, var(--danger) 40%);
+}
+
+.task-item[data-priority="Medium"] {
+  --task-accent: var(--warning);
+  --task-chip-bg: color-mix(in srgb, var(--warning) 20%, transparent);
+  --task-chip-color: color-mix(in srgb, var(--text-primary) 80%, var(--warning) 20%);
+  --task-priority-chip-bg: color-mix(in srgb, var(--warning) 34%, transparent);
+  --task-priority-chip-color: color-mix(in srgb, var(--text-primary) 75%, var(--warning) 25%);
+}
+
+.task-item[data-priority="Low"] {
+  --task-accent: var(--success);
+  --task-chip-bg: color-mix(in srgb, var(--success) 20%, transparent);
+  --task-chip-color: color-mix(in srgb, var(--text-primary) 80%, var(--success) 20%);
+  --task-priority-chip-bg: color-mix(in srgb, var(--success) 32%, transparent);
+  --task-priority-chip-color: color-mix(in srgb, var(--text-primary) 65%, var(--success) 35%);
+}
+
+.task-item:not([data-priority]) {
+  --task-accent: var(--accent);
 }
 
 .task-item.completed .task-title {
@@ -1331,6 +1379,7 @@ input::placeholder, textarea::placeholder {
   font-weight: 700;
   margin: 0 0 var(--space-1) 0;
   color: var(--text-primary);
+  color: color-mix(in srgb, var(--text-primary) 88%, var(--task-accent) 12%);
   line-height: 1.4;
 }
 
@@ -1340,7 +1389,28 @@ input::placeholder, textarea::placeholder {
   align-items: center;
   flex-wrap: wrap;
   font-size: var(--text-xs);
-  color: var(--text-muted);
+  color: var(--text-secondary);
+  color: color-mix(in srgb, var(--text-secondary) 85%, var(--task-accent) 15%);
+}
+
+.task-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--task-chip-bg, rgba(148, 163, 184, 0.2));
+  color: var(--task-chip-color, var(--text-secondary));
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  line-height: 1.4;
+}
+
+.task-chip[data-chip="priority"] {
+  background: var(--task-priority-chip-bg, var(--task-chip-bg));
+  color: var(--task-priority-chip-color, var(--task-chip-color));
 }
 
 .task-actions {

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -1803,13 +1803,20 @@ export async function initReminders(sel = {}) {
         div.dataset.today = 'true';
       }
       const dueTxt = r.due ? `${fmtTime(new Date(r.due))} • ${fmtDayDate(r.due.slice(0,10))}` : 'No due date';
+      const catLabel = catName ? escapeHtml(catName) : '';
+      const priorityLabel = escapeHtml(summary.priority);
+      const chipMarkup = [
+        `<span class="task-chip" data-chip="due">${escapeHtml(dueTxt)}</span>`,
+        catLabel ? `<span class="task-chip" data-chip="category">${catLabel}</span>` : '',
+        `<span class="task-chip" data-chip="priority">${priorityLabel}</span>`
+      ].filter(Boolean).join('');
       const notesHtml = r.notes ? `<div class="task-notes">${notesToHtml(r.notes)}</div>` : '';
       div.innerHTML = `
         <div class="task-content">
           <div class="task-title"><strong>${escapeHtml(r.title)}</strong></div>
           <div class="task-meta">
-            <div class="task-meta-row" style="gap:8px; flex-wrap:wrap;">
-              <span>${dueTxt}</span>
+            <div class="task-meta-row" style="display:flex; gap:8px; flex-wrap:wrap; align-items:center;">
+              ${chipMarkup}
             </div>
           </div>
           ${notesHtml}


### PR DESCRIPTION
## Summary
- add accent stripe, chip styling, and priority-aware color variables to teacher task cards
- mirror the updated accent and chip styles in the docs build assets
- render due date, category, and priority chips in reminder list items for mobile

## Testing
- npm test -- --runTestsByPath reminders.categories.test.js

------
https://chatgpt.com/codex/tasks/task_e_6906ff05ba388324a0115ae609704254