### PR TITLE
Flatten reminder list styles in mobile view

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -17,34 +17,48 @@
       padding: 0;
     }
 
-    /* Each reminder row */
-    #reminderList [data-reminder] {
+    /* Each reminder item: flatten card styles */
+    #reminderList > * {
       display: flex;
       align-items: baseline;
       justify-content: space-between;
       gap: 0.75rem;
       padding: 0.5rem 0.25rem;
+      margin: 0; /* remove card gaps */
       border-bottom: 1px solid rgba(148, 163, 184, 0.4);
       font-size: 0.875rem;
       line-height: 1.4;
+
+      /* strip “card” look */
+      background: transparent !important;
+      border-radius: 0 !important;
+      box-shadow: none !important;
+    }
+
+    /* If there are inner card containers, flatten them too */
+    #reminderList > * .card {
+      background: transparent !important;
+      border-radius: 0 !important;
+      box-shadow: none !important;
+      padding: 0 !important;
     }
 
     /* Remove divider on last item */
-    #reminderList [data-reminder]:last-child {
+    #reminderList > *:last-child {
       border-bottom: none;
     }
 
     /* Reminder title (left side) */
-    #reminderList [data-reminder] [data-reminder-title],
-    #reminderList [data-reminder] h3,
-    #reminderList [data-reminder] strong {
+    #reminderList > * h3,
+    #reminderList > * strong,
+    #reminderList > * [data-reminder-title] {
       margin: 0;
       font-weight: 500;
     }
 
     /* Meta info (right side: date/time/status) */
-    #reminderList [data-reminder] time,
-    #reminderList [data-reminder] .reminder-meta {
+    #reminderList > * time,
+    #reminderList > * .reminder-meta {
       font-size: 0.75rem;
       opacity: 0.75;
       white-space: nowrap;
@@ -52,7 +66,7 @@
 
     /* Slight hover feedback on devices with hover */
     @media (hover: hover) {
-      #reminderList [data-reminder]:hover {
+      #reminderList > *:hover {
         background-color: rgba(15, 23, 42, 0.03);
       }
     }


### PR DESCRIPTION
## Summary
- target direct children in the mobile reminders list so spacing applies consistently
- remove card styling and flatten any nested card containers for reminders

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691578a2f7a4832491572ea6a0ac8351)