### PR TITLE
Allow notebook textarea to use full width

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2695,8 +2695,8 @@
               Body
               <textarea
                 id="noteBodyMobile"
-                rows="8"
-                class="textarea textarea-bordered w-full"
+                rows="14"
+                class="textarea textarea-bordered w-full max-w-none"
                 placeholder="Write your note here…"
               ></textarea>
             </label>


### PR DESCRIPTION
## Summary
- allow the mobile notebook body textarea to ignore max-width constraints so it can expand to the full container width

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69180fa67adc83248d23fb186a10028b)