### PR TITLE
Reduce mobile header height by 25%

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -984,7 +984,7 @@
 
     /* Mobile-first optimizations */
     :root {
-      --mobile-header-height: 120px;
+      --mobile-header-height: 90px;
       --mobile-safe-area-top: env(safe-area-inset-top, 0px);
       --mobile-safe-area-bottom: env(safe-area-inset-bottom, 0px);
     }
@@ -1742,7 +1742,7 @@
   <!-- Clean Mobile Header -->
   <style id="mobile-header-compact" aria-hidden="true">
   :root {
-    --mobile-header-height: 120px;
+    --mobile-header-height: 90px;
   }
 
   /* Make header visually compact while preserving touch targets and accessibility */
@@ -2041,7 +2041,7 @@
       max-width: 28rem;          /* similar to max-w-md */
       margin-left: auto;
       margin-right: auto;
-      padding: 0.75rem 0.75rem;
+      padding: 0.5625rem 0.75rem;
       display: flex;
       align-items: center;
       justify-content: space-between;


### PR DESCRIPTION
## Summary
- decrease the mobile header height variable to keep layout spacing consistent with the smaller header
- tighten sticky header padding so the bar is 25% shorter without altering button sizing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69170e34e55c8324ad99fec7607544de)