### PR TITLE
Improve navigation dropdown active states

### DIFF
--- a/index.html
+++ b/index.html
@@ -1227,17 +1227,44 @@
           link.removeAttribute('aria-current');
         }
       });
+      const isGroupedRoute = groupedRoutes.has(activeRoute);
+      document
+        .querySelectorAll('#nav-more-menu [data-nav], #mobile-more-menu [data-nav]')
+        .forEach((link) => {
+          const isActive = link.dataset.nav === activeRoute;
+          link.classList.toggle('btn-active', isActive);
+          if (isActive) {
+            link.setAttribute('aria-current', 'page');
+          } else {
+            link.removeAttribute('aria-current');
+          }
+        });
       const moreSummary = document.querySelector('[data-nav-group="more"]');
       const moreDetails = moreSummary ? moreSummary.closest('details') : null;
       if (moreSummary && moreDetails) {
-        if (groupedRoutes.has(activeRoute)) {
+        if (isGroupedRoute) {
           moreDetails.setAttribute('open', '');
         } else {
           moreDetails.removeAttribute('open');
         }
-        moreSummary.classList.toggle('btn-active', groupedRoutes.has(activeRoute));
+        moreSummary.classList.toggle('btn-active', isGroupedRoute);
         moreSummary.setAttribute('aria-expanded', moreDetails.open ? 'true' : 'false');
+        moreSummary.classList.toggle('more-active', moreDetails.open);
       }
+      document.querySelectorAll('.mobile-nav-more').forEach((details) => {
+        const summary = details.querySelector('summary');
+        if (!summary) {
+          return;
+        }
+        if (isGroupedRoute) {
+          details.setAttribute('open', '');
+        } else {
+          details.removeAttribute('open');
+        }
+        summary.classList.toggle('btn-active', isGroupedRoute);
+        summary.setAttribute('aria-expanded', details.open ? 'true' : 'false');
+        summary.classList.toggle('more-active', details.open);
+      });
     }
     window.addEventListener('hashchange', renderRoute);
     window.addEventListener('DOMContentLoaded', renderRoute);
@@ -1246,8 +1273,10 @@
     const navMoreSummary = document.querySelector('[data-nav-group="more"]');
     if (navMoreDetails && navMoreSummary) {
       navMoreSummary.setAttribute('aria-expanded', navMoreDetails.open ? 'true' : 'false');
+      navMoreSummary.classList.toggle('more-active', navMoreDetails.open);
       navMoreDetails.addEventListener('toggle', () => {
         navMoreSummary.setAttribute('aria-expanded', navMoreDetails.open ? 'true' : 'false');
+        navMoreSummary.classList.toggle('more-active', navMoreDetails.open);
       });
     }
 
@@ -1257,8 +1286,10 @@
         return;
       }
       summary.setAttribute('aria-expanded', details.open ? 'true' : 'false');
+      summary.classList.toggle('more-active', details.open);
       details.addEventListener('toggle', () => {
         summary.setAttribute('aria-expanded', details.open ? 'true' : 'false');
+        summary.classList.toggle('more-active', details.open);
       });
     });
   </script>
@@ -1297,6 +1328,7 @@
             const summary = parentDetails.querySelector('summary');
             if (summary) {
               summary.setAttribute('aria-expanded', 'false');
+              summary.classList.remove('more-active');
             }
           }
         });

