### PR TITLE
Anchor mobile reminder actions to card footer

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -536,6 +536,7 @@
     .task-content {
       min-width: 0;
       text-align: left;
+      flex: 1 1 auto;
     }
     .task-title,
     .task-meta,
@@ -633,9 +634,11 @@
     }
     .task-actions {
       display: flex;
-      flex-direction: column;
-      gap: 0.375rem;
-      align-items: flex-end;
+      gap: 0.5rem;
+      align-items: center;
+      justify-content: flex-end;
+      margin-top: auto;
+      padding-top: 0.75rem;
     }
     .task-actions button {
       padding: 0.375rem 0.75rem;
@@ -720,6 +723,8 @@
       min-height: 80px;
       transition: all 0.2s ease;
       transform: translateZ(0);
+      display: flex;
+      flex-direction: column;
     }
 
     .task-item:active {
@@ -755,14 +760,14 @@
 
     /* 2-column layout on wider phones */
     @media (min-width: 380px) {
-      #reminderList {
+      #reminderList.grid-cols-2 {
         grid-template-columns: 1fr 1fr;
         gap: 10px;
       }
     }
 
     /* Adjust task items for grid layout */
-    .task-item {
+    #reminderList.grid-cols-2 .task-item {
       margin-bottom: 0 !important;
       padding: 12px;
       padding-left: 14px;
@@ -772,7 +777,7 @@
     }
 
     /* Truncate long content for grid layout */
-    .task-title {
+    #reminderList.grid-cols-2 .task-title {
       font-size: 14px;
       line-height: 1.3;
       display: -webkit-box;
@@ -782,7 +787,7 @@
       margin-bottom: 8px;
     }
 
-    .task-notes {
+    #reminderList.grid-cols-2 .task-notes {
       display: -webkit-box;
       -webkit-line-clamp: 1;
       -webkit-box-orient: vertical;
@@ -792,27 +797,25 @@
     }
 
     /* Compact task meta for grid */
-    .task-meta {
+    #reminderList.grid-cols-2 .task-meta {
       font-size: 11px;
       gap: 4px;
       margin-top: auto;
     }
 
-    .task-chip {
+    #reminderList.grid-cols-2 .task-chip {
       padding: 2px 6px;
       font-size: 10px;
     }
 
     /* Adjust task actions for grid */
-    .task-actions {
-      position: absolute;
-      top: 8px;
-      right: 8px;
-      flex-direction: row;
+    #reminderList.grid-cols-2 .task-actions {
       gap: 4px;
+      padding-top: 0.5rem;
+      justify-content: flex-end;
     }
 
-    .task-actions button {
+    #reminderList.grid-cols-2 .task-actions button {
       width: 28px;
       height: 28px;
       font-size: 12px;
@@ -820,7 +823,7 @@
     }
 
     /* Compact priority indicators */
-    .task-item {
+    #reminderList.grid-cols-2 .task-item {
       border-left-width: 3px;
       border-radius: 12px;
     }
@@ -841,17 +844,17 @@
 
     /* Single column on narrow phones */
     @media (max-width: 379px) {
-      #reminderList {
+      #reminderList.grid-cols-2 {
         grid-template-columns: 1fr;
       }
 
-      .task-item {
+      #reminderList.grid-cols-2 .task-item {
         padding: 16px;
         padding-left: 18px;
         border-left-width: 4px;
       }
 
-      .task-title {
+      #reminderList.grid-cols-2 .task-title {
         font-size: 15px;
         -webkit-line-clamp: 3;
       }


### PR DESCRIPTION
## Summary
- allow reminder cards to expand vertically so their content fills the panel
- pin the edit/delete action row to the bottom with consistent spacing in list and grid layouts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69084fbf4c74832493686f7fc3282f01