### PR TITLE
Ensure mobile drawer uses inert for accessibility

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1016,7 +1016,7 @@
   <aside
     id="mobile-drawer"
     class="fixed inset-y-0 left-0 z-40 flex w-72 max-w-full -translate-x-full transform flex-col border-r border-neutral-200 bg-white/90 px-4 pb-6 pt-6 font-medium text-neutral-900 shadow-xl transition-transform duration-200 ease-out backdrop-blur dark:border-neutral-800 dark:bg-neutral-900/85 dark:text-neutral-100"
-    aria-hidden="true"
+    inert
     tabindex="-1"
     style="padding-top: calc(env(safe-area-inset-top, 0px) + 1rem)"
   >
@@ -1118,8 +1118,8 @@
         if (nextState === isOpen) return;
 
         if (nextState) {
+          drawer.inert = false;
           drawer.classList.add('translate-x-0');
-          drawer.setAttribute('aria-hidden', 'false');
           drawerBtn?.setAttribute('aria-expanded', 'true');
           if (scrim) {
             scrim.classList.remove('pointer-events-none');
@@ -1139,7 +1139,6 @@
           }
         } else {
           drawer.classList.remove('translate-x-0');
-          drawer.setAttribute('aria-hidden', 'true');
           drawerBtn?.setAttribute('aria-expanded', 'false');
           if (scrim) {
             scrim.classList.add('opacity-0');
@@ -1148,6 +1147,14 @@
           }
           document.body.classList.remove('overflow-hidden');
           drawer.removeAttribute('data-focus-bound');
+          if (drawerBtn instanceof HTMLElement) {
+            try {
+              drawerBtn.focus({ preventScroll: true });
+            } catch {
+              drawerBtn.focus();
+            }
+          }
+          drawer.inert = true;
         }
       };
 


### PR DESCRIPTION
## Summary
- remove the static `aria-hidden` attribute from the mobile drawer and start it inert when hidden
- toggle the drawer's `inert` state when opening or closing and restore focus to the menu button on close

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69088b4a1da88324906d2b1ce0e64a55