### PR TITLE
Enable synced notebook notes on mobile

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -4122,28 +4122,253 @@
       let currentSearchIndex = 0;
       let searchMatches = [];
 
+      const FALLBACK_FIREBASE_CONFIG = Object.freeze({
+        apiKey: 'AIzaSyAmAMiz0zG3dAhZJhOy1DYj8fKVDObL36c',
+        authDomain: 'memory-cue-app.firebaseapp.com',
+        projectId: 'memory-cue-app',
+        storageBucket: 'memory-cue-app.firebasestorage.app',
+        messagingSenderId: '751284466633',
+        appId: '1:751284466633:web:3b10742970bef1a5d5ee18',
+        measurementId: 'G-R0V4M7VCE6'
+      });
+
+      let firebaseContextPromise;
+      let firebaseContext;
+      let remoteNotesUnsubscribe = null;
+      let remoteNotesDocRef = null;
+      let remoteSaveTimeout = null;
+      let remoteSyncActive = false;
+      let isApplyingRemoteUpdate = false;
+      let lastStoredLocalContent = '';
+      let lastRemoteContent = '';
+
+      const getFirebaseContext = () => {
+        if (firebaseContextPromise) {
+          return firebaseContextPromise;
+        }
+
+        firebaseContextPromise = (async () => {
+          try {
+            const [appMod, firestoreMod, authMod] = await Promise.all([
+              import('https://www.gstatic.com/firebasejs/12.2.1/firebase-app.js'),
+              import('https://www.gstatic.com/firebasejs/12.2.1/firebase-firestore.js'),
+              import('https://www.gstatic.com/firebasejs/12.2.1/firebase-auth.js'),
+            ]);
+
+            const { initializeApp, getApps, getApp } = appMod || {};
+            const { getFirestore, doc, onSnapshot, setDoc, serverTimestamp } = firestoreMod || {};
+            const { getAuth, onAuthStateChanged } = authMod || {};
+
+            if (
+              typeof initializeApp !== 'function' ||
+              typeof getFirestore !== 'function' ||
+              typeof getAuth !== 'function'
+            ) {
+              return null;
+            }
+
+            const api = window?.memoryCueFirebase || {};
+            const configCandidate = typeof api.getFirebaseConfig === 'function'
+              ? api.getFirebaseConfig()
+              : null;
+            const config =
+              (configCandidate && typeof configCandidate === 'object' ? configCandidate : null)
+              || (api.DEFAULT_FIREBASE_CONFIG ? { ...api.DEFAULT_FIREBASE_CONFIG } : null)
+              || FALLBACK_FIREBASE_CONFIG;
+
+            if (!config || !config.projectId) {
+              console.warn('Notes sync: Firebase config unavailable; remote sync disabled.');
+              return null;
+            }
+
+            const app = (typeof getApps === 'function' && getApps().length)
+              ? getApp()
+              : initializeApp(config);
+            const db = getFirestore(app);
+            const auth = getAuth(app);
+
+            return {
+              app,
+              db,
+              auth,
+              doc,
+              onSnapshot,
+              setDoc,
+              serverTimestamp,
+              onAuthStateChanged,
+            };
+          } catch (error) {
+            console.warn('Notes sync: Firebase modules unavailable; remote sync disabled.', error);
+            return null;
+          }
+        })();
+
+        return firebaseContextPromise;
+      };
+
+      const stopRemoteNotesSync = () => {
+        remoteSyncActive = false;
+        remoteNotesDocRef = null;
+        if (remoteSaveTimeout) {
+          clearTimeout(remoteSaveTimeout);
+          remoteSaveTimeout = null;
+        }
+        if (typeof remoteNotesUnsubscribe === 'function') {
+          try {
+            remoteNotesUnsubscribe();
+          } catch (error) {
+            console.warn('Notes sync: Unable to clean up listener', error);
+          }
+        }
+        remoteNotesUnsubscribe = null;
+      };
+
+      const scheduleRemoteSave = (content) => {
+        if (!remoteSyncActive || !firebaseContext || !remoteNotesDocRef) {
+          setStatus('saved', 'Saved');
+          setTimeout(() => setStatus('ready', 'Ready'), 1500);
+          return;
+        }
+
+        if (content === lastRemoteContent) {
+          setStatus('saved', 'Synced');
+          setTimeout(() => setStatus('ready', 'Ready'), 1200);
+          return;
+        }
+
+        if (remoteSaveTimeout) {
+          clearTimeout(remoteSaveTimeout);
+        }
+
+        remoteSaveTimeout = setTimeout(async () => {
+          try {
+            const payload = { content };
+            if (typeof firebaseContext.serverTimestamp === 'function') {
+              payload.updatedAt = firebaseContext.serverTimestamp();
+            } else {
+              payload.updatedAt = new Date();
+            }
+            await firebaseContext.setDoc(remoteNotesDocRef, payload, { merge: true });
+            lastRemoteContent = content;
+            setStatus('saved', 'Synced');
+            setTimeout(() => setStatus('ready', 'Ready'), 1200);
+          } catch (error) {
+            console.error('Notes sync: Failed to sync notes', error);
+            setStatus('error', 'Sync failed');
+          }
+        }, 400);
+      };
+
+      const handleRemoteSnapshot = (snapshot) => {
+        if (!snapshot || typeof snapshot.exists !== 'function') {
+          return;
+        }
+
+        if (!snapshot.exists()) {
+          if (lastStoredLocalContent) {
+            setStatus('saving', 'Syncing...');
+            scheduleRemoteSave(lastStoredLocalContent);
+          }
+          return;
+        }
+
+        const data = snapshot.data();
+        const remoteContent = typeof data?.content === 'string' ? data.content : '';
+        lastRemoteContent = remoteContent;
+
+        if (remoteContent === (notesEditor.innerHTML || '')) {
+          return;
+        }
+
+        isApplyingRemoteUpdate = true;
+        notesEditor.innerHTML = remoteContent;
+        updateWordCount();
+        try {
+          localStorage.setItem('memory-cue-notes', remoteContent);
+          lastStoredLocalContent = remoteContent;
+        } catch (error) {
+          console.warn('Notes sync: Unable to persist remote notes locally', error);
+        }
+        setStatus('saved', 'Synced');
+        setTimeout(() => setStatus('ready', 'Ready'), 1200);
+        isApplyingRemoteUpdate = false;
+      };
+
+      const startRemoteNotesSync = (user, context) => {
+        if (!user || !context || !context.db || typeof context.doc !== 'function' || typeof context.onSnapshot !== 'function') {
+          return;
+        }
+
+        stopRemoteNotesSync();
+        firebaseContext = context;
+        remoteSyncActive = true;
+        remoteNotesDocRef = context.doc(context.db, 'users', user.uid, 'notebook', 'scratch');
+
+        try {
+          remoteNotesUnsubscribe = context.onSnapshot(remoteNotesDocRef, handleRemoteSnapshot, (error) => {
+            console.error('Notes sync: Listener error', error);
+            setStatus('error', 'Sync error');
+          });
+        } catch (error) {
+          console.error('Notes sync: Unable to subscribe to updates', error);
+        }
+
+        const initialContent = notesEditor.innerHTML || lastStoredLocalContent;
+        if (initialContent && !isApplyingRemoteUpdate) {
+          setStatus('saving', 'Syncing...');
+          scheduleRemoteSave(initialContent);
+        }
+      };
+
+      const initRemoteNotebookSync = () => {
+        if (initRemoteNotebookSync._started) {
+          return;
+        }
+        initRemoteNotebookSync._started = true;
+
+        getFirebaseContext().then((context) => {
+          if (!context || !context.auth || typeof context.onAuthStateChanged !== 'function') {
+            return;
+          }
+
+          firebaseContext = context;
+          context.onAuthStateChanged(context.auth, (user) => {
+            if (user && user.uid) {
+              startRemoteNotesSync(user, context);
+            } else {
+              stopRemoteNotesSync();
+              setStatus('ready', 'Ready');
+            }
+          });
+        });
+      };
+
       // Auto-save functionality
       const autoSave = () => {
         if (!notesEditor) return;
-        
+
+        const content = notesEditor.innerHTML;
         clearTimeout(autoSaveTimeout);
-        setStatus('saving', 'Saving...');
-        
+        setStatus('saving', remoteSyncActive ? 'Syncing...' : 'Saving...');
+
         autoSaveTimeout = setTimeout(() => {
           try {
-            const content = notesEditor.innerHTML;
-            if (content !== localStorage.getItem('memory-cue-notes')) {
+            if (content !== lastStoredLocalContent) {
               localStorage.setItem('memory-cue-notes', content);
-              setStatus('saved', 'Saved');
-              setTimeout(() => setStatus('ready', 'Ready'), 1500);
-            } else {
-              setStatus('ready', 'Ready');
+              lastStoredLocalContent = content;
             }
           } catch (error) {
             console.error('Failed to save notes:', error);
             setStatus('error', 'Save failed');
-            // Retry after a delay
             setTimeout(autoSave, 3000);
+            return;
+          }
+
+          if (remoteSyncActive && !isApplyingRemoteUpdate) {
+            scheduleRemoteSave(content);
+          } else {
+            setStatus('saved', 'Saved');
+            setTimeout(() => setStatus('ready', 'Ready'), 1500);
           }
         }, 800);
       };
@@ -4168,13 +4393,19 @@
       const loadNotes = () => {
         try {
           const saved = localStorage.getItem('memory-cue-notes');
-          if (saved && notesEditor) {
+          if (typeof saved === 'string' && saved && notesEditor) {
             notesEditor.innerHTML = saved;
-            updateWordCount();
+            lastStoredLocalContent = saved;
+            lastRemoteContent = saved;
             setStatus('ready', 'Notes loaded');
+          } else {
+            lastStoredLocalContent = notesEditor.innerHTML || '';
+            lastRemoteContent = lastStoredLocalContent;
           }
         } catch (error) {
           console.error('Failed to load notes:', error);
+          lastStoredLocalContent = notesEditor.innerHTML || '';
+          lastRemoteContent = lastStoredLocalContent;
         }
       };
 
@@ -4461,6 +4692,7 @@
       // Initialize
       loadNotes();
       updateWordCount();
+      initRemoteNotebookSync();
       setStatus('ready', 'Ready');
       
       // Add mobile-friendly touch handling for toolbar


### PR DESCRIPTION
## Summary
- load Firebase modules in the mobile notebook view to enable cross-device syncing of notes
- persist scratch notes to Firestore when signed in while maintaining the local auto-save fallback and status updates

## Testing
- npm test *(fails: Jest cannot execute ESM imports from js/reminders.js in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691794f5ab20832496690d7a71aef95e)