### PR TITLE
Add mobile theme stylesheet for reminder app

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -1,0 +1,292 @@
+/* Base Styles */
+body {
+  background-color: #F3F4F6;
+  color: #111827;
+  font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+main,
+section,
+header,
+footer {
+  color: inherit;
+}
+
+/* Header / Top Bar */
+.app-header,
+header,
+.top-bar {
+  background-color: #0F172A;
+  color: #FFFFFF;
+  padding: 1rem 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.app-header h1,
+header h1,
+.top-bar h1,
+.app-header h2,
+header h2,
+.top-bar h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.app-header button,
+.top-bar button,
+header button,
+.app-header .icon-button,
+.top-bar .icon-button {
+  background: transparent;
+  border: none;
+  color: #FFFFFF;
+  cursor: pointer;
+  padding: 0.35rem;
+  border-radius: 999px;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.app-header button:focus-visible,
+.top-bar button:focus-visible,
+header button:focus-visible {
+  outline: 2px solid #2563EB;
+  outline-offset: 2px;
+}
+
+.app-header button:hover,
+.top-bar button:hover,
+header button:hover {
+  color: #2563EB;
+  background-color: rgba(37, 99, 235, 0.1);
+}
+
+.app-header button.is-active,
+.top-bar button.is-active {
+  color: #2563EB;
+}
+
+/* Card Styles */
+.card,
+.note-card,
+.reminder-card {
+  background-color: #FFFFFF;
+  border: 1px solid #E5E7EB;
+  border-radius: 0.75rem;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
+  padding: 1rem 1.25rem;
+  color: #111827;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.card h2,
+.card h3,
+.card h4,
+.card .title,
+.note-card h2,
+.note-card h3,
+.note-card h4,
+.note-card .title,
+.reminder-card h2,
+.reminder-card h3,
+.reminder-card h4,
+.reminder-card .title {
+  color: #111827;
+  margin: 0;
+}
+
+.card .meta,
+.note-card .meta,
+.reminder-card .meta,
+.text-secondary {
+  color: #6B7280;
+}
+
+/* Buttons */
+.btn-primary,
+button.btn-primary,
+.button-primary {
+  background-color: #2563EB;
+  color: #FFFFFF;
+  border: none;
+  border-radius: 0.65rem;
+  padding: 0.75rem 1.25rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.btn-primary:hover,
+button.btn-primary:hover,
+.button-primary:hover {
+  background-color: #1D4ED8;
+}
+
+.btn-primary:focus-visible,
+button.btn-primary:focus-visible,
+.button-primary:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.4);
+  outline-offset: 2px;
+}
+
+.btn-primary:active,
+button.btn-primary:active,
+.button-primary:active {
+  transform: translateY(1px);
+}
+
+/* Priority Pills */
+.priority-pill {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.priority-pill.priority-high {
+  background-color: #FEE2E2;
+  color: #B91C1C;
+}
+
+.priority-pill.priority-medium {
+  background-color: #FEF9C3;
+  color: #B45309;
+}
+
+.priority-pill.priority-low {
+  background-color: #DCFCE7;
+  color: #15803D;
+}
+
+/* Forms */
+input,
+select,
+textarea,
+button,
+.form-control {
+  font-family: inherit;
+}
+
+input,
+select,
+textarea,
+.form-control {
+  width: 100%;
+  background-color: #FFFFFF;
+  border: 1px solid #E5E7EB;
+  border-radius: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.9rem;
+  color: #111827;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus,
+.form-control:focus {
+  border-color: #2563EB;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  outline: none;
+}
+
+input::placeholder,
+select::placeholder,
+textarea::placeholder {
+  color: #6B7280;
+}
+
+label {
+  color: #111827;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+form .form-group,
+form .field,
+form .input-group {
+  margin-bottom: 1rem;
+}
+
+/* Links & Icons */
+a,
+.link,
+.icon,
+.text-accent {
+  color: #2563EB;
+  text-decoration: none;
+}
+
+a:hover,
+.link:hover,
+.hover\:text-accent-dark:hover {
+  color: #1D4ED8;
+}
+
+/* Utilities */
+.text-muted,
+.text-secondary,
+.meta-text {
+  color: #6B7280;
+}
+
+.text-primary {
+  color: #111827;
+}
+
+.bg-app,
+.app-background {
+  background-color: #F3F4F6;
+}
+
+.card-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+/* Accessibility Helpers */
+:focus-visible {
+  outline: 2px solid #2563EB;
+  outline-offset: 2px;
+}
+
+/* Media Queries */
+@media (max-width: 640px) {
+  .app-header,
+  header,
+  .top-bar {
+    padding: 1.25rem 1.5rem;
+  }
+
+  .card,
+  .note-card,
+  .reminder-card {
+    padding: 1.15rem 1.35rem;
+  }
+
+  .btn-primary,
+  button.btn-primary,
+  .button-primary {
+    width: 100%;
+    font-size: 1.05rem;
+    padding: 0.85rem 1.25rem;
+  }
+
+  .card-grid {
+    gap: 1.25rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `theme-mobile.css` stylesheet tailored for the mobile reminder UI
- implement color palette across header, cards, buttons, priority pills, and forms
- provide responsive tweaks and utility classes for accent text and secondary metadata

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916711316a48324b2ecfdd9d35fdf67)