### PR TITLE
Reduce reminder card footprint

### DIFF
--- a/docs/memory/memory.css
+++ b/docs/memory/memory.css
@@ -73,12 +73,12 @@
 .reminder-card {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 1.25rem;
+  gap: 0.85rem;
   align-items: start;
-  padding: 1.25rem 1.5rem 1.25rem 1.75rem;
-  border-radius: 20px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: linear-gradient(145deg, rgba(241, 245, 249, 0.95), rgba(226, 232, 240, 0.88));
+  padding: 0.9rem 1.1rem 0.9rem 1.2rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: linear-gradient(150deg, rgba(241, 245, 249, 0.9), rgba(226, 232, 240, 0.82));
   overflow: hidden;
 }
 
@@ -115,19 +115,19 @@
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 0.5rem;
-  min-width: 180px;
+  gap: 0.4rem;
+  min-width: 150px;
   text-align: right;
 }
 
 .reminder-card__due {
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   font-weight: 600;
   color: #1f2937;
 }
 
 .reminder-card__countdown {
-  font-size: 0.78rem;
+  font-size: 0.74rem;
   font-weight: 500;
   color: #475569;
 }
@@ -168,7 +168,7 @@
 @media (max-width: 640px) {
   .reminder-card {
     grid-template-columns: 1fr;
-    padding: 1.25rem 1.25rem 1.25rem 1.6rem;
+    padding: 0.95rem 1rem 0.95rem 1.1rem;
   }
 
   .reminder-card__meta {

--- a/memory/memory.css
+++ b/memory/memory.css
@@ -73,12 +73,12 @@
 .reminder-card {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 1.25rem;
+  gap: 0.85rem;
   align-items: start;
-  padding: 1.25rem 1.5rem 1.25rem 1.75rem;
-  border-radius: 20px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: linear-gradient(145deg, rgba(241, 245, 249, 0.95), rgba(226, 232, 240, 0.88));
+  padding: 0.9rem 1.1rem 0.9rem 1.2rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: linear-gradient(150deg, rgba(241, 245, 249, 0.9), rgba(226, 232, 240, 0.82));
   overflow: hidden;
 }
 
@@ -115,19 +115,19 @@
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 0.5rem;
-  min-width: 180px;
+  gap: 0.4rem;
+  min-width: 150px;
   text-align: right;
 }
 
 .reminder-card__due {
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   font-weight: 600;
   color: #1f2937;
 }
 
 .reminder-card__countdown {
-  font-size: 0.78rem;
+  font-size: 0.74rem;
   font-weight: 500;
   color: #475569;
 }
@@ -168,7 +168,7 @@
 @media (max-width: 640px) {
   .reminder-card {
     grid-template-columns: 1fr;
-    padding: 1.25rem 1.25rem 1.25rem 1.6rem;
+    padding: 0.95rem 1rem 0.95rem 1.1rem;
   }
 
   .reminder-card__meta {


### PR DESCRIPTION
## Summary
- shrink reminder card spacing, padding, and border radius to return to the previous compact footprint
- tighten metadata column and typography to match the restored sizing
- mirror the styling adjustments in the published docs build

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691660ba7b6c83248792540d7eda654f)