### PR TITLE
Refine mobile reminder meta presentation

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -2946,13 +2946,21 @@ export async function initReminders(sel = {}) {
         div.dataset.today = 'true';
       }
       const dueTxt = r.due ? `${fmtTime(new Date(r.due))} • ${fmtDayDate(r.due.slice(0,10))}` : 'No due date';
-      const catLabel = catName ? escapeHtml(catName) : '';
+      const dueLabel = r.due ? escapeHtml(dueTxt) : '';
+      const hasCustomCategory = Boolean(catName && catName !== DEFAULT_CATEGORY);
+      const catLabel = hasCustomCategory ? escapeHtml(catName) : '';
       const priorityLabel = escapeHtml(summary.priority);
-      const chipMarkup = [
-        `<span class="task-chip" data-chip="due">${escapeHtml(dueTxt)}</span>`,
-        catLabel ? `<span class="task-chip" data-chip="category">${catLabel}</span>` : '',
-        `<span class="task-chip" data-chip="priority">${priorityLabel}</span>`
-      ].filter(Boolean).join('');
+      const priorityChipMarkup = `<span class="task-chip" data-chip="priority">${priorityLabel}</span>`;
+      const metaTextParts = [];
+      if (dueLabel) {
+        metaTextParts.push(dueLabel);
+      }
+      if (catLabel) {
+        metaTextParts.push(catLabel);
+      }
+      const metaTextHtml = metaTextParts.length
+        ? `<div class="task-meta-text">${metaTextParts.join(' • ')}</div>`
+        : '';
       const notesHtml = r.notes ? `<div class="task-notes">${notesToHtml(r.notes)}</div>` : '';
       div.innerHTML = `
         <div class="task-content">
@@ -2965,10 +2973,9 @@ export async function initReminders(sel = {}) {
               </button>
             </div>
           </div>
+          ${metaTextHtml}
           <div class="task-meta">
-            <div class="task-meta-row" style="display:flex; gap:8px; flex-wrap:wrap; align-items:center;">
-              ${chipMarkup}
-            </div>
+            ${priorityChipMarkup}
           </div>
           ${notesHtml}
         </div>`;

--- a/mobile.html
+++ b/mobile.html
@@ -708,6 +708,19 @@
       gap: 0.5rem;
       align-items: center;
       font-size: 0.8125rem;
+      margin-top: 0.35rem;
+    }
+    .task-meta-text {
+      color: color-mix(in srgb, var(--text-secondary) 85%, var(--text-primary) 15%);
+      font-size: 0.8rem;
+      line-height: 1.4;
+      margin: 0;
+    }
+    .task-meta-text + .task-meta {
+      margin-top: 0.25rem;
+    }
+    .dark .task-meta-text {
+      color: color-mix(in srgb, var(--card-bg) 70%, var(--text-secondary) 30%);
     }
     .task-chip {
       display: inline-flex;
@@ -1008,6 +1021,16 @@
       font-size: 11px;
       gap: 4px;
       margin-top: auto;
+    }
+    .task-item[data-compact="true"] .task-meta-text {
+      font-size: 11px;
+      display: -webkit-box;
+      -webkit-line-clamp: 1;
+      line-clamp: 1;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      color: color-mix(in srgb, var(--text-secondary) 80%, var(--text-primary) 20%);
+      margin-bottom: 0.25rem;
     }
 
     .task-item[data-compact="true"] .task-chip {


### PR DESCRIPTION
## Summary
- render only the priority chip on mobile reminder cards while moving due/category details into muted text beneath the title
- add styling for the new metadata text so it remains subtle and truncated in compact mode
- keep compact mode behaviour consistent across views by hiding secondary chips outside the priority indicator

## Testing
- npm test *(fails: reminder note management › appends notes to an existing reminder and saves to firestore – Firebase configuration missing in test harness)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916859386a88324b73c8b5e7757dfd7)