### PR TITLE
Align mobile page PWA metadata

### DIFF
--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "Memory Cue — Reminders",
   "short_name": "Memory Cue",
-  "start_url": "./",
+  "start_url": "./mobile.html",
   "scope": "./",
   "display": "standalone",
   "theme_color": "#0f172a",

--- a/mobile.html
+++ b/mobile.html
@@ -384,8 +384,10 @@
     content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
   />
   <title>Memory Cue (Mobile)</title>
-  <meta name="theme-color" content="#A8D5B5" />
+  <meta name="theme-color" content="#10b981" media="(prefers-color-scheme: light)" />
+  <meta name="theme-color" content="#0f172a" media="(prefers-color-scheme: dark)" />
   <link rel="manifest" href="./manifest.webmanifest" id="manifestLink" />
+  <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />
   <link rel="icon" href="./icons/icon-192.svg" type="image/svg+xml" />
   <link rel="stylesheet" href="./styles/tokens.css" />
   <link rel="stylesheet" href="./styles/a11y.css" />


### PR DESCRIPTION
## Summary
- add light and dark theme-color declarations to the mobile shell so installed PWAs style the browser chrome correctly
- include the apple-touch icon link in mobile.html to surface the right icon when installed

## Testing
- npm test *(fails: Jest cannot run ESM modules such as js/reminders.js in this environment; existing baseline failure)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691859cac12483249d8844c9a4ea0df3)