### PR TITLE
Add debug logging for notes sync Firestore path

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -4191,6 +4191,14 @@
             } else {
               payload.updatedAt = new Date();
             }
+            const user = firebaseContext?.auth?.currentUser;
+            console.log(
+              'Notes sync debug:',
+              'user.uid =',
+              user?.uid,
+              'remoteNotesDocRef path =',
+              remoteNotesDocRef.path
+            );
             await firebaseContext.setDoc(remoteNotesDocRef, payload, { merge: true });
             lastRemoteContent = content;
             setStatus('saved', 'Synced');


### PR DESCRIPTION
## Summary
- add a console log before syncing notes to Firestore so the UID and document path are visible

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69179ffa73c88324b0f29f73e05de66c)