### PR TITLE
Add Google sign-in controls to desktop layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -347,6 +347,9 @@ const initialiseReminders = () => {
     emptyStateSel: '#emptyState',
     listWrapperSel: '#remindersWrapper',
     dateFeedbackSel: '#dateFeedback',
+    googleSignInBtnSel: '#googleSignInBtn',
+    googleSignOutBtnSel: '#googleSignOutBtn',
+    googleUserNameSel: '#googleUserName',
     variant: 'desktop'
   });
 };

--- a/docs/index.html
+++ b/docs/index.html
@@ -170,6 +170,16 @@
       box-shadow: 0 3px 8px rgba(15, 23, 42, 0.35);
     }
 
+    .google-user-chip {
+      display: none;
+      align-items: center;
+      gap: 0.35rem;
+    }
+
+    .google-user-chip:not(:empty) {
+      display: inline-flex;
+    }
+
     /* Dashboard overall spacing */
     section[data-route="dashboard"] {
       max-width: 56rem;
@@ -297,20 +307,13 @@
             </div>
           </div>
           <div class="flex w-full flex-wrap items-center justify-end gap-2 sm:w-auto">
-            <form id="auth-form" class="hidden flex flex-wrap items-center justify-end gap-2">
-              <label for="auth-email" class="sr-only">Email address</label>
-              <input
-                id="auth-email"
-                type="email"
-                required
-                autocomplete="email"
-                placeholder="you@school.edu"
-                class="input input-sm input-bordered w-full max-w-xs sm:w-56"
-              />
-              <button id="sign-in-btn" type="submit" class="btn btn-sm btn-primary">Send link</button>
-            </form>
+            <div
+              id="googleUserName"
+              class="google-user-chip text-xs sm:text-sm font-medium text-base-content/80 rounded-full border border-base-200 bg-base-100/80 px-3 py-1"
+            ></div>
+            <button id="googleSignInBtn" type="button" class="btn btn-sm btn-primary w-full sm:w-auto">Sign in</button>
             <button
-              id="sign-out-btn"
+              id="googleSignOutBtn"
               type="button"
               class="hidden btn btn-sm btn-outline border-base-300 bg-base-100/80 text-base-content w-full sm:w-auto"
             >

--- a/index.html
+++ b/index.html
@@ -171,6 +171,16 @@
       box-shadow: 0 3px 8px rgba(15, 23, 42, 0.35);
     }
 
+    .google-user-chip {
+      display: none;
+      align-items: center;
+      gap: 0.35rem;
+    }
+
+    .google-user-chip:not(:empty) {
+      display: inline-flex;
+    }
+
     /* Dashboard overall spacing */
     section[data-route="dashboard"] {
       max-width: 56rem;
@@ -298,20 +308,13 @@
             </div>
           </div>
           <div class="flex w-full flex-wrap items-center justify-end gap-2 sm:w-auto">
-            <form id="auth-form" class="hidden flex flex-wrap items-center justify-end gap-2">
-              <label for="auth-email" class="sr-only">Email address</label>
-              <input
-                id="auth-email"
-                type="email"
-                required
-                autocomplete="email"
-                placeholder="you@school.edu"
-                class="input input-sm input-bordered w-full max-w-xs sm:w-56"
-              />
-              <button id="sign-in-btn" type="submit" class="btn btn-sm btn-primary">Send link</button>
-            </form>
+            <div
+              id="googleUserName"
+              class="google-user-chip text-xs sm:text-sm font-medium text-base-content/80 rounded-full border border-base-200 bg-base-100/80 px-3 py-1"
+            ></div>
+            <button id="googleSignInBtn" type="button" class="btn btn-sm btn-primary w-full sm:w-auto">Sign in</button>
             <button
-              id="sign-out-btn"
+              id="googleSignOutBtn"
               type="button"
               class="hidden btn btn-sm btn-outline border-base-300 bg-base-100/80 text-base-content w-full sm:w-auto"
             >


### PR DESCRIPTION
## Summary
- replace the Supabase email auth form on the desktop page with the Google sign-in/out controls used on mobile
- add styling for the Google user badge and mirror the markup changes in the published docs build
- wire the desktop reminders bootstrap to pass the Google auth selectors to the shared reminders module

## Testing
- npm test *(fails: reminder note management › appends notes to an existing reminder and saves to firestore – expects Firebase config in test harness)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69167de804fc83248a462d20ed327c80)