### PR TITLE
Reduce mobile header height

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1020,7 +1020,7 @@
 
     /* Mobile-first optimizations */
     :root {
-      --mobile-header-height: calc(45px / 2);
+      --mobile-header-height: calc(45px / 4);
       --mobile-safe-area-top: env(safe-area-inset-top, 0px);
       --mobile-safe-area-bottom: env(safe-area-inset-bottom, 0px);
     }
@@ -1779,7 +1779,7 @@
   <!-- Clean Mobile Header -->
   <style id="mobile-header-compact" aria-hidden="true">
   :root {
-    --mobile-header-height: calc(45px / 2);
+    --mobile-header-height: calc(45px / 4);
   }
 
   /* Make header visually compact while preserving touch targets and accessibility */


### PR DESCRIPTION
## Summary
- halve the mobile header height variable to shrink the outer bar while keeping inner controls unchanged

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69185f07b1c88324b0bba2b5da6faa6e)