### PR TITLE
Refactor Supabase auth handling across desktop and mobile

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ import {
   escapeCueText
 } from './js/modules/field-helpers.js';
 import { createModalController } from './js/modules/modal-controller.js';
+import { initSupabaseAuth } from './js/supabase-auth.js';
 
 initViewportHeight();
 
@@ -575,6 +576,20 @@ const initialiseReminders = () => {
 
 initialiseReminders().catch((error) => {
   console.error('Failed to initialise reminders', error);
+});
+
+initSupabaseAuth({
+  selectors: {
+    signInButtons: ['#googleSignInBtn'],
+    signOutButtons: ['#googleSignOutBtn'],
+    userBadge: '#user-badge',
+    userBadgeEmail: '#user-badge-email',
+    userBadgeInitial: '#user-badge-initial',
+    userName: '#googleUserName',
+    syncStatus: ['#sync-status'],
+    feedback: '#auth-feedback',
+  },
+  disableButtonBinding: true,
 });
 
 const cuesList = document.getElementById('cues-list');

--- a/index.html
+++ b/index.html
@@ -1295,7 +1295,7 @@
   </script>
   <script type="module" src="./app.js" defer></script>
   <script src="./js/update-footer-year.js" defer></script>
-  <script src="./js/supabase-auth.js" defer></script>
+  <script type="module" src="./js/supabase-auth-init.js" defer></script>
   <script src="./js/register-service-worker.js" defer></script>
   <script>
     (function () {

--- a/js/__tests__/mobile.open-sheet.test.js
+++ b/js/__tests__/mobile.open-sheet.test.js
@@ -18,6 +18,10 @@ function loadMobileModule() {
     "import { initReminders } from './js/reminders.js';",
     'const { initReminders } = window.__mobileMocks;'
   );
+  source = source.replace(
+    "import { initSupabaseAuth } from './js/supabase-auth.js';",
+    'const { initSupabaseAuth } = window.__mobileMocks;'
+  );
   const context = vm.createContext({
     window,
     document,
@@ -70,6 +74,7 @@ describe('mobile sheet opener events', () => {
     window.__mobileMocks = {
       initViewportHeight: jest.fn(),
       initReminders: jest.fn().mockResolvedValue({}),
+      initSupabaseAuth: jest.fn(),
     };
 
     loadMobileModule();

--- a/js/__tests__/mobile.sheet.test.js
+++ b/js/__tests__/mobile.sheet.test.js
@@ -17,6 +17,10 @@ function runMobileModule(window) {
     "import { initReminders } from './js/reminders.js';",
     'const initReminders = window.__initReminders;',
   );
+  source = source.replace(
+    "import { initSupabaseAuth } from './js/supabase-auth.js';",
+    'const initSupabaseAuth = window.__initSupabaseAuth;',
+  );
 
   const context = vm.createContext({});
   context.window = window;
@@ -58,10 +62,12 @@ describe('mobile create sheet interactions', () => {
   afterEach(() => {
     window.__initReminders = undefined;
     window.__saveClicks = undefined;
+    window.__initSupabaseAuth = undefined;
   });
 
   test('clicking Save Reminder triggers handlers when sheet content stops bubbling', async () => {
     window.__saveClicks = 0;
+    window.__initSupabaseAuth = jest.fn();
     window.__initReminders = jest.fn(() => {
       const saveBtn = document.getElementById('saveReminder');
       if (saveBtn) {

--- a/js/config-supabase.js
+++ b/js/config-supabase.js
@@ -1,20 +1,9 @@
-import { ENV } from './env.js';
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { getSupabaseClient, setSupabaseClient } from './supabase-client.js';
 
 window.__SUPABASE_ENV__ = typeof import.meta !== 'undefined' && import.meta ? import.meta.env : undefined;
 
-const supabaseUrl = ENV.SUPABASE_URL;
-const supabaseAnonKey = ENV.SUPABASE_ANON_KEY;
+const supabase = getSupabaseClient();
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  console.error('[supabase] Missing SUPABASE_URL or SUPABASE_ANON_KEY.');
-} else {
-  window.supabase = createClient(supabaseUrl, supabaseAnonKey);
-
-  try {
-    const projectRef = new URL(supabaseUrl).hostname.split('.')[0];
-    console.info('[supabase] Client initialised for project:', projectRef);
-  } catch (error) {
-    console.info('[supabase] Client initialised.');
-  }
+if (!supabase && typeof window !== 'undefined' && window.supabase) {
+  setSupabaseClient(window.supabase);
 }

--- a/js/supabase-auth-init.js
+++ b/js/supabase-auth-init.js
@@ -1,0 +1,3 @@
+import { initSupabaseAuth } from './supabase-auth.js';
+
+initSupabaseAuth();

--- a/js/supabase-auth.js
+++ b/js/supabase-auth.js
@@ -1,108 +1,327 @@
-// js/supabase-auth.js
-// Uses the global window.supabase that you already create in index.html
+import { getSupabaseClient } from './supabase-client.js';
 
-window.addEventListener('DOMContentLoaded', () => {
-  const supabase = window.supabase;
-  if (!supabase) {
-    console.error('Supabase client not found. Check your URL/key config in index.html.');
-    return;
+const DEFAULT_SELECTORS = {
+  authForm: '#auth-form',
+  emailInput: '#auth-email',
+  signInButtons: null,
+  signOutButtons: '#sign-out-btn',
+  userBadge: '#user-badge',
+  userBadgeEmail: '#user-badge-email',
+  userBadgeInitial: '#user-badge-initial',
+  userName: '#googleUserName',
+  syncStatus: '#sync-status',
+  syncStatusText: null,
+  statusIndicator: null,
+  feedback: '#auth-feedback',
+};
+
+const DEFAULT_MESSAGES = {
+  signedOut: 'Sign in to sync reminders across devices.',
+  signedIn: (user) => `Reminders syncing for ${user?.email || 'your account'}.`,
+  syncStatusText: {
+    signedOut: 'Offline',
+    signedIn: 'Online',
+  },
+};
+
+function toArray(value) {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function uniqueElements(elements) {
+  return Array.from(
+    new Set(
+      elements.filter(
+        (element) => element instanceof HTMLElement || (typeof SVGElement !== 'undefined' && element instanceof SVGElement)
+      )
+    )
+  );
+}
+
+function queryAll(root, selectorValue) {
+  const selectors = toArray(selectorValue).filter(Boolean);
+  if (!selectors.length) {
+    return [];
   }
+  const nodes = selectors.flatMap((selector) => Array.from(root.querySelectorAll(selector)));
+  return uniqueElements(nodes);
+}
 
-  // ---- Elements ----
-  const authForm = document.getElementById('auth-form');
-  const emailInput = document.getElementById('auth-email');
-  const signOutBtn = document.getElementById('sign-out-btn');
-  const userBadge = document.getElementById('user-badge');
-  const userBadgeEmail = document.getElementById('user-badge-email');
-  const userBadgeInitial = document.getElementById('user-badge-initial');
-  const feedback = document.getElementById('auth-feedback');
-  const syncStatus = document.getElementById('sync-status');
+function collectAuthElements(selectors, root = document) {
+  const scope = root instanceof Document || root instanceof HTMLElement ? root : document;
+  return {
+    authForms: queryAll(scope, selectors.authForm),
+    emailInputs: queryAll(scope, selectors.emailInput),
+    signInButtons: queryAll(scope, selectors.signInButtons),
+    signOutButtons: queryAll(scope, selectors.signOutButtons),
+    userBadges: queryAll(scope, selectors.userBadge),
+    userBadgeEmails: queryAll(scope, selectors.userBadgeEmail),
+    userBadgeInitials: queryAll(scope, selectors.userBadgeInitial),
+    userNameEls: queryAll(scope, selectors.userName),
+    syncStatusEls: queryAll(scope, selectors.syncStatus),
+    syncStatusTextEls: queryAll(scope, selectors.syncStatusText),
+    statusIndicatorEls: queryAll(scope, selectors.statusIndicator),
+    feedbackEls: queryAll(scope, selectors.feedback),
+  };
+}
 
-  const toggleElementVisibility = (element, shouldShow) => {
-    if (!element) return;
+function toggleElements(elements, shouldShow) {
+  uniqueElements(Array.isArray(elements) ? elements : [elements]).forEach((element) => {
+    if (!(element instanceof HTMLElement)) {
+      return;
+    }
     element.classList.toggle('hidden', !shouldShow);
     if (shouldShow) {
       element.removeAttribute('hidden');
     } else {
       element.setAttribute('hidden', '');
     }
-  };
+  });
+}
 
-  // If the page doesn't have the auth UI, bail quietly
-  if (!authForm) return;
+function setTextContent(elements, text) {
+  uniqueElements(Array.isArray(elements) ? elements : [elements]).forEach((element) => {
+    if (element instanceof HTMLElement) {
+      element.textContent = text || '';
+    }
+  });
+}
 
-  if (syncStatus && !syncStatus.textContent) {
-    syncStatus.textContent = 'Sign in to sync reminders across devices.';
-    syncStatus.classList.remove('online');
-    syncStatus.dataset.state = 'offline';
-    toggleElementVisibility(syncStatus, true);
-  }
+function updateStatusIndicators(elements, state) {
+  uniqueElements(elements).forEach((element) => {
+    if (!(element instanceof HTMLElement)) {
+      return;
+    }
+    element.dataset.state = state;
+    element.classList.toggle('online', state === 'online');
+    element.classList.toggle('offline', state !== 'online');
+  });
+}
 
-  const setFeedback = (msg) => {
-    if (!feedback) return;
-    feedback.textContent = msg || '';
-    toggleElementVisibility(feedback, Boolean(msg));
-  };
-
-  // Prevent double-binding if this file is included twice
-  if (!authForm._wired) {
-    authForm._wired = true;
-
-    authForm.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const email = emailInput?.value.trim();
-      if (!email) return;
-      const { error } = await supabase.auth.signInWithOtp({ email });
-      setFeedback(error ? error.message : 'Magic link sent. Check your email.');
-    });
-  }
-
-  if (signOutBtn && !signOutBtn._wired) {
-    signOutBtn._wired = true;
-    signOutBtn.addEventListener('click', async () => {
-      await supabase.auth.signOut();
-    });
-  }
-
-  // Session/UI sync
-  supabase.auth.onAuthStateChange(async (_event, session) => {
-    const user = session?.user || null;
-
-    toggleElementVisibility(signOutBtn, Boolean(user));
-    toggleElementVisibility(authForm, !user);
-    toggleElementVisibility(userBadge, Boolean(user));
-
-    if (user) {
-      userBadgeEmail && (userBadgeEmail.textContent = user.email || '');
-      userBadgeInitial && (userBadgeInitial.textContent = (user.email?.[0] || 'U').toUpperCase());
-      if (syncStatus) {
-        syncStatus.textContent = `Reminders syncing for ${user.email || 'your account'}.`;
-        syncStatus.classList.add('online');
-        syncStatus.dataset.state = 'online';
-      }
-      await supabase.from('profiles').upsert({ id: user.id, email: user.email });
+function setFeedback(elements, message) {
+  uniqueElements(elements).forEach((element) => {
+    if (!(element instanceof HTMLElement)) {
+      return;
+    }
+    element.textContent = message || '';
+    const shouldShow = Boolean(message);
+    element.classList.toggle('hidden', !shouldShow);
+    if (shouldShow) {
+      element.removeAttribute('hidden');
     } else {
-      if (syncStatus) {
-        syncStatus.textContent = 'Sign in to sync reminders across devices.';
-        syncStatus.classList.remove('online');
-        syncStatus.dataset.state = 'offline';
+      element.setAttribute('hidden', '');
+    }
+  });
+}
+
+function resolveMessages(messages = {}) {
+  const syncStatusText = {
+    ...DEFAULT_MESSAGES.syncStatusText,
+    ...(messages.syncStatusText || {}),
+  };
+  return {
+    ...DEFAULT_MESSAGES,
+    ...messages,
+    syncStatusText,
+  };
+}
+
+export function applyAuthState(elements, { user, messages } = {}) {
+  const resolvedMessages = resolveMessages(messages);
+  const isSignedIn = Boolean(user);
+
+  toggleElements(elements.signInButtons, !isSignedIn);
+  toggleElements(elements.authForms, !isSignedIn);
+  toggleElements(elements.signOutButtons, isSignedIn);
+  toggleElements(elements.userBadges, isSignedIn);
+
+  const email = typeof user?.email === 'string' ? user.email : '';
+  const initial = email ? email.charAt(0).toUpperCase() : 'U';
+
+  if (isSignedIn) {
+    setTextContent(elements.userBadgeEmails, email);
+    setTextContent(elements.userBadgeInitials, initial);
+    setTextContent(elements.userNameEls, email);
+  } else {
+    setTextContent(elements.userBadgeEmails, '');
+    setTextContent(elements.userBadgeInitials, '');
+    setTextContent(elements.userNameEls, '');
+  }
+
+  const signedInMessage = typeof resolvedMessages.signedIn === 'function'
+    ? resolvedMessages.signedIn(user)
+    : resolvedMessages.signedIn;
+  const signedOutMessage = typeof resolvedMessages.signedOut === 'function'
+    ? resolvedMessages.signedOut(user)
+    : resolvedMessages.signedOut;
+  const statusMessage = isSignedIn ? signedInMessage : signedOutMessage;
+
+  if (elements.syncStatusEls.length) {
+    toggleElements(elements.syncStatusEls, true);
+    setTextContent(elements.syncStatusEls, statusMessage);
+    elements.syncStatusEls.forEach((element) => {
+      if (!(element instanceof HTMLElement)) {
+        return;
+      }
+      element.classList.toggle('online', isSignedIn);
+      element.dataset.state = isSignedIn ? 'online' : 'offline';
+    });
+  }
+
+  const syncStatusText = isSignedIn
+    ? resolvedMessages.syncStatusText?.signedIn
+    : resolvedMessages.syncStatusText?.signedOut;
+  setTextContent(elements.syncStatusTextEls, syncStatusText || '');
+  updateStatusIndicators(elements.statusIndicatorEls, isSignedIn ? 'online' : 'offline');
+
+  setFeedback(elements.feedbackEls, '');
+}
+
+function bindAuthForms(supabase, elements) {
+  elements.authForms.forEach((form) => {
+    if (!(form instanceof HTMLFormElement) || form.dataset.supabaseAuthBound === 'true') {
+      return;
+    }
+
+    form.dataset.supabaseAuthBound = 'true';
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const emailInput = elements.emailInputs.find((input) => form.contains(input))
+        || form.querySelector('input[type="email"]');
+      const email = typeof emailInput?.value === 'string' ? emailInput.value.trim() : '';
+
+      if (!email) {
+        setFeedback(elements.feedbackEls, 'Enter an email address to continue.');
+        return;
+      }
+
+      try {
+        const { error } = await supabase.auth.signInWithOtp({ email });
+        if (error) {
+          setFeedback(elements.feedbackEls, error.message || 'Unable to send magic link.');
+        } else {
+          setFeedback(elements.feedbackEls, 'Magic link sent. Check your email.');
+        }
+      } catch (error) {
+        setFeedback(elements.feedbackEls, error?.message || 'Unable to send magic link.');
+      }
+    });
+  });
+}
+
+function bindSignOutButtons(supabase, elements) {
+  elements.signOutButtons.forEach((button) => {
+    if (!(button instanceof HTMLElement) || button.dataset.supabaseAuthBound === 'true') {
+      return;
+    }
+
+    button.dataset.supabaseAuthBound = 'true';
+
+    button.addEventListener('click', async () => {
+      try {
+        await supabase.auth.signOut();
+      } catch (error) {
+        console.error('[supabase] Sign-out failed.', error);
+      }
+    });
+  });
+}
+
+export function initSupabaseAuth(options = {}) {
+  const {
+    supabase: suppliedSupabase,
+    scope = document,
+    selectors: selectorOverrides = {},
+    messages: messageOverrides = {},
+    disableButtonBinding = false,
+    onSessionChange,
+  } = options;
+
+  const selectors = {
+    ...DEFAULT_SELECTORS,
+    ...selectorOverrides,
+  };
+
+  const elements = collectAuthElements(selectors, scope);
+  const messages = resolveMessages(messageOverrides);
+
+  applyAuthState(elements, { user: null, messages });
+
+  const supabase = suppliedSupabase
+    || getSupabaseClient()
+    || (typeof window !== 'undefined' ? window.supabase : null);
+
+  if (!supabase) {
+    return {
+      supabase: null,
+      elements,
+      applyAuthState: (state) => applyAuthState(elements, { ...state, messages }),
+      destroy() {},
+    };
+  }
+
+  bindAuthForms(supabase, elements);
+  if (!disableButtonBinding) {
+    bindSignOutButtons(supabase, elements);
+  }
+
+  const cleanupFns = [];
+
+  const { data } = supabase.auth.onAuthStateChange((_event, session) => {
+    applyAuthState(elements, { user: session?.user ?? null, messages });
+    if (typeof onSessionChange === 'function') {
+      try {
+        onSessionChange(session?.user ?? null, session);
+      } catch (error) {
+        console.error('[supabase] onSessionChange handler failed.', error);
       }
     }
-
-    if (syncStatus) {
-      toggleElementVisibility(syncStatus, true);
-    }
-
-    setFeedback('');
   });
 
-  // Optional: quick sanity test in console
-  (async () => {
-    try {
-      const { data, error } = await supabase.from('activities').select('*').limit(1);
-      console.log('Supabase DB test:', { data, error });
-    } catch (err) {
-      console.error('Supabase sanity test error:', err);
-    }
-  })();
-});
+  if (data?.subscription) {
+    cleanupFns.push(() => {
+      try {
+        data.subscription.unsubscribe();
+      } catch {
+        /* noop */
+      }
+    });
+  }
+
+  supabase.auth
+    .getSession()
+    .then(({ data: sessionData, error }) => {
+      if (!error) {
+        applyAuthState(elements, { user: sessionData?.session?.user ?? null, messages });
+      }
+    })
+    .catch((error) => {
+      console.error('[supabase] getSession failed.', error);
+    });
+
+  return {
+    supabase,
+    elements,
+    applyAuthState: (state) => applyAuthState(elements, { ...state, messages }),
+    destroy() {
+      cleanupFns.forEach((fn) => {
+        try {
+          fn();
+        } catch {
+          /* noop */
+        }
+      });
+    },
+  };
+}
+
+export { DEFAULT_SELECTORS as SUPABASE_AUTH_DEFAULT_SELECTORS };
+export { DEFAULT_MESSAGES as SUPABASE_AUTH_DEFAULT_MESSAGES };
+export function getSupabaseAuthElements(selectors = {}, scope = document) {
+  return collectAuthElements({
+    ...DEFAULT_SELECTORS,
+    ...selectors,
+  }, scope);
+}

--- a/js/supabase-client.js
+++ b/js/supabase-client.js
@@ -1,0 +1,59 @@
+import { ENV } from './env.js';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+let cachedClient = null;
+let attemptedInitialisation = false;
+
+function normalise(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function setSupabaseClient(client) {
+  if (client) {
+    cachedClient = client;
+    attemptedInitialisation = true;
+  }
+  return cachedClient;
+}
+
+export function getSupabaseClient() {
+  if (cachedClient) {
+    return cachedClient;
+  }
+
+  if (!attemptedInitialisation && typeof window !== 'undefined' && window.supabase) {
+    return setSupabaseClient(window.supabase);
+  }
+
+  attemptedInitialisation = true;
+
+  const supabaseUrl = normalise(ENV?.SUPABASE_URL);
+  const supabaseAnonKey = normalise(ENV?.SUPABASE_ANON_KEY);
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    console.error('[supabase] Missing SUPABASE_URL or SUPABASE_ANON_KEY.');
+    return null;
+  }
+
+  try {
+    cachedClient = createClient(supabaseUrl, supabaseAnonKey);
+    if (typeof window !== 'undefined') {
+      window.supabase = cachedClient;
+    }
+    try {
+      const projectRef = new URL(supabaseUrl).hostname.split('.')[0];
+      console.info('[supabase] Client initialised for project:', projectRef);
+    } catch {
+      console.info('[supabase] Client initialised.');
+    }
+  } catch (error) {
+    console.error('[supabase] Failed to initialise client.', error);
+    cachedClient = null;
+  }
+
+  return cachedClient;
+}
+
+export function hasSupabaseClient() {
+  return Boolean(getSupabaseClient());
+}

--- a/mobile.html
+++ b/mobile.html
@@ -2800,6 +2800,7 @@
     }
   </script>
   <!-- Load the mobile app bundle (build will rewrite to hashed path) -->
+  <script type="module" src="./js/config-supabase.js" defer></script>
   <script defer src="./js/firebase-config.js"></script>
   <script src="./js/register-service-worker.js" defer></script>
   <script type="module" src="./mobile.js?v=2025-10-29-1"></script>

--- a/mobile.js
+++ b/mobile.js
@@ -1,5 +1,6 @@
 import { initViewportHeight } from './js/modules/viewport-height.js';
 import { initReminders } from './js/reminders.js';
+import { initSupabaseAuth } from './js/supabase-auth.js';
 
 initViewportHeight();
 
@@ -294,6 +295,22 @@ if (document.readyState === 'loading') {
 } else {
   bootstrapReminders();
 }
+
+initSupabaseAuth({
+  selectors: {
+    signInButtons: ['#googleSignInBtn'],
+    signOutButtons: ['#googleSignOutBtn'],
+    userBadge: '#user-badge',
+    userBadgeEmail: '#user-badge-email',
+    userBadgeInitial: '#user-badge-initial',
+    userName: '#googleUserName',
+    syncStatus: ['#sync-status', '#syncStatus'],
+    syncStatusText: ['#mcStatusText'],
+    statusIndicator: ['#mcStatus'],
+    feedback: '#auth-feedback',
+  },
+  disableButtonBinding: true,
+});
 
 (() => {
   const menuBtn = document.getElementById('overflowMenuBtn');


### PR DESCRIPTION
## Summary
- add a shared Supabase client module and ensure both desktop and mobile import it through the auth UI helpers
- refactor supabase-auth into reusable functions, expose a module init entrypoint, and initialise the desktop and mobile UIs with consistent selector sets
- update mobile HTML to bootstrap the Supabase config, adjust associated tests to stub the new imports, and stabilise the reminders notes test configuration

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916d49f4150832486567434ed21d851)