### PR TITLE
feat: create desktop reminders grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,90 +89,14 @@
       opacity: .85;
     }
 
-    /* Reminders: clean flat row layout */
-    [data-route="reminders"] ul.space-y-2 > li {
-      border-radius: 0.75rem;
-      border: 1px solid rgba(95, 122, 107, 0.35);
-      padding: 0.4rem 0.6rem;
-      background: linear-gradient(
-        135deg,
-        rgba(95, 122, 107, 0.14),
-        rgba(122, 154, 205, 0.12) 55%,
-        rgba(242, 166, 90, 0.16)
-      );
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      flex-wrap: wrap;
-      gap: 0.5rem;
-      box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
-      transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+    /* Reminders: desktop card hover polish */
+    [data-route="reminders"] .desktop-task-card {
+      transition: box-shadow 0.15s ease, transform 0.15s ease;
     }
 
-    [data-route="reminders"] ul.space-y-2 > li + li {
-      margin-top: 0.4rem;
-    }
-
-    [data-route="reminders"] ul.space-y-2 > li:hover {
-      border-color: rgba(122, 154, 205, 0.55);
-      background: linear-gradient(
-        135deg,
-        rgba(95, 122, 107, 0.18),
-        rgba(122, 154, 205, 0.18) 55%,
-        rgba(242, 166, 90, 0.22)
-      );
-      box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
-    }
-
-    [data-route="reminders"] ul.space-y-2 > li .reminder-main {
-      flex: 1 1 auto;
-      min-width: 0;
-    }
-
-    .reminder-item p {
-      font-size: 0.875rem;
-    }
-
-    .reminder-item .badge {
-      font-size: 0.75rem;
-      line-height: 1.2;
-    }
-
-    [data-route="reminders"] ul.space-y-2 > li .reminder-meta {
-      flex-shrink: 0;
-      font-size: 0.75rem;
-      opacity: 0.75;
-      text-align: right;
-      display: flex;
-      flex-direction: column;
-      gap: 0.4rem;
-      align-items: flex-end;
-    }
-
-    [data-route="reminders"] ul.space-y-2 > li .reminder-meta .reminder-actions {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.4rem;
-    }
-
-    [data-route="reminders"] ul.space-y-2 > li .card,
-    [data-route="reminders"] ul.space-y-2 > li .card-body {
-      background: transparent;
-      border: none;
-      box-shadow: none;
-      padding: 0;
-    }
-
-    [data-route="reminders"] ul.space-y-2 > li:has(.text-error) {
-      border-left: 4px solid var(--reminder-bio-orange);
-    }
-
-    [data-route="reminders"] ul.space-y-2 > li:has(.text-warning) {
-      border-left: 4px solid var(--reminder-quantum-blue);
-    }
-
-    [data-route="reminders"] ul.space-y-2 > li:has(.text-secondary) {
-      border-left: 4px solid var(--reminder-digital-sage);
+    [data-route="reminders"] .desktop-task-card:hover {
+      box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
+      transform: translateY(-1px);
     }
 
     #quick-action-toolbar {
@@ -693,9 +617,9 @@
             Add reminder
           </button>
         </div>
-        <ul id="reminders-list" class="space-y-1.5">
+        <ul id="reminders-list" class="grid list-none gap-4 sm:grid-cols-2 xl:grid-cols-2">
           <li
-            class="task-item reminder-card grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-300 bg-base-100/80 p-3 pl-[calc(0.75rem+3px)] text-sm shadow-sm transition hover:border-base-200 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+            class="task-item desktop-task-card reminder-card grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-4 text-sm shadow-sm transition hover:border-base-300 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
             role="button"
             tabindex="0"
             aria-label="Edit reminder: Submit unit overview"
@@ -723,7 +647,7 @@
             </div>
           </li>
           <li
-            class="task-item reminder-card grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-300 bg-base-100/80 p-3 pl-[calc(0.75rem+3px)] text-sm shadow-sm transition hover:border-base-200 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+            class="task-item desktop-task-card reminder-card grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-4 text-sm shadow-sm transition hover:border-base-300 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
             role="button"
             tabindex="0"
             aria-label="Edit reminder: Email newsletter blurb"
@@ -755,7 +679,7 @@
             </div>
           </li>
           <li
-            class="task-item reminder-card grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-300 bg-base-100/80 p-3 pl-[calc(0.75rem+3px)] text-sm shadow-sm transition hover:border-base-200 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+            class="task-item desktop-task-card reminder-card grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-4 text-sm shadow-sm transition hover:border-base-300 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
             role="button"
             tabindex="0"
             aria-label="Edit reminder: Call guardians"

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -3058,7 +3058,7 @@ export async function initReminders(sel = {}) {
 
       const itemEl = document.createElement(elementTag);
       itemEl.className =
-        'task-item reminder-card grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-300 bg-base-100/80 p-3 pl-[calc(0.75rem+3px)] text-sm shadow-sm transition hover:border-base-200 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60';
+        'task-item reminder-card desktop-task-card grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-4 text-sm shadow-sm transition hover:border-base-300 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60';
       if (isMobile) {
         itemEl.classList.add('w-full');
       }


### PR DESCRIPTION
## Summary
- convert the desktop reminders list into a responsive grid with two cards per row on wider screens
- refresh desktop reminder card styling and hover feedback to better fill the layout
- align dynamic reminder rendering with the new desktop card classes

## Testing
- npm test -- --runTestsByPath sample.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917982be82c8324b3ab8349ab9fbbd8)