### PR TITLE
Adjust mobile header actions layout

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -85,6 +85,17 @@
       gap: 0.75rem;
     }
 
+    .header-actions {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 0.75rem;
+    }
+
+    .header-actions > * {
+      flex-shrink: 0;
+    }
+
     /* Polished title */
     .header-title {
       font-size: 20px;
@@ -140,13 +151,13 @@
 
     /* Refined secondary button */
     .btn-secondary-action {
-      width: 44px;
-      height: 44px;
+      width: calc(44px * 0.85);
+      height: calc(44px * 0.85);
       border-radius: 12px;
       background: rgba(100, 116, 139, 0.1);
       border: 1px solid rgba(100, 116, 139, 0.2);
       color: rgba(100, 116, 139, 0.9);
-      font-size: 20px;
+      font-size: calc(20px * 0.85);
       transition: all 0.2s ease;
     }
 
@@ -168,13 +179,13 @@
       position: relative;
     }
     .add-primary-button {
-      width: 48px;
-      height: 48px;
+      width: calc(48px * 0.85);
+      height: calc(48px * 0.85);
       border-radius: 16px;
       background: linear-gradient(135deg, #10b981, #059669);
       border: none;
       color: white;
-      font-size: 28px;
+      font-size: calc(28px * 0.85);
       font-weight: 300;
       display: flex;
       align-items: center;
@@ -193,7 +204,7 @@
     }
     .add-options-fab {
       position: absolute;
-      bottom: 56px;
+      bottom: calc(100% + 8px);
       right: 0;
       display: none;
       flex-direction: column;
@@ -1119,7 +1130,7 @@
         </div>
       </div>
 
-      <div class="flex items-center gap-3">
+      <div class="header-actions">
         <div class="add-button-container">
           <button
             id="addReminderBtn"


### PR DESCRIPTION
## Summary
- ensure the mobile header action buttons stay aligned horizontally
- reduce the add and overflow button sizing by 15% and adjust the fab offset

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6907d0bc1374832485c095008c07cac1