### PR TITLE
Tighten navbar height

### DIFF
--- a/docs/styles/index.css
+++ b/docs/styles/index.css
@@ -49,6 +49,16 @@ html {
   -webkit-backdrop-filter: blur(18px);
 }
 
+.navbar {
+  min-height: 0;
+  padding-block: clamp(0.2rem, 0.8vw, 0.4rem);
+  align-items: center;
+}
+
+.navbar > * {
+  min-height: 0;
+}
+
 [data-theme="dark"] .navbar-glass {
   background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(30, 41, 59, 0.7));
   border-bottom-color: rgba(148, 163, 184, 0.22);

--- a/styles/index.css
+++ b/styles/index.css
@@ -49,6 +49,16 @@ html {
   -webkit-backdrop-filter: blur(18px);
 }
 
+.navbar {
+  min-height: 0;
+  padding-block: clamp(0.2rem, 0.8vw, 0.4rem);
+  align-items: center;
+}
+
+.navbar > * {
+  min-height: 0;
+}
+
 [data-theme="dark"] .navbar-glass {
   background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(30, 41, 59, 0.7));
   border-bottom-color: rgba(148, 163, 184, 0.22);


### PR DESCRIPTION
## Summary
- reduce the navbar's minimum height to allow the bar to hug the content closely
- lower the vertical padding so the blue header background is only slightly taller than the text and icons

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916773e22f0832494a526eb33c4e4f9)