### PR TITLE
Update mobile header branding

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -567,15 +567,9 @@
 <body class="min-h-screen bg-base-200 text-base-content show-full">
   <a class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-full focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-primary-content" href="#main">Skip to main content</a>
 
-  <header class="navbar sticky top-0 z-50 flex items-center justify-between px-4 py-2 bg-base-100/90 backdrop-blur">
+  <header class="navbar sticky top-0 z-50 flex items-center justify-between w-full px-4 py-2 bg-base-100/90 backdrop-blur">
     <div class="flex items-center gap-2 min-w-0">
-      <a href="#" class="flex items-center min-w-0">
-        <img src="./icons/icon-192.png" alt="Memory Cue" class="h-6 w-6 mr-2" />
-        <span class="font-semibold truncate">
-          <span class="sm:inline hidden">Memory Cue</span>
-          <span class="sm:hidden inline">MC</span>
-        </span>
-      </a>
+      <span class="font-bold text-lg text-base-content">MC</span>
       <span id="mcStatus" class="sync-dot offline" role="status" aria-live="polite" aria-label="Offline">●</span>
       <span id="mcStatusText" class="sr-only">Offline</span>
     </div>


### PR DESCRIPTION
## Summary
- make the mobile header span the full width of the screen
- replace the linked logo block with a simplified MC text label

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6907b7e123608324ba29661d2cacdd97