### PR TITLE
Improve mobile reminder action button contrast

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -295,6 +295,18 @@
       font-weight: 600;
       border-radius: 0.5rem;
       transition: all 0.15s ease;
+      color: rgba(30, 41, 59, 0.88);
+    }
+    .task-actions button:hover,
+    .task-actions button:focus-visible {
+      color: rgba(30, 41, 59, 1);
+    }
+    .dark .task-actions button {
+      color: rgba(226, 232, 240, 0.92);
+    }
+    .dark .task-actions button:hover,
+    .dark .task-actions button:focus-visible {
+      color: rgba(248, 250, 252, 1);
     }
     /* Today-specific task styling - more prominent */
     .task-item[data-today="true"],


### PR DESCRIPTION
## Summary
- ensure reminder action buttons on mobile have readable text colors in light and dark themes
- adjust hover and focus states to preserve contrast

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6907b8a6b3c4832485025c2461f17bee