### PR TITLE
Refine overflow menu styling

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -42,6 +42,60 @@
     transform: translateY(-2px);
   }
 
+  .menu-card {
+    background: color-mix(in srgb, var(--card-bg, #ffffff) 82%, transparent);
+    border: 1px solid color-mix(in srgb, var(--border-color, rgba(148, 163, 184, 0.2)) 75%, transparent);
+    box-shadow: 0 22px 45px rgba(15, 23, 42, 0.16);
+    color: var(--text-primary, rgba(15, 23, 42, 0.9));
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+    z-index: 50;
+  }
+
+  html[data-theme="dark"] .menu-card {
+    background: color-mix(in srgb, rgba(15, 23, 42, 0.92) 88%, transparent);
+    border-color: rgba(148, 163, 184, 0.32);
+    box-shadow: 0 26px 52px rgba(2, 6, 23, 0.6);
+    color: rgba(226, 232, 240, 0.95);
+  }
+
+  @supports not (color-mix(in srgb, red, transparent)) {
+    .menu-card {
+      background: rgba(255, 255, 255, 0.9);
+      border-color: rgba(148, 163, 184, 0.2);
+    }
+
+    html[data-theme="dark"] .menu-card {
+      background: rgba(15, 23, 42, 0.9);
+    }
+  }
+
+  .menu-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    width: 100%;
+    text-align: left;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    border-radius: 0.5rem;
+    color: inherit;
+    font: inherit;
+    transition: background-color 0.2s ease;
+  }
+
+  .menu-item:hover,
+  .menu-item:focus-visible {
+    background: rgba(15, 23, 42, 0.06);
+    outline: none;
+  }
+
+  html[data-theme="dark"] .menu-item:hover,
+  html[data-theme="dark"] .menu-item:focus-visible {
+    background: rgba(148, 163, 184, 0.12);
+  }
+
   /* Reminders wrapper spacing on mobile */
   #remindersWrapper {
     margin-top: 0.75rem;
@@ -1830,12 +1884,7 @@
           <span class="text-xl leading-none">⚙️</span>
         </button>
 
-        <div
-          id="overflowMenu"
-          class="menu-card hidden absolute right-0 mt-2 w-52 rounded-xl shadow-lg bg-base-100 border border-base-200/40 dark:bg-slate-800"
-          role="menu"
-          aria-hidden="true"
-        >
+        <div id="overflowMenu" class="menu-card hidden absolute right-0 mt-2 w-52 rounded-xl shadow-lg" role="menu" aria-hidden="true">
           <ul class="py-2 text-sm">
             <li>
               <button id="voiceAddBtn" type="button" class="menu-item text-left px-4 py-2">

--- a/mobile.html
+++ b/mobile.html
@@ -60,6 +60,34 @@
     transform: translateY(-2px);
   }
 
+  .menu-card {
+    background: color-mix(in srgb, var(--card-bg, #ffffff) 82%, transparent);
+    border: 1px solid color-mix(in srgb, var(--card-border, rgba(148, 163, 184, 0.2)) 75%, transparent);
+    box-shadow: 0 22px 45px rgba(15, 23, 42, 0.16);
+    color: var(--text-primary, rgba(15, 23, 42, 0.9));
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+    z-index: 50;
+  }
+
+  html[data-theme="dark"] .menu-card {
+    background: color-mix(in srgb, rgba(15, 23, 42, 0.92) 88%, transparent);
+    border-color: rgba(148, 163, 184, 0.32);
+    box-shadow: 0 26px 52px rgba(2, 6, 23, 0.6);
+    color: rgba(226, 232, 240, 0.95);
+  }
+
+  @supports not (color-mix(in srgb, red, transparent)) {
+    .menu-card {
+      background: rgba(255, 255, 255, 0.9);
+      border-color: rgba(148, 163, 184, 0.2);
+    }
+
+    html[data-theme="dark"] .menu-card {
+      background: rgba(15, 23, 42, 0.9);
+    }
+  }
+
   .menu-item {
     display: flex;
     align-items: center;
@@ -77,8 +105,13 @@
 
   .menu-item:hover,
   .menu-item:focus-visible {
-    background: rgba(15, 23, 42, 0.05);
+    background: rgba(15, 23, 42, 0.06);
     outline: none;
+  }
+
+  html[data-theme="dark"] .menu-item:hover,
+  html[data-theme="dark"] .menu-item:focus-visible {
+    background: rgba(148, 163, 184, 0.12);
   }
 
   .menu-icon {
@@ -2105,12 +2138,7 @@
           <span class="text-xl leading-none">⚙️</span>
         </button>
 
-        <div
-          id="overflowMenu"
-          class="menu-card hidden absolute right-0 mt-2 w-52 rounded-xl shadow-lg bg-base-100 border border-base-200/40 dark:bg-slate-800"
-          role="menu"
-          aria-hidden="true"
-        >
+        <div id="overflowMenu" class="menu-card hidden absolute right-0 mt-2 w-52 rounded-xl shadow-lg" role="menu" aria-hidden="true">
           <ul class="py-2 text-sm">
             <li>
               <button


### PR DESCRIPTION
## Summary
- blend the overflow menu background with existing theme tokens so it no longer appears as an opaque white block over the settings surface
- add hover treatments for dark mode and a color-mix fallback so the quick actions remain legible across browsers
- raise the overflow menu stacking context to keep it aligned with the trigger button without covering surrounding controls unnecessarily

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69169a77d1008324962c4c3bd7d778f9)