### PR TITLE
Update Firebase config to memory-cue-app

### DIFF
--- a/js/__tests__/firebase-config.test.js
+++ b/js/__tests__/firebase-config.test.js
@@ -29,7 +29,7 @@ describe('firebase-config', () => {
     const config = getFirebaseConfig();
     expect(config).toEqual(DEFAULT_FIREBASE_CONFIG);
     expect(config).not.toBe(DEFAULT_FIREBASE_CONFIG);
-    expect(config.projectId).toBe('memory-cue-pro');
+    expect(config.projectId).toBe('memory-cue-app');
   });
 
   it('merges direct global overrides', () => {

--- a/js/__tests__/mobile.sheet.test.js
+++ b/js/__tests__/mobile.sheet.test.js
@@ -10,6 +10,10 @@ function runMobileModule(window) {
   const filePath = path.resolve(__dirname, '../../mobile.js');
   let source = fs.readFileSync(filePath, 'utf8');
   source = source.replace(
+    "import { initViewportHeight } from './js/modules/viewport-height.js';",
+    'const initViewportHeight = () => () => {};',
+  );
+  source = source.replace(
     "import { initReminders } from './js/reminders.js';",
     'const initReminders = window.__initReminders;',
   );

--- a/js/__tests__/reminders.save-click.test.js
+++ b/js/__tests__/reminders.save-click.test.js
@@ -30,6 +30,7 @@ function loadRemindersModule() {
     Blob: global.Blob,
     Response: global.Response,
     URL: global.URL,
+    HTMLElement: window.HTMLElement,
   };
   vm.runInNewContext(source, sandbox, { filename: filePath });
   return module.exports;
@@ -94,6 +95,9 @@ describe('mobile save interactions', () => {
     global.fetch = jest.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
     window.fetch = global.fetch;
 
+    global.HTMLElement = window.HTMLElement;
+    window.HTMLElement = window.HTMLElement || global.HTMLElement;
+
     global.Notification = MockNotification;
     window.Notification = MockNotification;
 
@@ -135,6 +139,7 @@ describe('mobile save interactions', () => {
     jest.clearAllTimers();
     delete window.toast;
     delete global.toast;
+    delete global.HTMLElement;
   });
 
   test('clicking Save creates and then updates a reminder without duplicate handlers', () => {
@@ -160,9 +165,9 @@ describe('mobile save interactions', () => {
     expect(events.filter((entry) => entry[0] === 'memoryCue:remindersUpdated').length).toBe(initialMemoryCueUpdated + 1);
 
     // Enter edit mode via rendered list button
-    const editButton = document.querySelector('[data-edit]');
-    expect(editButton).toBeTruthy();
-    editButton.click();
+    const reminderRow = document.querySelector('[data-reminder-item="true"]');
+    expect(reminderRow).toBeTruthy();
+    reminderRow.click();
 
     title.value = 'Call Alex Updated';
     highChip.checked = true;

--- a/js/firebase-config.js
+++ b/js/firebase-config.js
@@ -1,11 +1,11 @@
 const DEFAULT_FIREBASE_CONFIG = Object.freeze({
-  apiKey: 'AIzaSyB8n0PCndJgHnU_i5y4PiFv8zn2eA1New0',
-  authDomain: 'memory-cue-pro.firebaseapp.com',
-  projectId: 'memory-cue-pro',
-  storageBucket: 'memory-cue-pro.firebasestorage.app',
-  messagingSenderId: '494760962301',
-  appId: '1:494760962301:web:52c0fe3567f0c8f8b9e5e6',
-  measurementId: 'G-1H4CPRO123'
+  apiKey: 'AIzaSyAmAMiz0zG3dAhZJhOy1DYj8fKVDObL36c',
+  authDomain: 'memory-cue-app.firebaseapp.com',
+  projectId: 'memory-cue-app',
+  storageBucket: 'memory-cue-app.firebasestorage.app',
+  messagingSenderId: '751284466633',
+  appId: '1:751284466633:web:3b10742970bef1a5d5ee18',
+  measurementId: 'G-R0V4M7VCE6'
 });
 
 function normalizeConfigCandidate(candidate) {

--- a/js/firebase-init.js
+++ b/js/firebase-init.js
@@ -1,12 +1,12 @@
 /* firebase-init.js */
 const FALLBACK_FIREBASE_CONFIG = Object.freeze({
-  apiKey: 'AIzaSyB8n0PCndJgHnU_i5y4PiFv8zn2eA1New0',
-  authDomain: 'memory-cue-pro.firebaseapp.com',
-  projectId: 'memory-cue-pro',
-  storageBucket: 'memory-cue-pro.firebasestorage.app',
-  messagingSenderId: '494760962301',
-  appId: '1:494760962301:web:52c0fe3567f0c8f8b9e5e6',
-  measurementId: 'G-1H4CPRO123'
+  apiKey: 'AIzaSyAmAMiz0zG3dAhZJhOy1DYj8fKVDObL36c',
+  authDomain: 'memory-cue-app.firebaseapp.com',
+  projectId: 'memory-cue-app',
+  storageBucket: 'memory-cue-app.firebasestorage.app',
+  messagingSenderId: '751284466633',
+  appId: '1:751284466633:web:3b10742970bef1a5d5ee18',
+  measurementId: 'G-R0V4M7VCE6'
 });
 
 const scope = typeof globalThis !== 'undefined'

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -30,13 +30,13 @@ const OFFLINE_REMINDERS_KEY = 'memoryCue:offlineReminders';
 const ORDER_INDEX_GAP = 1024;
 
 const FALLBACK_FIREBASE_CONFIG = Object.freeze({
-  apiKey: 'AIzaSyB8n0PCndJgHnU_i5y4PiFv8zn2eA1New0',
-  authDomain: 'memory-cue-pro.firebaseapp.com',
-  projectId: 'memory-cue-pro',
-  storageBucket: 'memory-cue-pro.firebasestorage.app',
-  messagingSenderId: '494760962301',
-  appId: '1:494760962301:web:52c0fe3567f0c8f8b9e5e6',
-  measurementId: 'G-1H4CPRO123'
+  apiKey: 'AIzaSyAmAMiz0zG3dAhZJhOy1DYj8fKVDObL36c',
+  authDomain: 'memory-cue-app.firebaseapp.com',
+  projectId: 'memory-cue-app',
+  storageBucket: 'memory-cue-app.firebasestorage.app',
+  messagingSenderId: '751284466633',
+  appId: '1:751284466633:web:3b10742970bef1a5d5ee18',
+  measurementId: 'G-R0V4M7VCE6'
 });
 
 let cachedFirebaseConfig = null;

--- a/theme-toggle.test.js
+++ b/theme-toggle.test.js
@@ -2,6 +2,29 @@
  * @jest-environment jsdom
  */
 const { test, expect, beforeEach } = require('@jest/globals');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function runMainModule() {
+  const filePath = path.resolve(__dirname, './js/main.js');
+  let source = fs.readFileSync(filePath, 'utf8');
+  source = source.replace(
+    "import { initViewportHeight } from './modules/viewport-height.js';",
+    'const initViewportHeight = () => () => {};',
+  );
+  const script = new vm.Script(source, { filename: filePath });
+  const context = vm.createContext({
+    window,
+    document,
+    console,
+    localStorage,
+    CustomEvent: window.CustomEvent,
+    setTimeout,
+    clearTimeout,
+  });
+  script.runInContext(context);
+}
 
 beforeEach(() => {
   // Minimal DOM with theme toggle button
@@ -23,7 +46,7 @@ beforeEach(() => {
     ),
   };
   jest.resetModules();
-  require('./js/main.js');
+  runMainModule();
 });
 
 test('toggle persists theme', () => {


### PR DESCRIPTION
## Summary
- update the shared Firebase fallback config to use the memory-cue-app project values
- refresh reminder and support tests to match the current DOM structure and provide HTMLElement stubs
- adjust mobile and theme toggle tests to execute ESM entry points via VM helpers

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691665ba4168832494af2d6f700d400c)