### PR TITLE
Refine mobile header styling

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -58,6 +58,96 @@
     .menu-item:hover {
       background: rgba(0, 0, 0, 0.04);
     }
+    /* Enhanced header container */
+    header.navbar {
+      background: rgba(255, 255, 255, 0.95);
+      backdrop-filter: blur(20px);
+      -webkit-backdrop-filter: blur(20px);
+      border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06);
+      padding-top: env(safe-area-inset-top, 16px);
+      padding-bottom: 16px;
+    }
+
+    .dark header.navbar {
+      background: rgba(15, 23, 42, 0.95);
+      border-bottom-color: rgba(255, 255, 255, 0.08);
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+    }
+
+    /* Polished title */
+    .header-title {
+      font-size: 20px;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      color: rgba(15, 23, 42, 0.95);
+    }
+
+    .dark .header-title {
+      color: rgba(241, 245, 249, 0.95);
+    }
+
+    /* Refined sync status */
+    .sync-status-indicator {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 8px;
+      border-radius: 12px;
+      background: rgba(100, 116, 139, 0.1);
+      font-size: 12px;
+      font-weight: 600;
+      color: rgba(100, 116, 139, 0.9);
+      transition: all 0.2s ease;
+    }
+
+    .sync-status-indicator.online {
+      background: rgba(34, 197, 94, 0.15);
+      color: rgba(22, 163, 74, 0.9);
+    }
+
+    /* Polished primary action button */
+    .btn-primary-action {
+      width: 44px;
+      height: 44px;
+      border-radius: 12px;
+      background: linear-gradient(135deg, #3b82f6, #2563eb);
+      border: none;
+      color: white;
+      font-size: 24px;
+      font-weight: 300;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+      transition: all 0.2s ease;
+    }
+
+    .btn-primary-action:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 6px 16px rgba(59, 130, 246, 0.4);
+    }
+
+    .btn-primary-action:active {
+      transform: translateY(0);
+    }
+
+    /* Refined secondary button */
+    .btn-secondary-action {
+      width: 44px;
+      height: 44px;
+      border-radius: 12px;
+      background: rgba(100, 116, 139, 0.1);
+      border: 1px solid rgba(100, 116, 139, 0.2);
+      color: rgba(100, 116, 139, 0.9);
+      font-size: 20px;
+      transition: all 0.2s ease;
+    }
+
+    .btn-secondary-action:hover {
+      background: rgba(100, 116, 139, 0.15);
+      border-color: rgba(100, 116, 139, 0.3);
+    }
     /* Icon circle fallback */
     .btn-circle {
       width: 44px;
@@ -579,18 +669,20 @@
 <body class="min-h-screen bg-base-200 text-base-content show-full">
   <a class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-full focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-primary-content" href="#main">Skip to main content</a>
 
-  <header class="navbar sticky top-0 z-50 flex items-center justify-between w-full px-4 py-2 bg-base-100/90 backdrop-blur">
-    <div class="flex items-center gap-2 min-w-0">
-      <span class="font-bold text-lg text-base-content">MC</span>
-      <span id="mcStatus" class="sync-dot offline" role="status" aria-live="polite" aria-label="Offline">●</span>
-      <span id="mcStatusText" class="sr-only">Offline</span>
+  <header class="navbar sticky top-0 z-50 flex items-center justify-between px-4">
+    <div class="flex items-center gap-3">
+      <h1 class="header-title">MC</h1>
+      <div id="syncStatus" class="sync-status-indicator" role="status" aria-live="polite">
+        <span id="mcStatus" class="sync-dot offline" aria-hidden="true">●</span>
+        <span id="mcStatusText" class="sync-text">Offline</span>
+      </div>
     </div>
 
-    <div class="flex items-center gap-3">
+    <div class="flex items-center gap-2">
       <button
         id="addReminderBtn"
         type="button"
-        class="btn btn-ghost btn-circle text-2xl"
+        class="btn-primary-action"
         aria-label="Add reminder"
         data-open-add-task
       >
@@ -600,7 +692,7 @@
         <button
           id="overflowMenuBtn"
           type="button"
-          class="btn btn-ghost btn-circle text-xl"
+          class="btn-secondary-action"
           aria-label="More options"
           aria-haspopup="menu"
           aria-controls="overflowMenu"
@@ -1100,6 +1192,7 @@
     })();
 
     (function () {
+      const statusContainer = document.getElementById('syncStatus');
       const statusDotEl = document.getElementById('mcStatus');
       const statusTextEl = document.getElementById('mcStatusText');
       if (!statusTextEl) return;
@@ -1143,13 +1236,19 @@
       const setStatus = (state, message) => {
         currentState = state;
         ACTIVE_CLASSES.forEach((cls) => statusTextEl.classList.remove(cls));
+        if (statusContainer) {
+          ACTIVE_CLASSES.forEach((cls) => statusContainer.classList.remove(cls));
+        }
 
         if (state === 'online') {
           statusTextEl.classList.add('online');
+          if (statusContainer) statusContainer.classList.add('online');
         } else if (state === 'error') {
           statusTextEl.classList.add('error');
+          if (statusContainer) statusContainer.classList.add('error');
         } else {
           statusTextEl.classList.add('offline');
+          if (statusContainer) statusContainer.classList.add('offline');
         }
 
         const fullText =

--- a/mobile.js
+++ b/mobile.js
@@ -637,6 +637,7 @@ document.addEventListener('click', (ev) => {
 
 /* BEGIN GPT CHANGE: sync controls */
 (function () {
+  const statusContainer = document.getElementById('syncStatus');
   const statusDotEl = document.getElementById('mcStatus');
   const statusTextEl = document.getElementById('mcStatusText');
   const syncUrlInput = document.getElementById('syncUrl');
@@ -681,13 +682,19 @@ document.addEventListener('click', (ev) => {
   function setStatus(state, message) {
     currentState = state;
     ACTIVE_CLASSES.forEach((cls) => statusTextEl.classList.remove(cls));
+    if (statusContainer) {
+      ACTIVE_CLASSES.forEach((cls) => statusContainer.classList.remove(cls));
+    }
 
     if (state === 'online') {
       statusTextEl.classList.add('online');
+      if (statusContainer) statusContainer.classList.add('online');
     } else if (state === 'error') {
       statusTextEl.classList.add('error');
+      if (statusContainer) statusContainer.classList.add('error');
     } else {
       statusTextEl.classList.add('offline');
+      if (statusContainer) statusContainer.classList.add('offline');
     }
 
     const fullText =


### PR DESCRIPTION
## Summary
- add glassmorphism-inspired header, button, and sync indicator styles to the mobile shell
- rebuild the mobile header markup for the new layout while keeping the overflow menu intact
- update sync status scripts to toggle the new indicator states consistently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6907bb09a6ac8324b8d5962b4fdf7f2c