### PR TITLE
Apply Ocean Blue styling to mobile reminder cards

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -6,25 +6,33 @@
   <link rel="stylesheet" href="./styles/index.css" />
   <style>
     :root {
-      --primary-color: #5e72e4;
-      --primary-dark: #4c63d2;
-      --secondary-color: #f5365c;
-      --success-color: #2dce89;
-      --warning-color: #fb6340;
-      --info-color: #11cdef;
-      --text-primary: #32325d;
-      --text-secondary: #8898aa;
-      --bg-color: #f4f5f7;
-      --card-bg: #ffffff;
-      --border-color: #e9ecef;
-      --priority-high-border: #d92d20;
-      --priority-high-bg: #fef3f2;
-      --priority-medium-border: #f79009;
-      --priority-medium-bg: #fef6e7;
-      --priority-low-border: #12b76a;
-      --priority-low-bg: #ecfdf3;
-      --shadow-sm: 0 0 0.5rem rgba(0, 0, 0, 0.075);
-      --shadow-md: 0 0 2rem rgba(136, 152, 170, 0.15);
+      --card-bg: #FFFFFF;
+      --card-border: #E2E8F0;
+      --text-primary: #1E293B;
+      --text-secondary: #64748B;
+      --accent-color: #0EA5E9;
+      --success-color: #10B981;
+      --background-color: #F8FAFC;
+      --hover-bg: #F1F5F9;
+      --shadow-color: rgba(0, 0, 0, 0.05);
+      --delete-color: #EF4444;
+
+      /* Legacy tokens mapped to Ocean Blue Professional palette */
+      --primary-color: var(--accent-color);
+      --primary-dark: #0369A1;
+      --secondary-color: #0EA5E9;
+      --warning-color: #F59E0B;
+      --info-color: var(--accent-color);
+      --bg-color: var(--background-color);
+      --border-color: var(--card-border);
+      --priority-high-border: #EF4444;
+      --priority-high-bg: rgba(239, 68, 68, 0.08);
+      --priority-medium-border: #F59E0B;
+      --priority-medium-bg: rgba(245, 158, 11, 0.08);
+      --priority-low-border: #10B981;
+      --priority-low-bg: rgba(16, 185, 129, 0.08);
+      --shadow-sm: 0 1px 3px var(--shadow-color);
+      --shadow-md: 0 4px 12px var(--shadow-color);
       --transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     }
 
@@ -60,38 +68,44 @@
     padding: 0;
   }
 
-    /* Each reminder item: flatten all card styling */
+    /* Each reminder item uses the Ocean Blue card styling */
     #reminderList > * {
       display: grid;
       grid-template-columns: minmax(0, 1fr) auto;
       align-items: start;
       gap: 0.75rem;
-      padding: 0.75rem 0.5rem;
-      margin: 0; /* remove gaps between items */
-      border-bottom: 1px solid color-mix(in srgb, var(--border-color) 40%, transparent);
-      font-size: 0.875rem;
-      line-height: 1.4;
-
-      /* strip “card” look */
-      background: transparent !important;
-      border-radius: 0 !important;
-      box-shadow: none !important;
+      padding: 20px;
+      margin: 0 0 16px 0;
+      border: 1px solid var(--card-border);
+      font-size: 0.95rem;
+      line-height: 1.5;
+      background: var(--card-bg);
+      border-radius: 12px;
+      box-shadow: 0 1px 3px var(--shadow-color);
+      transition: all 0.2s ease;
     }
 
-    /* If reminders are wrapped in DaisyUI cards, flatten them too */
+    #reminderList > *:hover {
+      box-shadow: 0 4px 12px var(--shadow-color);
+      transform: translateY(-2px);
+      border-color: var(--accent-color);
+      background: var(--hover-bg);
+    }
+
+    /* If reminders are wrapped in DaisyUI cards, ensure they inherit the new look */
     #reminderList > * .card,
     #reminderList > * .card-body {
-      background: transparent !important;
-      border-radius: 0 !important;
-      box-shadow: none !important;
-      padding: 0 !important;
-      margin: 0 !important;
-      border: none !important;
+      background: transparent;
+      border-radius: inherit;
+      box-shadow: none;
+      padding: 0;
+      margin: 0;
+      border: none;
     }
 
-  /* Remove divider on last item */
+  /* Remove extra spacing on the last item */
   #reminderList > *:last-child {
-    border-bottom: none;
+    margin-bottom: 0;
   }
 
     /* Title on the left */
@@ -100,7 +114,10 @@
     #reminderList > * strong,
     #reminderList > * [data-reminder-title] {
       margin: 0;
-      font-weight: 500;
+      color: var(--text-primary);
+      font-weight: 600;
+      font-size: 18px;
+      margin-bottom: 12px;
       grid-column: 1;
       min-width: 0; /* allow text to truncate */
       overflow: hidden;
