### PR TITLE
Fix overflow menu background styling

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -42,6 +42,22 @@
     transform: translateY(-2px);
   }
 
+  .menu-card {
+    background: rgba(255, 255, 255, 0.92);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    box-shadow: 0 22px 45px rgba(15, 23, 42, 0.18);
+    color: rgba(15, 23, 42, 0.9);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+  }
+
+  html[data-theme="dark"] .menu-card {
+    background: rgba(15, 23, 42, 0.92);
+    border-color: rgba(148, 163, 184, 0.32);
+    box-shadow: 0 26px 52px rgba(2, 6, 23, 0.6);
+    color: rgba(226, 232, 240, 0.95);
+  }
+
   /* Reminders wrapper spacing on mobile */
   #remindersWrapper {
     margin-top: 0.75rem;
@@ -1830,12 +1846,7 @@
           <span class="text-xl leading-none">⚙️</span>
         </button>
 
-        <div
-          id="overflowMenu"
-          class="menu-card hidden absolute right-0 mt-2 w-52 rounded-xl shadow-lg bg-base-100 border border-base-200/40 dark:bg-slate-800"
-          role="menu"
-          aria-hidden="true"
-        >
+        <div id="overflowMenu" class="menu-card hidden absolute right-0 mt-2 w-52 rounded-xl shadow-lg" role="menu" aria-hidden="true">
           <ul class="py-2 text-sm">
             <li>
               <button id="voiceAddBtn" type="button" class="menu-item text-left px-4 py-2">

--- a/mobile.html
+++ b/mobile.html
@@ -60,6 +60,22 @@
     transform: translateY(-2px);
   }
 
+  .menu-card {
+    background: rgba(255, 255, 255, 0.92);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    box-shadow: 0 22px 45px rgba(15, 23, 42, 0.18);
+    color: rgba(15, 23, 42, 0.9);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+  }
+
+  html[data-theme="dark"] .menu-card {
+    background: rgba(15, 23, 42, 0.92);
+    border-color: rgba(148, 163, 184, 0.32);
+    box-shadow: 0 26px 52px rgba(2, 6, 23, 0.6);
+    color: rgba(226, 232, 240, 0.95);
+  }
+
   .menu-item {
     display: flex;
     align-items: center;
@@ -2105,12 +2121,7 @@
           <span class="text-xl leading-none">⚙️</span>
         </button>
 
-        <div
-          id="overflowMenu"
-          class="menu-card hidden absolute right-0 mt-2 w-52 rounded-xl shadow-lg bg-base-100 border border-base-200/40 dark:bg-slate-800"
-          role="menu"
-          aria-hidden="true"
-        >
+        <div id="overflowMenu" class="menu-card hidden absolute right-0 mt-2 w-52 rounded-xl shadow-lg" role="menu" aria-hidden="true">
           <ul class="py-2 text-sm">
             <li>
               <button


### PR DESCRIPTION
## Summary
- restyle the mobile overflow menu container with a translucent glass effect that respects light and dark themes
- remove conflicting Tailwind background classes so the dropdown no longer renders as a solid white block

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69169a77d1008324962c4c3bd7d778f9)