### PR TITLE
Simplify header navigation on desktop and mobile

### DIFF
--- a/app.js
+++ b/app.js
@@ -203,7 +203,7 @@ const initialiseReminders = () => {
       syncUrlInputSel: '#syncUrl',
       saveSettingsSel: '#saveSyncSettings',
       testSyncSel: '#testSync',
-      openSettingsSel: '#openSettings',
+      openSettingsSel: '[data-open="settings"]',
       dateFeedbackSel: '#dateFeedback'
     });
   }

--- a/index.html
+++ b/index.html
@@ -116,8 +116,7 @@
             MC
           </span>
           <span class="flex flex-col leading-tight">
-            <span class="sr-only">Memory Cue</span>
-            <span class="text-xs font-normal text-base-content/70">Balanced planning for busy teachers</span>
+            <span class="text-base font-semibold text-base-content">Memory Cue</span>
           </span>
         </a>
       </div>
@@ -141,18 +140,7 @@
           <li>
             <a href="#templates" data-nav="templates" id="nav-templates" class="btn btn-sm btn-ghost">Templates</a>
           </li>
-          <li>
-            <a href="#settings" data-nav="settings" id="nav-settings" class="btn btn-sm btn-ghost">Settings</a>
-          </li>
         </ul>
-      </div>
-      <div class="navbar-end gap-2">
-        <div class="hidden flex-col text-right text-xs font-medium leading-tight text-base-content/60 lg:flex">
-          <span>Next prep window</span>
-          <span class="text-base-content">Today · 3:15 PM</span>
-        </div>
-        <button id="theme-toggle" type="button" class="btn btn-sm btn-ghost text-base-content">Toggle theme</button>
-        <a href="#planner" class="btn btn-sm btn-primary hidden sm:inline-flex">Open planner</a>
       </div>
     </div>
     <div
@@ -172,7 +160,6 @@
           <li><a href="#notes" data-nav="notes" class="btn btn-ghost justify-start">Notes</a></li>
           <li><a href="#resources" data-nav="resources" class="btn btn-ghost justify-start">Resources</a></li>
           <li><a href="#templates" data-nav="templates" class="btn btn-ghost justify-start">Templates</a></li>
-          <li><a href="#settings" data-nav="settings" class="btn btn-ghost justify-start">Settings</a></li>
         </ul>
         <a href="#planner" class="btn btn-primary btn-sm mt-3 w-full">Jump into planner</a>
       </div>

--- a/mobile.html
+++ b/mobile.html
@@ -1125,31 +1125,10 @@
         id="openSettings"
         type="button"
         class="mc-quick-link"
+        data-open="settings"
       >
         <span>Settings</span>
         <span class="mc-quick-link__hint" aria-hidden="true">⌘,</span>
-      </button>
-      <button
-        id="themeToggle"
-        type="button"
-        class="mc-quick-link"
-      >
-        <span>Theme</span>
-        <span class="mc-quick-link__hint" aria-hidden="true">⌘T</span>
-      </button>
-      <button
-        id="googleSignInBtn"
-        type="button"
-        class="mc-quick-link"
-      >
-        <span>Sign in</span>
-      </button>
-      <button
-        id="googleSignOutBtn"
-        type="button"
-        class="mc-quick-link hidden"
-      >
-        <span>Sign out</span>
       </button>
     </nav>
 
@@ -1167,11 +1146,6 @@
         <span id="mcStatusText" class="sr-only">Offline</span>
 
         <div class="mc-actions" id="headerQuickActions" role="group" aria-label="Header actions">
-          <!-- Add / Quick create -->
-          <button id="addReminderBtn" type="button" class="mc-btn btn btn-ghost icon-only" aria-label="Add reminder" data-open-add-task>
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true" focusable="false"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-          </button>
-
           <!-- Overflow / more -->
           <div style="position:relative;">
             <button id="overflowMenuBtn" type="button" class="mc-btn btn btn-ghost icon-only" aria-label="More options" aria-haspopup="true" aria-controls="overflowMenu" aria-expanded="false">
@@ -1180,13 +1154,16 @@
 
             <div id="overflowMenu" class="menu-card hidden absolute right-0 mt-2 w-44 rounded-xl shadow-lg bg-base-100 border" role="menu" aria-hidden="true">
               <ul class="py-2 text-sm" role="none">
-                <li role="none"><button id="voiceAddBtn" type="button" class="menu-item text-left px-4 py-2" role="menuitem">🎙️ Dictate reminder</button></li>
-                <li><div class="h-px bg-base-300 my-1"></div></li>
-                <li role="none"><button id="openSettings" type="button" class="menu-item text-left px-4 py-2" role="menuitem">Settings</button></li>
-                <li role="none"><button id="themeToggle" type="button" class="menu-item text-left px-4 py-2" role="menuitem">Theme</button></li>
-                <li><div class="h-px bg-base-300 my-1"></div></li>
-                <li role="none"><button id="googleSignInBtn" type="button" class="menu-item text-left px-4 py-2" role="menuitem">Sign in</button></li>
-                <li role="none"><button id="googleSignOutBtn" type="button" class="menu-item text-left px-4 py-2 hidden" role="menuitem">Sign out</button></li>
+                <li role="none">
+                  <button
+                    type="button"
+                    class="menu-item text-left px-4 py-2"
+                    role="menuitem"
+                    data-open="settings"
+                  >
+                    Settings
+                  </button>
+                </li>
               </ul>
             </div>
           </div>
@@ -2101,10 +2078,15 @@
     })();
 
     (function () {
-      const openBtn = document.querySelector('[data-open="settings"]') || document.getElementById('openSettings');
+      const openBtns = Array.from(
+        new Set([
+          ...Array.from(document.querySelectorAll('[data-open="settings"]')),
+          ...Array.from(document.querySelectorAll('#openSettings')),
+        ]),
+      ).filter((btn) => btn instanceof HTMLElement);
       const modal = document.getElementById('settingsModal');
       const closeBtn = document.getElementById('closeSettings');
-      if (!openBtn || !modal || !closeBtn) return;
+      if (!openBtns.length || !modal || !closeBtn) return;
 
       const open = () => {
         modal.classList.remove('hidden');
@@ -2114,7 +2096,7 @@
         modal.classList.add('hidden');
       };
 
-      openBtn.addEventListener('click', open);
+      openBtns.forEach((btn) => btn.addEventListener('click', open));
       closeBtn.addEventListener('click', close);
       modal.addEventListener('click', (event) => {
         if (event.target instanceof HTMLElement && event.target.matches('[data-close]')) {

--- a/mobile.js
+++ b/mobile.js
@@ -276,7 +276,7 @@ const bootstrapReminders = () => {
     syncUrlInputSel: '#syncUrl',
     saveSettingsSel: '#saveSyncSettings',
     testSyncSel: '#testSync',
-    openSettingsSel: '#openSettings',
+    openSettingsSel: '[data-open="settings"]',
     notesSel: '#notes',
     saveNotesBtnSel: '#saveNotes',
     loadNotesBtnSel: '#loadNotes',


### PR DESCRIPTION
## Summary
- streamline the desktop navbar so it only shows Memory Cue branding and the primary navigation links
- simplify the mobile header by removing extra quick actions, keeping Settings in the overflow menu, and updating settings triggers
- update shared scripts to look for data-open="settings" so both desktop and mobile hooks remain consistent

## Testing
- npm test -- theme-toggle.test.js *(fails: Jest cannot parse ESM imports in js/main.js without additional transform configuration)*

------
https://chatgpt.com/codex/tasks/task_e_690906b97a5483249d6b2e54f0362e8a