### PR TITLE
Handle Firestore permission errors when loading cues

### DIFF
--- a/app.js
+++ b/app.js
@@ -1037,12 +1037,21 @@ function renderPinnedNotesList(cues) {
   pinnedNotesList.innerHTML = markup;
 }
 
+function renderCueListMessage(message, { tone = 'muted' } = {}) {
+  if (!cuesList) {
+    return;
+  }
+  const classes = ['text-sm'];
+  classes.push(tone === 'error' ? 'text-error' : 'text-base-content/60');
+  cuesList.innerHTML = `<p class="${classes.join(' ')}">${escapeCueText(message)}</p>`;
+}
+
 function renderCueList(cues) {
   if (!cuesList) {
     return;
   }
   if (!Array.isArray(cues) || cues.length === 0) {
-    cuesList.innerHTML = '<p class="text-sm text-base-content/60">No cues yet.</p>';
+    renderCueListMessage('No cues yet.');
     return;
   }
   const markup = cues
@@ -1190,6 +1199,11 @@ async function refreshCueList() {
     renderPinnedNotesList(cues);
   } catch (error) {
     console.error('Failed to load cues', error);
+    if (isPermissionDeniedError(error)) {
+      renderCueListMessage('Sign in to view your cues.', { tone: 'muted' });
+    } else {
+      renderCueListMessage('Unable to load cues right now.', { tone: 'error' });
+    }
     renderPinnedNotesList([]);
   }
 }


### PR DESCRIPTION
## Summary
- add a helper for rendering cue list status messages and reuse it for the empty state
- display sign-in guidance when Firestore rejects cue fetches with permission errors and show a general error message otherwise

## Testing
- npm test -- --runInBand *(fails: Jest VM loader hits "Cannot use import statement outside a module" for reminders.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916dd14a1648324aed42744a4ae5649)