### PR TITLE
Use two-column reminder grid on small devices

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -932,7 +932,7 @@
     #reminderList {
       display: grid;
       grid-template-columns: 1fr;
-      gap: 8px;
+      gap: 4px;
       align-content: start;
       width: 100%;
     }
@@ -951,7 +951,7 @@
     @media (min-width: 380px) {
       #reminderList.grid-cols-2 {
         grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: 8px;
+        gap: 4px;
       }
     }
     
@@ -2378,7 +2378,7 @@
           <p id="reminderReorderHint" class="sr-only">
             Press, hold, and drag a reminder card to reorder your list. Screen reader users can double-tap and hold, then drag to move a reminder.
           </p>
-          <ul id="reminderList" class="grid gap-3 w-full" aria-describedby="reminderReorderHint"></ul>
+          <ul id="reminderList" class="grid grid-cols-2 gap-1 w-full" aria-describedby="reminderReorderHint"></ul>
           <p class="text-xs text-base-content/50 mt-4 pt-3 px-4 border-t border-base-200/30">Total reminders: <span id="totalCount">0</span></p>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- default the mobile reminder list to a two-column grid layout on screens 380px and wider
- tighten the grid spacing to 4px for a lighter presentation

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691684f2c1848324b43d06f91233f1ac)