### PR TITLE
Set mobile header text color to black and update background color

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2239,7 +2239,7 @@
     }
   </style>
 
-  <header class="sticky top-0 z-20 bg-slate-900 text-slate-50 shadow-md">
+  <header class="sticky top-0 z-20 text-black shadow-md" style="background-color: #002233;">
     <div class="mx-auto max-w-md px-3 py-1 flex items-center justify-between gap-2">
       <!-- Left: Home button -->
       <button


### PR DESCRIPTION
## Summary
- update the mobile header text color utility class to render header text in black
- change the mobile header background color to #002233

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69170f7e10088324bb608f065e315bfb)