### PR TITLE
Adjust reminder layouts for compact look

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
       align-items: center;
       justify-content: space-between;
       flex-wrap: wrap;
-      gap: 0.75rem;
+      gap: 0.5rem;
       box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
       transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
     }
@@ -127,6 +127,15 @@
     [data-route="reminders"] ul.space-y-2 > li .reminder-main {
       flex: 1 1 auto;
       min-width: 0;
+    }
+
+    .reminder-item p {
+      font-size: 0.875rem;
+    }
+
+    .reminder-item .badge {
+      font-size: 0.75rem;
+      line-height: 1.2;
     }
 
     [data-route="reminders"] ul.space-y-2 > li .reminder-meta {

--- a/mobile.html
+++ b/mobile.html
@@ -946,6 +946,10 @@
     #reminderList .task-toolbar-btn .task-toolbar-label {
       display: none;
     }
+    .task-toolbar-btn.delete span[aria-hidden="true"] {
+      font-size: 1.2rem;
+      line-height: 1;
+    }
     .dark .task-toolbar-btn {
       color: color-mix(in srgb, var(--card-bg) 92%, transparent);
       border-color: transparent;
@@ -1089,6 +1093,7 @@
       box-sizing: border-box;
       margin-left: 0;
       margin-right: 0;
+      padding: 0.5rem 0.75rem;
     }
     
     /* Remove any inherited margins/padding that might constrain width */
@@ -1100,7 +1105,7 @@
     /* Compact reminder card styling */
     .task-item[data-compact="true"] {
       margin-bottom: 0.5rem !important;
-      padding: 0.75rem 0.875rem;
+      padding: 0.6rem 0.85rem;
       min-height: 64px;
       border-left-width: 3px;
       border-radius: 0.75rem;


### PR DESCRIPTION
## Summary
- reduce reminder card spacing and typography in the desktop layout for a compact presentation
- standardise reminder badge sizing for readability
- tighten mobile reminder padding and ensure the delete icon button scales correctly

## Testing
- not run (css-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69170d2895a48324986955fa2ffc08f0)