### PR TITLE
Remove reorder hint text from mobile UI

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2135,10 +2135,6 @@
         </button>
         <div class="w-full" id="remindersWrapper">
           <div id="emptyState" class="hidden text-center text-base-content/60 py-8 px-4"></div>
-          <div class="flex items-center gap-2 px-4 pb-3 text-xs text-base-content/70">
-            <span aria-hidden="true" class="text-base">↕️</span>
-            <span>Press, hold, and drag a card to reorder your reminders.</span>
-          </div>
           <p id="reminderReorderHint" class="sr-only">
             Press, hold, and drag a reminder card to reorder your list. Screen reader users can double-tap and hold, then drag to move a reminder.
           </p>


### PR DESCRIPTION
## Summary
- remove the inline reorder hint block from the mobile reminders view to declutter the UI

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69165b633ab08324bd175856ed7e54e9)