### PR TITLE
Reposition mobile sync status indicator near header actions

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -89,11 +89,17 @@
       display: flex;
       align-items: center;
       justify-content: flex-end;
-      gap: 0.75rem;
+      gap: 0.6rem;
+      flex-wrap: nowrap;
     }
 
     .header-actions > * {
       flex-shrink: 0;
+    }
+
+    .header-actions #syncStatus {
+      flex-shrink: 1;
+      min-width: 0;
     }
 
     /* Polished title */
@@ -151,13 +157,13 @@
 
     /* Refined secondary button */
     .btn-secondary-action {
-      width: calc(44px * 0.85);
-      height: calc(44px * 0.85);
+      width: calc(44px * 0.68);
+      height: calc(44px * 0.68);
       border-radius: 12px;
       background: rgba(100, 116, 139, 0.1);
       border: 1px solid rgba(100, 116, 139, 0.2);
       color: rgba(100, 116, 139, 0.9);
-      font-size: calc(20px * 0.85);
+      font-size: calc(20px * 0.68);
       transition: all 0.2s ease;
     }
 
@@ -179,13 +185,13 @@
       position: relative;
     }
     .add-primary-button {
-      width: calc(48px * 0.85);
-      height: calc(48px * 0.85);
+      width: calc(48px * 0.68);
+      height: calc(48px * 0.68);
       border-radius: 16px;
       background: linear-gradient(135deg, #10b981, #059669);
       border: none;
       color: white;
-      font-size: calc(28px * 0.85);
+      font-size: calc(28px * 0.68);
       font-weight: 300;
       display: flex;
       align-items: center;
@@ -1127,13 +1133,13 @@
     <div class="navbar-content">
       <div class="flex items-center gap-3">
         <h1 class="header-title">MC</h1>
+      </div>
+
+      <div class="header-actions">
         <div id="syncStatus" class="sync-status-indicator" role="status" aria-live="polite">
           <span id="mcStatus" class="sync-dot offline" aria-hidden="true">●</span>
           <span id="mcStatusText" class="sync-text">Offline</span>
         </div>
-      </div>
-
-      <div class="header-actions">
         <div class="add-button-container">
           <button
             id="addReminderBtn"


### PR DESCRIPTION
## Summary
- move the mobile sync status indicator alongside the header action buttons
- reduce the size of the mobile add and overflow buttons to better align with the tighter layout

## Testing
- Not run (HTML/CSS change only)


------
https://chatgpt.com/codex/tasks/task_e_69085b80704c8324b9fe08a6fc431014