### PR TITLE
Sync reminders page with shared reminders data

### DIFF
--- a/index.html
+++ b/index.html
@@ -1217,7 +1217,7 @@
           </label>
           <div class="flex justify-end gap-3 pt-2">
             <button type="button" class="btn" data-close-modal>Cancel</button>
-            <button type="submit" class="btn btn-primary">Save</button>
+            <button type="button" id="saveReminder" class="btn btn-primary">Save</button>
           </div>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- hook the desktop reminders modal into the shared reminders controller by dispatching cue events and removing the inline list logic
- align the desktop reminders selectors with the actual modal fields and list so synced reminders render on the reminders page
- update the modal Save button to use the shared controller trigger

## Testing
- NODE_OPTIONS=--experimental-vm-modules npm test *(fails: SyntaxError: Cannot use import statement outside a module when loading js/reminders.js in Jest sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69178e42d39c8324bf76bdaf732118b0)