### PR TITLE
Restore priority accents in flat reminder list

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -711,10 +711,44 @@
       align-items: baseline !important;
       justify-content: space-between !important;
       gap: 0.75rem !important;
-      padding: 0.5rem 0.25rem !important;
-      border-bottom: 1px solid rgba(148, 163, 184, 0.4) !important;
+      padding: 0.5rem 0.5rem !important;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.35) !important;
       font-size: 0.875rem !important;
       line-height: 1.4 !important;
+      background: transparent !important;
+    }
+
+    #reminderList [data-reminder][data-priority="High"] {
+      border-left: 3px solid rgba(239, 68, 68, 0.7) !important;
+      padding-left: calc(0.5rem - 1.5px) !important;
+      background-color: rgba(239, 68, 68, 0.06) !important;
+    }
+
+    .dark #reminderList [data-reminder][data-priority="High"] {
+      border-left-color: rgba(248, 113, 113, 0.8) !important;
+      background-color: rgba(248, 113, 113, 0.08) !important;
+    }
+
+    #reminderList [data-reminder][data-priority="Medium"] {
+      border-left: 3px solid rgba(245, 158, 11, 0.7) !important;
+      padding-left: calc(0.5rem - 1.5px) !important;
+      background-color: rgba(245, 158, 11, 0.06) !important;
+    }
+
+    .dark #reminderList [data-reminder][data-priority="Medium"] {
+      border-left-color: rgba(251, 191, 36, 0.8) !important;
+      background-color: rgba(251, 191, 36, 0.08) !important;
+    }
+
+    #reminderList [data-reminder][data-priority="Low"] {
+      border-left: 3px solid rgba(34, 197, 94, 0.7) !important;
+      padding-left: calc(0.5rem - 1.5px) !important;
+      background-color: rgba(34, 197, 94, 0.06) !important;
+    }
+
+    .dark #reminderList [data-reminder][data-priority="Low"] {
+      border-left-color: rgba(74, 222, 128, 0.8) !important;
+      background-color: rgba(74, 222, 128, 0.08) !important;
     }
 
     /* Remove divider on the last reminder */


### PR DESCRIPTION
## Summary
- keep the flattened reminder layout while reintroducing subtle row separators
- add slim priority accents that reuse the existing high, medium, and low colours in light and dark themes

## Testing
- not run (css-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915a4b4c0648324a1faa0f73d63c489)