@@ -114,29 +131,26 @@
     /* Meta info (right side: date/time/status) */
     #reminderList > * time,
     #reminderList > * .reminder-meta {
-      font-size: 0.75rem;
-      opacity: 0.75;
-      margin-left: 0.5rem;
-      grid-column: 2;
-      justify-self: end;
-      text-align: right;
-      align-self: start;
+      color: var(--text-secondary);
+      font-size: 14px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 0.75rem;
+      margin-top: 16px;
+      grid-column: 1 / -1;
     }
 
-    /* Hide extra description/details to keep list minimal */
+    #reminderList > * time {
+      justify-content: flex-end;
+      text-align: right;
+    }
+
     #reminderList > * p,
     #reminderList > * .description,
-    #reminderList > * .details,
-    #reminderList > * .card-actions {
-      display: none !important;
+    #reminderList > * .details {
+      color: var(--text-secondary);
     }
-
-  /* Slight hover feedback on devices with hover */
-  @media (hover: hover) {
-    #reminderList > *:hover {
-      background-color: color-mix(in srgb, var(--text-primary) 3%, transparent);
-    }
-  }
   </style>
   <meta charset="UTF-8" />
   <meta
@@ -385,7 +399,34 @@
         font-size: 16px; /* Prevent zoom on iOS */
       }
     }
-    
+
+    .search-input,
+    .filter-select,
+    #searchPanel input,
+    #searchPanel select {
+      border: 1px solid var(--card-border);
+      background: var(--card-bg);
+      color: var(--text-primary);
+      border-radius: 10px;
+      padding: 0.65rem 0.85rem;
+      transition: all 0.2s ease;
+      box-shadow: 0 1px 2px var(--shadow-color);
+    }
+
+    .search-input::placeholder,
+    #searchPanel input::placeholder {
+      color: color-mix(in srgb, var(--text-secondary) 70%, transparent);
+    }
+
+    .search-input:focus,
+    .filter-select:focus,
+    #searchPanel input:focus,
+    #searchPanel select:focus {
+      border-color: var(--accent-color);
+      box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.1);
+      outline: none;
+    }
+
     /* Auto-save status indicator */
     .sync-dot {
       width: 0.5rem;
@@ -418,6 +459,11 @@
       padding-bottom: 0.25rem;
       scrollbar-width: none;
       scroll-snap-type: x proximity;
+    }
+
+    .section-header h2,
+    .view-panel h2 {
+      color: var(--text-primary);
     }
     .section-jump::-webkit-scrollbar {
       display: none;
@@ -716,7 +762,7 @@
     /* Enhanced mobile body */
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-      background-color: var(--bg-color);
+      background-color: var(--background-color);
       color: var(--text-primary);
       line-height: 1.6;
       margin: 0;
@@ -962,121 +1008,195 @@
       box-shadow: var(--shadow-sm);
     }
 
-    /* --- Reminder list: force flat list layout, neutralize old card styles --- */
+    /* --- Reminder list: Ocean Blue Professional card styling --- */
 
-    /* Neutralize any card/grid wrapper for reminders */
     #reminderList .task-item,
     #reminderList .task-card,
     #reminderList .card,
     #reminderList .card-body,
     #reminderList .task-grid {
-      background: transparent !important;
-      border-radius: 0 !important;
-      box-shadow: none !important;
-      margin: 0 !important;
-      padding: 0 !important;
-      border: none !important;
+      background: transparent;
+      border: none;
+      border-radius: 0;
+      box-shadow: none;
+      margin: 0;
+      padding: 0;
     }
 
-    /* Ensure each reminder behaves like a flat row */
+    .cue-item,
     #reminderList [data-reminder] {
-      display: grid !important;
-      grid-template-columns: minmax(0, 1fr) auto !important;
-      align-items: start !important;
-      gap: 0.75rem !important;
-      padding: 0.5rem 0.5rem !important;
-      border-bottom: 1px solid color-mix(in srgb, var(--border-color) 35%, transparent) !important;
-      font-size: 0.875rem !important;
-      line-height: 1.4 !important;
-      background: transparent !important;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: start;
+      gap: 0.75rem;
+      padding: 20px;
+      margin-bottom: 16px;
+      background: var(--card-bg);
+      border: 1px solid var(--card-border);
+      border-radius: 12px;
+      box-shadow: 0 1px 3px var(--shadow-color);
+      transition: all 0.2s ease;
     }
 
