### PR TITLE
Limit compact reminder styling to grid view

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -755,14 +755,14 @@
 
     /* 2-column layout on wider phones */
     @media (min-width: 380px) {
-      #reminderList {
+      #reminderList.grid-cols-2 {
         grid-template-columns: 1fr 1fr;
         gap: 10px;
       }
     }
 
     /* Adjust task items for grid layout */
-    .task-item {
+    #reminderList.grid-cols-2 .task-item {
       margin-bottom: 0 !important;
       padding: 12px;
       padding-left: 14px;
@@ -772,7 +772,7 @@
     }
 
     /* Truncate long content for grid layout */
-    .task-title {
+    #reminderList.grid-cols-2 .task-title {
       font-size: 14px;
       line-height: 1.3;
       display: -webkit-box;
@@ -782,7 +782,7 @@
       margin-bottom: 8px;
     }
 
-    .task-notes {
+    #reminderList.grid-cols-2 .task-notes {
       display: -webkit-box;
       -webkit-line-clamp: 1;
       -webkit-box-orient: vertical;
@@ -792,19 +792,19 @@
     }
 
     /* Compact task meta for grid */
-    .task-meta {
+    #reminderList.grid-cols-2 .task-meta {
       font-size: 11px;
       gap: 4px;
       margin-top: auto;
     }
 
-    .task-chip {
+    #reminderList.grid-cols-2 .task-chip {
       padding: 2px 6px;
       font-size: 10px;
     }
 
     /* Adjust task actions for grid */
-    .task-actions {
+    #reminderList.grid-cols-2 .task-actions {
       position: absolute;
       top: 8px;
       right: 8px;
@@ -812,7 +812,7 @@
       gap: 4px;
     }
 
-    .task-actions button {
+    #reminderList.grid-cols-2 .task-actions button {
       width: 28px;
       height: 28px;
       font-size: 12px;
@@ -820,7 +820,7 @@
     }
 
     /* Compact priority indicators */
-    .task-item {
+    #reminderList.grid-cols-2 .task-item {
       border-left-width: 3px;
       border-radius: 12px;
     }
@@ -841,17 +841,17 @@
 
     /* Single column on narrow phones */
     @media (max-width: 379px) {
-      #reminderList {
+      #reminderList.grid-cols-2 {
         grid-template-columns: 1fr;
       }
 
-      .task-item {
+      #reminderList.grid-cols-2 .task-item {
         padding: 16px;
         padding-left: 18px;
         border-left-width: 4px;
       }
 
-      .task-title {
+      #reminderList.grid-cols-2 .task-title {
         font-size: 15px;
         -webkit-line-clamp: 3;
       }


### PR DESCRIPTION
## Summary
- scope the compact reminder layout rules in `mobile.html` to the grid-view class
- only apply the two-column reminder grid when the toggle enables it so full-width panels remain readable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69084fbf4c74832493686f7fc3282f01