### PR TITLE
Ensure build script rewrites stylesheet references

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -145,6 +145,7 @@ async function rewriteHtml(assetMap, cssPath) {
     try {
       let html = await fs.readFile(targetPath, 'utf8');
       html = html.replace(/\.\/dist\/styles\.css/g, cssPath);
+      html = html.replace(/(^|['"(\s])dist\/styles\.css/g, (match, prefix) => `${prefix}${cssPath}`);
       for (const [original, hashed] of assetMap) {
         const pattern = new RegExp(original.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
         html = html.replace(pattern, hashed);


### PR DESCRIPTION
## Summary
- update the build HTML rewrite step to replace both `./dist/styles.css` and `dist/styles.css` with the hashed CSS filename

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916d432cc5c832486617c87119b3e65)