### PR TITLE
Align desktop auth wiring with mobile flow

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,5 @@
 import { initViewportHeight } from './js/modules/viewport-height.js';
 import { initReminders } from './js/reminders.js';
-import { startSignInFlow, startSignOutFlow } from './js/supabase-auth.js';
 import {
   CUE_FIELD_DEFINITIONS,
   DEFAULT_CUE_MODAL_TITLE,
@@ -571,44 +570,12 @@ const initialiseReminders = () => {
     googleSignInBtnSel: '#googleSignInBtn',
     googleSignOutBtnSel: '#googleSignOutBtn',
     googleUserNameSel: '#googleUserName',
-    variant: 'desktop'
+    variant: 'desktop',
+    autoWireAuthButtons: true
   });
 };
 
-const desktopGoogleSignInBtn = document.getElementById('googleSignInBtn');
-const desktopGoogleSignOutBtn = document.getElementById('googleSignOutBtn');
-
-initialiseReminders()
-  .then(() => {
-    if (desktopGoogleSignInBtn && !desktopGoogleSignInBtn._authWired) {
-      desktopGoogleSignInBtn.addEventListener('click', async (event) => {
-        event.preventDefault();
-        try {
-          await startSignInFlow();
-        } catch (error) {
-          console.error('Sign-in failed:', error);
-          const feedback = document.getElementById('auth-feedback');
-          if (feedback) {
-            feedback.textContent = 'Sign-in failed. Please try again.';
-          }
-        }
-      });
-      desktopGoogleSignInBtn._authWired = true;
-    }
-
-    if (desktopGoogleSignOutBtn && !desktopGoogleSignOutBtn._authWired) {
-      desktopGoogleSignOutBtn.addEventListener('click', async (event) => {
-        event.preventDefault();
-        try {
-          await startSignOutFlow();
-        } catch (error) {
-          console.error('Sign-out failed:', error);
-        }
-      });
-      desktopGoogleSignOutBtn._authWired = true;
-    }
-  })
-  .catch((error) => {
+initialiseReminders().catch((error) => {
     console.error('Failed to initialise reminders', error);
   });
 

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -458,6 +458,8 @@ export async function initReminders(sel = {}) {
   const listWrapper = $(sel.listWrapperSel);
   const categoryDatalist = $(sel.categoryOptionsSel);
   const variant = sel.variant || 'mobile';
+  const autoWireAuthButtons =
+    typeof sel.autoWireAuthButtons === 'boolean' ? sel.autoWireAuthButtons : variant !== 'desktop';
 
   const LAST_DEFAULTS_KEY = 'mc:lastDefaults';
 
@@ -2294,7 +2296,7 @@ export async function initReminders(sel = {}) {
     toast,
   });
 
-  const shouldWireAuthButtons = variant !== 'desktop';
+  const shouldWireAuthButtons = autoWireAuthButtons;
 
   const wireAuthButton = (button, handler) => {
     if (!(button instanceof HTMLElement) || button._authWired) {


### PR DESCRIPTION
## Summary
- enable `initReminders` to opt into automatic auth button wiring
- switch the desktop bundle to use the same auth wiring path as mobile and drop the manual handlers

## Testing
- npm test *(fails: Jest vm harness cannot parse ES module imports from js/reminders.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916e5be2e7c832484788bd882cfba3b)