### PR TITLE
Soften overflow menu styling

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -42,6 +42,61 @@
     transform: translateY(-2px);
   }
 
+  .menu-card {
+    padding: 0.25rem 0;
+    background: color-mix(in srgb, var(--card-bg, #ffffff) 70%, transparent);
+    border: 1px solid color-mix(in srgb, var(--border-color, rgba(148, 163, 184, 0.28)) 65%, transparent);
+    box-shadow: 0 16px 28px rgba(15, 23, 42, 0.18);
+    color: var(--text-primary, rgba(15, 23, 42, 0.88));
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    z-index: 50;
+  }
+
+  html[data-theme="dark"] .menu-card {
+    background: color-mix(in srgb, rgba(15, 23, 42, 0.92) 80%, transparent);
+    border-color: rgba(148, 163, 184, 0.28);
+    box-shadow: 0 24px 40px rgba(2, 6, 23, 0.6);
+    color: rgba(226, 232, 240, 0.92);
+  }
+
+  @supports not (color-mix(in srgb, red, transparent)) {
+    .menu-card {
+      background: rgba(255, 255, 255, 0.82);
+      border-color: rgba(148, 163, 184, 0.24);
+    }
+
+    html[data-theme="dark"] .menu-card {
+      background: rgba(15, 23, 42, 0.88);
+    }
+  }
+
+    .menu-item {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      width: 100%;
+      text-align: left;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      border-radius: 0.5rem;
+      color: inherit;
+      font: inherit;
+      transition: background-color 0.2s ease;
+    }
+
+  .menu-item:hover,
+  .menu-item:focus-visible {
+    background: rgba(15, 23, 42, 0.06);
+    outline: none;
+  }
+
+  html[data-theme="dark"] .menu-item:hover,
+  html[data-theme="dark"] .menu-item:focus-visible {
+    background: rgba(148, 163, 184, 0.12);
+  }
+
   /* Reminders wrapper spacing on mobile */
   #remindersWrapper {
     margin-top: 0.75rem;
@@ -1818,24 +1873,26 @@
 
       <!-- Right: Settings button with quick menu -->
       <div class="relative">
-        <button
-          id="overflowMenuBtn"
-          type="button"
-          class="inline-flex items-center justify-center w-9 h-9 rounded-full bg-slate-800/80 hover:bg-slate-700 active:scale-95 transition"
-          aria-label="Open menu"
-          aria-haspopup="true"
-          aria-controls="overflowMenu"
-          aria-expanded="false"
-        >
-          <span class="text-xl leading-none">⚙️</span>
-        </button>
+          <button
+            id="overflowMenuBtn"
+            type="button"
+            class="inline-flex items-center justify-center w-9 h-9 rounded-full bg-slate-800/80 hover:bg-slate-700 active:scale-95 transition"
+            aria-label="Open menu"
+            aria-haspopup="menu"
+            aria-controls="overflowMenu"
+            aria-expanded="false"
+          >
+            <span class="text-xl leading-none">⚙️</span>
+          </button>
 
         <div
           id="overflowMenu"
-          class="menu-card hidden absolute right-0 mt-2 w-52 rounded-xl shadow-lg bg-base-100 border border-base-200/40 dark:bg-slate-800"
+          class="menu-card hidden absolute right-0 mt-2 w-52 rounded-xl shadow-lg"
           role="menu"
           aria-hidden="true"
+          aria-labelledby="overflowMenuHeading"
         >
+          <h2 id="overflowMenuHeading" class="sr-only">Quick settings</h2>
           <ul class="py-2 text-sm">
             <li>
               <button id="voiceAddBtn" type="button" class="menu-item text-left px-4 py-2">

--- a/mobile.html
+++ b/mobile.html
@@ -60,6 +60,35 @@
     transform: translateY(-2px);
   }
 
+  .menu-card {
+    padding: 0.25rem 0;
+    background: color-mix(in srgb, var(--card-bg, #ffffff) 70%, transparent);
+    border: 1px solid color-mix(in srgb, var(--card-border, rgba(148, 163, 184, 0.28)) 65%, transparent);
+    box-shadow: 0 16px 28px rgba(15, 23, 42, 0.18);
+    color: var(--text-primary, rgba(15, 23, 42, 0.88));
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    z-index: 50;
+  }
+
+  html[data-theme="dark"] .menu-card {
+    background: color-mix(in srgb, rgba(15, 23, 42, 0.92) 80%, transparent);
+    border-color: rgba(148, 163, 184, 0.28);
+    box-shadow: 0 24px 40px rgba(2, 6, 23, 0.6);
+    color: rgba(226, 232, 240, 0.92);
+  }
+
+  @supports not (color-mix(in srgb, red, transparent)) {
+    .menu-card {
+      background: rgba(255, 255, 255, 0.82);
+      border-color: rgba(148, 163, 184, 0.24);
+    }
+
+    html[data-theme="dark"] .menu-card {
+      background: rgba(15, 23, 42, 0.88);
+    }
+  }
+
   .menu-item {
     display: flex;
     align-items: center;
@@ -77,8 +106,13 @@
 
   .menu-item:hover,
   .menu-item:focus-visible {
-    background: rgba(15, 23, 42, 0.05);
+    background: rgba(15, 23, 42, 0.06);
     outline: none;
+  }
+
+  html[data-theme="dark"] .menu-item:hover,
+  html[data-theme="dark"] .menu-item:focus-visible {
+    background: rgba(148, 163, 184, 0.12);
   }
 
   .menu-icon {
@@ -2107,10 +2141,12 @@
 
         <div
           id="overflowMenu"
-          class="menu-card hidden absolute right-0 mt-2 w-52 rounded-xl shadow-lg bg-base-100 border border-base-200/40 dark:bg-slate-800"
+          class="menu-card hidden absolute right-0 mt-2 w-52 rounded-xl shadow-lg"
           role="menu"
           aria-hidden="true"
+          aria-labelledby="overflowMenuHeading"
         >
+          <h2 id="overflowMenuHeading" class="sr-only">Quick settings</h2>
           <ul class="py-2 text-sm">
             <li>
               <button


### PR DESCRIPTION
## Summary
- soften the quick settings surface so it regains a compact glassmorphism treatment instead of a large opaque block
- hide the explanatory heading visually while keeping it available to assistive tech via `aria-labelledby`

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69169a77d1008324962c4c3bd7d778f9)