### PR TITLE
Refine header navigation layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,12 +266,36 @@
             <li>
               <a href="#notes" data-nav="notes" class="btn btn-sm btn-ghost w-full justify-start" role="menuitem">Notes</a>
             </li>
-            <li class="menu-title">More</li>
             <li>
-              <a href="#resources" data-nav="resources" class="btn btn-sm btn-ghost w-full justify-start" role="menuitem">Resources</a>
-            </li>
-            <li>
-              <a href="#templates" data-nav="templates" class="btn btn-sm btn-ghost w-full justify-start" role="menuitem">Templates</a>
+              <details class="nav-mobile-more">
+                <summary
+                  class="nav-mobile-more-summary btn btn-sm btn-ghost w-full justify-between"
+                  aria-expanded="false"
+                  aria-haspopup="menu"
+                  aria-controls="mobile-more-menu"
+                >
+                  <span>More</span>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    class="nav-mobile-more-chevron size-4"
+                    aria-hidden="true"
+                  >
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m6 9 6 6 6-6" />
+                  </svg>
+                </summary>
+                <ul id="mobile-more-menu" class="nav-mobile-more-menu" role="menu">
+                  <li>
+                    <a href="#resources" data-nav="resources" class="btn btn-sm btn-ghost w-full justify-start" role="menuitem">Resources</a>
+                  </li>
+                  <li>
+                    <a href="#templates" data-nav="templates" class="btn btn-sm btn-ghost w-full justify-start" role="menuitem">Templates</a>
+                  </li>
+                </ul>
+              </details>
             </li>
           </ul>
         </details>
@@ -304,7 +328,7 @@
                 class="btn btn-sm btn-ghost nav-more-summary items-center gap-1"
                 data-nav-group="more"
                 aria-expanded="false"
-                aria-haspopup="true"
+                aria-haspopup="menu"
                 aria-controls="nav-more-menu"
               >
                 <span>More</span>

--- a/js/router.js
+++ b/js/router.js
@@ -74,6 +74,34 @@ function initMobileNavHandlers() {
 
   navMobileDetails.addEventListener('toggle', syncExpanded);
 
+  const navMobileMoreDetails = navMobileDetails.querySelector('.nav-mobile-more');
+  if (navMobileMoreDetails) {
+    const navMobileMoreSummary = navMobileMoreDetails.querySelector('.nav-mobile-more-summary');
+    const syncMobileMoreExpanded = () => {
+      if (navMobileMoreSummary) {
+        navMobileMoreSummary.setAttribute('aria-expanded', navMobileMoreDetails.open ? 'true' : 'false');
+      }
+    };
+
+    syncMobileMoreExpanded();
+
+    navMobileMoreDetails.addEventListener('toggle', syncMobileMoreExpanded);
+
+    navMobileDetails.addEventListener('toggle', () => {
+      if (!navMobileDetails.open) {
+        navMobileMoreDetails.removeAttribute('open');
+        syncMobileMoreExpanded();
+      }
+    });
+
+    navMobileMoreDetails.querySelectorAll('[data-nav]').forEach((link) => {
+      link.addEventListener('click', () => {
+        navMobileMoreDetails.removeAttribute('open');
+        syncMobileMoreExpanded();
+      });
+    });
+  }
+
   navMobileDetails.querySelectorAll('[data-nav]').forEach((link) => {
     link.addEventListener('click', () => {
       navMobileDetails.removeAttribute('open');

--- a/styles/index.css
+++ b/styles/index.css
@@ -418,6 +418,47 @@ textarea {
   font-weight: 600;
 }
 
+.nav-mobile-more {
+  display: block;
+  margin-top: 0.25rem;
+}
+
+.nav-mobile-more summary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  cursor: pointer;
+  list-style: none;
+}
+
+.nav-mobile-more summary::-webkit-details-marker,
+.nav-mobile-more summary::marker {
+  display: none;
+}
+
+.nav-mobile-more .nav-mobile-more-chevron {
+  transition: transform 0.2s ease;
+}
+
+.nav-mobile-more[open] .nav-mobile-more-summary {
+  font-weight: 600;
+}
+
+.nav-mobile-more[open] .nav-mobile-more-chevron {
+  transform: rotate(180deg);
+}
+
+.nav-mobile-more-menu {
+  margin-top: 0.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0;
+  margin-inline: 0;
+  list-style: none;
+}
+
 .nav-mobile[open] .nav-mobile-chevron {
   transform: rotate(180deg);
 }


### PR DESCRIPTION
## Summary
- restructure the mobile navigation drawer to surface core links first and tuck Resources and Templates into a More section
- tighten the desktop navigation markup so the More dropdown uses a consistent aria-haspopup value
- add styles and toggle handling so the mobile More section presents clear open and closed states

## Testing
- npm test --silent *(fails: existing Jest suite expects CommonJS modules and aborts on ESM imports)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69170144b1608324a41dfdf66585b80d)