### PR TITLE
Add settings save confirmation message

### DIFF
--- a/app.js
+++ b/app.js
@@ -126,6 +126,28 @@ function initReminderModalUI() {
 
 initReminderModalUI();
 
+const settingsSaveButton = document.getElementById('settings-save-button');
+const settingsSaveConfirmation = document.getElementById('settings-save-confirmation');
+const liveStatusRegion = document.getElementById('live-status');
+let hideSettingsSaveConfirmationTimeoutId = null;
+
+if (settingsSaveButton && settingsSaveConfirmation) {
+  settingsSaveButton.addEventListener('click', (event) => {
+    event.preventDefault();
+    settingsSaveConfirmation.classList.remove('hidden');
+    settingsSaveConfirmation.textContent = 'Settings saved!';
+    if (liveStatusRegion) {
+      liveStatusRegion.textContent = 'Settings saved!';
+    }
+    if (hideSettingsSaveConfirmationTimeoutId) {
+      window.clearTimeout(hideSettingsSaveConfirmationTimeoutId);
+    }
+    hideSettingsSaveConfirmationTimeoutId = window.setTimeout(() => {
+      settingsSaveConfirmation.classList.add('hidden');
+    }, 3000);
+  });
+}
+
 const titleInput = document.getElementById('title');
 const mobileTitleInput = document.getElementById('reminderText');
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -842,8 +842,9 @@
                 Notify me when resources are shared with my class
               </p>
             </div>
-            <div class="flex justify-end">
-              <button class="btn btn-primary" type="button">Save changes</button>
+            <div class="flex flex-col items-end gap-2">
+              <button id="settings-save-button" class="btn btn-primary" type="button">Save changes</button>
+              <p id="settings-save-confirmation" class="text-sm text-success hidden">Settings saved!</p>
             </div>
           </div>
           <aside class="rounded-2xl border border-dashed border-base-300 bg-base-100/70 p-4 text-sm text-base-content/80">
@@ -1035,7 +1036,29 @@
       });
     }
     window.addEventListener('hashchange', renderRoute);
-    window.addEventListener('DOMContentLoaded', renderRoute);
+    window.addEventListener('DOMContentLoaded', () => {
+      renderRoute();
+      const settingsSaveButton = document.getElementById('settings-save-button');
+      const settingsSaveConfirmation = document.getElementById('settings-save-confirmation');
+      const liveStatusRegion = document.getElementById('live-status');
+      if (settingsSaveButton && settingsSaveConfirmation) {
+        let hideSettingsSaveTimeoutId = null;
+        settingsSaveButton.addEventListener('click', (event) => {
+          event.preventDefault();
+          settingsSaveConfirmation.classList.remove('hidden');
+          settingsSaveConfirmation.textContent = 'Settings saved!';
+          if (liveStatusRegion) {
+            liveStatusRegion.textContent = 'Settings saved!';
+          }
+          if (hideSettingsSaveTimeoutId) {
+            window.clearTimeout(hideSettingsSaveTimeoutId);
+          }
+          hideSettingsSaveTimeoutId = window.setTimeout(() => {
+            settingsSaveConfirmation.classList.add('hidden');
+          }, 3000);
+        });
+      }
+    });
   </script>
   <script type="module" src="./assets/app-KGXXFHHO.js" defer></script>
   <script src="./assets/update-footer-year-EFMYO4DK.js" defer></script>

--- a/index.html
+++ b/index.html
@@ -858,8 +858,9 @@
                 Notify me when resources are shared with my class
               </p>
             </div>
-            <div class="flex justify-end">
-              <button class="btn btn-primary" type="button">Save changes</button>
+            <div class="flex flex-col items-end gap-2">
+              <button id="settings-save-button" class="btn btn-primary" type="button">Save changes</button>
+              <p id="settings-save-confirmation" class="text-sm text-success hidden">Settings saved!</p>
             </div>
           </div>
           <aside class="rounded-2xl border border-dashed border-base-300 bg-base-100/70 p-4 text-sm text-base-content/80">


### PR DESCRIPTION
## Summary
- show a success confirmation beneath the Settings save button
- add a click handler to display and hide the feedback while updating the live status region
- mirror the same behaviour on the static docs build

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6907b7f051ac83249afb1b60c67ae87e