### PR TITLE
Add placeholder open notes button for reminder notes

### DIFF
--- a/index.html
+++ b/index.html
@@ -694,6 +694,7 @@
             <div class="reminder-meta flex flex-col items-end gap-2 sm:flex-row sm:items-center sm:gap-3">
               <span class="badge badge-outline text-warning">Due soon</span>
               <div class="reminder-actions flex flex-wrap items-center justify-end gap-2">
+                <button class="btn btn-sm btn-outline" type="button">Open notes</button>
               </div>
             </div>
           </li>


### PR DESCRIPTION
## Summary
- add an "Open notes" placeholder button to the sample reminder that includes hidden note text so note-bearing items show the call-to-action in static markup

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69170afea268832481028e3175e1d0e0)