### PR TITLE
Add owner UID to Firestore reminder documents

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -2385,6 +2385,7 @@ export async function initReminders(sel = {}) {
     if(!firebaseReady || !userId || !db || typeof doc !== 'function' || typeof setDoc !== 'function' || typeof serverTimestamp !== 'function') return;
     try {
       await setDoc(doc(db, 'users', userId, 'reminders', item.id), {
+        ownerUid: userId,
         title: item.title, priority: item.priority, notes: item.notes || '', done: !!item.done, due: item.due || null,
         category: item.category || DEFAULT_CATEGORY,
         orderIndex: Number.isFinite(item.orderIndex) ? item.orderIndex : null,


### PR DESCRIPTION
## Summary
- include the signed-in user UID when persisting reminders to Firestore so security rules that expect an owner field pass

## Testing
- npm test *(fails: legacy Jest harness cannot load ESM modules)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916fc16a8208324b708e0642a57112b)