### PR TITLE
Set mobile PWA start URL

### DIFF
--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "Memory Cue — Reminders",
   "short_name": "Memory Cue",
-  "start_url": "./",
+  "start_url": "./mobile.html",
   "scope": "./",
   "display": "standalone",
   "theme_color": "#0f172a",


### PR DESCRIPTION
## Summary
- update the web manifest start_url so the installed PWA opens the mobile experience

## Testing
- npm test *(fails: Jest cannot run ESM modules such as js/reminders.js in this environment, same as prior baseline failures)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691859cac12483249d8844c9a4ea0df3)