### PR TITLE
Simplify navigation and add tooltips

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,14 +287,40 @@
           <li>
             <a href="#planner" data-nav="planner" id="nav-planner" class="btn btn-sm btn-ghost">Planner</a>
           </li>
-          <li>
-            <a href="#notes" data-nav="notes" id="nav-notes" class="btn btn-sm btn-ghost">Notes</a>
-          </li>
-          <li>
-            <a href="#resources" data-nav="resources" id="nav-resources" class="btn btn-sm btn-ghost">Resources</a>
-          </li>
-          <li>
-            <a href="#templates" data-nav="templates" id="nav-templates" class="btn btn-sm btn-ghost">Templates</a>
+          <li class="nav-more-item">
+            <details class="nav-more-details">
+              <summary
+                class="btn btn-sm btn-ghost"
+                data-nav-group="more"
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-controls="nav-more-menu"
+              >
+                <span>More</span>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  class="size-4"
+                  aria-hidden="true"
+                >
+                  <path stroke-linecap="round" stroke-linejoin="round" d="m6 9 6 6 6-6" />
+                </svg>
+              </summary>
+              <ul id="nav-more-menu" class="nav-more-menu menu menu-sm gap-1">
+                <li>
+                  <a href="#notes" data-nav="notes" id="nav-notes" class="btn btn-ghost btn-sm">Notes</a>
+                </li>
+                <li>
+                  <a href="#resources" data-nav="resources" id="nav-resources" class="btn btn-ghost btn-sm">Resources</a>
+                </li>
+                <li>
+                  <a href="#templates" data-nav="templates" id="nav-templates" class="btn btn-ghost btn-sm">Templates</a>
+                </li>
+              </ul>
+            </details>
           </li>
         </ul>
       </div>
@@ -347,9 +373,34 @@
           <li><a href="#dashboard" data-nav="dashboard" class="btn btn-ghost justify-start">Dashboard</a></li>
           <li><a href="#reminders" data-nav="reminders" class="btn btn-ghost justify-start">Reminders</a></li>
           <li><a href="#planner" data-nav="planner" class="btn btn-ghost justify-start">Planner</a></li>
-          <li><a href="#notes" data-nav="notes" class="btn btn-ghost justify-start">Notes</a></li>
-          <li><a href="#resources" data-nav="resources" class="btn btn-ghost justify-start">Resources</a></li>
-          <li><a href="#templates" data-nav="templates" class="btn btn-ghost justify-start">Templates</a></li>
+          <li>
+            <details class="mobile-nav-more">
+              <summary
+                class="btn btn-ghost justify-between"
+                aria-haspopup="true"
+                aria-controls="mobile-more-menu"
+                aria-expanded="false"
+              >
+                <span>More</span>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  class="size-4"
+                  aria-hidden="true"
+                >
+                  <path stroke-linecap="round" stroke-linejoin="round" d="m6 9 6 6 6-6" />
+                </svg>
+              </summary>
+              <ul id="mobile-more-menu" class="mt-2 space-y-1 text-sm">
+                <li><a href="#notes" data-nav="notes" class="btn btn-ghost justify-start">Notes</a></li>
+                <li><a href="#resources" data-nav="resources" class="btn btn-ghost justify-start">Resources</a></li>
+                <li><a href="#templates" data-nav="templates" class="btn btn-ghost justify-start">Templates</a></li>
+              </ul>
+            </details>
+          </li>
         </ul>
         <a href="#planner" class="btn btn-primary btn-sm mt-3 w-full">Jump into planner</a>
       </div>
@@ -1159,6 +1210,8 @@
     </div>
   </div>
   <script>
+    const groupedRoutes = new Set(['notes', 'resources', 'templates']);
+
     function renderRoute() {
       const route = (location.hash || '#dashboard').replace('#', '');
       document.querySelectorAll('[data-route]').forEach((node) => {
@@ -1175,9 +1228,40 @@
           link.removeAttribute('aria-current');
         }
       });
+      const moreSummary = document.querySelector('[data-nav-group="more"]');
+      const moreDetails = moreSummary ? moreSummary.closest('details') : null;
+      if (moreSummary && moreDetails) {
+        if (groupedRoutes.has(activeRoute)) {
+          moreDetails.setAttribute('open', '');
+        } else {
+          moreDetails.removeAttribute('open');
+        }
+        moreSummary.classList.toggle('btn-active', groupedRoutes.has(activeRoute));
+        moreSummary.setAttribute('aria-expanded', moreDetails.open ? 'true' : 'false');
+      }
     }
     window.addEventListener('hashchange', renderRoute);
     window.addEventListener('DOMContentLoaded', renderRoute);
+
+    const navMoreDetails = document.querySelector('.nav-more-details');
+    const navMoreSummary = document.querySelector('[data-nav-group="more"]');
+    if (navMoreDetails && navMoreSummary) {
+      navMoreSummary.setAttribute('aria-expanded', navMoreDetails.open ? 'true' : 'false');
+      navMoreDetails.addEventListener('toggle', () => {
+        navMoreSummary.setAttribute('aria-expanded', navMoreDetails.open ? 'true' : 'false');
+      });
+    }
+
+    document.querySelectorAll('.mobile-nav-more').forEach((details) => {
+      const summary = details.querySelector('summary');
+      if (!summary) {
+        return;
+      }
+      summary.setAttribute('aria-expanded', details.open ? 'true' : 'false');
+      details.addEventListener('toggle', () => {
+        summary.setAttribute('aria-expanded', details.open ? 'true' : 'false');
+      });
+    });
   </script>
   <script type="module" src="./app.js" defer></script>
   <script src="./js/update-footer-year.js" defer></script>
