### PR TITLE
Open mobile reminders for editing on row click

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -2524,6 +2524,9 @@ export async function initReminders(sel = {}) {
       div.dataset.reminderItem = 'true';
       div.setAttribute('draggable', 'true');
       div.classList.add('reminder-draggable');
+      div.setAttribute('role', 'button');
+      div.tabIndex = 0;
+      div.setAttribute('aria-label', `Edit reminder: ${r.title}`);
       if (summary.dueIso) div.dataset.due = summary.dueIso; // ISO string
       if (pendingNotificationIds.has(summary.id)) {
         div.dataset.notificationActive = 'true';
@@ -2550,10 +2553,6 @@ export async function initReminders(sel = {}) {
           <div class="task-header">
             <div class="task-title"><strong>${escapeHtml(r.title)}</strong></div>
             <div class="task-toolbar" role="toolbar" aria-label="Reminder actions">
-              <button class="task-toolbar-btn" data-edit type="button" aria-label="Edit reminder">
-                <span aria-hidden="true">✏️</span>
-                <span class="task-toolbar-label">Edit</span>
-              </button>
               <button class="task-toolbar-btn" data-del type="button" aria-label="Delete reminder">
                 <span aria-hidden="true">🗑️</span>
                 <span class="task-toolbar-label">Delete</span>
@@ -2567,8 +2566,29 @@ export async function initReminders(sel = {}) {
           </div>
           ${notesHtml}
         </div>`;
-      div.querySelector('[data-edit]').addEventListener('click', () => loadForEdit(r.id));
-      div.querySelector('[data-del]').addEventListener('click', () => removeItem(r.id));
+      const deleteBtn = div.querySelector('[data-del]');
+      if (deleteBtn) {
+        deleteBtn.addEventListener('click', (event) => {
+          event.stopPropagation();
+          removeItem(r.id);
+        });
+      }
+      const openReminder = () => loadForEdit(r.id);
+      div.addEventListener('click', (event) => {
+        if (event.defaultPrevented) return;
+        if (event.target instanceof HTMLElement && event.target.closest('[data-del]')) {
+          return;
+        }
+        openReminder();
+      });
+      div.addEventListener('keydown', (event) => {
+        if (event.defaultPrevented) return;
+        if (event.target !== div) return;
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          openReminder();
+        }
+      });
       return div;
     };
 


### PR DESCRIPTION
## Summary
- remove the edit button from mobile reminder rows and make the entire row behave as the edit trigger
- keep the delete action while preventing it from opening the edit sheet
- add keyboard support and an accessible label so reminder rows can be opened with Enter or Space

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691659992144832495c1938475ab955a)