### PR TITLE
Ensure mobile flow loads service worker registration

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2548,6 +2548,7 @@
   </script>
   <!-- Load the mobile app bundle (build will rewrite to hashed path) -->
   <script defer src="./js/firebase-config.js"></script>
+  <script src="./js/register-service-worker.js" defer></script>
   <script type="module" src="./mobile.js?v=2025-10-29-1"></script>
   <script type="module" src="./js/mobile-theme-toggle.js"></script>
   <!-- BEGIN GPT CHANGE: bottom sheet for Create Reminder -->


### PR DESCRIPTION
## Summary
- load the shared service worker registration script in the mobile entry page so reminders benefit from background sync

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69166dc914608324abfacde1bcdedc00)