@@ -1208,6 +1292,14 @@
         link.addEventListener('click', () => {
           mobileMenu.setAttribute('hidden', '');
           toggleButton.setAttribute('aria-expanded', 'false');
+          const parentDetails = link.closest('details');
+          if (parentDetails) {
+            parentDetails.removeAttribute('open');
+            const summary = parentDetails.querySelector('summary');
+            if (summary) {
+              summary.setAttribute('aria-expanded', 'false');
+            }
+          }
         });
       });
     })();

--- a/styles/index.css
+++ b/styles/index.css
@@ -42,6 +42,72 @@ textarea {
   font-family: inherit;
 }
 
+.tooltip,
+:where([title]:not([title=""])) {
+  position: relative;
+}
+
+.tooltip::after,
+:where([title]:not([title=""]))::after {
+  position: absolute;
+  bottom: calc(100% + 0.5rem);
+  left: 50%;
+  transform: translate(-50%, 0.25rem);
+  background-color: rgba(15, 23, 42, 0.9);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.2;
+  padding: 0.35rem 0.5rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.25);
+  opacity: 0;
+  pointer-events: none;
+  white-space: nowrap;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  z-index: 60;
+}
+
+.tooltip::after {
+  content: attr(data-tooltip);
+}
+
+:where([title]:not([title=""]))::after {
+  content: attr(title);
+}
+
+.tooltip::before,
+:where([title]:not([title=""]))::before {
+  content: '';
+  position: absolute;
+  bottom: calc(100% + 0.25rem);
+  left: 50%;
+  transform: translate(-50%, 0.25rem);
+  border-width: 0.35rem;
+  border-style: solid;
+  border-color: rgba(15, 23, 42, 0.9) transparent transparent transparent;
+  opacity: 0;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  pointer-events: none;
+  z-index: 59;
+}
+
+.tooltip:focus-visible::after,
+.tooltip:hover::after,
+:where([title]:not([title=""])):focus-visible::after,
+:where([title]:not([title=""])):hover::after {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.tooltip:focus-visible::before,
+.tooltip:hover::before,
+:where([title]:not([title=""])):focus-visible::before,
+:where([title]:not([title=""])):hover::before {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
 :root :where(.btn) {
   border-radius: 9999px;
   font-family: var(--font-body);
@@ -196,6 +262,110 @@ textarea {
   background: linear-gradient(135deg, rgba(20, 184, 166, 0.35), rgba(56, 189, 248, 0.28));
   color: rgb(187 247 208);
   box-shadow: 0 16px 30px rgba(45, 212, 191, 0.32);
+}
+
+.nav-more-item {
+  position: relative;
+}
+
+.nav-more-details {
+  position: relative;
+  display: inline-flex;
+  align-items: stretch;
+}
+
+.nav-more-details summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.nav-more-details summary::-webkit-details-marker,
+.nav-more-details summary::marker {
+  display: none;
+}
+
+.nav-more-details summary svg {
+  width: 0.75rem;
+  height: 0.75rem;
+}
+
+.nav-more-menu {
+  position: absolute;
+  top: calc(100% + 0.6rem);
+  right: 0;
+  min-width: 11rem;
+  border-radius: 0.85rem;
+  padding: 0.5rem;
+  background: rgba(248, 250, 252, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 20px 35px rgba(15, 23, 42, 0.2);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  opacity: 0;
+  transform: translateY(-0.25rem);
+  pointer-events: none;
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  z-index: 55;
+}
+
+.nav-more-details[open] .nav-more-menu {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+[data-theme="dark"] .nav-more-menu,
+.dark .nav-more-menu {
+  background: rgba(30, 41, 59, 0.95);
+  border-color: rgba(148, 163, 184, 0.4);
+  box-shadow: 0 24px 45px rgba(2, 6, 23, 0.55);
+}
+
+.nav-more-menu .btn {
+  width: 100%;
+  justify-content: flex-start;
+}
+
+.mobile-nav-more {
+  border-radius: 0.75rem;
+  background: rgba(148, 163, 184, 0.08);
+  padding: 0.25rem 0.4rem;
+}
+
+.mobile-nav-more summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.35rem;
+  cursor: pointer;
+  list-style: none;
+  padding: 0.35rem 0.5rem;
+  border-radius: 999px;
+  width: 100%;
+}
+
+.mobile-nav-more summary::-webkit-details-marker,
+.mobile-nav-more summary::marker {
+  display: none;
+}
+
+.mobile-nav-more summary:hover,
+.mobile-nav-more summary:focus-visible {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.mobile-nav-more[open] summary {
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.mobile-nav-more ul {
+  margin-top: 0.4rem;
+  padding-left: 0.75rem;
+  display: grid;
+  gap: 0.3rem;
 }
 
 .mobile-nav-glass {


### PR DESCRIPTION
## Summary
- add a reusable tooltip style for title-bearing elements so quick actions show consistent hover help
- group secondary desktop navigation links under a More dropdown and highlight active routes
- mirror the More grouping in the mobile menu and keep aria-expanded states in sync when the drawer toggles

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916b802059c832490075c86601a54e1)