### PR TITLE
Make reminder titles bold across desktop and mobile

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -3124,7 +3124,7 @@ export async function initReminders(sel = {}) {
       content.className = 'flex min-w-0 flex-col gap-2';
 
       const titleEl = document.createElement('p');
-      titleEl.className = 'text-sm font-semibold leading-snug text-base-content';
+      titleEl.className = 'text-sm font-bold leading-snug text-base-content';
       titleEl.classList.add('desktop-reminder-title');
       if (!isMobile) {
         titleEl.classList.add('sm:text-[0.95rem]');

--- a/mobile.html
+++ b/mobile.html
@@ -250,7 +250,7 @@
       #reminderList > .reminder-card [data-reminder-title] {
         margin: 0;
         font-size: 1rem;
-        font-weight: 600;
+        font-weight: 700;
       }
 
       #reminderList > .reminder-card time,
@@ -311,7 +311,7 @@
     #reminderList > * [data-reminder-title] {
       margin: 0;
       color: var(--text-primary);
-      font-weight: 600;
+      font-weight: 700;
       font-size: 1rem;
       margin-bottom: 0.5rem;
       grid-column: 1;


### PR DESCRIPTION
## Summary
- increase the reminder title font weight to bold in the shared reminders renderer
- update the mobile reminder list styles so reminder titles render at font-weight 700

## Testing
- npm test --silent *(fails: Jest cannot run ESM modules because js/reminders.js uses `import` statements in the CommonJS test harness)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917a73d42a483248e6aee1e4f322f77)