### PR TITLE
Adjust spacing between header and quick add on mobile

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -925,7 +925,7 @@
   /* Make header visually compact while preserving touch targets and accessibility */
   .mc-header {
     padding-top: calc(env(safe-area-inset-top, 0px) + 8px);
-    padding-bottom: 12px;
+    padding-bottom: 6px;
     padding-left: 12px;
     padding-right: 12px;
     display: flex;
@@ -1349,7 +1349,7 @@
     })();
   </script>
 
-  <main id="main" class="max-w-md mx-auto px-4 pt-4 pb-4" tabindex="-1" data-active-view="reminders">
+  <main id="main" class="max-w-md mx-auto px-4 pt-0 pb-4" tabindex="-1" data-active-view="reminders">
     <!-- BEGIN GPT CHANGE: create form moved to bottom sheet -->
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: reminders view -->


### PR DESCRIPTION
## Summary
- reduce the header padding to tighten its bottom edge
- remove the extra top padding on the main content so the quick add bar sits closer to the header

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690923b1b7c48324b181da5f10d3adb2