### PR TITLE
Hide delete label on mobile reminders view

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -928,6 +928,9 @@
     .task-toolbar-btn .task-toolbar-label {
       display: inline-block;
     }
+    #reminderList .task-toolbar-btn .task-toolbar-label {
+      display: none;
+    }
     .dark .task-toolbar-btn {
       color: color-mix(in srgb, var(--card-bg) 92%, transparent);
       border-color: transparent;


### PR DESCRIPTION
## Summary
- hide the delete button text label within the mobile reminders list so only the icon remains visible

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691705b4701c83248cd56c4d9813232b)