### PR TITLE
Wire header theme controls to shared events

### DIFF
--- a/404.html
+++ b/404.html
@@ -178,12 +178,12 @@
                 role="menu"
                 tabindex="0"
               >
-                <li><a href="#" data-theme-option="light" role="menuitemradio" aria-checked="false">Light</a></li>
-                <li><a href="#" data-theme-option="dark" role="menuitemradio" aria-checked="false">Dark</a></li>
-                <li><a href="#" data-theme-option="dracula" role="menuitemradio" aria-checked="false">Dracula</a></li>
-                <li><a href="#" data-theme-option="cupcake" role="menuitemradio" aria-checked="false">Cupcake</a></li>
-                <li><a href="#" data-theme-option="caramellatte" role="menuitemradio" aria-checked="false">Caramellatte</a></li>
-                <li><a href="#" data-theme-option="synthwave" role="menuitemradio" aria-checked="false">Synthwave</a></li>
+                <li><a href="#" data-theme-name="light" data-theme-option="light" role="menuitemradio" aria-checked="false">Light</a></li>
+                <li><a href="#" data-theme-name="dark" data-theme-option="dark" role="menuitemradio" aria-checked="false">Dark</a></li>
+                <li><a href="#" data-theme-name="dracula" data-theme-option="dracula" role="menuitemradio" aria-checked="false">Dracula</a></li>
+                <li><a href="#" data-theme-name="cupcake" data-theme-option="cupcake" role="menuitemradio" aria-checked="false">Cupcake</a></li>
+                <li><a href="#" data-theme-name="caramellatte" data-theme-option="caramellatte" role="menuitemradio" aria-checked="false">Caramellatte</a></li>
+                <li><a href="#" data-theme-name="synthwave" data-theme-option="synthwave" role="menuitemradio" aria-checked="false">Synthwave</a></li>
               </ul>
             </div>
             <div

--- a/docs/404.html
+++ b/docs/404.html
@@ -178,12 +178,12 @@
                 role="menu"
                 tabindex="0"
               >
-                <li><a href="#" data-theme-option="light" role="menuitemradio" aria-checked="false">Light</a></li>
-                <li><a href="#" data-theme-option="dark" role="menuitemradio" aria-checked="false">Dark</a></li>
-                <li><a href="#" data-theme-option="dracula" role="menuitemradio" aria-checked="false">Dracula</a></li>
-                <li><a href="#" data-theme-option="cupcake" role="menuitemradio" aria-checked="false">Cupcake</a></li>
-                <li><a href="#" data-theme-option="caramellatte" role="menuitemradio" aria-checked="false">Caramellatte</a></li>
-                <li><a href="#" data-theme-option="synthwave" role="menuitemradio" aria-checked="false">Synthwave</a></li>
+                <li><a href="#" data-theme-name="light" data-theme-option="light" role="menuitemradio" aria-checked="false">Light</a></li>
+                <li><a href="#" data-theme-name="dark" data-theme-option="dark" role="menuitemradio" aria-checked="false">Dark</a></li>
+                <li><a href="#" data-theme-name="dracula" data-theme-option="dracula" role="menuitemradio" aria-checked="false">Dracula</a></li>
+                <li><a href="#" data-theme-name="cupcake" data-theme-option="cupcake" role="menuitemradio" aria-checked="false">Cupcake</a></li>
+                <li><a href="#" data-theme-name="caramellatte" data-theme-option="caramellatte" role="menuitemradio" aria-checked="false">Caramellatte</a></li>
+                <li><a href="#" data-theme-name="synthwave" data-theme-option="synthwave" role="menuitemradio" aria-checked="false">Synthwave</a></li>
               </ul>
             </div>
             <div


### PR DESCRIPTION
## Summary
- add shared theme change event handling so the header theme toggle and menu stay in sync
- persist menu selections, update aria states, and reflect the active theme on load
- annotate header menu options with the expected data attributes in both source and built HTML

## Testing
- npm test -- --watch=false *(fails: Jest is not configured to transform ESM imports such as js/main.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916559702ec8324a0ea43572a2ce3b8)