### PR TITLE
Fix sign-in wiring when reminders UI is hidden

### DIFF
--- a/404.html
+++ b/404.html
@@ -31,11 +31,12 @@
     http-equiv="Content-Security-Policy"
     content="default-src 'self';
              connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.open-meteo.com https://api.bigdatacloud.net https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://www.googleapis.com https://cdn.jsdelivr.net;
-             script-src 'self' https://cdn.jsdelivr.net https://esm.sh https://www.gstatic.com;
+             script-src 'self' https://cdn.jsdelivr.net https://esm.sh https://www.gstatic.com https://apis.google.com;
              style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;
              img-src 'self' data:;
              font-src 'self' data:;
              worker-src 'self';
+             frame-src 'self' https://*.firebaseapp.com https://accounts.google.com https://*.google.com;
              base-uri 'self';
              form-action 'self'"
   >

--- a/app.js
+++ b/app.js
@@ -512,10 +512,6 @@ const initialiseReminders = () => {
   const hasDesktopForm = Boolean(titleInput);
   const hasMobileForm = Boolean(mobileTitleInput);
 
-  if (!hasDesktopForm && !hasMobileForm) {
-    return Promise.resolve();
-  }
-
   if (hasMobileForm) {
     return initReminders({
       variant: 'mobile',
@@ -549,7 +545,7 @@ const initialiseReminders = () => {
     });
   }
 
-  return initReminders({
+  const desktopConfig = {
     titleSel: '#title',
     dateSel: '#date',
     timeSel: '#time',
@@ -572,7 +568,32 @@ const initialiseReminders = () => {
     googleUserNameSel: '#googleUserName',
     variant: 'desktop',
     autoWireAuthButtons: true
-  });
+  };
+
+  if (!hasDesktopForm) {
+    return initReminders({
+      ...desktopConfig,
+      // Ensure auth feedback continues to surface in the header even when
+      // the desktop reminder form is not rendered on the page.
+      listSel: null,
+      listWrapperSel: null,
+      emptyStateSel: null,
+      countTotalSel: null,
+      voiceBtnSel: null,
+      categoryOptionsSel: null,
+      dateSel: null,
+      timeSel: null,
+      prioritySel: null,
+      categorySel: null,
+      saveBtnSel: null,
+      cancelEditBtnSel: null,
+      detailsSel: null,
+      titleSel: null,
+      dateFeedbackSel: null,
+    });
+  }
+
+  return initReminders(desktopConfig);
 };
 
 initialiseReminders().catch((error) => {

--- a/docs/404.html
+++ b/docs/404.html
@@ -40,11 +40,12 @@
     http-equiv="Content-Security-Policy"
     content="default-src 'self';
              connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.open-meteo.com https://api.bigdatacloud.net https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://www.googleapis.com https://cdn.jsdelivr.net;
-             script-src 'self' 'sha256-kMYc78URdr+aJUHWA/38o1X+RSC6JA2C6q6/FuuMHxs=' https://cdn.jsdelivr.net https://esm.sh https://www.gstatic.com;
+             script-src 'self' 'sha256-kMYc78URdr+aJUHWA/38o1X+RSC6JA2C6q6/FuuMHxs=' https://cdn.jsdelivr.net https://esm.sh https://www.gstatic.com https://apis.google.com;
              style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;
              img-src 'self' data:;
              font-src 'self' data:;
              worker-src 'self';
+             frame-src 'self' https://*.firebaseapp.com https://accounts.google.com https://*.google.com;
              base-uri 'self';
              form-action 'self'"
   >

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,11 +41,12 @@
     http-equiv="Content-Security-Policy"
     content="default-src 'self';
              connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.open-meteo.com https://api.bigdatacloud.net https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://www.googleapis.com https://cdn.jsdelivr.net;
-             script-src 'self' 'sha256-kMYc78URdr+aJUHWA/38o1X+RSC6JA2C6q6/FuuMHxs=' 'sha256-TJ0CUW9xqAVyWqDifQ0y55Q5DjTIO9oJDxnWme8x0s4=' 'sha256-KG8CGrF3wtkuXLG8uh8X8AZybyhNMJXtaKgai1NIG8s=' https://cdn.jsdelivr.net https://esm.sh https://www.gstatic.com;
+             script-src 'self' 'sha256-kMYc78URdr+aJUHWA/38o1X+RSC6JA2C6q6/FuuMHxs=' 'sha256-TJ0CUW9xqAVyWqDifQ0y55Q5DjTIO9oJDxnWme8x0s4=' 'sha256-KG8CGrF3wtkuXLG8uh8X8AZybyhNMJXtaKgai1NIG8s=' https://cdn.jsdelivr.net https://esm.sh https://www.gstatic.com https://apis.google.com;
              style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;
              img-src 'self' data:;
              font-src 'self' data:;
              worker-src 'self';
+             frame-src 'self' https://*.firebaseapp.com https://accounts.google.com https://*.google.com;
              base-uri 'self';
              form-action 'self'"
   >

--- a/index.html
+++ b/index.html
@@ -32,11 +32,12 @@
     http-equiv="Content-Security-Policy"
     content="default-src 'self';
              connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.open-meteo.com https://api.bigdatacloud.net https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://www.googleapis.com https://cdn.jsdelivr.net;
-             script-src 'self' https://cdn.jsdelivr.net https://esm.sh https://www.gstatic.com;
+             script-src 'self' https://cdn.jsdelivr.net https://esm.sh https://www.gstatic.com https://apis.google.com;
              style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;
              img-src 'self' data:;
              font-src 'self' data:;
              worker-src 'self';
+             frame-src 'self' https://*.firebaseapp.com https://accounts.google.com https://*.google.com;
              base-uri 'self';
              form-action 'self'"
   >


### PR DESCRIPTION
## Summary
- ensure the reminders module still initialises auth wiring when the desktop form is absent
- relax the CSP to permit Firebase/Google auth scripts and frames so the popup can load
- mirror the CSP adjustments in the generated docs pages

## Testing
- npm test *(fails: Jest VM runner cannot import ESM modules such as js/reminders.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916ff40bd8c83248477f820a6ecc364)