### PR TITLE
Move add reminder button into header

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1298,9 +1298,15 @@
       </button>
 
       <!-- Centre: Title -->
-      <h1 class="text-base font-semibold tracking-wide text-slate-50">
-        Reminders
-      </h1>
+      <button
+        id="addReminderBtn"
+        type="button"
+        class="mc-add-btn mc-add-btn-wide"
+        data-open-add-task
+      >
+        <span class="mc-add-btn-icon" aria-hidden="true">＋</span>
+        <span class="mc-add-btn-label">Add reminder</span>
+      </button>
 
       <!-- Right: Settings button -->
       <button
@@ -1321,16 +1327,6 @@
         </div>
         <span id="mcStatusText" class="mc-status-text">Offline</span>
       </div>
-
-      <button
-        id="addReminderBtn"
-        type="button"
-        class="mc-add-btn mc-add-btn-wide"
-        data-open-add-task
-      >
-        <span class="mc-add-btn-icon" aria-hidden="true">＋</span>
-        <span class="mc-add-btn-label">Add reminder</span>
-      </button>
 
       <div class="mc-quick-more">
         <button


### PR DESCRIPTION
## Summary
- move the existing Add reminder button into the header bar
- remove the redundant Reminders heading from the header

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915957197e88324b46172d4ae362610)