### PR TITLE
Adjust desktop reminder save button label

### DIFF
--- a/404.html
+++ b/404.html
@@ -1001,7 +1001,7 @@
                     <button id="cancelEditBtn" class="btn btn-ghost hidden" type="button">Cancel Edit</button>
                     <div class="ml-auto flex gap-2">
                       <button id="closeCueModal" type="button" class="btn btn-outline">Cancel</button>
-                      <button id="saveBtn" class="btn btn-primary" type="button">Save Cue</button>
+                      <button id="saveBtn" class="btn btn-primary" type="button">Save</button>
                     </div>
                   </div>
                 </form>

--- a/docs/404.html
+++ b/docs/404.html
@@ -1009,7 +1009,7 @@
                     <button id="cancelEditBtn" class="btn btn-ghost hidden" type="button">Cancel Edit</button>
                     <div class="ml-auto flex gap-2">
                       <button id="closeCueModal" type="button" class="btn btn-outline">Cancel</button>
-                      <button id="saveBtn" class="btn btn-primary" type="button">Save Cue</button>
+                      <button id="saveBtn" class="btn btn-primary" type="button">Save</button>
                     </div>
                   </div>
                 </form>

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -2409,7 +2409,7 @@ export async function initReminders(sel = {}) {
     if(categoryInput) categoryInput.value = DEFAULT_CATEGORY;
     applyStoredDefaultsToInputs();
     editingId=null;
-    if(saveBtn) saveBtn.textContent='Save Cue';
+    if(saveBtn) saveBtn.textContent='Save';
     cancelEditBtn?.classList.add('hidden');
   }
   function loadForEdit(id){ const it = items.find(x=>x.id===id); if(!it) return; if(title) title.value=it.title||''; if(date&&time){ if(it.due){ date.value=isoToLocalDate(it.due); time.value=isoToLocalTime(it.due); } else { date.value=''; time.value=''; } } setPriorityInputValue(it?.priority || 'Medium'); if(categoryInput) categoryInput.value = normalizeCategory(it.category); if(details) details.value = typeof it.notes === 'string' ? it.notes : ''; editingId=id; if(saveBtn) saveBtn.textContent='Update'; cancelEditBtn?.classList.remove('hidden'); window.scrollTo({top:0,behavior:'smooth'}); title?.focus(); dispatchCueEvent('cue:open', { mode: 'edit' }); }


### PR DESCRIPTION
## Summary
- remove "Cue" from the desktop reminder save button label so it reads "Save"
- update the offline fallback markup to match the new label text

## Testing
- `npm test -- --runTestsByPath reminders.categories.test.js` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918650bb2b08324af63290052db8416)