### PR TITLE
Adjust Reminders nav label styling

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2805,7 +2805,7 @@
 
   <nav class="btm-nav fixed bottom-0 left-0 right-0 bg-base-100 border-t" aria-label="Primary navigation">
     <button type="button" aria-current="page" class="active">
-      <span class="btm-nav-label">Reminders</span>
+      <span class="btm-nav-label text-lg font-extrabold" style="font-size: var(--text-lg); font-weight: 800;">Reminders</span>
     </button>
     <button type="button">
       <span class="btm-nav-label">Notebook</span>


### PR DESCRIPTION
## Summary
- update the Reminders bottom navigation label to use the larger text token and heavier font weight for emphasis

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69186271a1488324901f93167d1d75e4)