### PR TITLE
style: align desktop reminders palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,90 +89,99 @@
       opacity: .85;
     }
 
-    /* Reminders: clean flat row layout */
-    [data-route="reminders"] ul.space-y-2 > li {
-      border-radius: 0.75rem;
-      border: 1px solid rgba(95, 122, 107, 0.35);
-      padding: 0.4rem 0.6rem;
-      background: linear-gradient(
-        135deg,
-        rgba(95, 122, 107, 0.14),
-        rgba(122, 154, 205, 0.12) 55%,
-        rgba(242, 166, 90, 0.16)
-      );
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      flex-wrap: wrap;
-      gap: 0.5rem;
-      box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
-      transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+    [data-route="reminders"] {
+      --card-bg: #ffffff;
+      --card-border: #cbe6d5;
+      --border-color: var(--card-border);
+      --text-primary: #1f2a24;
+      --text-secondary: #4c6457;
+      --accent-color: #b5a9ff;
+      --success-color: #63c69b;
+      --hover-bg: #dcefe2;
+      --shadow-color: rgba(31, 42, 36, 0.08);
+      --shadow-sm: 0 1px 3px var(--shadow-color);
+      --shadow-md: 0 4px 12px var(--shadow-color);
+      --delete-color: #ef6a6a;
+      --priority-high-border: #f4a259;
+      --priority-high-bg: color-mix(in srgb, var(--priority-high-border) 18%, #ffffff);
+      --priority-medium-border: #6c8ae4;
+      --priority-medium-bg: color-mix(in srgb, var(--priority-medium-border) 16%, #ffffff);
+      --priority-low-border: #6b8f71;
+      --priority-low-bg: color-mix(in srgb, var(--priority-low-border) 16%, #ffffff);
     }
 
-    [data-route="reminders"] ul.space-y-2 > li + li {
-      margin-top: 0.4rem;
+    /* Reminders: desktop card styling */
+    [data-route="reminders"] .desktop-task-card {
+      background: var(--card-bg);
+      border: 1px solid var(--card-border);
+      border-left: 3px solid var(--border-color);
+      box-shadow: var(--shadow-sm);
+      color: var(--text-secondary);
+      transition: box-shadow 0.15s ease, transform 0.15s ease, border-color 0.15s ease,
+        background 0.15s ease;
     }
 
-    [data-route="reminders"] ul.space-y-2 > li:hover {
-      border-color: rgba(122, 154, 205, 0.55);
-      background: linear-gradient(
-        135deg,
-        rgba(95, 122, 107, 0.18),
-        rgba(122, 154, 205, 0.18) 55%,
-        rgba(242, 166, 90, 0.22)
-      );
-      box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+    [data-route="reminders"] .desktop-task-card:hover {
+      box-shadow: var(--shadow-md);
+      transform: translateY(-1px);
+      border-color: var(--accent-color);
+      border-left-color: var(--accent-color);
+      background: var(--hover-bg);
     }
 
-    [data-route="reminders"] ul.space-y-2 > li .reminder-main {
-      flex: 1 1 auto;
-      min-width: 0;
+    [data-route="reminders"] .desktop-task-card[data-priority="High"] {
+      background-color: var(--priority-high-bg);
+      border-left-color: var(--priority-high-border);
     }
 
-    .reminder-item p {
-      font-size: 0.875rem;
+    [data-route="reminders"] .desktop-task-card[data-priority="Medium"] {
+      background-color: var(--priority-medium-bg);
+      border-left-color: var(--priority-medium-border);
     }
 
-    .reminder-item .badge {
-      font-size: 0.75rem;
-      line-height: 1.2;
+    [data-route="reminders"] .desktop-task-card[data-priority="Low"] {
+      background-color: var(--priority-low-bg);
+      border-left-color: var(--priority-low-border);
     }
 
-    [data-route="reminders"] ul.space-y-2 > li .reminder-meta {
-      flex-shrink: 0;
-      font-size: 0.75rem;
-      opacity: 0.75;
-      text-align: right;
-      display: flex;
-      flex-direction: column;
-      gap: 0.4rem;
-      align-items: flex-end;
+    [data-route="reminders"] .desktop-reminder-title {
+      color: var(--text-primary);
     }
 
-    [data-route="reminders"] ul.space-y-2 > li .reminder-meta .reminder-actions {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.4rem;
+    [data-route="reminders"] .desktop-reminder-meta {
+      color: var(--text-secondary);
     }
 
-    [data-route="reminders"] ul.space-y-2 > li .card,
-    [data-route="reminders"] ul.space-y-2 > li .card-body {
-      background: transparent;
-      border: none;
-      box-shadow: none;
-      padding: 0;
+    [data-route="reminders"] .desktop-reminder-chip {
+      border-color: color-mix(in srgb, var(--card-border) 75%, transparent 25%);
+      background: color-mix(in srgb, var(--hover-bg) 28%, var(--card-bg) 72%);
+      color: var(--text-secondary);
+      transition: background 0.15s ease, border-color 0.15s ease;
     }
 
-    [data-route="reminders"] ul.space-y-2 > li:has(.text-error) {
-      border-left: 4px solid var(--reminder-bio-orange);
+    [data-route="reminders"] .desktop-reminder-chip:hover {
+      background: color-mix(in srgb, var(--hover-bg) 40%, var(--card-bg) 60%);
+      border-color: var(--accent-color);
     }
 
-    [data-route="reminders"] ul.space-y-2 > li:has(.text-warning) {
-      border-left: 4px solid var(--reminder-quantum-blue);
+    [data-route="reminders"] .desktop-reminder-chip__dot {
+      background: rgba(31, 42, 36, 0.35);
     }
 
-    [data-route="reminders"] ul.space-y-2 > li:has(.text-secondary) {
-      border-left: 4px solid var(--reminder-digital-sage);
+    [data-route="reminders"] .desktop-reminder-chip[data-tone="category"] .desktop-reminder-chip__dot {
+      background: var(--accent-color);
+    }
+
+    [data-route="reminders"] .desktop-reminder-chip[data-tone="due"] .desktop-reminder-chip__dot {
+      background: rgba(31, 42, 36, 0.45);
+    }
+
+    [data-route="reminders"] .desktop-task-card .btn.text-success {
+      color: var(--success-color);
+    }
+
+    [data-route="reminders"] .desktop-task-card .btn.text-error {
+      color: var(--delete-color);
     }
 
     #quick-action-toolbar {
@@ -693,22 +702,22 @@
             Add reminder
           </button>
         </div>
-        <ul id="reminders-list" class="space-y-1.5">
+        <ul id="reminders-list" class="grid list-none gap-4 sm:grid-cols-2 xl:grid-cols-2">
           <li
-            class="task-item reminder-card grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-300 bg-base-100/80 p-3 pl-[calc(0.75rem+3px)] text-sm shadow-sm transition hover:border-base-200 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+            class="task-item desktop-task-card reminder-card grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-4 text-sm shadow-sm transition hover:border-base-300 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
             role="button"
             tabindex="0"
             aria-label="Edit reminder: Submit unit overview"
           >
             <div class="flex min-w-0 flex-col gap-2">
-              <p class="text-sm font-semibold leading-snug text-base-content">Submit unit overview</p>
-              <div class="flex flex-wrap items-center gap-1 text-xs text-base-content/70">
-                <span class="inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70">
-                  <span class="h-1.5 w-1.5 rounded-full bg-base-content/40"></span>
+              <p class="desktop-reminder-title text-sm font-semibold leading-snug text-base-content">Submit unit overview</p>
+              <div class="desktop-reminder-meta flex flex-wrap items-center gap-1 text-xs text-base-content/70">
+                <span class="desktop-reminder-chip inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70" data-tone="due">
+                  <span class="desktop-reminder-chip__dot h-1.5 w-1.5 rounded-full"></span>
                   <span class="truncate">Due Friday</span>
                 </span>
-                <span class="inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70">
-                  <span class="h-1.5 w-1.5 rounded-full bg-primary"></span>
+                <span class="desktop-reminder-chip inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70" data-tone="category">
+                  <span class="desktop-reminder-chip__dot h-1.5 w-1.5 rounded-full"></span>
                   <span class="truncate">Curriculum team</span>
                 </span>
               </div>
@@ -723,24 +732,24 @@
             </div>
           </li>
           <li
-            class="task-item reminder-card grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-300 bg-base-100/80 p-3 pl-[calc(0.75rem+3px)] text-sm shadow-sm transition hover:border-base-200 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+            class="task-item desktop-task-card reminder-card grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-4 text-sm shadow-sm transition hover:border-base-300 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
             role="button"
             tabindex="0"
             aria-label="Edit reminder: Email newsletter blurb"
           >
             <div class="flex min-w-0 flex-col gap-2">
-              <p class="text-sm font-semibold leading-snug text-base-content">Email newsletter blurb</p>
-              <div class="flex flex-wrap items-center gap-1 text-xs text-base-content/70">
-                <span class="inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70">
-                  <span class="h-1.5 w-1.5 rounded-full bg-base-content/40"></span>
+              <p class="desktop-reminder-title text-sm font-semibold leading-snug text-base-content">Email newsletter blurb</p>
+              <div class="desktop-reminder-meta flex flex-wrap items-center gap-1 text-xs text-base-content/70">
+                <span class="desktop-reminder-chip inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70" data-tone="due">
+                  <span class="desktop-reminder-chip__dot h-1.5 w-1.5 rounded-full"></span>
                   <span class="truncate">Due next week</span>
                 </span>
-                <span class="inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-secondary">
-                  <span class="h-1.5 w-1.5 rounded-full bg-secondary"></span>
+                <span class="desktop-reminder-chip inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-secondary" data-tone="category">
+                  <span class="desktop-reminder-chip__dot h-1.5 w-1.5 rounded-full"></span>
                   <span class="truncate">Communications</span>
                 </span>
-                <span class="inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-secondary">
-                  <span class="h-1.5 w-1.5 rounded-full bg-secondary"></span>
+                <span class="desktop-reminder-chip inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-secondary">
+                  <span class="desktop-reminder-chip__dot h-1.5 w-1.5 rounded-full"></span>
                   <span class="truncate">Scheduled</span>
                 </span>
               </div>
@@ -755,16 +764,16 @@
             </div>
           </li>
           <li
-            class="task-item reminder-card grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-300 bg-base-100/80 p-3 pl-[calc(0.75rem+3px)] text-sm shadow-sm transition hover:border-base-200 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+            class="task-item desktop-task-card reminder-card grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-4 text-sm shadow-sm transition hover:border-base-300 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
             role="button"
             tabindex="0"
             aria-label="Edit reminder: Call guardians"
           >
             <div class="flex min-w-0 flex-col gap-2">
-              <p class="text-sm font-semibold leading-snug text-base-content">Call guardians</p>
-              <div class="flex flex-wrap items-center gap-1 text-xs text-base-content/70">
-                <span class="inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70">
-                  <span class="h-1.5 w-1.5 rounded-full bg-base-content/40"></span>
+              <p class="desktop-reminder-title text-sm font-semibold leading-snug text-base-content">Call guardians</p>
+              <div class="desktop-reminder-meta flex flex-wrap items-center gap-1 text-xs text-base-content/70">
+                <span class="desktop-reminder-chip inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70" data-tone="due">
+                  <span class="desktop-reminder-chip__dot h-1.5 w-1.5 rounded-full"></span>
                   <span class="truncate">Due tomorrow</span>
                 </span>
               </div>

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -3021,11 +3021,12 @@ export async function initReminders(sel = {}) {
     const createMetaChip = (label, tone = 'neutral') => {
       const chip = document.createElement('span');
       chip.className =
-        'inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70';
+        'desktop-reminder-chip inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70';
       chip.title = label;
+      chip.dataset.tone = tone;
 
       const dot = document.createElement('span');
-      dot.className = 'h-1.5 w-1.5 rounded-full';
+      dot.className = 'desktop-reminder-chip__dot h-1.5 w-1.5 rounded-full';
       if (tone === 'priority-high') {
         dot.classList.add('bg-error');
       } else if (tone === 'priority-medium') {
@@ -3058,7 +3059,7 @@ export async function initReminders(sel = {}) {
 
       const itemEl = document.createElement(elementTag);
       itemEl.className =
-        'task-item reminder-card grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-300 bg-base-100/80 p-3 pl-[calc(0.75rem+3px)] text-sm shadow-sm transition hover:border-base-200 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60';
+        'task-item reminder-card desktop-task-card grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-4 text-sm shadow-sm transition hover:border-base-300 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60';
       if (isMobile) {
         itemEl.classList.add('w-full');
       }
@@ -3103,6 +3104,7 @@ export async function initReminders(sel = {}) {
 
       const titleEl = document.createElement('p');
       titleEl.className = 'text-sm font-semibold leading-snug text-base-content';
+      titleEl.classList.add('desktop-reminder-title');
       if (!isMobile) {
         titleEl.classList.add('sm:text-[0.95rem]');
       }
@@ -3113,7 +3115,7 @@ export async function initReminders(sel = {}) {
       content.appendChild(titleEl);
 
       const metaRow = document.createElement('div');
-      metaRow.className = 'flex flex-wrap items-center gap-1 text-xs text-base-content/70';
+      metaRow.className = 'desktop-reminder-meta flex flex-wrap items-center gap-1 text-xs text-base-content/70';
 
       const dueLabelRaw = formatDesktopDue(reminder);
       const dueLabel = dueLabelRaw && dueLabelRaw !== 'No due date' ? dueLabelRaw : '';


### PR DESCRIPTION
## Summary
- apply the Calming Tones reminder palette to the desktop grid with shared CSS tokens
- refresh desktop reminder chips and controls to mirror the mobile card treatment
- tag rendered reminder content with helper classes so runtime rendering picks up the palette

## Testing
- npm test -- --runTestsByPath sample.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917982be82c8324b3ab8349ab9fbbd8)