### PR TITLE
style(mobile): simplify reminders list

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -4,6 +4,59 @@
   <base href="/memory-cue/" />
   <!-- Production CSS: compiled via Tailwind/PostCSS; build rewrites this to a hashed asset -->
   <link rel="stylesheet" href="./styles/index.css" />
+  <style>
+    /* Reminders wrapper spacing on mobile */
+    #remindersWrapper {
+      margin-top: 0.75rem;
+    }
+
+    /* Main reminders list container */
+    #reminderList {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    /* Each reminder row */
+    #reminderList [data-reminder] {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 0.75rem;
+      padding: 0.5rem 0.25rem;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.4);
+      font-size: 0.875rem;
+      line-height: 1.4;
+    }
+
+    /* Remove divider on last item */
+    #reminderList [data-reminder]:last-child {
+      border-bottom: none;
+    }
+
+    /* Reminder title (left side) */
+    #reminderList [data-reminder] [data-reminder-title],
+    #reminderList [data-reminder] h3,
+    #reminderList [data-reminder] strong {
+      margin: 0;
+      font-weight: 500;
+    }
+
+    /* Meta info (right side: date/time/status) */
+    #reminderList [data-reminder] time,
+    #reminderList [data-reminder] .reminder-meta {
+      font-size: 0.75rem;
+      opacity: 0.75;
+      white-space: nowrap;
+    }
+
+    /* Slight hover feedback on devices with hover */
+    @media (hover: hover) {
+      #reminderList [data-reminder]:hover {
+        background-color: rgba(15, 23, 42, 0.03);
+      }
+    }
+  </style>
   <meta charset="UTF-8" />
   <meta
     name="viewport"


### PR DESCRIPTION
## Summary
- restyle the mobile reminders list to use slim Apple-style rows
- adjust spacing, typography, and hover feedback for reminder items

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691574bb25d48324af6947a52c5f021a)