### PR TITLE
Default mobile reminders to compact cards

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2608,13 +2608,13 @@
         }
 
         updateToggleIcons(isGridView);
-        setCompactMode(isGridView);
+        setCompactMode(true);
         applyNotificationHighlights();
       };
 
       const observer = new MutationObserver(() => {
         const isGridView = reminderList.classList.contains('grid-cols-2');
-        setCompactMode(isGridView);
+        setCompactMode(true);
         applyNotificationHighlights();
       });
 
@@ -2625,13 +2625,13 @@
           reminderList.classList.remove('grid-cols-2');
           reminderList.classList.add('space-y-3');
           updateToggleIcons(false);
-          setCompactMode(false);
         } else {
           reminderList.classList.add('grid-cols-2');
           reminderList.classList.remove('space-y-3');
           updateToggleIcons(true);
-          setCompactMode(true);
         }
+
+        setCompactMode(true);
 
         applyNotificationHighlights();
       });


### PR DESCRIPTION
## Summary
- always apply the compact card styling after reminders render and when the view toggles so cards use reduced spacing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691683c1d5d88324a454f3b5cada58e7)