### PR TITLE
Highlight reminders with scheduled notifications

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -2114,6 +2114,14 @@ export async function initReminders(sel = {}) {
     const hasAny = items.length > 0;
     const hasRows = rows.length > 0;
 
+    const pendingNotificationIds = (() => {
+      if (typeof Notification === 'undefined' || Notification.permission !== 'granted') {
+        return new Set();
+      }
+      const entries = Object.values(scheduledReminders || {}).filter((entry) => entry && typeof entry === 'object' && entry.id);
+      return new Set(entries.map((entry) => entry.id));
+    })();
+
     if(emptyStateEl){
       if(!hasRows){
         const description = hasAny ? 'No reminders to show right now.' : emptyInitialText;
@@ -2180,6 +2188,11 @@ export async function initReminders(sel = {}) {
       div.dataset.priority = summary.priority;
       div.dataset.done = String(summary.done);
       if (summary.dueIso) div.dataset.due = summary.dueIso; // ISO string
+      if(pendingNotificationIds.has(summary.id)){
+        div.dataset.notificationActive = 'true';
+      } else {
+        div.removeAttribute('data-notification-active');
+      }
       const dueDate = summary.dueIso ? new Date(summary.dueIso) : null;
       const dueIsToday = highlightToday && dueDate && dueDate >= t0 && dueDate <= t1;
       if (dueIsToday) {
@@ -2290,6 +2303,11 @@ export async function initReminders(sel = {}) {
           if (summary.dueIso) itemEl.dataset.due = summary.dueIso;
           itemEl.dataset.reminder = JSON.stringify(summary);
           itemEl.className = 'card bg-base-100 shadow-xl w-full lg:w-96 border border-base-200';
+          if(pendingNotificationIds.has(summary.id)){
+            itemEl.dataset.notificationActive = 'true';
+          } else {
+            itemEl.removeAttribute('data-notification-active');
+          }
           const dueLabel = formatDesktopDue(r);
           const titleClasses = r.done ? 'line-through text-base-content/50' : 'text-base-content';
           const statusLabel = r.done ? 'Completed' : 'Active';
@@ -2477,6 +2495,7 @@ export async function initReminders(sel = {}) {
         adviseInstallForBackground();
       }
       rescheduleAllReminders();
+      render();
       return;
     }
     try {
@@ -2490,6 +2509,7 @@ export async function initReminders(sel = {}) {
           adviseInstallForBackground();
         }
         rescheduleAllReminders();
+        render();
       } else {
         toast('Notifications blocked');
       }

--- a/mobile.html
+++ b/mobile.html
@@ -318,6 +318,23 @@
       border-left-color: rgba(129, 140, 248, 1);
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3), 0 2px 6px rgba(0, 0, 0, 0.2);
     }
+    .task-item[data-notification-active="true"] {
+      border-color: rgba(34, 197, 94, 0.75);
+      border-left-color: rgba(22, 163, 74, 0.95);
+      box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.35), 0 8px 18px rgba(34, 197, 94, 0.25);
+    }
+    .task-item[data-notification-active="true"]:hover {
+      box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.45), 0 10px 22px rgba(34, 197, 94, 0.35);
+      transform: translateY(-1px);
+    }
+    .dark .task-item[data-notification-active="true"] {
+      border-color: rgba(74, 222, 128, 0.85);
+      border-left-color: rgba(134, 239, 172, 0.95);
+      box-shadow: 0 0 0 2px rgba(74, 222, 128, 0.35), 0 10px 24px rgba(22, 163, 74, 0.35);
+    }
+    .dark .task-item[data-notification-active="true"]:hover {
+      box-shadow: 0 0 0 2px rgba(74, 222, 128, 0.5), 0 12px 26px rgba(22, 163, 74, 0.45);
+    }
     .task-item[data-priority="High"] {
       border-left-color: rgba(239, 68, 68, 0.7);
       background: linear-gradient(135deg, rgba(254, 226, 226, 0.4), rgba(255, 255, 255, 0.95));
@@ -652,6 +669,18 @@
 
     .task-item[data-compact="true"] .task-toolbar-btn .task-toolbar-label {
       display: none;
+    }
+
+    .task-item[data-compact="true"][data-notification-active="true"] {
+      border-color: rgba(34, 197, 94, 0.75);
+      border-left-color: rgba(22, 163, 74, 0.95);
+      box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.35), 0 8px 18px rgba(34, 197, 94, 0.25);
+    }
+
+    .dark .task-item[data-compact="true"][data-notification-active="true"] {
+      border-color: rgba(74, 222, 128, 0.85);
+      border-left-color: rgba(134, 239, 172, 0.95);
+      box-shadow: 0 0 0 2px rgba(74, 222, 128, 0.35), 0 10px 24px rgba(22, 163, 74, 0.35);
     }
 
     /* Single column on narrow phones */

--- a/styles/index.css
+++ b/styles/index.css
@@ -1148,3 +1148,14 @@ html {
   border-color: rgba(148, 163, 184, 0.45);
   color: rgb(226 232 240);
 }
+
+[data-reminder][data-notification-active="true"] {
+  border-color: rgb(34 197 94);
+  box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.35), 0 10px 25px -15px rgba(34, 197, 94, 0.45);
+}
+
+.dark [data-reminder][data-notification-active="true"],
+[data-theme="dark"] [data-reminder][data-notification-active="true"] {
+  border-color: rgb(74 222 128);
+  box-shadow: 0 0 0 2px rgba(74, 222, 128, 0.35), 0 10px 25px -12px rgba(34, 197, 94, 0.55);
+}


### PR DESCRIPTION
## Summary
- compute the set of reminders with scheduled notifications and tag rendered rows
- refresh the reminder list after enabling notifications so highlights appear immediately
- style desktop and mobile reminder cards marked with active notifications with a green border/glow

## Testing
- npm test *(fails: existing ESM import handling in jest)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69151b28bae48324bff5176941f897f1)