### PR TITLE
Fix notes font toolbar selection on mobile

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -4156,6 +4156,61 @@
 
       if (!notesEditor) return;
 
+      let savedSelectionRange = null;
+
+      const focusEditor = () => {
+        try {
+          notesEditor.focus({ preventScroll: true });
+        } catch {
+          notesEditor.focus();
+        }
+      };
+
+      const saveSelectionRange = () => {
+        const selection = window.getSelection();
+        if (!selection || selection.rangeCount === 0) {
+          return;
+        }
+
+        const range = selection.getRangeAt(0);
+        const container = range.commonAncestorContainer;
+        const containerElement =
+          container && container.nodeType === 1
+            ? container
+            : container?.parentElement || null;
+
+        if (!containerElement || !notesEditor.contains(containerElement)) {
+          return;
+        }
+
+        savedSelectionRange = range.cloneRange();
+      };
+
+      const restoreSelectionRange = () => {
+        if (!savedSelectionRange) {
+          return false;
+        }
+
+        const selection = window.getSelection();
+        if (!selection) {
+          return false;
+        }
+
+        try {
+          selection.removeAllRanges();
+          selection.addRange(savedSelectionRange);
+          return true;
+        } catch {
+          savedSelectionRange = null;
+          return false;
+        }
+      };
+
+      document.addEventListener('selectionchange', saveSelectionRange);
+      notesEditor.addEventListener('mouseup', saveSelectionRange);
+      notesEditor.addEventListener('keyup', saveSelectionRange);
+      notesEditor.addEventListener('touchend', saveSelectionRange);
+
       let autoSaveTimeout;
       let currentSearchIndex = 0;
       let searchMatches = [];
@@ -4338,6 +4393,7 @@
 
         isApplyingRemoteUpdate = true;
         notesEditor.innerHTML = remoteContent;
+        savedSelectionRange = null;
         updateWordCount();
         try {
           localStorage.setItem('memory-cue-notes', remoteContent);
@@ -4475,6 +4531,7 @@
           const saved = localStorage.getItem('memory-cue-notes');
           if (typeof saved === 'string' && saved && notesEditor) {
             notesEditor.innerHTML = saved;
+            savedSelectionRange = null;
             lastStoredLocalContent = saved;
             lastRemoteContent = saved;
             setStatus('ready', 'Notes loaded');
@@ -4491,14 +4548,42 @@
 
       // Formatting functions
       const formatText = (command, value = null) => {
+        if (typeof document.execCommand !== 'function') {
+          return;
+        }
+
+        focusEditor();
+        if (!restoreSelectionRange()) {
+          const selection = window.getSelection();
+          if (selection) {
+            const fallbackRange = document.createRange();
+            fallbackRange.selectNodeContents(notesEditor);
+            fallbackRange.collapse(false);
+            selection.removeAllRanges();
+            selection.addRange(fallbackRange);
+          }
+        }
+
         document.execCommand(command, false, value);
-        notesEditor.focus();
+        saveSelectionRange();
         autoSave();
       };
 
       const insertAtCursor = (html) => {
+        focusEditor();
+        if (!restoreSelectionRange()) {
+          const selection = window.getSelection();
+          if (selection) {
+            const fallbackRange = document.createRange();
+            fallbackRange.selectNodeContents(notesEditor);
+            fallbackRange.collapse(false);
+            selection.removeAllRanges();
+            selection.addRange(fallbackRange);
+          }
+        }
+
         const selection = window.getSelection();
-        if (selection.rangeCount > 0) {
+        if (selection && selection.rangeCount > 0) {
           const range = selection.getRangeAt(0);
           range.deleteContents();
           const fragment = range.createContextualFragment(html);
@@ -4506,8 +4591,10 @@
           range.collapse(false);
           selection.removeAllRanges();
           selection.addRange(range);
+          savedSelectionRange = range.cloneRange();
         }
         autoSave();
+        saveSelectionRange();
       };
 
       // Toolbar event handlers
@@ -4573,7 +4660,8 @@
           
           const highlightedContent = content.replace(regex, '<span class="highlight">$1</span>');
           notesEditor.innerHTML = highlightedContent;
-          
+          savedSelectionRange = null;
+
           searchMatches = Array.from(notesEditor.querySelectorAll('.highlight'));
           updateSearchResults(searchMatches.length);
           
@@ -4594,6 +4682,7 @@
           parent.replaceChild(document.createTextNode(highlight.textContent), highlight);
           parent.normalize();
         });
+        savedSelectionRange = null;
       };
 
       const highlightCurrentMatch = () => {
@@ -4711,6 +4800,7 @@
       notesEditor.addEventListener('input', () => {
         updateWordCount();
         autoSave();
+        saveSelectionRange();
       });
 
       notesEditor.addEventListener('paste', (e) => {
@@ -4718,6 +4808,7 @@
         setTimeout(() => {
           updateWordCount();
           autoSave();
+          saveSelectionRange();
         }, 100);
       });
 
@@ -4746,11 +4837,13 @@
         if (element && element.textContent) {
           element.textContent = element.textContent === '☐' ? '☑' : '☐';
           autoSave();
+          saveSelectionRange();
         }
       };
       
       // Improve mobile keyboard handling
       notesEditor.addEventListener('focus', () => {
+        restoreSelectionRange();
         // Prevent zoom on iOS
         if (window.navigator.userAgent.includes('iPhone') || window.navigator.userAgent.includes('iPad')) {
           const viewport = document.querySelector('meta[name="viewport"]');
@@ -4759,8 +4852,9 @@
           }
         }
       });
-      
+
       notesEditor.addEventListener('blur', () => {
+        saveSelectionRange();
         // Re-enable zoom
         const viewport = document.querySelector('meta[name="viewport"]');
         if (viewport) {


### PR DESCRIPTION
## Summary
- add selection tracking utilities for the mobile notes editor so toolbar commands restore the previous caret range
- reset saved selections when the editor content is replaced and keep them updated after inserts, paste, checkbox toggles, and search highlighting changes
- ensure formatting and insertion helpers refocus the editor, fall back to a sensible range, and resave the updated selection

## Testing
- npm test -- --runTestsByPath sample.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691863f35e7c8324946526b269477683)