### PR TITLE
Promote Notes navigation link and trim More menus

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,6 +287,9 @@
           <li>
             <a href="#planner" data-nav="planner" id="nav-planner" class="btn btn-sm btn-ghost">Planner</a>
           </li>
+          <li>
+            <a href="#notes" data-nav="notes" id="nav-notes" class="btn btn-sm btn-ghost">Notes</a>
+          </li>
           <li class="nav-more-item">
             <details class="nav-more-details">
               <summary
@@ -310,9 +313,6 @@
                 </svg>
               </summary>
               <ul id="nav-more-menu" class="nav-more-menu menu menu-sm gap-1">
-                <li>
-                  <a href="#notes" data-nav="notes" id="nav-notes" class="btn btn-ghost btn-sm">Notes</a>
-                </li>
                 <li>
                   <a href="#resources" data-nav="resources" id="nav-resources" class="btn btn-ghost btn-sm">Resources</a>
                 </li>
@@ -373,6 +373,7 @@
           <li><a href="#dashboard" data-nav="dashboard" class="btn btn-ghost justify-start">Dashboard</a></li>
           <li><a href="#reminders" data-nav="reminders" class="btn btn-ghost justify-start">Reminders</a></li>
           <li><a href="#planner" data-nav="planner" class="btn btn-ghost justify-start">Planner</a></li>
+          <li><a href="#notes" data-nav="notes" class="btn btn-ghost justify-start">Notes</a></li>
           <li>
             <details class="mobile-nav-more">
               <summary
@@ -395,14 +396,12 @@
                 </svg>
               </summary>
               <ul id="mobile-more-menu" class="mt-2 space-y-1 text-sm">
-                <li><a href="#notes" data-nav="notes" class="btn btn-ghost justify-start">Notes</a></li>
                 <li><a href="#resources" data-nav="resources" class="btn btn-ghost justify-start">Resources</a></li>
                 <li><a href="#templates" data-nav="templates" class="btn btn-ghost justify-start">Templates</a></li>
               </ul>
             </details>
           </li>
         </ul>
-        <a href="#planner" class="btn btn-primary btn-sm mt-3 w-full">Jump into planner</a>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
- promote the Notes shortcut into the primary desktop and mobile navigation lists
- leave the More dropdown with only Resources and Templates and remove the redundant mobile planner button

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916cf0649e48324bbf54b6725c30bd7)