### PR TITLE
Centralize Firebase configuration for reminders

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
 <!-- BEGIN GPT CHANGE: supabase init via env module -->
 <script type="module" src="./js/config-supabase.js" defer></script>
 <!-- END GPT CHANGE -->
+  <script defer src="./js/firebase-config.js"></script>
 <!-- === /SUPABASE CONFIG === -->
 <!-- BEGIN GPT CHANGE: supabase keys moved to env.js -->
 <!-- END GPT CHANGE -->

--- a/js/__tests__/firebase-config.test.js
+++ b/js/__tests__/firebase-config.test.js
@@ -1,0 +1,49 @@
+const { DEFAULT_FIREBASE_CONFIG, getFirebaseConfig } = require('../firebase-config.js');
+
+describe('firebase-config', () => {
+  const originalEnv = globalThis.__ENV;
+  const originalDirect = globalThis.__FIREBASE_CONFIG;
+  const originalMemoryCue = globalThis.memoryCueFirebase;
+
+  beforeEach(() => {
+    globalThis.__ENV = undefined;
+    globalThis.__FIREBASE_CONFIG = undefined;
+    delete globalThis.memoryCueFirebase;
+  });
+
+  afterEach(() => {
+    delete globalThis.memoryCueFirebase;
+  });
+
+  afterAll(() => {
+    globalThis.__ENV = originalEnv;
+    globalThis.__FIREBASE_CONFIG = originalDirect;
+    if (originalMemoryCue) {
+      globalThis.memoryCueFirebase = originalMemoryCue;
+    } else {
+      delete globalThis.memoryCueFirebase;
+    }
+  });
+
+  it('returns the default firebase project values', () => {
+    const config = getFirebaseConfig();
+    expect(config).toEqual(DEFAULT_FIREBASE_CONFIG);
+    expect(config).not.toBe(DEFAULT_FIREBASE_CONFIG);
+    expect(config.projectId).toBe('memory-cue-pro');
+  });
+
+  it('merges direct global overrides', () => {
+    globalThis.__FIREBASE_CONFIG = { projectId: 'custom-project', apiKey: 'custom-key' };
+    const config = getFirebaseConfig();
+    expect(config.projectId).toBe('custom-project');
+    expect(config.apiKey).toBe('custom-key');
+    expect(config.storageBucket).toBe(DEFAULT_FIREBASE_CONFIG.storageBucket);
+  });
+
+  it('merges __ENV overrides when direct config missing', () => {
+    globalThis.__ENV = { FIREBASE_CONFIG: { measurementId: 'G-TESTING1234' } };
+    const config = getFirebaseConfig();
+    expect(config.measurementId).toBe('G-TESTING1234');
+    expect(config.projectId).toBe(DEFAULT_FIREBASE_CONFIG.projectId);
+  });
+});

--- a/js/firebase-config.js
+++ b/js/firebase-config.js
@@ -1,0 +1,71 @@
+const DEFAULT_FIREBASE_CONFIG = Object.freeze({
+  apiKey: 'AIzaSyB8n0PCndJgHnU_i5y4PiFv8zn2eA1New0',
+  authDomain: 'memory-cue-pro.firebaseapp.com',
+  projectId: 'memory-cue-pro',
+  storageBucket: 'memory-cue-pro.firebasestorage.app',
+  messagingSenderId: '494760962301',
+  appId: '1:494760962301:web:52c0fe3567f0c8f8b9e5e6',
+  measurementId: 'G-1H4CPRO123'
+});
+
+function normalizeConfigCandidate(candidate) {
+  if (!candidate || typeof candidate !== 'object') {
+    return null;
+  }
+  const entries = Object.entries(candidate).filter(([key, value]) => typeof value === 'string' && value.trim() !== '');
+  if (!entries.length) {
+    return null;
+  }
+  return Object.fromEntries(entries);
+}
+
+function readConfigFromGlobals() {
+  const scope = typeof globalThis !== 'undefined' ? globalThis : (typeof window !== 'undefined' ? window : {});
+  const direct = normalizeConfigCandidate(scope?.__FIREBASE_CONFIG);
+  if (direct) {
+    return direct;
+  }
+  const env = normalizeConfigCandidate(scope?.__ENV?.FIREBASE_CONFIG);
+  if (env) {
+    return env;
+  }
+  const legacyMap = {
+    FIREBASE_API_KEY: 'apiKey',
+    FIREBASE_AUTH_DOMAIN: 'authDomain',
+    FIREBASE_PROJECT_ID: 'projectId',
+    FIREBASE_STORAGE_BUCKET: 'storageBucket',
+    FIREBASE_MESSAGING_SENDER_ID: 'messagingSenderId',
+    FIREBASE_APP_ID: 'appId',
+    FIREBASE_MEASUREMENT_ID: 'measurementId'
+  };
+  const legacy = Object.entries(legacyMap).reduce((acc, [legacyKey, targetKey]) => {
+    const value = scope?.__ENV?.[legacyKey] ?? scope?.[legacyKey];
+    if (typeof value === 'string' && value.trim() !== '') {
+      acc[targetKey] = value;
+    }
+    return acc;
+  }, {});
+  return Object.keys(legacy).length ? legacy : null;
+}
+
+function getFirebaseConfig() {
+  const overrides = readConfigFromGlobals();
+  if (!overrides) {
+    return { ...DEFAULT_FIREBASE_CONFIG };
+  }
+  return { ...DEFAULT_FIREBASE_CONFIG, ...overrides };
+}
+
+const api = { DEFAULT_FIREBASE_CONFIG, getFirebaseConfig };
+
+if (typeof globalThis !== 'undefined') {
+  const scope = globalThis;
+  scope.memoryCueFirebase = scope.memoryCueFirebase || {};
+  scope.memoryCueFirebase.getFirebaseConfig = getFirebaseConfig;
+  scope.memoryCueFirebase.DEFAULT_FIREBASE_CONFIG = DEFAULT_FIREBASE_CONFIG;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = api;
+  module.exports.default = api;
+}

