### PR TITLE
Revamp reminder card layout

### DIFF
--- a/css/teacher.css
+++ b/css/teacher.css
@@ -1408,6 +1408,40 @@ input::placeholder, textarea::placeholder {
   line-height: 1.4;
 }
 
+.task-item[data-compact="true"] {
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  padding-left: calc(var(--space-3) + 3px);
+  align-items: flex-start;
+}
+
+.task-item[data-compact="true"] .task-title {
+  font-size: var(--text-sm);
+  line-height: 1.35;
+  margin-bottom: var(--space-1);
+}
+
+.task-item[data-compact="true"] .task-meta {
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+}
+
+.task-item[data-compact="true"] .task-chip {
+  padding: 2px 6px;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.task-item[data-compact="true"] .btn.btn-xs {
+  min-height: 1.75rem;
+  height: 1.75rem;
+  width: 1.75rem;
+  padding: 0;
+}
+
 .task-chip[data-chip="priority"] {
   background: var(--task-priority-chip-bg, var(--task-chip-bg));
   color: var(--task-priority-chip-color, var(--task-chip-color));

--- a/index.html
+++ b/index.html
@@ -693,42 +693,97 @@
             Add reminder
           </button>
         </div>
-        <ul id="reminders-list" class="space-y-2">
-          <li class="reminder-item">
-            <div class="reminder-main space-y-2">
-              <p class="font-semibold text-base-content">Submit unit overview</p>
-              <p class="text-sm text-base-content/70">Due Friday · Curriculum team</p>
-              <p class="text-sm text-base-content/60 hidden">Attach the new literacy checkpoints before sending.</p>
-            </div>
-            <div class="reminder-meta flex flex-col items-end gap-2 sm:flex-row sm:items-center sm:gap-3">
-              <span class="badge badge-outline text-warning">Due soon</span>
-              <div class="reminder-actions flex flex-wrap items-center justify-end gap-2">
-                <button class="btn btn-sm btn-outline" type="button">Open notes</button>
+        <ul id="reminders-list" class="space-y-1.5">
+          <li
+            class="task-item reminder-card grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-300 bg-base-100/80 p-3 pl-[calc(0.75rem+3px)] text-sm shadow-sm transition hover:border-base-200 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+            role="button"
+            tabindex="0"
+            aria-label="Edit reminder: Submit unit overview"
+          >
+            <div class="flex min-w-0 flex-col gap-2">
+              <p class="text-sm font-semibold leading-snug text-base-content">Submit unit overview</p>
+              <div class="flex flex-wrap items-center gap-1 text-xs text-base-content/70">
+                <span class="inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70">
+                  <span class="h-1.5 w-1.5 rounded-full bg-base-content/40"></span>
+                  <span class="truncate">Due Friday</span>
+                </span>
+                <span class="inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70">
+                  <span class="h-1.5 w-1.5 rounded-full bg-primary"></span>
+                  <span class="truncate">Curriculum team</span>
+                </span>
+                <span class="inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-warning">
+                  <span class="h-1.5 w-1.5 rounded-full bg-warning"></span>
+                  <span class="truncate">Medium priority</span>
+                </span>
               </div>
+            </div>
+            <div class="flex items-start gap-1">
+              <button type="button" class="btn btn-ghost btn-circle btn-xs text-success" aria-label="Mark reminder as done">
+                <span aria-hidden="true">✓</span>
+              </button>
+              <button type="button" class="btn btn-ghost btn-circle btn-xs text-error" aria-label="Delete reminder">
+                <span aria-hidden="true">🗑️</span>
+              </button>
             </div>
           </li>
-          <li class="reminder-item">
-            <div class="reminder-main space-y-2">
-              <p class="font-semibold text-base-content">Email newsletter blurb</p>
-              <p class="text-sm text-base-content/70 hidden">Add upcoming excursions to the weekly update.</p>
-            </div>
-            <div class="reminder-meta flex flex-col items-end gap-2 sm:flex-row sm:items-center sm:gap-3">
-              <span class="badge badge-outline text-secondary">This week</span>
-              <div class="reminder-actions flex flex-wrap items-center justify-end gap-2">
-                <button class="btn btn-sm btn-outline" type="button">Open notes</button>
+          <li
+            class="task-item reminder-card grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-300 bg-base-100/80 p-3 pl-[calc(0.75rem+3px)] text-sm shadow-sm transition hover:border-base-200 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+            role="button"
+            tabindex="0"
+            aria-label="Edit reminder: Email newsletter blurb"
+          >
+            <div class="flex min-w-0 flex-col gap-2">
+              <p class="text-sm font-semibold leading-snug text-base-content">Email newsletter blurb</p>
+              <div class="flex flex-wrap items-center gap-1 text-xs text-base-content/70">
+                <span class="inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70">
+                  <span class="h-1.5 w-1.5 rounded-full bg-base-content/40"></span>
+                  <span class="truncate">Due next week</span>
+                </span>
+                <span class="inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-secondary">
+                  <span class="h-1.5 w-1.5 rounded-full bg-secondary"></span>
+                  <span class="truncate">Communications</span>
+                </span>
+                <span class="inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-secondary">
+                  <span class="h-1.5 w-1.5 rounded-full bg-secondary"></span>
+                  <span class="truncate">Scheduled</span>
+                </span>
               </div>
+            </div>
+            <div class="flex items-start gap-1">
+              <button type="button" class="btn btn-ghost btn-circle btn-xs text-success" aria-label="Mark reminder as done">
+                <span aria-hidden="true">✓</span>
+              </button>
+              <button type="button" class="btn btn-ghost btn-circle btn-xs text-error" aria-label="Delete reminder">
+                <span aria-hidden="true">🗑️</span>
+              </button>
             </div>
           </li>
-          <li class="reminder-item">
-            <div class="reminder-main space-y-2">
-              <p class="font-semibold text-base-content">Call guardians</p>
-              <p class="text-sm text-base-content/70">Follow up on field trip permissions · Family liaison</p>
-            </div>
-            <div class="reminder-meta flex flex-col items-end gap-2 sm:flex-row sm:items-center sm:gap-3">
-              <span class="badge badge-outline text-error">High priority</span>
-              <div class="reminder-actions flex flex-wrap items-center justify-end gap-2">
-                <button class="btn btn-sm btn-outline" type="button">Log call</button>
+          <li
+            class="task-item reminder-card grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-300 bg-base-100/80 p-3 pl-[calc(0.75rem+3px)] text-sm shadow-sm transition hover:border-base-200 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+            role="button"
+            tabindex="0"
+            aria-label="Edit reminder: Call guardians"
+          >
+            <div class="flex min-w-0 flex-col gap-2">
+              <p class="text-sm font-semibold leading-snug text-base-content">Call guardians</p>
+              <div class="flex flex-wrap items-center gap-1 text-xs text-base-content/70">
+                <span class="inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70">
+                  <span class="h-1.5 w-1.5 rounded-full bg-base-content/40"></span>
+                  <span class="truncate">Due tomorrow</span>
+                </span>
+                <span class="inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-error">
+                  <span class="h-1.5 w-1.5 rounded-full bg-error"></span>
+                  <span class="truncate">High priority</span>
+                </span>
               </div>
+            </div>
+            <div class="flex items-start gap-1">
+              <button type="button" class="btn btn-ghost btn-circle btn-xs text-success" aria-label="Mark reminder as done">
+                <span aria-hidden="true">✓</span>
+              </button>
+              <button type="button" class="btn btn-ghost btn-circle btn-xs text-error" aria-label="Delete reminder">
+                <span aria-hidden="true">🗑️</span>
+              </button>
             </div>
           </li>
         </ul>


### PR DESCRIPTION
## Summary
- restyle desktop and mobile reminder cards with a compact grid layout, priority chips, and icon controls for edit/toggle/delete
- align the sample reminders list and modal-created items with the new card design and interactions
- tighten compact task-item styling for smaller typography, spacing, and icon button sizing

## Testing
- npm test *(fails: Jest vm loader cannot parse ESM imports in js/reminders.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69170f0fd10083249b64e17d479fd2b8)