### PR TITLE
Refine mobile task cards and delete button styling

### DIFF
--- a/css/teacher.css
+++ b/css/teacher.css
@@ -1312,7 +1312,7 @@ input::placeholder, textarea::placeholder {
   gap: var(--space-4);
   align-items: center;
   padding: var(--space-4);
-  padding-left: calc(var(--space-4) + 4px);
+  padding-left: calc(var(--space-4) + 3px);
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
   background: color-mix(in srgb, var(--bg-tertiary) 88%, var(--task-accent) 12%);
@@ -1326,7 +1326,7 @@ input::placeholder, textarea::placeholder {
   content: '';
   position: absolute;
   inset: var(--space-2) auto var(--space-2) 0;
-  width: 4px;
+  width: 3px;
   border-radius: var(--radius-md) 0 0 var(--radius-md);
   background: var(--task-accent);
 }

--- a/docs/assets/chunk-TNSY42FZ.js
+++ b/docs/assets/chunk-TNSY42FZ.js
@@ -5,7 +5,7 @@ ${o}`:o,n.updatedAt=Date.now(),H(n),N(),P(),Q({action:"updated",label:`Reminder 
           <div class="task-header">
             <div class="task-title"><strong>${ce(c.title)}</strong></div>
             <div class="task-toolbar" role="toolbar" aria-label="Reminder actions">
-              <button class="task-toolbar-btn" data-del type="button" aria-label="Delete reminder">
+              <button class="task-toolbar-btn cue-btn delete" data-del type="button" aria-label="Delete reminder">
                 <span aria-hidden="true">\u{1F5D1}\uFE0F</span>
                 <span class="task-toolbar-label">Delete</span>
               </button>

--- a/docs/css/teacher.css
+++ b/docs/css/teacher.css
@@ -1312,7 +1312,7 @@ input::placeholder, textarea::placeholder {
   gap: var(--space-4);
   align-items: center;
   padding: var(--space-4);
-  padding-left: calc(var(--space-4) + 4px);
+  padding-left: calc(var(--space-4) + 3px);
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
   background: color-mix(in srgb, var(--bg-tertiary) 88%, var(--task-accent) 12%);
@@ -1326,7 +1326,7 @@ input::placeholder, textarea::placeholder {
   content: '';
   position: absolute;
   inset: var(--space-2) auto var(--space-2) 0;
-  width: 4px;
+  width: 3px;
   border-radius: var(--radius-md) 0 0 var(--radius-md);
   background: var(--task-accent);
 }

--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -438,9 +438,9 @@
       margin-bottom: 0.75rem;
       background: color-mix(in srgb, var(--card-bg) 95%, transparent);
       border: 1px solid color-mix(in srgb, var(--border-color) 30%, transparent);
-      border-left-width: 4px;
+      border-left-width: 3px;
       border-left-color: color-mix(in srgb, var(--primary-color) 60%, transparent);
-      border-radius: 0.75rem;
+      border-radius: 0.5rem;
       box-shadow: var(--shadow-sm);
       transition: var(--transition);
     }
@@ -655,6 +655,13 @@
       transition: var(--transition);
       line-height: 1.2;
     }
+    .task-toolbar-btn.cue-btn {
+      padding: 0.35rem 0.6rem;
+      border-radius: 999px;
+      border: 1px solid transparent;
+      color: color-mix(in srgb, var(--text-primary) 82%, transparent);
+      line-height: 1.2;
+    }
     .task-toolbar-btn:hover,
     .task-toolbar-btn:focus-visible {
       color: var(--text-primary);
@@ -733,8 +740,8 @@
     .task-item {
       margin-bottom: 16px;
       padding: 16px;
-      border-radius: 16px;
-      border-left-width: 4px;
+      border-radius: 12px;
+      border-left-width: 3px;
       min-height: 80px;
       transition: var(--transition);
       transform: translateZ(0);
@@ -824,7 +831,7 @@
       display: flex;
       flex-direction: column;
       border-left-width: 3px;
-      border-radius: 12px;
+      border-radius: 0.5rem;
     }
 
     .task-item[data-compact="true"] .task-title {
@@ -906,7 +913,7 @@
       .task-item[data-compact="true"] {
         padding: 16px;
         padding-left: 18px;
-        border-left-width: 4px;
+        border-left-width: 3px;
       }
 
       .task-item[data-compact="true"] .task-title {

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -2967,7 +2967,7 @@ export async function initReminders(sel = {}) {
           <div class="task-header">
             <div class="task-title"><strong>${escapeHtml(r.title)}</strong></div>
             <div class="task-toolbar" role="toolbar" aria-label="Reminder actions">
-              <button class="task-toolbar-btn" data-del type="button" aria-label="Delete reminder">
+              <button class="task-toolbar-btn cue-btn delete" data-del type="button" aria-label="Delete reminder">
                 <span aria-hidden="true">🗑️</span>
                 <span class="task-toolbar-label">Delete</span>
               </button>

--- a/mobile.html
+++ b/mobile.html
@@ -592,9 +592,9 @@
       margin-bottom: var(--reminder-card-gap);
       background: color-mix(in srgb, var(--card-bg) 95%, transparent);
       border: 1px solid color-mix(in srgb, var(--border-color) 30%, transparent);
-      border-left-width: 4px;
+      border-left-width: 3px;
       border-left-color: color-mix(in srgb, var(--primary-color) 60%, transparent);
-      border-radius: 0.75rem;
+      border-radius: 0.5rem;
       box-shadow: var(--shadow-sm);
       transition: var(--transition);
     }
@@ -822,6 +822,13 @@
       transition: var(--transition);
       line-height: 1.2;
     }
+    .task-toolbar-btn.cue-btn {
+      padding: 0.35rem 0.6rem;
+      border-radius: 999px;
+      border: 1px solid transparent;
+      color: color-mix(in srgb, var(--text-primary) 82%, transparent);
+      line-height: 1.2;
+    }
     .task-toolbar-btn:hover,
     .task-toolbar-btn:focus-visible {
       color: var(--text-primary);
@@ -900,8 +907,8 @@
     .task-item {
       margin-bottom: 16px;
       padding: 16px;
-      border-radius: 16px;
-      border-left-width: 4px;
+      border-radius: 12px;
+      border-left-width: 3px;
       min-height: 80px;
       transition: var(--transition);
       transform: translateZ(0);
@@ -991,7 +998,7 @@
       display: flex;
       flex-direction: column;
       border-left-width: 3px;
-      border-radius: 12px;
+      border-radius: 0.5rem;
     }
 
     .task-item[data-compact="true"] .task-title {
@@ -1083,7 +1090,7 @@
       .task-item[data-compact="true"] {
         padding: 16px;
         padding-left: 18px;
-        border-left-width: 4px;
+        border-left-width: 3px;
       }
 
       .task-item[data-compact="true"] .task-title {


### PR DESCRIPTION
## Summary
- slim the reminder cards on mobile by narrowing the accent border and reducing card radii
- ensure the task toolbar delete control keeps its cue button styling and hover affordance on generated reminders
- sync the updated styles to the documentation and teacher view assets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691688057fd08324868bd674ec8eab33)