### PR TITLE
Hide dashboard sections when empty

### DIFF
--- a/index.html
+++ b/index.html
@@ -518,15 +518,17 @@
         </div>
 
         <div class="grid gap-6 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
-          <section class="card border border-base-300 bg-base-200/70 shadow-sm dashboard-pinned-notes">
-            <div class="card-body gap-4">
-              <div class="flex flex-wrap items-center justify-between gap-3">
-                <h2 class="text-lg font-semibold text-base-content">Pinned notes</h2>
-                <button class="btn btn-sm btn-primary" type="button" disabled title="Coming soon">New note</button>
+          <div id="pinnedNotesCard" class="h-full">
+            <section class="card border border-base-300 bg-base-200/70 shadow-sm dashboard-pinned-notes">
+              <div class="card-body gap-4">
+                <div class="flex flex-wrap items-center justify-between gap-3">
+                  <h2 class="text-lg font-semibold text-base-content">Pinned notes</h2>
+                  <button class="btn btn-sm btn-primary" type="button" disabled title="Coming soon">New note</button>
+                </div>
+                <ul id="pinnedNotesList" class="space-y-3"></ul>
               </div>
-              <ul id="pinnedNotesList" class="space-y-3"></ul>
-            </div>
-          </section>
+            </section>
+          </div>
 
           <section class="card border border-base-300 bg-base-200/70 shadow-sm dashboard-shortcuts">
             <div class="card-body gap-5">


### PR DESCRIPTION
## Summary
- wrap the pinned notes card so it can be toggled and hide it when no pinned cues exist
- add automatic empty-state handling for the week-at-a-glance list and subtle fallback copy for empty lists
- tweak dashboard fallback messages to use lighter, italic styling so they read as placeholders

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916b6a8e7e88324a9c56a35fbc17e23)