### PR TITLE
Move reminders view toggle into quick add controls

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -916,21 +916,6 @@
       }
     }
 
-    /* View toggle button - positioned over the reminders */
-    .view-toggle {
-      position: absolute;
-      top: 8px;
-      right: 8px;
-      z-index: 10;
-      background: rgba(255, 255, 255, 0.9);
-      backdrop-filter: blur(4px);
-      border: 1px solid rgba(0, 0, 0, 0.1);
-    }
-    
-    .dark .view-toggle {
-      background: rgba(0, 0, 0, 0.7);
-      border-color: rgba(255, 255, 255, 0.1);
-    }
   </style>
   <!-- Skip-link CSS: fully hidden until keyboard focus -->
   <style id="skip-link-css">
@@ -1709,6 +1694,14 @@
       min-width: 0;
     }
 
+    .mc-quick-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      align-items: center;
+      flex-shrink: 0;
+    }
+
     .mc-quick-input {
       flex: 1;
       min-width: 0;
@@ -1725,7 +1718,8 @@
     }
 
     .mc-quick-submit,
-    .mc-quick-voice {
+    .mc-quick-voice,
+    .mc-quick-toggle {
       display: inline-flex;
       align-items: center;
       justify-content: center;
@@ -1757,6 +1751,23 @@
       color: var(--card-bg);
     }
 
+    .mc-quick-toggle {
+      background: color-mix(in srgb, var(--text-secondary) 28%, transparent);
+      color: color-mix(in srgb, var(--card-bg) 95%, transparent);
+      font-size: 0.8rem;
+      padding: 0;
+    }
+
+    .mc-quick-toggle .grid-icon,
+    .mc-quick-toggle .list-icon {
+      line-height: 1;
+    }
+
+    .mc-quick-toggle:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--primary-color) 80%, transparent);
+      outline-offset: 2px;
+    }
+
     @media (max-width: 420px) {
       .mc-quick-add-inner {
         gap: 0.5rem;
@@ -1764,6 +1775,10 @@
 
       .mc-quick-add-row {
         gap: 0.4rem;
+      }
+
+      .mc-quick-actions {
+        gap: 0.3rem;
       }
 
       .mc-quick-submit {
@@ -1868,14 +1883,25 @@
         >
           Add
         </button>
-        <button
-          id="quickAddVoice"
-          type="button"
-          class="mc-quick-voice"
-          aria-label="Use voice to add reminder"
-        >
-          🎤
-        </button>
+        <div class="mc-quick-actions">
+          <button
+            id="quickAddVoice"
+            type="button"
+            class="mc-quick-voice"
+            aria-label="Use voice to add reminder"
+          >
+            🎤
+          </button>
+          <button
+            id="viewToggle"
+            type="button"
+            class="mc-quick-toggle"
+            aria-label="Switch between compact and full reminder layouts"
+          >
+            <span class="grid-icon" aria-hidden="true">⊞</span>
+            <span class="list-icon hidden" aria-hidden="true">☰</span>
+          </button>
+        </div>
       </div>
     </div>
   </section>
@@ -2129,10 +2155,6 @@
         id="reminderListSection"
         class="w-full relative"
       >
-        <button id="viewToggle" class="view-toggle btn btn-ghost btn-xs absolute top-2 right-2 z-10" type="button">
-          <span class="grid-icon">⊞</span>
-          <span class="list-icon hidden">☰</span>
-        </button>
         <div class="w-full" id="remindersWrapper">
           <div id="emptyState" class="hidden text-center text-base-content/60 py-8 px-4"></div>
           <div class="flex items-center gap-2 px-4 pb-3 text-xs text-base-content/70">

--- a/mobile.html
+++ b/mobile.html
@@ -1070,21 +1070,6 @@
       }
     }
 
-    /* View toggle button - positioned over the reminders */
-    .view-toggle {
-      position: absolute;
-      top: 8px;
-      right: 8px;
-      z-index: 10;
-      background: rgba(255, 255, 255, 0.9);
-      backdrop-filter: blur(4px);
-      border: 1px solid rgba(0, 0, 0, 0.1);
-    }
-    
-    .dark .view-toggle {
-      background: rgba(0, 0, 0, 0.7);
-      border-color: rgba(255, 255, 255, 0.1);
-    }
   </style>
   <!-- Skip-link CSS: fully hidden until keyboard focus -->
   <style id="skip-link-css">
@@ -1946,6 +1931,14 @@
       min-width: 0;
     }
 
+    .mc-quick-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      align-items: center;
+      flex-shrink: 0;
+    }
+
     .mc-quick-input {
       flex: 1;
       min-width: 0;
@@ -1962,7 +1955,8 @@
     }
 
     .mc-quick-submit,
-    .mc-quick-voice {
+    .mc-quick-voice,
+    .mc-quick-toggle {
       display: inline-flex;
       align-items: center;
       justify-content: center;
@@ -1994,6 +1988,23 @@
       color: var(--card-bg);
     }
 
+    .mc-quick-toggle {
+      background: color-mix(in srgb, var(--text-secondary) 28%, transparent);
+      color: color-mix(in srgb, var(--card-bg) 95%, transparent);
+      font-size: 0.8rem;
+      padding: 0;
+    }
+
+    .mc-quick-toggle .grid-icon,
+    .mc-quick-toggle .list-icon {
+      line-height: 1;
+    }
+
+    .mc-quick-toggle:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--primary-color) 80%, transparent);
+      outline-offset: 2px;
+    }
+
     @media (max-width: 420px) {
       .mc-quick-add-inner {
         gap: 0.5rem;
@@ -2001,6 +2012,10 @@
 
       .mc-quick-add-row {
         gap: 0.4rem;
+      }
+
+      .mc-quick-actions {
+        gap: 0.3rem;
       }
 
       .mc-quick-submit {
@@ -2108,14 +2123,25 @@
         >
           Add
         </button>
-        <button
-          id="quickAddVoice"
-          type="button"
-          class="mc-quick-voice"
-          aria-label="Use voice to add reminder"
-        >
-          🎤
-        </button>
+        <div class="mc-quick-actions">
+          <button
+            id="quickAddVoice"
+            type="button"
+            class="mc-quick-voice"
+            aria-label="Use voice to add reminder"
+          >
+            🎤
+          </button>
+          <button
+            id="viewToggle"
+            type="button"
+            class="mc-quick-toggle"
+            aria-label="Switch between compact and full reminder layouts"
+          >
+            <span class="grid-icon" aria-hidden="true">⊞</span>
+            <span class="list-icon hidden" aria-hidden="true">☰</span>
+          </button>
+        </div>
       </div>
     </div>
   </section>
@@ -2369,10 +2395,6 @@
         id="reminderListSection"
         class="w-full relative"
       >
-        <button id="viewToggle" class="view-toggle btn btn-ghost btn-xs absolute top-2 right-2 z-10" type="button">
-          <span class="grid-icon">⊞</span>
-          <span class="list-icon hidden">☰</span>
-        </button>
         <div class="w-full" id="remindersWrapper">
           <div id="emptyState" class="hidden text-center text-base-content/60 py-8 px-4"></div>
           <p id="reminderReorderHint" class="sr-only">


### PR DESCRIPTION
## Summary
- relocate the reminders compact/full toggle into the quick reminder action stack
- style the new quick reminder toggle and update the docs/mobile snapshot to match

## Testing
- npm test -- theme-toggle.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916843e2b0c83249a5204d52dc0026e)