### PR TITLE
Improve mobile reminder list layout

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -56,9 +56,9 @@
 
     /* Each reminder item: flatten all card styling */
     #reminderList > * {
-      display: flex;
-      align-items: baseline;
-      justify-content: space-between;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: start;
       gap: 0.75rem;
       padding: 0.75rem 0.5rem;
       margin: 0; /* remove gaps between items */
@@ -66,11 +66,11 @@
       font-size: 0.875rem;
       line-height: 1.4;
 
-    /* strip “card” look */
-    background: transparent !important;
-    border-radius: 0 !important;
-    box-shadow: none !important;
-  }
+      /* strip “card” look */
+      background: transparent !important;
+      border-radius: 0 !important;
+      box-shadow: none !important;
+    }
 
     /* If reminders are wrapped in DaisyUI cards, flatten them too */
     #reminderList > * .card,
@@ -95,11 +95,14 @@
     #reminderList > * [data-reminder-title] {
       margin: 0;
       font-weight: 500;
-      flex: 1;
+      grid-column: 1;
       min-width: 0; /* allow text to truncate */
       overflow: hidden;
       text-overflow: ellipsis;
-      white-space: nowrap;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      line-clamp: 2;
     }
 
     /* Meta info (right side: date/time/status) */
@@ -107,9 +110,11 @@
     #reminderList > * .reminder-meta {
       font-size: 0.75rem;
       opacity: 0.75;
-      white-space: nowrap;
       margin-left: 0.5rem;
-      flex-shrink: 0;
+      grid-column: 2;
+      justify-self: end;
+      text-align: right;
+      align-self: start;
     }
 
     /* Hide extra description/details to keep list minimal */
@@ -969,9 +974,9 @@
 
     /* Ensure each reminder behaves like a flat row */
     #reminderList [data-reminder] {
-      display: flex !important;
-      align-items: baseline !important;
-      justify-content: space-between !important;
+      display: grid !important;
+      grid-template-columns: minmax(0, 1fr) auto !important;
+      align-items: start !important;
       gap: 0.75rem !important;
       padding: 0.5rem 0.5rem !important;
       border-bottom: 1px solid color-mix(in srgb, var(--border-color) 35%, transparent) !important;
@@ -1025,11 +1030,14 @@
     #reminderList [data-reminder] [data-reminder-title] {
       margin: 0 !important;
       font-weight: 500 !important;
-      flex: 1 1 auto !important;
+      grid-column: 1 !important;
       min-width: 0 !important;
       overflow: hidden !important;
       text-overflow: ellipsis !important;
-      white-space: nowrap !important;
+      display: -webkit-box !important;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      line-clamp: 2;
     }
 
     /* Meta info (date/time/status) on the right */
@@ -1037,9 +1045,11 @@
     #reminderList [data-reminder] .reminder-meta {
       font-size: 0.75rem !important;
       opacity: 0.75 !important;
-      white-space: nowrap !important;
       margin-left: 0.5rem !important;
-      flex-shrink: 0 !important;
+      grid-column: 2 !important;
+      justify-self: end !important;
+      text-align: right !important;
+      align-self: start !important;
     }
 
     /* Hide extra verbose details to keep list minimal */


### PR DESCRIPTION
## Summary
- switch the mobile reminder list rows to a start-aligned grid layout that preserves padding and priority styling
- allow reminder titles to wrap via line clamp while keeping metadata in a right-aligned column

## Testing
- Manual validation of mobile.html list/grid views in a mobile-width viewport


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916552a8d9483249078767104dee928)