### PR TITLE
Optimize mobile header sync status for small screens

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -917,6 +917,83 @@
   <a class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-full focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-primary-content" href="#main">Skip to main content</a>
 
   <!-- Clean Mobile Header -->
+  <style id="header-compact-css">
+    @media (max-width: 360px) {
+      #syncStatus {
+        position: relative;
+        padding: 0.2rem 0.4rem;
+        gap: 0.2rem;
+        min-width: auto;
+        max-width: none;
+      }
+
+      #syncStatus .sync-dot {
+        width: 0.45rem;
+        height: 0.45rem;
+        box-shadow: none;
+      }
+
+      #mcStatusText {
+        position: absolute !important;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: 0;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        clip-path: inset(50%);
+        white-space: nowrap;
+        border: 0;
+      }
+
+      #syncStatus::after {
+        content: '';
+        display: inline-block;
+        margin-left: 0.15rem;
+        font-size: 0.625rem;
+        font-weight: 700;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+      }
+
+      #syncStatus[data-state='online']::after {
+        content: 'On';
+      }
+
+      #syncStatus[data-state='offline']::after {
+        content: 'Off';
+      }
+
+      #syncStatus[data-state='checking']::after {
+        content: 'Chk';
+      }
+
+      #syncStatus[data-state='syncing']::after {
+        content: 'Sync';
+      }
+
+      #syncStatus[data-state='error']::after {
+        content: 'Err';
+      }
+
+      #syncStatus[data-state='info']::after {
+        content: 'Info';
+      }
+
+      #headerQuickActions {
+        gap: 0.35rem;
+      }
+
+      #headerQuickActions button {
+        padding: 0.35rem;
+      }
+
+      #headerQuickActions svg {
+        width: 1.1rem;
+        height: 1.1rem;
+      }
+    }
+  </style>
   <header
     class="sticky top-0 z-40 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-neutral-900/70 border-b border-neutral-200 dark:border-neutral-800"
     style="padding-top: env(safe-area-inset-top, 0px)"
@@ -945,13 +1022,14 @@
         class="sync-status-indicator offline ml-1 inline-flex min-w-0 max-w-[11rem] items-center truncate"
         role="status"
         aria-live="polite"
+        data-state="offline"
       >
         <span id="mcStatus" class="sync-dot offline" aria-hidden="true"></span>
         <span id="mcStatusText" class="truncate">Offline</span>
       </div>
 
       <!-- Right: Quick actions -->
-      <div class="ml-auto flex items-center gap-1">
+      <div id="headerQuickActions" class="ml-auto flex items-center gap-1">
         <button
           id="btn-quick-add"
           class="rounded-xl p-2 hover:bg-neutral-100 active:scale-95 dark:hover:bg-neutral-800"
@@ -2041,6 +2119,10 @@
         ACTIVE_CLASSES.forEach((cls) => statusTextEl.classList.remove(cls));
         if (statusContainer) {
           ACTIVE_CLASSES.forEach((cls) => statusContainer.classList.remove(cls));
+        }
+
+        if (statusContainer) {
+          statusContainer.setAttribute('data-state', state);
         }
 
         if (state === 'online') {


### PR DESCRIPTION
## Summary
- add a compact mobile-header stylesheet that abbreviates the sync indicator and tightens spacing under 360px
- allow the quick-action buttons to shrink slightly so the header contents stay on one line at narrow widths
- propagate sync state to the status container for use with compact labels

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69088d4692708324ba52ee5b96d69067