### PR TITLE
Expand notebook editor width

### DIFF
--- a/index.html
+++ b/index.html
@@ -468,7 +468,7 @@
     </div>
   </nav>
     <main id="mainContent" class="pt-24 min-h-screen" tabindex="-1">
-    <div class="mx-auto max-w-6xl px-4 py-6 space-y-8">
+    <div class="mx-auto max-w-7xl px-4 py-6 space-y-8">
       <section data-route="dashboard" class="space-y-6 lg:space-y-12">
         <div
           class="dashboard-card dashboard-card--hero relative overflow-hidden bg-gradient-to-br from-primary/15 via-base-100 to-base-200/70"
@@ -891,7 +891,7 @@
           <h1 class="text-2xl font-semibold text-base-content">Notes</h1>
           <p class="text-base-content/70">Capture observations, behaviour wins, and quick reflections to revisit later.</p>
         </header>
-        <div class="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+        <div class="grid gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,4fr)_minmax(0,1fr)]">
           <article class="card border border-base-300 bg-base-200/70 shadow-sm">
             <div class="card-body gap-4">
               <div class="flex flex-col gap-3">


### PR DESCRIPTION
## Summary
- expand the main content container to a wider max width so desktop layouts can use more of the screen
- widen the notes view grid ratios so the notebook editor has additional space for the title and body inputs

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917efb289e483249d3cd4c8fe98a741)