### PR TITLE
Remove priority chips from mobile reminders

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -3258,8 +3258,7 @@
         }
 
         if (priorityChip) {
-          priorityChip.classList.add('priority-chip-dot');
-          metaSlot.appendChild(priorityChip);
+          priorityChip.remove();
         }
         if (metaContainer instanceof HTMLElement) {
           metaContainer.remove();


### PR DESCRIPTION
## Summary
- stop appending priority chips into reminder cards on mobile so their text and icons no longer appear

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917198c62688324b16bb69957f7c2ab)