### PR TITLE
Move mobile new reminder action into header

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1019,119 +1019,65 @@
   .mc-actions { display: flex; gap: 6px; align-items: center; }
 
   /* Reduce hit area bloat visually but keep target size via padding if needed for a11y */
-  .mc-header .btn { padding: 0; }
+  .mc-header .mc-btn { padding: 0; }
 
-  .mc-quick-links {
-    display: flex;
-    gap: 8px;
-    width: 100%;
-    overflow-x: auto;
-    padding-bottom: 2px;
-    margin-top: 2px;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: none;
-    order: 1;
-  }
-  .mc-quick-links::-webkit-scrollbar { display: none; }
-
-  .mc-quick-link {
-    flex: 0 0 auto;
+  .mc-add-btn {
     display: inline-flex;
     align-items: center;
     justify-content: space-between;
     gap: 10px;
-    min-width: 140px;
-    padding: 0.6rem 0.85rem;
+    padding: 0.55rem 0.85rem;
     border-radius: 12px;
     font-size: 0.8125rem;
     font-weight: 600;
-    background: rgba(255,255,255,0.88);
-    color: rgba(15,23,42,0.92);
-    border: 1px solid rgba(148,163,184,0.25);
-    box-shadow: 0 1px 2px rgba(15,23,42,0.08);
+    line-height: 1.1;
+    background: rgba(255, 255, 255, 0.88);
+    color: rgba(15, 23, 42, 0.92);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
     transition: background-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+    white-space: nowrap;
+    flex-shrink: 0;
   }
 
-  .mc-quick-link:hover,
-  .mc-quick-link:focus-visible {
-    background: rgba(255,255,255,0.95);
-    box-shadow: 0 4px 12px rgba(15,23,42,0.12);
+  .mc-add-btn:hover,
+  .mc-add-btn:focus-visible {
+    background: rgba(255, 255, 255, 0.95);
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.12);
     transform: translateY(-1px);
   }
 
-  .mc-quick-link:focus-visible {
-    outline: 2px solid rgba(99,102,241,0.45);
+  .mc-add-btn:focus-visible {
+    outline: 2px solid rgba(59, 130, 246, 0.4);
     outline-offset: 2px;
   }
 
-  .mc-quick-link--primary {
-    background: linear-gradient(135deg, rgba(59,130,246,0.92), rgba(37,99,235,0.95));
-    color: #fff;
-    border: none;
-    box-shadow: 0 8px 16px rgba(37, 99, 235, 0.35);
-  }
-
-  .mc-quick-link--primary:hover,
-  .mc-quick-link--primary:focus-visible {
-    background: linear-gradient(135deg, rgba(59,130,246,1), rgba(29,78,216,1));
-    box-shadow: 0 10px 18px rgba(29, 78, 216, 0.45);
-  }
-
-  .mc-quick-link__hint {
+  .mc-add-btn__hint {
     font-size: 0.75rem;
     opacity: 0.7;
+    font-weight: 500;
   }
 
-  .mc-quick-link--primary .mc-quick-link__hint {
-    opacity: 0.85;
+  .dark .mc-add-btn {
+    background: rgba(15, 23, 42, 0.7);
+    color: rgba(226, 232, 240, 0.9);
+    border-color: rgba(71, 85, 105, 0.45);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
   }
 
-  .dark .mc-quick-link {
-    background: rgba(15,23,42,0.7);
-    color: rgba(226,232,240,0.9);
-    border-color: rgba(71,85,105,0.45);
-    box-shadow: 0 1px 2px rgba(0,0,0,0.25);
-  }
-
-  .dark .mc-quick-link:hover,
-  .dark .mc-quick-link:focus-visible {
-    background: rgba(30,41,59,0.8);
-    box-shadow: 0 6px 14px rgba(15,23,42,0.45);
-  }
-
-  .dark .mc-quick-link--primary {
-    background: linear-gradient(135deg, rgba(59,130,246,0.95), rgba(37,99,235,1));
-    box-shadow: 0 10px 20px rgba(15,23,42,0.55);
+  .dark .mc-add-btn:hover,
+  .dark .mc-add-btn:focus-visible {
+    background: rgba(30, 41, 59, 0.8);
+    box-shadow: 0 6px 14px rgba(15, 23, 42, 0.45);
   }
 
   /* On slightly larger phones show small text label next to logo (optional) */
   @media (min-width: 420px) {
     .mc-brand .title { display: inline; font-size: 0.95rem; }
-    .mc-quick-links { gap: 10px; }
   }
   </style>
 
   <header class="mc-header" role="banner" aria-label="Primary header">
-    <nav class="mc-quick-links" aria-label="Quick links">
-      <button
-        type="button"
-        class="mc-quick-link mc-quick-link--primary"
-        data-open-add-task
-      >
-        <span>New reminder</span>
-        <span class="mc-quick-link__hint" aria-hidden="true">＋</span>
-      </button>
-      <button
-        id="openSettings"
-        type="button"
-        class="mc-quick-link"
-        data-open="settings"
-      >
-        <span>Settings</span>
-        <span class="mc-quick-link__hint" aria-hidden="true">⌘,</span>
-      </button>
-    </nav>
-
     <div class="mc-header-top">
       <div class="mc-brand" aria-hidden="false">
         <a href="#" class="logo" title="Memory Cue">MC</a>
@@ -1146,6 +1092,10 @@
         <span id="mcStatusText" class="sr-only">Offline</span>
 
         <div class="mc-actions" id="headerQuickActions" role="group" aria-label="Header actions">
+          <button type="button" class="mc-add-btn" data-open-add-task>
+            <span>New reminder</span>
+            <span class="mc-add-btn__hint" aria-hidden="true">＋</span>
+          </button>
           <!-- Overflow / more -->
           <div style="position:relative;">
             <button id="overflowMenuBtn" type="button" class="mc-btn btn btn-ghost icon-only" aria-label="More options" aria-haspopup="true" aria-controls="overflowMenu" aria-expanded="false">
@@ -1153,18 +1103,7 @@
             </button>
 
             <div id="overflowMenu" class="menu-card hidden absolute right-0 mt-2 w-44 rounded-xl shadow-lg bg-base-100 border" role="menu" aria-hidden="true">
-              <ul class="py-2 text-sm" role="none">
-                <li role="none">
-                  <button
-                    type="button"
-                    class="menu-item text-left px-4 py-2"
-                    role="menuitem"
-                    data-open="settings"
-                  >
-                    Settings
-                  </button>
-                </li>
-              </ul>
+              <ul class="py-2 text-sm" role="none"></ul>
             </div>
           </div>
         </div>
@@ -2079,10 +2018,7 @@
 
     (function () {
       const openBtns = Array.from(
-        new Set([
-          ...Array.from(document.querySelectorAll('[data-open="settings"]')),
-          ...Array.from(document.querySelectorAll('#openSettings')),
-        ]),
+        document.querySelectorAll('[data-open="settings"]'),
       ).filter((btn) => btn instanceof HTMLElement);
       const modal = document.getElementById('settingsModal');
       const closeBtn = document.getElementById('closeSettings');


### PR DESCRIPTION
## Summary
- replace the quick link tray with a styled New reminder button embedded in the header actions
- remove the mobile settings shortcut and adjust the settings modal trigger lookup
- add dedicated styles for the relocated New reminder control in light and dark themes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690921b7b3c883249a6bd190230c1378