### PR TITLE
Tidy desktop and mobile navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,7 +216,65 @@
   <a class="skip-link" href="#mainContent">Skip to main content</a>
   <nav aria-label="Primary" class="relative fixed top-0 z-50 w-full navbar-glass">
     <div class="navbar mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-      <div class="navbar-start">
+      <div class="navbar-start items-center gap-2">
+        <details class="nav-mobile dropdown dropdown-bottom lg:hidden">
+          <summary
+            class="nav-mobile-summary btn btn-sm btn-ghost gap-2"
+            aria-label="Toggle navigation menu"
+            aria-haspopup="menu"
+            aria-controls="mobile-nav-menu"
+            aria-expanded="false"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              class="size-5"
+              aria-hidden="true"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M4 7h16M4 12h16M4 17h16" />
+            </svg>
+            <span>Menu</span>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              class="nav-mobile-chevron size-4"
+              aria-hidden="true"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="m6 9 6 6 6-6" />
+            </svg>
+          </summary>
+          <ul
+            id="mobile-nav-menu"
+            class="nav-mobile-menu menu menu-sm dropdown-content mt-3 w-56 gap-1 rounded-box bg-base-100/95 p-3 text-sm text-base-content shadow-lg"
+            role="menu"
+          >
+            <li>
+              <a href="#dashboard" data-nav="dashboard" class="btn btn-sm btn-ghost w-full justify-start" role="menuitem">Dashboard</a>
+            </li>
+            <li>
+              <a href="#reminders" data-nav="reminders" class="btn btn-sm btn-ghost w-full justify-start" role="menuitem">Reminders</a>
+            </li>
+            <li>
+              <a href="#planner" data-nav="planner" class="btn btn-sm btn-ghost w-full justify-start" role="menuitem">Planner</a>
+            </li>
+            <li>
+              <a href="#notes" data-nav="notes" class="btn btn-sm btn-ghost w-full justify-start" role="menuitem">Notes</a>
+            </li>
+            <li class="menu-title">More</li>
+            <li>
+              <a href="#resources" data-nav="resources" class="btn btn-sm btn-ghost w-full justify-start" role="menuitem">Resources</a>
+            </li>
+            <li>
+              <a href="#templates" data-nav="templates" class="btn btn-sm btn-ghost w-full justify-start" role="menuitem">Templates</a>
+            </li>
+          </ul>
+        </details>
         <a href="#dashboard" class="btn btn-ghost gap-2 text-left text-lg font-semibold normal-case text-base-content">
           <span class="inline-flex size-9 items-center justify-center rounded-full bg-primary/15 text-primary">
             MC
@@ -243,7 +301,7 @@
           <li class="nav-more-item">
             <details class="nav-more-details">
               <summary
-                class="btn btn-sm btn-ghost"
+                class="btn btn-sm btn-ghost nav-more-summary items-center gap-1"
                 data-nav-group="more"
                 aria-expanded="false"
                 aria-haspopup="true"
@@ -256,7 +314,7 @@
                   fill="none"
                   stroke="currentColor"
                   stroke-width="1.5"
-                  class="size-4"
+                  class="nav-more-chevron size-4"
                   aria-hidden="true"
                 >
                   <path stroke-linecap="round" stroke-linejoin="round" d="m6 9 6 6 6-6" />

--- a/js/router.js
+++ b/js/router.js
@@ -57,8 +57,34 @@ function initGroupedNavHandlers() {
   }
 }
 
+function initMobileNavHandlers() {
+  const navMobileDetails = document.querySelector('.nav-mobile');
+  if (!navMobileDetails) {
+    return;
+  }
+
+  const navMobileSummary = navMobileDetails.querySelector('.nav-mobile-summary');
+  const syncExpanded = () => {
+    if (navMobileSummary) {
+      navMobileSummary.setAttribute('aria-expanded', navMobileDetails.open ? 'true' : 'false');
+    }
+  };
+
+  syncExpanded();
+
+  navMobileDetails.addEventListener('toggle', syncExpanded);
+
+  navMobileDetails.querySelectorAll('[data-nav]').forEach((link) => {
+    link.addEventListener('click', () => {
+      navMobileDetails.removeAttribute('open');
+      syncExpanded();
+    });
+  });
+}
+
 function initRouter() {
   initGroupedNavHandlers();
+  initMobileNavHandlers();
   renderRoute();
 }
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -293,7 +293,8 @@ textarea {
   transition: transform 0.2s ease;
 }
 