-    #reminderList [data-reminder][data-priority="High"] {
-      border-left: 3px solid var(--priority-high-border) !important;
-      padding-left: calc(0.5rem - 1.5px) !important;
-      background-color: var(--priority-high-bg) !important;
-      color: color-mix(in srgb, var(--priority-high-border) 18%, var(--text-primary) 82%);
-    }
-
-    .dark #reminderList [data-reminder][data-priority="High"] {
-      border-left-color: color-mix(in srgb, var(--priority-high-border) 70%, transparent) !important;
-      background-color: color-mix(in srgb, var(--priority-high-border) 22%, #0b1220) !important;
-      color: color-mix(in srgb, var(--priority-high-border) 25%, #e2e8f0);
-    }
-
-    #reminderList [data-reminder][data-priority="Medium"] {
-      border-left: 3px solid var(--priority-medium-border) !important;
-      padding-left: calc(0.5rem - 1.5px) !important;
-      background-color: var(--priority-medium-bg) !important;
-      color: color-mix(in srgb, var(--priority-medium-border) 14%, var(--text-primary) 86%);
-    }
-
-    .dark #reminderList [data-reminder][data-priority="Medium"] {
-      border-left-color: color-mix(in srgb, var(--priority-medium-border) 70%, transparent) !important;
-      background-color: color-mix(in srgb, var(--priority-medium-border) 20%, #0b1220) !important;
-      color: color-mix(in srgb, var(--priority-medium-border) 18%, #e2e8f0);
-    }
-
-    #reminderList [data-reminder][data-priority="Low"] {
-      border-left: 3px solid var(--priority-low-border) !important;
-      padding-left: calc(0.5rem - 1.5px) !important;
-      background-color: var(--priority-low-bg) !important;
-      color: color-mix(in srgb, var(--priority-low-border) 12%, var(--text-primary) 88%);
-    }
-
-    .dark #reminderList [data-reminder][data-priority="Low"] {
-      border-left-color: color-mix(in srgb, var(--priority-low-border) 65%, transparent) !important;
-      background-color: color-mix(in srgb, var(--priority-low-border) 18%, #0b1220) !important;
-      color: color-mix(in srgb, var(--priority-low-border) 20%, #e2e8f0);
-    }
-
-    /* Remove divider on the last reminder */
+    .cue-item:last-child,
     #reminderList [data-reminder]:last-child {
-      border-bottom: none !important;
+      margin-bottom: 0;
     }
 
-    /* Title/label on the left */
+    .cue-item:hover,
+    #reminderList [data-reminder]:hover {
+      box-shadow: 0 4px 12px var(--shadow-color);
+      transform: translateY(-2px);
+      border-color: var(--accent-color);
+      background: var(--hover-bg);
+    }
+
+    .dark .cue-item,
+    .dark #reminderList [data-reminder] {
+      background: color-mix(in srgb, rgba(15, 23, 42, 0.92) 85%, var(--card-bg) 15%);
+      border-color: color-mix(in srgb, var(--card-border) 45%, transparent);
+      box-shadow: none;
+    }
+
+    .dark .cue-item:hover,
+    .dark #reminderList [data-reminder]:hover {
+      background: color-mix(in srgb, rgba(30, 41, 59, 0.95) 75%, var(--accent-color) 25%);
+    }
+
+    .cue-item[data-priority="High"],
+    #reminderList [data-reminder][data-priority="High"] {
+      border-left: 3px solid var(--priority-high-border);
+      background: var(--priority-high-bg);
+      padding-left: calc(20px - 1.5px);
+    }
+
+    .cue-item[data-priority="Medium"],
+    #reminderList [data-reminder][data-priority="Medium"] {
+      border-left: 3px solid var(--priority-medium-border);
+      background: var(--priority-medium-bg);
+      padding-left: calc(20px - 1.5px);
+    }
+
+    .cue-item[data-priority="Low"],
+    #reminderList [data-reminder][data-priority="Low"] {
+      border-left: 3px solid var(--priority-low-border);
+      background: var(--priority-low-bg);
+      padding-left: calc(20px - 1.5px);
+    }
+
+    .dark .cue-item[data-priority="High"],
+    .dark #reminderList [data-reminder][data-priority="High"] {
+      background: color-mix(in srgb, rgba(239, 68, 68, 0.22) 60%, rgba(15, 23, 42, 0.92) 40%);
+      border-left-color: color-mix(in srgb, var(--priority-high-border) 80%, transparent);
+    }
+
+    .dark .cue-item[data-priority="Medium"],
+    .dark #reminderList [data-reminder][data-priority="Medium"] {
+      background: color-mix(in srgb, rgba(245, 158, 11, 0.22) 60%, rgba(15, 23, 42, 0.92) 40%);
+      border-left-color: color-mix(in srgb, var(--priority-medium-border) 80%, transparent);
+    }
+
+    .dark .cue-item[data-priority="Low"],
+    .dark #reminderList [data-reminder][data-priority="Low"] {
+      background: color-mix(in srgb, rgba(16, 185, 129, 0.22) 60%, rgba(15, 23, 42, 0.92) 40%);
+      border-left-color: color-mix(in srgb, var(--priority-low-border) 80%, transparent);
+    }
+
+    .cue-name,
     #reminderList [data-reminder] h3,
     #reminderList [data-reminder] h4,
     #reminderList [data-reminder] strong,
     #reminderList [data-reminder] [data-reminder-title] {
