### PR TITLE
Adjust mobile add reminder button spacing

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1261,6 +1261,24 @@
     box-shadow: 0 2px 8px rgba(59, 130, 246, 0.35), 0 1px 4px rgba(59, 130, 246, 0.2);
   }
 
+  /* Improve Add Reminder button visibility */
+  .mc-add-btn {
+    padding: 0.25rem 0.75rem !important;
+    border-radius: 999px !important;
+  }
+
+  .mc-add-btn-wide {
+    padding: 0.35rem 0.85rem !important;
+    border-radius: 999px !important;
+    font-size: 0.9rem !important;
+    line-height: 1.2 !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    white-space: nowrap !important;
+    max-width: 100% !important;
+  }
+
   /* On slightly larger phones show small text label next to logo (optional) */
   @media (min-width: 420px) {
     .mc-brand .title { display: inline; font-size: 0.95rem; }


### PR DESCRIPTION
## Summary
- increase the padding and rounded shape overrides for the mobile header Add reminder button
- ensure the wide variant uses inline-flex layout and retains readable text without clipping

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915a6326bfc8324a9bdfd0e04475716)