-.nav-more-menu {
+.nav-more-menu,
+.nav-mobile-menu {
   position: absolute;
   top: calc(100% + 0.6rem);
   right: 0;
@@ -312,20 +313,29 @@ textarea {
   z-index: 55;
 }
 
-.nav-more-details[open] .nav-more-menu {
+.nav-mobile-menu {
+  left: 0;
+  right: auto;
+}
+
+.nav-more-details[open] .nav-more-menu,
+.nav-mobile[open] .nav-mobile-menu {
   opacity: 1;
   transform: translateY(0);
   pointer-events: auto;
 }
 
 [data-theme="dark"] .nav-more-menu,
-.dark .nav-more-menu {
+[data-theme="dark"] .nav-mobile-menu,
+.dark .nav-more-menu,
+.dark .nav-mobile-menu {
   background: rgba(30, 41, 59, 0.95);
   border-color: rgba(148, 163, 184, 0.4);
   box-shadow: 0 24px 45px rgba(2, 6, 23, 0.55);
 }
 
-.nav-more-menu .btn {
+.nav-more-menu .btn,
+.nav-mobile-menu .btn {
   width: 100%;
   justify-content: flex-start;
   border-radius: 9999px;
@@ -334,35 +344,56 @@ textarea {
 }
 
 .nav-more-menu .btn:hover,
-.nav-more-menu .btn:focus-visible {
+.nav-more-menu .btn:focus-visible,
+.nav-mobile-menu .btn:hover,
+.nav-mobile-menu .btn:focus-visible {
   background-color: rgba(59, 130, 246, 0.12);
   color: rgba(15, 23, 42, 0.95);
 }
 
 [data-theme="dark"] .nav-more-menu .btn,
-.dark .nav-more-menu .btn {
+[data-theme="dark"] .nav-mobile-menu .btn,
+.dark .nav-more-menu .btn,
+.dark .nav-mobile-menu .btn {
   color: rgba(226, 232, 240, 0.9);
 }
 
 [data-theme="dark"] .nav-more-menu .btn:hover,
 [data-theme="dark"] .nav-more-menu .btn:focus-visible,
+[data-theme="dark"] .nav-mobile-menu .btn:hover,
+[data-theme="dark"] .nav-mobile-menu .btn:focus-visible,
 .dark .nav-more-menu .btn:hover,
-.dark .nav-more-menu .btn:focus-visible {
+.dark .nav-more-menu .btn:focus-visible,
+.dark .nav-mobile-menu .btn:hover,
+.dark .nav-mobile-menu .btn:focus-visible {
   background-color: rgba(148, 163, 184, 0.2);
   color: rgba(226, 232, 240, 1);
 }
 
-.nav-more-menu .btn.btn-active {
+.nav-more-menu .btn.btn-active,
+.nav-mobile-menu .btn.btn-active {
   background: linear-gradient(135deg, rgba(16, 185, 129, 0.28), rgba(56, 189, 248, 0.22));
   color: rgb(15 118 110);
   box-shadow: 0 12px 24px rgba(45, 212, 191, 0.3);
 }
 
 [data-theme="dark"] .nav-more-menu .btn.btn-active,
-.dark .nav-more-menu .btn.btn-active {
+[data-theme="dark"] .nav-mobile-menu .btn.btn-active,
+.dark .nav-more-menu .btn.btn-active,
+.dark .nav-mobile-menu .btn.btn-active {
   background: linear-gradient(135deg, rgba(20, 184, 166, 0.35), rgba(56, 189, 248, 0.28));
   color: rgb(187 247 208);
   box-shadow: 0 16px 30px rgba(45, 212, 191, 0.32);
+}
+
+.nav-more-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.nav-more-summary .nav-more-chevron {
+  transition: transform 0.2s ease;
 }
 
 .nav-more-details summary.more-active {
@@ -370,6 +401,24 @@ textarea {
 }
 
 .nav-more-details summary.more-active svg {
+  transform: rotate(180deg);
+}
+
+.nav-mobile-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.nav-mobile .nav-mobile-chevron {
+  transition: transform 0.2s ease;
+}
+
+.nav-mobile[open] .nav-mobile-summary {
+  font-weight: 600;
+}
+
+.nav-mobile[open] .nav-mobile-chevron {
   transform: rotate(180deg);
 }
 


### PR DESCRIPTION
## Summary
- add a compact mobile navigation dropdown with primary routes and a More section for secondary links
- polish the desktop More menu styling so the summary control shows its expanded state
- sync aria-expanded state and close the new mobile menu through router helpers without altering route activation

## Testing
- npm test --silent *(fails: SyntaxError: Cannot use import statement outside a module in existing reminder tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916f9ace78c8324aab05aab5d73121a)