### PR TITLE
Refactor auth helpers and wire desktop sign-in

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 import { initViewportHeight } from './js/modules/viewport-height.js';
 import { initReminders } from './js/reminders.js';
+import { startSignInFlow, startSignOutFlow } from './js/supabase-auth.js';
 import {
   CUE_FIELD_DEFINITIONS,
   DEFAULT_CUE_MODAL_TITLE,
@@ -468,9 +469,42 @@ const initialiseReminders = () => {
   });
 };
 
-initialiseReminders().catch((error) => {
-  console.error('Failed to initialise reminders', error);
-});
+const desktopGoogleSignInBtn = document.getElementById('googleSignInBtn');
+const desktopGoogleSignOutBtn = document.getElementById('googleSignOutBtn');
+
+initialiseReminders()
+  .then(() => {
+    if (desktopGoogleSignInBtn && !desktopGoogleSignInBtn._authWired) {
+      desktopGoogleSignInBtn.addEventListener('click', async (event) => {
+        event.preventDefault();
+        try {
+          await startSignInFlow();
+        } catch (error) {
+          console.error('Sign-in failed:', error);
+          const feedback = document.getElementById('auth-feedback');
+          if (feedback) {
+            feedback.textContent = 'Sign-in failed. Please try again.';
+          }
+        }
+      });
+      desktopGoogleSignInBtn._authWired = true;
+    }
+
+    if (desktopGoogleSignOutBtn && !desktopGoogleSignOutBtn._authWired) {
+      desktopGoogleSignOutBtn.addEventListener('click', async (event) => {
+        event.preventDefault();
+        try {
+          await startSignOutFlow();
+        } catch (error) {
+          console.error('Sign-out failed:', error);
+        }
+      });
+      desktopGoogleSignOutBtn._authWired = true;
+    }
+  })
+  .catch((error) => {
+    console.error('Failed to initialise reminders', error);
+  });
 
 const cuesList = document.getElementById('cues-list');
 const pinnedNotesCard = document.getElementById('pinnedNotesCard');

--- a/index.html
+++ b/index.html
@@ -1295,7 +1295,7 @@
   </script>
   <script type="module" src="./app.js" defer></script>
   <script src="./js/update-footer-year.js" defer></script>
-  <script src="./js/supabase-auth.js" defer></script>
+  <script type="module" src="./js/supabase-auth.js" defer></script>
   <script src="./js/register-service-worker.js" defer></script>
   <script>
     (function () {


### PR DESCRIPTION
## Summary
- convert the Supabase auth helper to an ES module that exports shared Firebase sign-in and sign-out flows while keeping the existing magic-link UI wiring
- update the reminders module to set the shared auth context and reuse the exported helpers for mobile buttons, preventing duplicate bindings on desktop
- load the new module version in index.html and have app.js attach desktop sign-in/sign-out handlers that invoke the shared flows with basic feedback

## Testing
- npm test -- sample.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916d33890508324ad6e280ab76629e1)