### PR TITLE
Update sign-in sync message

### DIFF
--- a/docs/assets/supabase-auth.js
+++ b/docs/assets/supabase-auth.js
@@ -30,7 +30,7 @@ window.addEventListener('DOMContentLoaded', () => {
   if (!authForm) return;
 
   if (syncStatus && !syncStatus.textContent) {
-    syncStatus.textContent = 'Sign in to sync reminders across devices.';
+    syncStatus.textContent = 'Sign in to sync your reminders.';
     syncStatus.classList.remove('online');
     syncStatus.dataset.state = 'offline';
     toggleElementVisibility(syncStatus, true);
@@ -76,7 +76,7 @@ window.addEventListener('DOMContentLoaded', () => {
       }
       await supabase.from('profiles').upsert({ id: user.id, email: user.email });
     } else if (syncStatus) {
-      syncStatus.textContent = 'Sign in to sync reminders across devices.';
+      syncStatus.textContent = 'Sign in to sync your reminders.';
       syncStatus.classList.remove('online');
       syncStatus.dataset.state = 'offline';
     }

--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -1973,7 +1973,7 @@
         <div id="syncStatus" class="sync-inline" data-state="offline" title="Sync status">
           <span id="mcStatus" class="sync-dot offline" role="status" aria-hidden="true"></span>
         </div>
-        <p id="sync-status" class="mc-sync-message">Sign in to sync reminders across devices.</p>
+        <p id="sync-status" class="mc-sync-message">Sign in to sync your reminders.</p>
         <span id="mcStatusText" class="mc-status-text">Offline</span>
       </div>
 

--- a/js/supabase-auth.js
+++ b/js/supabase-auth.js
@@ -118,7 +118,7 @@ const DEFAULT_SELECTORS = {
 };
 
 const DEFAULT_MESSAGES = {
-  signedOut: 'Sign in to sync reminders across devices.',
+  signedOut: 'Sign in to sync your reminders.',
   signedIn: (user) => `Reminders syncing for ${user?.email || 'your account'}.`,
   syncStatusText: {
     signedOut: 'Offline',


### PR DESCRIPTION
## Summary
- replace the sign-in sync prompt with "Sign in to sync your reminders." in docs and scripts

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69178fb00e0083248164d14ac3eb3b0b)