### PR TITLE
Adjust mobile header sizing

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -486,7 +486,7 @@
 
     /* Mobile-first optimizations */
     :root {
-      --mobile-header-height: 64px;
+      --mobile-header-height: 48px;
       --mobile-safe-area-top: env(safe-area-inset-top, 0px);
       --mobile-safe-area-bottom: env(safe-area-inset-bottom, 0px);
     }
@@ -998,7 +998,7 @@
     class="sticky top-0 z-40 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-neutral-900/70 border-b border-neutral-200 dark:border-neutral-800"
     style="padding-top: env(safe-area-inset-top, 0px)"
   >
-    <div class="mx-auto flex min-h-12 max-w-screen-sm items-center gap-2 px-3 py-1">
+    <div class="mx-auto flex min-h-10 max-w-screen-sm items-center gap-2 px-3 py-0.5">
       <!-- Left: Menu -->
       <button
         id="btn-open-drawer"


### PR DESCRIPTION
## Summary
- reduce the mobile header wrapper height by tightening its flex minimum height and vertical padding
- align the --mobile-header-height CSS variable with the compacted header so main content padding remains accurate

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69088e58ee8c832488e1cade7ef00670