### PR TITLE
Restore quick add row on mobile reminders

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1210,6 +1210,12 @@
       cursor: pointer;
     }
 
+    header.sticky .header-action-group {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
     header.sticky button span {
       font-size: 1.2rem;
       line-height: 1;
@@ -1236,7 +1242,7 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: 0.5rem;
+      gap: 0.75rem;
     }
 
     .mc-quick-status {
@@ -1256,20 +1262,6 @@
       height: 0.5rem;
     }
 
-    .mc-add-btn.mc-add-btn-wide {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      gap: 0.25rem;
-      width: auto;
-      min-height: 2.1rem;
-      border-radius: 999px;
-      font-size: 0.8rem;
-      font-weight: 500;
-      padding-inline: 0.75rem;
-      white-space: nowrap;
-    }
-
     .mc-quick-more {
       display: flex;
       align-items: center;
@@ -1283,6 +1275,76 @@
       display: inline-flex;
       align-items: center;
       justify-content: center;
+    }
+
+    .mc-quick-add-row {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      flex: 1;
+      min-width: 0;
+    }
+
+    .mc-quick-input {
+      flex: 1;
+      min-width: 0;
+      padding: 0.4rem 0.65rem;
+      border-radius: 999px;
+      border: 1px solid rgba(148, 163, 184, 0.5);
+      background-color: rgba(15, 23, 42, 0.35);
+      color: inherit;
+      font-size: 0.8rem;
+    }
+
+    .mc-quick-input::placeholder {
+      color: rgba(148, 163, 184, 0.8);
+    }
+
+    .mc-quick-submit,
+    .mc-quick-voice {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 2.1rem;
+      min-height: 2.1rem;
+      border-radius: 999px;
+      border: none;
+      background: rgba(59, 130, 246, 0.85);
+      color: #fff;
+      font-size: 0.8rem;
+      font-weight: 500;
+      padding: 0 0.75rem;
+      cursor: pointer;
+    }
+
+    .mc-quick-submit {
+      padding-inline: 0.9rem;
+    }
+
+    .mc-quick-voice {
+      background: rgba(148, 163, 184, 0.35);
+      color: rgba(241, 245, 249, 0.95);
+      padding-inline: 0.6rem;
+      font-size: 1rem;
+    }
+
+    .mc-quick-voice.is-listening {
+      background: rgba(59, 130, 246, 0.95);
+      color: #fff;
+    }
+
+    @media (max-width: 420px) {
+      .mc-quick-add-inner {
+        gap: 0.5rem;
+      }
+
+      .mc-quick-add-row {
+        gap: 0.4rem;
+      }
+
+      .mc-quick-submit {
+        padding-inline: 0.7rem;
+      }
     }
   </style>
 
@@ -1302,14 +1364,25 @@
         Reminders
       </h1>
 
-      <!-- Right: Settings button -->
-      <button
-        type="button"
-        class="inline-flex items-center justify-center w-9 h-9 rounded-full bg-slate-800/80 hover:bg-slate-700 active:scale-95 transition"
-        aria-label="Open settings"
-      >
-        <span class="text-xl leading-none">⚙️</span>
-      </button>
+      <!-- Right: Actions -->
+      <div class="header-action-group">
+        <button
+          id="addReminderBtn"
+          type="button"
+          class="inline-flex items-center justify-center w-9 h-9 rounded-full bg-slate-800/80 hover:bg-slate-700 active:scale-95 transition"
+          data-open-add-task
+          aria-label="Add reminder"
+        >
+          <span class="text-xl leading-none">＋</span>
+        </button>
+        <button
+          type="button"
+          class="inline-flex items-center justify-center w-9 h-9 rounded-full bg-slate-800/80 hover:bg-slate-700 active:scale-95 transition"
+          aria-label="Open settings"
+        >
+          <span class="text-xl leading-none">⚙️</span>
+        </button>
+      </div>
     </div>
   </header>
 
@@ -1322,15 +1395,32 @@
         <span id="mcStatusText" class="mc-status-text">Offline</span>
       </div>
 
-      <button
-        id="addReminderBtn"
-        type="button"
-        class="mc-add-btn mc-add-btn-wide"
-        data-open-add-task
-      >
-        <span class="mc-add-btn-icon" aria-hidden="true">＋</span>
-        <span class="mc-add-btn-label">Add reminder</span>
-      </button>
+      <div class="mc-quick-add-row" role="group" aria-label="Quick add reminder">
+        <label for="quickAddInput" class="sr-only">Quick add reminder</label>
+        <input
+          type="text"
+          id="quickAddInput"
+          class="mc-quick-input"
+          placeholder="Quick add reminder..."
+          autocomplete="off"
+        />
+        <button
+          type="button"
+          id="quickAddSubmit"
+          class="mc-quick-submit"
+        >
+          Add
+        </button>
+        <button
+          type="button"
+          id="quickAddVoiceBtn"
+          class="mc-quick-voice"
+          aria-label="Start voice input"
+          title="Start voice input"
+        >
+          🎤
+        </button>
+      </div>
 
       <div class="mc-quick-more">
         <button


### PR DESCRIPTION
## Summary
- move the add reminder button into the header action group so the sheet trigger remains available
- insert a quick add row with the existing input, add, and voice selectors beneath the reminders header
- add lightweight styling so the quick add controls align with the updated layout

## Testing
- not run (not required)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69159643620483249d69c0664deb560a)