--- a/styles/index.css
+++ b/styles/index.css
@@ -290,6 +290,7 @@ textarea {
 .nav-more-details summary svg {
   width: 0.75rem;
   height: 0.75rem;
+  transition: transform 0.2s ease;
 }
 
 .nav-more-menu {
@@ -327,6 +328,54 @@ textarea {
 .nav-more-menu .btn {
   width: 100%;
   justify-content: flex-start;
+  border-radius: 9999px;
+  color: rgba(30, 41, 59, 0.85);
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.nav-more-menu .btn:hover,
+.nav-more-menu .btn:focus-visible {
+  background-color: rgba(59, 130, 246, 0.12);
+  color: rgba(15, 23, 42, 0.95);
+}
+
+[data-theme="dark"] .nav-more-menu .btn,
+.dark .nav-more-menu .btn {
+  color: rgba(226, 232, 240, 0.9);
+}
+
+[data-theme="dark"] .nav-more-menu .btn:hover,
+[data-theme="dark"] .nav-more-menu .btn:focus-visible,
+.dark .nav-more-menu .btn:hover,
+.dark .nav-more-menu .btn:focus-visible {
+  background-color: rgba(148, 163, 184, 0.2);
+  color: rgba(226, 232, 240, 1);
+}
+
+.nav-more-menu .btn.btn-active,
+.mobile-nav-more ul .btn.btn-active {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.28), rgba(56, 189, 248, 0.22));
+  color: rgb(15 118 110);
+  box-shadow: 0 12px 24px rgba(45, 212, 191, 0.3);
+}
+
+[data-theme="dark"] .nav-more-menu .btn.btn-active,
+[data-theme="dark"] .mobile-nav-more ul .btn.btn-active,
+.dark .nav-more-menu .btn.btn-active,
+.dark .mobile-nav-more ul .btn.btn-active {
+  background: linear-gradient(135deg, rgba(20, 184, 166, 0.35), rgba(56, 189, 248, 0.28));
+  color: rgb(187 247 208);
+  box-shadow: 0 16px 30px rgba(45, 212, 191, 0.32);
+}
+
+.nav-more-details summary.more-active,
+.mobile-nav-more summary.more-active {
+  font-weight: 700;
+}
+
+.nav-more-details summary.more-active svg,
+.mobile-nav-more summary.more-active svg {
+  transform: rotate(180deg);
 }
 
 .mobile-nav-more {
@@ -345,6 +394,7 @@ textarea {
   padding: 0.35rem 0.5rem;
   border-radius: 999px;
   width: 100%;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .mobile-nav-more summary::-webkit-details-marker,
@@ -361,11 +411,54 @@ textarea {
   background: rgba(148, 163, 184, 0.16);
 }
 
+.mobile-nav-more summary svg {
+  transition: transform 0.2s ease;
+}
+
 .mobile-nav-more ul {
   margin-top: 0.4rem;
   padding-left: 0.75rem;
   display: grid;
   gap: 0.3rem;
+}
+
+.mobile-nav-more ul .btn {
+  border-radius: 9999px;
+  justify-content: flex-start;
+  color: rgba(30, 41, 59, 0.85);
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.mobile-nav-more ul .btn:hover,
+.mobile-nav-more ul .btn:focus-visible {
+  background-color: rgba(59, 130, 246, 0.12);
+  color: rgba(15, 23, 42, 0.95);
+}
+
+[data-theme="dark"] .mobile-nav-more ul .btn,
+.dark .mobile-nav-more ul .btn {
+  color: rgba(226, 232, 240, 0.9);
+}
+
+[data-theme="dark"] .mobile-nav-more ul .btn:hover,
+[data-theme="dark"] .mobile-nav-more ul .btn:focus-visible,
+.dark .mobile-nav-more ul .btn:hover,
+.dark .mobile-nav-more ul .btn:focus-visible {
+  background-color: rgba(148, 163, 184, 0.2);
+  color: rgba(226, 232, 240, 1);
+}
+
+.mobile-nav-more summary.btn-active {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.28), rgba(56, 189, 248, 0.22));
+  color: rgb(15 118 110);
+  box-shadow: 0 12px 24px rgba(45, 212, 191, 0.3);
+}
+
+[data-theme="dark"] .mobile-nav-more summary.btn-active,
+.dark .mobile-nav-more summary.btn-active {
+  background: linear-gradient(135deg, rgba(20, 184, 166, 0.35), rgba(56, 189, 248, 0.28));
+  color: rgb(187 247 208);
+  box-shadow: 0 16px 30px rgba(45, 212, 191, 0.32);
 }
 
 .mobile-nav-glass {


### PR DESCRIPTION
## Summary
- highlight the desktop "More" summary when its dropdown is open and expand mobile summaries in lockstep with grouped routes
- ensure resources/templates links in desktop and mobile dropdowns mirror the primary nav active styling
- refresh dropdown hover/focus styles and arrow animations to align with the pill navigation design

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916d0ee5c9c83249bf7f64bcf883423)