### PR TITLE
Restore theme toggle in main navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -334,6 +334,47 @@
             </div>
           </div>
           <div class="flex w-full flex-wrap items-center justify-end gap-2 sm:w-auto">
+            <button
+              id="theme-toggle"
+              type="button"
+              class="btn btn-sm btn-ghost text-base-content"
+              data-icon-dark="🌙"
+              data-icon-light="☀️"
+            ></button>
+            <div class="dropdown dropdown-end">
+              <button
+                type="button"
+                class="btn btn-sm btn-ghost gap-2 text-base-content"
+                aria-haspopup="menu"
+                aria-expanded="false"
+              >
+                <span>Theme</span>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke-width="1.5"
+                  stroke="currentColor"
+                  class="size-4"
+                  aria-hidden="true"
+                >
+                  <path stroke-linecap="round" stroke-linejoin="round" d="m6 9 6 6 6-6" />
+                </svg>
+              </button>
+              <ul
+                id="theme-menu"
+                class="menu dropdown-content bg-base-100 text-base-content rounded-box z-[1] mt-3 w-48 p-2 shadow"
+                role="menu"
+                tabindex="0"
+              >
+                <li><a href="#" data-theme-name="light" data-theme-option="light" role="menuitemradio" aria-checked="false">Light</a></li>
+                <li><a href="#" data-theme-name="dark" data-theme-option="dark" role="menuitemradio" aria-checked="false">Dark</a></li>
+                <li><a href="#" data-theme-name="dracula" data-theme-option="dracula" role="menuitemradio" aria-checked="false">Dracula</a></li>
+                <li><a href="#" data-theme-name="cupcake" data-theme-option="cupcake" role="menuitemradio" aria-checked="false">Cupcake</a></li>
+                <li><a href="#" data-theme-name="caramellatte" data-theme-option="caramellatte" role="menuitemradio" aria-checked="false">Caramellatte</a></li>
+                <li><a href="#" data-theme-name="synthwave" data-theme-option="synthwave" role="menuitemradio" aria-checked="false">Synthwave</a></li>
+              </ul>
+            </div>
             <div
               id="googleUserName"
               class="google-user-chip text-xs sm:text-sm font-medium text-base-content/80 rounded-full border border-base-200 bg-base-100/80 px-3 py-1"


### PR DESCRIPTION
## Summary
- reintroduce the theme toggle button and menu to the primary navbar on the main page so users can switch themes again

## Testing
- npm test -- --runInBand *(fails: existing SyntaxError in js/reminders.js when run under Jest sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916e9b38c688324b3bcb1692d9fdd00)