### PR TITLE
Reduce mobile header padding

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2010,7 +2010,7 @@
   </style>
 
   <header class="sticky top-0 z-20 bg-slate-900 text-slate-50 shadow-md">
-    <div class="mx-auto max-w-md px-3 py-3 flex items-center justify-between gap-2">
+    <div class="mx-auto max-w-md px-3 py-1 flex items-center justify-between gap-2">
       <!-- Left: Home button -->
       <button
         id="btn-open-drawer"


### PR DESCRIPTION
## Summary
- reduce the vertical padding in the mobile header wrapper so the blue bar hugs the controls more closely

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69167e1c941083248ef58ff4f49e869d)