### PR TITLE
Refactor mobile reminder actions into header toolbar

### DIFF
--- a/css/teacher.css
+++ b/css/teacher.css
@@ -1413,15 +1413,58 @@ input::placeholder, textarea::placeholder {
   color: var(--task-priority-chip-color, var(--task-chip-color));
 }
 
-.task-actions {
+.task-header {
   display: flex;
-  gap: var(--space-2);
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-3);
 }
 
-.task-actions button {
-  padding: var(--space-2);
+.task-toolbar {
+  display: inline-flex;
+  gap: var(--space-2);
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.task-toolbar-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
   font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 999px;
   min-width: auto;
+  line-height: 1.2;
+}
+
+.task-toolbar-btn:hover,
+.task-toolbar-btn:focus-visible {
+  color: var(--text-primary);
+  border-color: color-mix(in srgb, var(--task-accent) 40%, transparent);
+  background: color-mix(in srgb, var(--task-accent) 10%, transparent);
+}
+
+.task-toolbar-btn .task-toolbar-label {
+  display: inline-block;
+}
+
+.dark .task-toolbar-btn {
+  color: color-mix(in srgb, var(--text-secondary) 85%, var(--text-primary) 15%);
+  border-color: transparent;
+}
+
+.dark .task-toolbar-btn:hover,
+.dark .task-toolbar-btn:focus-visible {
+  color: var(--text-primary);
+  border-color: color-mix(in srgb, var(--task-accent) 55%, transparent);
+  background: color-mix(in srgb, var(--task-accent) 25%, transparent);
 }
 
 /* Checkbox styling */

--- a/docs/css/teacher.css
+++ b/docs/css/teacher.css
@@ -1413,15 +1413,58 @@ input::placeholder, textarea::placeholder {
   color: var(--task-priority-chip-color, var(--task-chip-color));
 }
 
-.task-actions {
+.task-header {
   display: flex;
-  gap: var(--space-2);
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-3);
 }
 
-.task-actions button {
-  padding: var(--space-2);
+.task-toolbar {
+  display: inline-flex;
+  gap: var(--space-2);
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.task-toolbar-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
   font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 999px;
   min-width: auto;
+  line-height: 1.2;
+}
+
+.task-toolbar-btn:hover,
+.task-toolbar-btn:focus-visible {
+  color: var(--text-primary);
+  border-color: color-mix(in srgb, var(--task-accent) 40%, transparent);
+  background: color-mix(in srgb, var(--task-accent) 10%, transparent);
+}
+
+.task-toolbar-btn .task-toolbar-label {
+  display: inline-block;
+}
+
+.dark .task-toolbar-btn {
+  color: color-mix(in srgb, var(--text-secondary) 85%, var(--text-primary) 15%);
+  border-color: transparent;
+}
+
+.dark .task-toolbar-btn:hover,
+.dark .task-toolbar-btn:focus-visible {
+  color: var(--text-primary);
+  border-color: color-mix(in srgb, var(--task-accent) 55%, transparent);
+  background: color-mix(in srgb, var(--task-accent) 25%, transparent);
 }
 
 /* Checkbox styling */

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -1931,17 +1931,25 @@ export async function initReminders(sel = {}) {
       const notesHtml = r.notes ? `<div class="task-notes">${notesToHtml(r.notes)}</div>` : '';
       div.innerHTML = `
         <div class="task-content">
-          <div class="task-title"><strong>${escapeHtml(r.title)}</strong></div>
+          <div class="task-header">
+            <div class="task-title"><strong>${escapeHtml(r.title)}</strong></div>
+            <div class="task-toolbar" role="toolbar" aria-label="Reminder actions">
+              <button class="task-toolbar-btn" data-edit type="button" aria-label="Edit reminder">
+                <span aria-hidden="true">✏️</span>
+                <span class="task-toolbar-label">Edit</span>
+              </button>
+              <button class="task-toolbar-btn" data-del type="button" aria-label="Delete reminder">
+                <span aria-hidden="true">🗑️</span>
+                <span class="task-toolbar-label">Delete</span>
+              </button>
+            </div>
+          </div>
           <div class="task-meta">
             <div class="task-meta-row" style="display:flex; gap:8px; flex-wrap:wrap; align-items:center;">
               ${chipMarkup}
             </div>
           </div>
           ${notesHtml}
-        </div>
-        <div class="task-actions">
-          <button class="btn-ghost" data-edit type="button">Edit</button>
-          <button class="btn-ghost" data-del type="button">Del</button>
         </div>`;
       div.querySelector('[data-edit]').addEventListener('click', () => loadForEdit(r.id));
       div.querySelector('[data-del]').addEventListener('click', () => removeItem(r.id));

--- a/mobile.html
+++ b/mobile.html
@@ -441,32 +441,52 @@
       border-top-color: rgba(71, 85, 105, 0.3);
       color: rgba(203, 213, 225, 0.8);
     }
-    .task-actions {
+    .task-header {
       display: flex;
-      gap: 0.5rem;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.75rem;
+    }
+    .task-toolbar {
+      display: inline-flex;
+      gap: 0.375rem;
       align-items: center;
-      justify-content: flex-end;
-      margin-top: auto;
-      padding-top: 0.75rem;
+      flex-shrink: 0;
     }
-    .task-actions button {
-      padding: 0.375rem 0.75rem;
-      font-size: 0.8125rem;
+    .task-toolbar-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 0.35rem 0.6rem;
+      font-size: 0.75rem;
       font-weight: 600;
-      border-radius: 0.5rem;
+      border-radius: 999px;
+      border: 1px solid transparent;
+      background: transparent;
+      color: rgba(30, 41, 59, 0.82);
       transition: all 0.15s ease;
-      color: rgba(30, 41, 59, 0.88);
+      line-height: 1.2;
     }
-    .task-actions button:hover,
-    .task-actions button:focus-visible {
+    .task-toolbar-btn:hover,
+    .task-toolbar-btn:focus-visible {
       color: rgba(30, 41, 59, 1);
+      border-color: rgba(59, 130, 246, 0.35);
+      background: rgba(59, 130, 246, 0.12);
     }
-    .dark .task-actions button {
+    .task-toolbar-btn .task-toolbar-label {
+      display: inline-block;
+    }
+    .dark .task-toolbar-btn {
       color: rgba(226, 232, 240, 0.92);
+      border-color: transparent;
     }
-    .dark .task-actions button:hover,
-    .dark .task-actions button:focus-visible {
+    .dark .task-toolbar-btn:hover,
+    .dark .task-toolbar-btn:focus-visible {
       color: rgba(248, 250, 252, 1);
+      border-color: rgba(96, 165, 250, 0.35);
+      background: rgba(59, 130, 246, 0.2);
     }
     /* Today-specific task styling - more prominent */
     .task-item[data-today="true"],
@@ -601,18 +621,23 @@
       font-size: 10px;
     }
 
-    /* Adjust task actions for grid */
-    #reminderList.grid-cols-2 .task-actions {
-      gap: 4px;
-      padding-top: 0.5rem;
-      justify-content: flex-end;
+    /* Adjust task header for grid */
+    #reminderList.grid-cols-2 .task-header {
+      gap: 0.5rem;
+      align-items: center;
     }
 
-    #reminderList.grid-cols-2 .task-actions button {
-      width: 28px;
-      height: 28px;
-      font-size: 12px;
-      padding: 0;
+    #reminderList.grid-cols-2 .task-toolbar {
+      gap: 0.25rem;
+    }
+
+    #reminderList.grid-cols-2 .task-toolbar-btn {
+      padding: 0.25rem 0.45rem;
+      font-size: 0.7rem;
+    }
+
+    #reminderList.grid-cols-2 .task-toolbar-btn .task-toolbar-label {
+      display: none;
     }
 
     /* Compact priority indicators */


### PR DESCRIPTION
## Summary
- refactor the mobile reminder item template to use a header toolbar for edit and delete actions
- add styling for the toolbar in shared and mobile CSS, including dark theme states
- tune the mobile grid layout styles to accommodate the new toolbar spacing

## Testing
- No automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690cff7a26608324be6cf750e3c0b778