### PR TITLE
Show expanded reminder cards by default on mobile

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -3235,8 +3235,12 @@
           content.appendChild(secondaryRow);
         }
 
-        card.dataset.compact = 'true';
         card.dataset.compactLayout = 'true';
+        if (list.classList.contains('grid-cols-2')) {
+          card.dataset.compact = 'true';
+        } else {
+          card.removeAttribute('data-compact');
+        }
       };
 
       const upgrade = (node) => {


### PR DESCRIPTION
## Summary
- ensure reminder cards only enter compact mode when the grid layout is active so the default mobile view stays expanded

## Testing
- npm test -- --runInBand *(fails: SyntaxError: Cannot use import statement outside a module in reminders tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917073eabd083249345b6a2cf4befbf)