### PR TITLE
Add Supabase-backed notes synchronisation

### DIFF
--- a/js/modules/notes-sync.js
+++ b/js/modules/notes-sync.js
@@ -1,0 +1,208 @@
+import { getSupabaseClient } from '../supabase-client.js';
+import {
+  createNote,
+  loadAllNotes,
+  saveAllNotes,
+  setRemoteSyncHandler,
+} from './notes-storage.js';
+
+const DEFAULT_TABLE_NAME = 'notes';
+const DEFAULT_USER_COLUMN = 'user_id';
+const DEFAULT_UPDATED_AT_COLUMN = 'updated_at';
+
+const toTimestamp = (value) => {
+  if (typeof value !== 'string') {
+    return 0;
+  }
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+const mergeNotes = (localNotes = [], remoteNotes = []) => {
+  const merged = new Map();
+
+  remoteNotes.forEach((note) => {
+    if (note && typeof note.id === 'string') {
+      merged.set(note.id, note);
+    }
+  });
+
+  localNotes.forEach((note) => {
+    if (!note || typeof note.id !== 'string') {
+      return;
+    }
+    const existing = merged.get(note.id);
+    if (!existing) {
+      merged.set(note.id, note);
+      return;
+    }
+    const localTime = toTimestamp(note.updatedAt);
+    const remoteTime = toTimestamp(existing.updatedAt);
+    if (localTime > remoteTime) {
+      merged.set(note.id, note);
+    }
+  });
+
+  return Array.from(merged.values()).sort((a, b) => toTimestamp(b?.updatedAt) - toTimestamp(a?.updatedAt));
+};
+
+const mapRowToNoteFactory = (updatedAtColumn) => (row) => {
+  if (!row || typeof row !== 'object') {
+    return null;
+  }
+  const overrides = {
+    id: typeof row.id === 'string' && row.id ? row.id : undefined,
+    updatedAt: typeof row[updatedAtColumn] === 'string' ? row[updatedAtColumn] : undefined,
+  };
+  return createNote(row.title, row.body, overrides);
+};
+
+export const initNotesSync = (options = {}) => {
+  const {
+    tableName = DEFAULT_TABLE_NAME,
+    userColumn = DEFAULT_USER_COLUMN,
+    updatedAtColumn = DEFAULT_UPDATED_AT_COLUMN,
+    supabase: suppliedSupabase = null,
+  } = options;
+
+  let supabase = suppliedSupabase || null;
+  let currentUserId = null;
+  let isApplyingRemote = false;
+  let lastSyncedIds = new Set();
+
+  const ensureSupabase = () => {
+    if (supabase) {
+      return supabase;
+    }
+    supabase = getSupabaseClient();
+    return supabase;
+  };
+
+  const mapRowToNote = mapRowToNoteFactory(updatedAtColumn);
+
+  const syncToRemote = async (notes) => {
+    const client = ensureSupabase();
+    if (!client || !currentUserId) {
+      return;
+    }
+    const sanitized = Array.isArray(notes)
+      ? notes.filter((note) => note && typeof note.id === 'string')
+      : [];
+
+    const payload = sanitized.map((note) => ({
+      id: note.id,
+      [userColumn]: currentUserId,
+      title: note.title,
+      body: note.body,
+      [updatedAtColumn]: typeof note.updatedAt === 'string' && note.updatedAt
+        ? note.updatedAt
+        : new Date().toISOString(),
+    }));
+
+    const localIds = new Set(payload.map((item) => item.id));
+
+    if (payload.length) {
+      const { error } = await client.from(tableName).upsert(payload);
+      if (error) {
+        throw error;
+      }
+    }
+
+    const idsToDelete = [...lastSyncedIds].filter((id) => id && !localIds.has(id));
+    if (idsToDelete.length) {
+      const { error } = await client
+        .from(tableName)
+        .delete()
+        .in('id', idsToDelete)
+        .eq(userColumn, currentUserId);
+      if (error) {
+        throw error;
+      }
+    }
+
+    lastSyncedIds = new Set(localIds);
+  };
+
+  const pullFromRemote = async () => {
+    const client = ensureSupabase();
+    if (!client || !currentUserId) {
+      return;
+    }
+
+    try {
+      const { data, error } = await client
+        .from(tableName)
+        .select(`id,title,body,${updatedAtColumn}`)
+        .eq(userColumn, currentUserId);
+      if (error) {
+        throw error;
+      }
+
+      const rows = Array.isArray(data) ? data : [];
+      lastSyncedIds = new Set(rows.map((row) => (typeof row.id === 'string' ? row.id : null)).filter(Boolean));
+      const remoteNotes = rows.map(mapRowToNote).filter(Boolean);
+      const localNotes = loadAllNotes();
+
+      if (!remoteNotes.length) {
+        if (localNotes.length) {
+          try {
+            await syncToRemote(localNotes);
+          } catch (syncError) {
+            console.error('[notes-sync] Failed to upload local notes to Supabase.', syncError);
+          }
+        }
+        return;
+      }
+
+      const merged = mergeNotes(localNotes, remoteNotes);
+
+      isApplyingRemote = true;
+      const saved = saveAllNotes(merged, { skipRemoteSync: true });
+      isApplyingRemote = false;
+
+      if (!saved) {
+        console.warn('[notes-sync] Unable to cache notes locally after remote sync.');
+      }
+
+      try {
+        await syncToRemote(merged);
+      } catch (syncError) {
+        console.error('[notes-sync] Failed to reconcile notes with Supabase.', syncError);
+      }
+    } catch (error) {
+      console.error('[notes-sync] Failed to fetch notes from Supabase.', error);
+    } finally {
+      isApplyingRemote = false;
+    }
+  };
+
+  setRemoteSyncHandler(async (notes) => {
+    if (isApplyingRemote) {
+      return;
+    }
+    try {
+      await syncToRemote(notes);
+    } catch (error) {
+      console.error('[notes-sync] Failed to sync notes to Supabase.', error);
+    }
+  });
+
+  const handleSessionChange = async (user) => {
+    currentUserId = typeof user?.id === 'string' ? user.id : null;
+    if (!currentUserId) {
+      lastSyncedIds = new Set();
+      return;
+    }
+    await pullFromRemote();
+  };
+
+  return {
+    setSupabaseClient(client) {
+      if (client) {
+        supabase = client;
+      }
+    },
+    handleSessionChange,
+    syncFromRemote: pullFromRemote,
+  };
+};


### PR DESCRIPTION
## Summary
- add a Supabase-powered notes sync module that merges remote notes and pushes local updates
- notify the notes synchroniser from desktop and mobile auth flows so sessions trigger fetches
- allow the notes storage helper to call an optional remote sync handler after saving

## Testing
- npm test *(fails: existing Jest harness cannot import ESM modules such as reminders.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69186990d66c8324817534e4f095678e)