### PR TITLE
Move total reminders label above reminder list

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -2263,8 +2263,8 @@
           <p id="reminderReorderHint" class="sr-only">
             Press, hold, and drag a reminder card to reorder your list. Screen reader users can double-tap and hold, then drag to move a reminder.
           </p>
+          <p class="text-xs text-base-content/50 mb-2 pb-2 px-4 border-b border-base-200/30">Total reminders: <span id="totalCount">0</span></p>
           <ul id="reminderList" class="grid gap-3 w-full" aria-describedby="reminderReorderHint"></ul>
-          <p class="text-xs text-base-content/50 mt-4 pt-3 px-4 border-t border-base-200/30">Total reminders: <span id="totalCount">0</span></p>
         </div>
       </section>
     </section>

--- a/mobile.html
+++ b/mobile.html
@@ -2620,8 +2620,8 @@
           <p id="reminderReorderHint" class="sr-only">
             Press, hold, and drag a reminder card to reorder your list. Screen reader users can double-tap and hold, then drag to move a reminder.
           </p>
+          <p class="text-xs text-base-content/50 mb-2 pb-2 px-4 border-b border-base-200/30">Total reminders: <span id="totalCount">0</span></p>
           <ul id="reminderList" class="grid grid-cols-2 gap-1 w-full" aria-describedby="reminderReorderHint"></ul>
-          <p class="text-xs text-base-content/50 mt-4 pt-3 px-4 border-t border-base-200/30">Total reminders: <span id="totalCount">0</span></p>
         </div>
       </section>
     </section>


### PR DESCRIPTION
## Summary
- move the total reminders count above the reminder list so it appears as a header for the grid

## Testing
- npm test -- --runInBand *(fails: SyntaxError: Cannot use import statement outside a module in existing tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916e978fa408324914315c5217f4f65)