--- a/js/firebase-init.js
+++ b/js/firebase-init.js
@@ -1,16 +1,56 @@
 /* firebase-init.js */
-const firebaseConfig = {
-  apiKey: 'AIzaSyAmAMiz0zG3dAhZJhOy1DYj8fKVDObL36c',
-  authDomain: 'memory-cue-app.firebaseapp.com',
-  projectId: 'memory-cue-app',
-  storageBucket: 'memory-cue-app.firebasestorage.app',
-  messagingSenderId: '751284466633',
-  appId: '1:751284466633:web:3b10742970bef1a5d5ee18',
-  measurementId: 'G-R0V4M7VCE6'
-};
+const FALLBACK_FIREBASE_CONFIG = Object.freeze({
+  apiKey: 'AIzaSyB8n0PCndJgHnU_i5y4PiFv8zn2eA1New0',
+  authDomain: 'memory-cue-pro.firebaseapp.com',
+  projectId: 'memory-cue-pro',
+  storageBucket: 'memory-cue-pro.firebasestorage.app',
+  messagingSenderId: '494760962301',
+  appId: '1:494760962301:web:52c0fe3567f0c8f8b9e5e6',
+  measurementId: 'G-1H4CPRO123'
+});
+
+const scope = typeof globalThis !== 'undefined'
+  ? globalThis
+  : (typeof window !== 'undefined' ? window : {});
+
+let firebaseConfig = null;
+
+if (scope?.memoryCueFirebase?.getFirebaseConfig) {
+  firebaseConfig = scope.memoryCueFirebase.getFirebaseConfig();
+} else if (typeof require === 'function') {
+  try {
+    const moduleValue = require('./firebase-config.js');
+    const getter = typeof moduleValue?.getFirebaseConfig === 'function'
+      ? moduleValue.getFirebaseConfig
+      : typeof moduleValue?.default?.getFirebaseConfig === 'function'
+        ? moduleValue.default.getFirebaseConfig
+        : null;
+    if (getter) {
+      firebaseConfig = getter();
+    }
+  } catch {
+    // ignore – likely executed in browser without require support
+  }
+}
+
+if (!firebaseConfig && scope?.memoryCueFirebase?.DEFAULT_FIREBASE_CONFIG) {
+  firebaseConfig = { ...scope.memoryCueFirebase.DEFAULT_FIREBASE_CONFIG };
+}
+
+if (!firebaseConfig) {
+  firebaseConfig = { ...FALLBACK_FIREBASE_CONFIG };
+}
+
+if (!firebaseConfig || typeof firebaseConfig !== 'object' || !firebaseConfig.projectId) {
+  console.warn('Firebase config missing or invalid; skipping init.');
+}
+
+const hasValidConfig = firebaseConfig && typeof firebaseConfig === 'object' && typeof firebaseConfig.projectId === 'string';
 
 if (typeof firebase === 'undefined') {
   console.warn('Firebase SDK not available; auth features disabled.');
+} else if (!hasValidConfig) {
+  console.warn('Firebase config missing projectId; auth features disabled.');
 } else if (!firebase.apps.length) {
   try {
     firebase.initializeApp(firebaseConfig);

--- a/mobile.html
+++ b/mobile.html
@@ -2541,6 +2541,7 @@
     }
   </script>
   <!-- Load the mobile app bundle (build will rewrite to hashed path) -->
+  <script defer src="./js/firebase-config.js"></script>
   <script type="module" src="./mobile.js?v=2025-10-29-1"></script>
   <script type="module" src="./js/mobile-theme-toggle.js"></script>
   <!-- BEGIN GPT CHANGE: bottom sheet for Create Reminder -->


### PR DESCRIPTION
## Summary
- add a reusable `firebase-config` helper that exposes the updated project credentials and supports environment overrides
- have `reminders.js`/`firebase-init.js` consume the shared config with fallbacks and telemetry when Firebase initialises
- ensure the Firebase bootstrap runs before the app bundles on desktop/mobile and add regression tests for the config helper

## Testing
- npm test *(fails: existing jest environment cannot parse ESM imports in js/main.js and mobile.js; reminder save-click flow also fails due to Firebase mocks rejecting module loads)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69166210a8408324a51809022beebd8c)