### PR TITLE
Adjust Add reminder button pill width

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1267,6 +1267,12 @@
     border-radius: 999px !important;
   }
 
+  /* Prevent circle constraint on generic add button */
+  .mc-add-btn {
+    width: auto !important;
+    height: auto !important;
+  }
+
   .mc-add-btn-wide {
     padding: 0.35rem 0.85rem !important;
     border-radius: 999px !important;
@@ -1277,6 +1283,18 @@
     justify-content: center !important;
     white-space: nowrap !important;
     max-width: 100% !important;
+  }
+
+  /* Ensure Add Reminder button can expand horizontally */
+  .mc-add-btn-wide {
+    width: auto !important;
+    height: auto !important;
+    padding: 0.35rem 0.9rem !important;
+    border-radius: 999px !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    white-space: nowrap !important;
   }
 
   /* On slightly larger phones show small text label next to logo (optional) */


### PR DESCRIPTION
## Summary
- allow the Add reminder button to size automatically without forcing a circle
- ensure the wide variant stretches as a pill around the label text

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915a7ac67848324a329dc27cb7e1971)