-      margin: 0 !important;
-      font-weight: 500 !important;
-      grid-column: 1 !important;
-      min-width: 0 !important;
-      overflow: hidden !important;
-      text-overflow: ellipsis !important;
-      display: -webkit-box !important;
+      margin: 0;
+      color: var(--text-primary);
+      font-weight: 600;
+      font-size: 18px;
+      margin-bottom: 12px;
+      grid-column: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;
       -webkit-line-clamp: 2;
       -webkit-box-orient: vertical;
       line-clamp: 2;
     }
 
-    /* Meta info (date/time/status) on the right */
+    .cue-meta,
     #reminderList [data-reminder] time,
     #reminderList [data-reminder] .reminder-meta {
-      font-size: 0.75rem !important;
-      opacity: 0.75 !important;
-      margin-left: 0.5rem !important;
-      grid-column: 2 !important;
-      justify-self: end !important;
-      text-align: right !important;
-      align-self: start !important;
+      color: var(--text-secondary);
+      font-size: 14px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 0.75rem;
+      margin-top: 16px;
+      grid-column: 1 / -1;
     }
 
-    /* Hide extra verbose details to keep list minimal */
+    #reminderList [data-reminder] time {
+      justify-content: flex-end;
+      text-align: right;
+    }
+
+    .cue-content,
     #reminderList [data-reminder] p,
     #reminderList [data-reminder] .description,
-    #reminderList [data-reminder] .details,
-    #reminderList [data-reminder] .card-actions {
-      display: none !important;
+    #reminderList [data-reminder] .details {
+      color: var(--text-secondary);
     }
 
-    /* Subtle hover feedback for pointer devices */
-    @media (hover: hover) {
-      #reminderList [data-reminder]:hover {
-        background-color: color-mix(in srgb, var(--text-primary) 3%, transparent) !important;
-      }
+    .cue-actions,
+    #reminderList [data-reminder] .card-actions {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: flex-end;
+      align-items: center;
+      grid-column: 1 / -1;
+      margin-top: 12px;
+    }
+
+    .cue-btn,
+    #reminderList [data-reminder] .card-actions button,
+    #reminderList [data-reminder] button {
+      color: var(--text-secondary);
+      background: transparent;
+      border: none;
+      padding: 6px;
+      border-radius: 6px;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      font-size: 16px;
+      line-height: 1;
+    }
+
+    .cue-btn:hover,
+    #reminderList [data-reminder] .card-actions button:hover,
+    #reminderList [data-reminder] button:hover {
+      color: var(--accent-color);
+      background: rgba(14, 165, 233, 0.1);
+    }
+
+    .cue-btn.delete:hover,
+    #reminderList [data-reminder] .card-actions .delete:hover,
+    #reminderList [data-reminder] button.delete:hover,
+    #reminderList [data-reminder] button[data-action="delete"]:hover {
+      color: var(--delete-color);
+      background: rgba(239, 68, 68, 0.1);
+    }
+
+    .cue-audio,
+    #reminderList [data-reminder] audio {
+      width: 100%;
+      margin-top: 12px;
+      border-radius: 8px;
+      display: block;
+    }
+
+    .cue-item audio::-webkit-media-controls-panel,
+    #reminderList [data-reminder] audio::-webkit-media-controls-panel {
+      background-color: var(--hover-bg);
     }
   </style>
   <!-- BEGIN GPT CHANGE: bottom sheet styles -->
@@ -1289,14 +1409,15 @@
       font-size: 1rem;
       font-weight: 600;
       line-height: 1.4;
+      color: var(--text-primary);
     }
     #emptyState .empty-state-compact p {
       font-size: 0.875rem;
       line-height: 1.5;
-      color: color-mix(in srgb, var(--text-secondary) 85%, var(--text-primary) 15%);
+      color: var(--text-secondary);
     }
     .dark #emptyState .empty-state-compact p {
-      color: color-mix(in srgb, var(--card-bg) 80%, transparent);
+      color: color-mix(in srgb, var(--card-bg) 85%, transparent);
     }
     #emptyState .empty-state-actions {
       display: flex;


### PR DESCRIPTION
## Summary
- replace the mobile theme variables with the Ocean Blue Professional palette and update the page background
- restyle reminder list items, actions, and audio controls to use the new card colors and hover treatments
- refresh search/filter controls and empty state messaging to rely on the new color variables

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69165ea76e8c8324aa771a3084c5d8ca)