### PR TITLE
Adjust quick add layout in mobile UI

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1221,22 +1221,21 @@
     }
 
     .mc-quick-add-bar {
-      position: sticky;
-      top: 3.25rem;
-      z-index: 19;
-      background: rgba(15, 23, 42, 0.97);
-      backdrop-filter: blur(10px);
-      -webkit-backdrop-filter: blur(10px);
-      border-bottom: 1px solid rgba(148, 163, 184, 0.3);
+      /* No longer sticky – just part of the normal flow under the header */
+      position: static;
+      background: transparent;
+      border-bottom: none;
+      backdrop-filter: none;
+      margin: 0.25rem 0 0.25rem;
     }
 
     .mc-quick-add-inner {
       max-width: 28rem;
       margin: 0 auto;
-      padding: 0.5rem 0.75rem;
-      display: grid;
-      grid-template-columns: auto 1fr auto;
+      padding: 0.25rem 0.75rem;
+      display: flex;
       align-items: center;
+      justify-content: space-between;
       gap: 0.5rem;
     }
 
@@ -1244,8 +1243,8 @@
       display: flex;
       align-items: center;
       gap: 0.25rem;
-      font-size: 0.75rem;
-      color: rgba(226, 232, 240, 0.85);
+      font-size: 0.7rem;
+      color: rgba(226, 232, 240, 0.8);
     }
 
     .mc-status-text {
@@ -1261,13 +1260,14 @@
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      gap: 0.35rem;
-      width: 100%;
-      min-height: 2.5rem;
+      gap: 0.25rem;
+      width: auto;
+      min-height: 2.1rem;
       border-radius: 999px;
-      font-size: 0.85rem;
+      font-size: 0.8rem;
       font-weight: 500;
       padding-inline: 0.75rem;
+      white-space: nowrap;
     }
 
     .mc-quick-more {


### PR DESCRIPTION
## Summary
- make the quick add bar part of the normal flow and lighten its footprint
- compress the quick add inner layout spacing for a slimmer appearance
- restyle the quick add button so it is compact but still tappable

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69158f3c4d6483248eb54dd93b6eb8e7)