### PR TITLE
Fix mobile sync prompt visibility and contrast

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -296,7 +296,7 @@
       </div>
       <div class="navbar-end flex-1 justify-end">
         <div class="flex w-full flex-col items-end gap-1 text-right">
-          <p id="sync-status" class="sync-status hidden text-xs text-base-content/70" data-compact="true"></p>
+          <p id="sync-status" class="sync-status hidden text-xs text-base-content" data-compact="true"></p>
           <div
             id="user-badge"
             class="hidden items-center gap-3 rounded-full border border-base-200 bg-base-100/80 px-3 py-1.5 text-sm shadow-sm backdrop-blur"

--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -1727,7 +1727,18 @@
       align-items: center;
       gap: 0.25rem;
       font-size: 0.7rem;
-      color: color-mix(in srgb, var(--card-bg) 80%, transparent);
+      color: color-mix(in srgb, var(--text-primary, rgba(15, 23, 42, 0.88)) 85%, rgba(15, 23, 42, 0.9));
+    }
+
+    .dark .mc-quick-status {
+      color: color-mix(in srgb, rgba(226, 232, 240, 0.92) 90%, transparent);
+    }
+
+    .mc-sync-message {
+      margin: 0;
+      display: inline-flex;
+      align-items: center;
+      white-space: nowrap;
     }
 
     .mc-status-text {
@@ -1962,6 +1973,7 @@
         <div id="syncStatus" class="sync-inline" data-state="offline" title="Sync status">
           <span id="mcStatus" class="sync-dot offline" role="status" aria-hidden="true"></span>
         </div>
+        <p id="sync-status" class="mc-sync-message">Sign in to sync reminders across devices.</p>
         <span id="mcStatusText" class="mc-status-text">Offline</span>
       </div>
 

--- a/docs/styles/index.css
+++ b/docs/styles/index.css
@@ -149,12 +149,12 @@ html {
 }
 
 .sync-status {
-  --indicator-color: rgba(100, 116, 139, 0.9);
+  --indicator-color: rgba(30, 41, 59, 0.9);
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
   padding: 0.125rem 0.25rem;
-  color: rgb(100 116 139);
+  color: rgb(30 41 59);
   font-size: 0.875rem;
   line-height: 1.25;
   transition: color 0.2s ease;

--- a/index.html
+++ b/index.html
@@ -318,7 +318,7 @@
       </div>
       <div class="navbar-end flex-1 justify-end">
         <div class="flex w-full flex-col items-end gap-1 text-right">
-          <p id="sync-status" class="sync-status hidden text-xs text-base-content/70" data-compact="true"></p>
+          <p id="sync-status" class="sync-status hidden text-xs text-base-content" data-compact="true"></p>
           <div
             id="user-badge"
             class="hidden items-center gap-3 rounded-full border border-base-200 bg-base-100/80 px-3 py-1.5 text-sm shadow-sm backdrop-blur"

--- a/js/supabase-auth.js
+++ b/js/supabase-auth.js
@@ -258,9 +258,9 @@ export function applyAuthState(elements, { user, messages } = {}) {
     ? resolvedMessages.signedOut(user)
     : resolvedMessages.signedOut;
   const statusMessage = isSignedIn ? signedInMessage : signedOutMessage;
+  const shouldShowSyncStatus = !isSignedIn;
 
   if (elements.syncStatusEls.length) {
-    toggleElements(elements.syncStatusEls, true);
     setTextContent(elements.syncStatusEls, statusMessage);
     elements.syncStatusEls.forEach((element) => {
       if (!(element instanceof HTMLElement)) {
@@ -269,6 +269,7 @@ export function applyAuthState(elements, { user, messages } = {}) {
       element.classList.toggle('online', isSignedIn);
       element.dataset.state = isSignedIn ? 'online' : 'offline';
     });
+    toggleElements(elements.syncStatusEls, shouldShowSyncStatus);
   }
 
   const syncStatusText = isSignedIn

--- a/mobile.html
+++ b/mobile.html
@@ -2090,7 +2090,18 @@
       align-items: center;
       gap: 0.25rem;
       font-size: 0.7rem;
-      color: color-mix(in srgb, var(--card-bg) 80%, transparent);
+      color: color-mix(in srgb, var(--text-primary, rgba(15, 23, 42, 0.88)) 85%, rgba(15, 23, 42, 0.9));
+    }
+
+    .dark .mc-quick-status {
+      color: color-mix(in srgb, rgba(226, 232, 240, 0.92) 90%, transparent);
+    }
+
+    .mc-sync-message {
+      margin: 0;
+      display: inline-flex;
+      align-items: center;
+      white-space: nowrap;
     }
 
     .mc-status-text {
@@ -2334,6 +2345,7 @@
         <div id="syncStatus" class="sync-inline" data-state="offline" title="Sync status">
           <span id="mcStatus" class="sync-dot offline" role="status" aria-hidden="true"></span>
         </div>
+        <p id="sync-status" class="mc-sync-message">Sign in to sync reminders across devices.</p>
         <span id="mcStatusText" class="mc-status-text">Offline</span>
       </div>
 

--- a/mobile.js
+++ b/mobile.js
@@ -304,7 +304,7 @@ initSupabaseAuth({
     userBadgeEmail: '#user-badge-email',
     userBadgeInitial: '#user-badge-initial',
     userName: '#googleUserName',
-    syncStatus: ['#sync-status', '#syncStatus'],
+    syncStatus: ['#sync-status'],
     syncStatusText: ['#mcStatusText'],
     statusIndicator: ['#mcStatus'],
     feedback: '#auth-feedback',

--- a/styles/index.css
+++ b/styles/index.css
@@ -494,12 +494,12 @@ textarea {
 }
 
 .sync-status {
-  --indicator-color: rgba(100, 116, 139, 0.9);
+  --indicator-color: rgba(30, 41, 59, 0.9);
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
   padding: 0.125rem 0.25rem;
-  color: rgb(100 116 139);
+  color: rgb(30 41 59);
   font-size: 0.875rem;
   line-height: 1.25;
   transition: color 0.2s ease;


### PR DESCRIPTION
## Summary
- Darken the mobile quick-status typography and add a dedicated sync prompt element so the message can be hidden after signing in. 【F:mobile.html†L2088-L2105】【F:mobile.html†L2344-L2349】【F:docs/mobile.html†L1725-L1742】【F:docs/mobile.html†L1972-L1977】
- Update the mobile Supabase auth wiring to reference the new sync prompt element for session-aware visibility. 【F:mobile.js†L299-L313】

## Testing
- npm test -- --runInBand *(fails: existing Jest suite cannot load the ESM imports in js/reminders.js in this environment)* 【e0025c†L1-L101】

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916e879a3a08324a800f0fc2b8bc240)