### PR TITLE
Adjust reminder panel layout to prevent text squashing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -503,14 +503,14 @@
         </div>
         <ul class="space-y-3">
           <li class="rounded-2xl border border-base-300 bg-base-200/70 p-5 shadow-sm">
-            <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-              <div class="space-y-1">
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+              <div class="space-y-1 sm:flex-1 sm:min-w-0">
                 <p class="font-medium text-base-content">
                   <span class="font-semibold">Submit unit overview</span>
                 </p>
                 <p class="text-sm text-base-content/70">Due Friday · Curriculum team</p>
               </div>
-              <div class="flex flex-wrap items-center gap-2">
+              <div class="flex flex-wrap items-center gap-2 sm:flex-shrink-0">
                 <span class="badge badge-outline text-warning">Due soon</span>
                 <button class="btn btn-sm btn-success" type="button" disabled title="Coming soon">Complete</button>
                 <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Snooze</button>
@@ -519,28 +519,28 @@
             <p class="mt-3 text-sm text-base-content/60">Attach the new literacy checkpoints before sending.</p>
           </li>
           <li class="rounded-2xl border border-base-300 bg-base-200/70 p-5 shadow-sm">
-            <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-              <div class="space-y-1">
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+              <div class="space-y-1 sm:flex-1 sm:min-w-0">
                 <p class="font-medium text-base-content">
                   <span class="font-semibold">Email newsletter blurb</span>
                 </p>
                 <p class="text-sm text-base-content/70">Add upcoming excursions to the weekly update.</p>
               </div>
-              <div class="flex flex-wrap items-center gap-2">
+              <div class="flex flex-wrap items-center gap-2 sm:flex-shrink-0">
                 <span class="badge badge-outline text-secondary">This week</span>
                 <button class="btn btn-sm btn-outline" type="button">Open notes</button>
               </div>
             </div>
           </li>
           <li class="rounded-2xl border border-base-300 bg-base-200/70 p-5 shadow-sm">
-            <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-              <div class="space-y-1">
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+              <div class="space-y-1 sm:flex-1 sm:min-w-0">
                 <p class="font-medium text-base-content">
                   <span class="font-semibold">Call guardians</span>
                 </p>
                 <p class="text-sm text-base-content/70">Follow up on field trip permissions · Family liaison</p>
               </div>
-              <div class="flex flex-wrap items-center gap-2">
+              <div class="flex flex-wrap items-center gap-2 sm:flex-shrink-0">
                 <span class="badge badge-outline text-error">High priority</span>
                 <button class="btn btn-sm btn-outline" type="button">Log call</button>
               </div>

--- a/index.html
+++ b/index.html
@@ -519,14 +519,14 @@
         </div>
         <ul class="space-y-3">
           <li class="rounded-2xl border border-base-300 bg-base-200/70 p-5 shadow-sm">
-            <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-              <div class="space-y-1">
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+              <div class="space-y-1 sm:flex-1 sm:min-w-0">
                 <p class="font-medium text-base-content">
                   <span class="font-semibold">Submit unit overview</span>
                 </p>
                 <p class="text-sm text-base-content/70">Due Friday · Curriculum team</p>
               </div>
-              <div class="flex flex-wrap items-center gap-2">
+              <div class="flex flex-wrap items-center gap-2 sm:flex-shrink-0">
                 <span class="badge badge-outline text-warning">Due soon</span>
                 <button class="btn btn-sm btn-success" type="button" disabled title="Coming soon">Complete</button>
                 <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Snooze</button>
@@ -535,28 +535,28 @@
             <p class="mt-3 text-sm text-base-content/60">Attach the new literacy checkpoints before sending.</p>
           </li>
           <li class="rounded-2xl border border-base-300 bg-base-200/70 p-5 shadow-sm">
-            <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-              <div class="space-y-1">
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+              <div class="space-y-1 sm:flex-1 sm:min-w-0">
                 <p class="font-medium text-base-content">
                   <span class="font-semibold">Email newsletter blurb</span>
                 </p>
                 <p class="text-sm text-base-content/70">Add upcoming excursions to the weekly update.</p>
               </div>
-              <div class="flex flex-wrap items-center gap-2">
+              <div class="flex flex-wrap items-center gap-2 sm:flex-shrink-0">
                 <span class="badge badge-outline text-secondary">This week</span>
                 <button class="btn btn-sm btn-outline" type="button">Open notes</button>
               </div>
             </div>
           </li>
           <li class="rounded-2xl border border-base-300 bg-base-200/70 p-5 shadow-sm">
-            <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-              <div class="space-y-1">
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+              <div class="space-y-1 sm:flex-1 sm:min-w-0">
                 <p class="font-medium text-base-content">
                   <span class="font-semibold">Call guardians</span>
                 </p>
                 <p class="text-sm text-base-content/70">Follow up on field trip permissions · Family liaison</p>
               </div>
-              <div class="flex flex-wrap items-center gap-2">
+              <div class="flex flex-wrap items-center gap-2 sm:flex-shrink-0">
                 <span class="badge badge-outline text-error">High priority</span>
                 <button class="btn btn-sm btn-outline" type="button">Log call</button>
               </div>


### PR DESCRIPTION
## Summary
- add responsive spacing and flex-growth utilities to reminder list items
- prevent the action button group from forcing the reminder text column to shrink
- mirror the layout refinements in the generated docs build

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_6907d21ab3208324911d945197dd39e6