### PR TITLE
Remove priority indicators from reminder cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -711,10 +711,6 @@
                   <span class="h-1.5 w-1.5 rounded-full bg-primary"></span>
                   <span class="truncate">Curriculum team</span>
                 </span>
-                <span class="inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-warning">
-                  <span class="h-1.5 w-1.5 rounded-full bg-warning"></span>
-                  <span class="truncate">Medium priority</span>
-                </span>
               </div>
             </div>
             <div class="flex items-start gap-1">
@@ -770,10 +766,6 @@
                 <span class="inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70">
                   <span class="h-1.5 w-1.5 rounded-full bg-base-content/40"></span>
                   <span class="truncate">Due tomorrow</span>
-                </span>
-                <span class="inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-error">
-                  <span class="h-1.5 w-1.5 rounded-full bg-error"></span>
-                  <span class="truncate">High priority</span>
                 </span>
               </div>
             </div>

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -3126,17 +3126,6 @@ export async function initReminders(sel = {}) {
         metaRow.appendChild(createMetaChip(catName, 'category'));
       }
 
-      const priorityKey = (summary.priority || '').trim().toLowerCase();
-      const priorityTone =
-        priorityKey === 'high'
-          ? 'priority-high'
-          : priorityKey === 'low'
-            ? 'priority-low'
-            : priorityKey === 'medium'
-              ? 'priority-medium'
-              : 'neutral';
-      metaRow.appendChild(createMetaChip(summary.priority, priorityTone));
-
       if (metaRow.children.length) {
         content.appendChild(metaRow);
       }

--- a/styles/index.css
+++ b/styles/index.css
@@ -1407,3 +1407,9 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   border-color: rgb(74 222 128);
   box-shadow: 0 0 0 2px rgba(74, 222, 128, 0.35), 0 10px 25px -12px rgba(34, 197, 94, 0.55);
 }
+
+[data-chip="priority"],
+[data-priority-pill],
+.priority-pill {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
- stop rendering priority chips on reminder cards for both desktop and mobile views
- remove priority badge markup from the static reminder examples
- hide any remaining priority pill elements globally as a safety fallback

## Testing
- npm test *(fails: SyntaxError: Cannot use import statement outside a module when loading js/reminders.js in Jest)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69171e1347388324a786e7bf76322abf)