### PR TITLE
Apply sleek desktop dashboard styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,11 +281,11 @@
   </style>
   <script src="./js/runtime-env-shim.js" defer></script>
 </head>
-<body id="top" class="bg-base-100 text-base-content antialiased leading-7 min-h-screen">
+<body id="top" class="bg-base-100 text-base-content antialiased leading-7 min-h-screen desktop-shell">
   <a class="skip-link" href="#mainContent">Skip to main content</a>
-  <nav aria-label="Primary" class="relative fixed top-0 z-50 w-full navbar-glass">
-    <div class="navbar mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-      <div class="navbar-start items-center gap-2">
+  <div class="dashboard-root">
+    <header class="desktop-header" aria-label="Primary">
+      <div class="desktop-header-brand">
         <details class="nav-mobile dropdown dropdown-bottom lg:hidden">
           <summary
             class="nav-mobile-summary btn btn-sm btn-ghost gap-2"
@@ -368,16 +368,17 @@
             </li>
           </ul>
         </details>
-        <a href="#dashboard" class="btn btn-ghost gap-2 text-left text-lg font-semibold normal-case text-base-content">
-          <span class="inline-flex size-9 items-center justify-center rounded-full bg-primary/15 text-primary">
+        <a href="#dashboard" class="desktop-header-brand-link btn btn-ghost gap-2 text-left normal-case text-base-content">
+          <span class="desktop-header-logo inline-flex size-9 items-center justify-center rounded-full bg-primary/15 text-primary">
             MC
           </span>
           <span class="flex flex-col leading-tight">
-            <span class="text-base font-semibold text-base-content">Memory Cue</span>
+            <span class="desktop-header-title text-base font-semibold text-base-content">Memory Cue</span>
+            <span class="desktop-header-subtitle">Teacher workspace</span>
           </span>
         </a>
       </div>
-      <div class="navbar-center nav-desktop hidden lg:flex">
+      <nav class="desktop-header-nav nav-desktop hidden lg:flex" aria-label="Primary navigation">
         <ul class="menu menu-horizontal gap-1 nav-pill-glass text-sm">
           <li>
             <a href="#dashboard" data-nav="dashboard" id="nav-dashboard" class="btn btn-sm btn-ghost">Dashboard</a>
@@ -424,86 +425,84 @@
             </details>
           </li>
         </ul>
-      </div>
-      <div class="navbar-end flex-1 justify-end">
-        <div class="flex w-full flex-col items-end gap-1 text-right">
-          <p id="sync-status" class="sync-status hidden text-xs text-base-content" data-compact="true"></p>
-          <div
-            id="user-badge"
-            class="hidden items-center gap-3 rounded-full border border-base-200 bg-base-100/80 px-3 py-1.5 text-sm shadow-sm backdrop-blur"
-          >
-            <span
-              id="user-badge-initial"
-              class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-primary text-primary-content text-base font-semibold"
-              aria-hidden="true"
-            >T</span>
-            <div class="text-left leading-tight">
-              <p id="user-badge-email" class="text-sm font-semibold text-base-content"></p>
-              <p class="text-xs text-base-content/60">Reminders syncing</p>
-            </div>
+      </nav>
+      <div class="desktop-header-actions">
+        <p id="sync-status" class="sync-status hidden text-xs text-base-content" data-compact="true"></p>
+        <div
+          id="user-badge"
+          class="hidden items-center gap-3 rounded-full border border-base-200 bg-base-100/80 px-3 py-1.5 text-sm shadow-sm backdrop-blur"
+        >
+          <span
+            id="user-badge-initial"
+            class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-primary text-primary-content text-base font-semibold"
+            aria-hidden="true"
+          >T</span>
+          <div class="text-left leading-tight">
+            <p id="user-badge-email" class="text-sm font-semibold text-base-content"></p>
+            <p class="text-xs text-base-content/60">Reminders syncing</p>
           </div>
-          <div class="flex w-full flex-wrap items-center justify-end gap-2 sm:w-auto">
-            <button
-              id="theme-toggle"
-              type="button"
-              class="btn btn-sm btn-ghost text-base-content"
-              data-icon-dark="🌙"
-              data-icon-light="☀️"
-            ></button>
-            <div class="dropdown dropdown-end">
-              <button
-                type="button"
-                class="btn btn-sm btn-ghost gap-2 text-base-content"
-                aria-haspopup="menu"
-                aria-expanded="false"
-              >
-                <span>Theme</span>
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke-width="1.5"
-                  stroke="currentColor"
-                  class="size-4"
-                  aria-hidden="true"
-                >
-                  <path stroke-linecap="round" stroke-linejoin="round" d="m6 9 6 6 6-6" />
-                </svg>
-              </button>
-              <ul
-                id="theme-menu"
-                class="menu dropdown-content bg-base-100 text-base-content rounded-box z-[1] mt-3 w-48 p-2 shadow"
-                role="menu"
-                tabindex="0"
-              >
-                <li><a href="#" data-theme-name="light" data-theme-option="light" role="menuitemradio" aria-checked="false">Light</a></li>
-                <li><a href="#" data-theme-name="dark" data-theme-option="dark" role="menuitemradio" aria-checked="false">Dark</a></li>
-                <li><a href="#" data-theme-name="dracula" data-theme-option="dracula" role="menuitemradio" aria-checked="false">Dracula</a></li>
-                <li><a href="#" data-theme-name="cupcake" data-theme-option="cupcake" role="menuitemradio" aria-checked="false">Cupcake</a></li>
-                <li><a href="#" data-theme-name="caramellatte" data-theme-option="caramellatte" role="menuitemradio" aria-checked="false">Caramellatte</a></li>
-                <li><a href="#" data-theme-name="synthwave" data-theme-option="synthwave" role="menuitemradio" aria-checked="false">Synthwave</a></li>
-              </ul>
-            </div>
-            <div
-              id="googleUserName"
-              class="google-user-chip text-xs sm:text-sm font-medium text-base-content/80 rounded-full border border-base-200 bg-base-100/80 px-3 py-1"
-            ></div>
-            <button id="googleSignInBtn" type="button" class="btn btn-sm btn-primary w-full sm:w-auto">Sign in</button>
-            <button
-              id="googleSignOutBtn"
-              type="button"
-              class="hidden btn btn-sm btn-outline border-base-300 bg-base-100/80 text-base-content w-full sm:w-auto"
-            >
-              Sign out
-            </button>
-          </div>
-          <div id="auth-feedback" class="text-xs text-base-content/70" role="status" aria-live="polite"></div>
         </div>
+        <div class="desktop-header-action-bar flex w-full flex-wrap items-center justify-end gap-2 sm:w-auto">
+          <button
+            id="theme-toggle"
+            type="button"
+            class="btn btn-sm btn-ghost text-base-content"
+            data-icon-dark="🌙"
+            data-icon-light="☀️"
+          ></button>
+          <div class="dropdown dropdown-end">
+            <button
+              type="button"
+              class="btn btn-sm btn-ghost gap-2 text-base-content"
+              aria-haspopup="menu"
+              aria-expanded="false"
+            >
+              <span>Theme</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke="currentColor"
+                class="size-4"
+                aria-hidden="true"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" d="m6 9 6 6 6-6" />
+              </svg>
+            </button>
+            <ul
+              id="theme-menu"
+              class="menu dropdown-content bg-base-100 text-base-content rounded-box z-[1] mt-3 w-48 p-2 shadow"
+              role="menu"
+              tabindex="0"
+            >
+              <li><a href="#" data-theme-name="light" data-theme-option="light" role="menuitemradio" aria-checked="false">Light</a></li>
+              <li><a href="#" data-theme-name="dark" data-theme-option="dark" role="menuitemradio" aria-checked="false">Dark</a></li>
+              <li><a href="#" data-theme-name="dracula" data-theme-option="dracula" role="menuitemradio" aria-checked="false">Dracula</a></li>
+              <li><a href="#" data-theme-name="cupcake" data-theme-option="cupcake" role="menuitemradio" aria-checked="false">Cupcake</a></li>
+              <li><a href="#" data-theme-name="caramellatte" data-theme-option="caramellatte" role="menuitemradio" aria-checked="false">Caramellatte</a></li>
+              <li><a href="#" data-theme-name="synthwave" data-theme-option="synthwave" role="menuitemradio" aria-checked="false">Synthwave</a></li>
+            </ul>
+          </div>
+          <div
+            id="googleUserName"
+            class="google-user-chip text-xs sm:text-sm font-medium text-base-content/80 rounded-full border border-base-200 bg-base-100/80 px-3 py-1"
+          ></div>
+          <button id="googleSignInBtn" type="button" class="btn btn-sm btn-primary w-full sm:w-auto">Sign in</button>
+          <button
+            id="googleSignOutBtn"
+            type="button"
+            class="hidden btn btn-sm btn-outline border-base-300 bg-base-100/80 text-base-content w-full sm:w-auto"
+          >
+            Sign out
+          </button>
+        </div>
+        <div id="auth-feedback" class="text-xs text-base-content/70" role="status" aria-live="polite"></div>
       </div>
     </div>
-  </nav>
-    <main id="mainContent" class="pt-24 min-h-screen" tabindex="-1">
-    <div class="mx-auto max-w-7xl px-4 py-6 space-y-8">
+  </header>
+    <main id="mainContent" class="desktop-main" tabindex="-1">
+      <div class="desktop-main-inner space-y-8">
       <section data-route="dashboard" class="space-y-6 lg:space-y-12">
         <div
           class="dashboard-card dashboard-card--hero relative overflow-hidden bg-gradient-to-br from-primary/15 via-base-100 to-base-200/70"
@@ -716,37 +715,40 @@
       </section>
 
       <section data-route="reminders" class="space-y-6" style="display: none;">
-        <header class="space-y-2">
-          <h1 class="text-2xl font-semibold text-base-content">Reminders</h1>
-          <p class="text-base-content/70">Keep track of tasks, family updates, and prep work in one organised list.</p>
-        </header>
-        <div class="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-200/70 p-4 shadow-sm">
-          <div class="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">
+        <div class="desktop-panel desktop-panel--reminders">
+          <header class="desktop-panel-header">
+            <div class="flex flex-col gap-1">
+              <h1 class="desktop-panel-title">Reminders</h1>
+              <p class="desktop-panel-subtitle">Keep track of tasks, family updates, and prep work in one organised list.</p>
+            </div>
+            <div class="desktop-panel-actions">
+              <button
+                type="button"
+                class="btn btn-primary"
+                data-open-reminder-modal
+                aria-haspopup="dialog"
+                aria-controls="add-reminder-modal"
+              >
+                Add reminder
+              </button>
+            </div>
+          </header>
+          <div class="desktop-panel-toolbar flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">
             <span class="btn btn-xs btn-secondary cursor-default" title="Filtering not available yet">All</span>
             <button type="button" class="btn btn-xs btn-secondary" disabled title="Filtering not available yet">Today</button>
             <button type="button" class="btn btn-xs btn-secondary" disabled title="Filtering not available yet">This week</button>
             <button type="button" class="btn btn-xs btn-secondary" disabled title="Filtering not available yet">Later</button>
           </div>
-          <button
-            type="button"
-            class="btn btn-primary"
-            data-open-reminder-modal
-            aria-haspopup="dialog"
-            aria-controls="add-reminder-modal"
-          >
-            Add reminder
-          </button>
-        </div>
-        <ul id="reminders-list" class="grid list-none gap-4 sm:grid-cols-2 xl:grid-cols-2">
+          <ul id="reminders-list" class="desktop-reminders-list list-none">
           <li
-            class="task-item desktop-task-card reminder-card grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-4 text-sm shadow-sm transition hover:border-base-300 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+            class="reminder-item task-item desktop-task-card reminder-card grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-4 text-sm shadow-sm transition hover:border-base-300 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
             role="button"
             tabindex="0"
             aria-label="Edit reminder: Submit unit overview"
           >
             <div class="flex min-w-0 flex-col gap-2">
-              <p class="desktop-reminder-title text-sm font-semibold leading-snug text-base-content">Submit unit overview</p>
-              <div class="desktop-reminder-meta flex flex-wrap items-center gap-1 text-xs text-base-content/70">
+              <p class="desktop-reminder-title reminder-title text-sm font-semibold leading-snug text-base-content">Submit unit overview</p>
+              <div class="desktop-reminder-meta reminder-meta flex flex-wrap items-center gap-1 text-xs text-base-content/70">
                 <span class="desktop-reminder-chip inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70" data-tone="due">
                   <span class="desktop-reminder-chip__dot h-1.5 w-1.5 rounded-full"></span>
                   <span class="truncate">Due Friday</span>
@@ -767,14 +769,14 @@
             </div>
           </li>
           <li
-            class="task-item desktop-task-card reminder-card grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-4 text-sm shadow-sm transition hover:border-base-300 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+            class="reminder-item task-item desktop-task-card reminder-card grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-4 text-sm shadow-sm transition hover:border-base-300 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
             role="button"
             tabindex="0"
             aria-label="Edit reminder: Email newsletter blurb"
           >
             <div class="flex min-w-0 flex-col gap-2">
-              <p class="desktop-reminder-title text-sm font-semibold leading-snug text-base-content">Email newsletter blurb</p>
-              <div class="desktop-reminder-meta flex flex-wrap items-center gap-1 text-xs text-base-content/70">
+              <p class="desktop-reminder-title reminder-title text-sm font-semibold leading-snug text-base-content">Email newsletter blurb</p>
+              <div class="desktop-reminder-meta reminder-meta flex flex-wrap items-center gap-1 text-xs text-base-content/70">
                 <span class="desktop-reminder-chip inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70" data-tone="due">
                   <span class="desktop-reminder-chip__dot h-1.5 w-1.5 rounded-full"></span>
                   <span class="truncate">Due next week</span>
@@ -799,14 +801,14 @@
             </div>
           </li>
           <li
-            class="task-item desktop-task-card reminder-card grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-4 text-sm shadow-sm transition hover:border-base-300 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+            class="reminder-item task-item desktop-task-card reminder-card grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-4 text-sm shadow-sm transition hover:border-base-300 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
             role="button"
             tabindex="0"
             aria-label="Edit reminder: Call guardians"
           >
             <div class="flex min-w-0 flex-col gap-2">
-              <p class="desktop-reminder-title text-sm font-semibold leading-snug text-base-content">Call guardians</p>
-              <div class="desktop-reminder-meta flex flex-wrap items-center gap-1 text-xs text-base-content/70">
+              <p class="desktop-reminder-title reminder-title text-sm font-semibold leading-snug text-base-content">Call guardians</p>
+              <div class="desktop-reminder-meta reminder-meta flex flex-wrap items-center gap-1 text-xs text-base-content/70">
                 <span class="desktop-reminder-chip inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70" data-tone="due">
                   <span class="desktop-reminder-chip__dot h-1.5 w-1.5 rounded-full"></span>
                   <span class="truncate">Due tomorrow</span>
@@ -823,26 +825,28 @@
             </div>
           </li>
         </ul>
+        </div>
       </section>
 
       <section data-route="planner" class="space-y-6" style="display: none;">
-        <header class="space-y-2">
-          <h1 class="text-2xl font-semibold text-base-content">Weekly planner</h1>
-          <p class="text-base-content/70">Draft the key lessons, checkpoints, and resources your classes need this week.</p>
-        </header>
-        <div class="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-200/70 p-4 shadow-sm">
-          <div class="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">
+        <div class="desktop-panel desktop-panel--planner">
+          <header class="desktop-panel-header">
+            <div class="flex flex-col gap-1">
+              <h1 class="desktop-panel-title">Weekly planner</h1>
+              <p class="desktop-panel-subtitle">Draft the key lessons, checkpoints, and resources your classes need this week.</p>
+            </div>
+            <div class="desktop-panel-actions flex flex-wrap items-center gap-2">
+              <button type="button" class="btn btn-sm btn-outline" disabled title="Coming soon">Duplicate plan</button>
+              <button type="button" class="btn btn-sm btn-primary" disabled title="Coming soon">New lesson</button>
+            </div>
+          </header>
+          <div class="desktop-panel-toolbar flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">
             <span class="btn btn-xs btn-secondary cursor-default">Week 7</span>
             <button type="button" class="btn btn-xs btn-secondary">Week 8</button>
             <button type="button" class="btn btn-xs btn-secondary">Week 9</button>
           </div>
-          <div class="flex flex-wrap items-center gap-2">
-            <button type="button" class="btn btn-sm btn-outline" disabled title="Coming soon">Duplicate plan</button>
-            <button type="button" class="btn btn-sm btn-primary" disabled title="Coming soon">New lesson</button>
-          </div>
-        </div>
-        <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-          <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow">
+          <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow">
             <div class="card-body gap-4">
               <div>
                 <h2 class="text-lg font-semibold text-base-content">Monday</h2>
@@ -918,16 +922,21 @@
               <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Add detail</button>
             </div>
           </article>
+          </div>
         </div>
       </section>
 
       <section data-route="notes" class="space-y-6" style="display: none;">
-        <header class="space-y-2">
-          <h1 class="text-2xl font-semibold text-base-content">Notes</h1>
-          <p class="text-base-content/70">Capture observations, behaviour wins, and quick reflections to revisit later.</p>
-        </header>
-        <div class="grid gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,4fr)_minmax(0,1fr)]">
-          <article class="card notes-editor-card border border-base-300 bg-base-200/70 shadow-sm">
+        <div class="desktop-panel desktop-panel--notes-intro">
+          <header class="desktop-panel-header">
+            <div class="flex flex-col gap-1">
+              <h1 class="desktop-panel-title">Notes</h1>
+              <p class="desktop-panel-subtitle">Capture observations, behaviour wins, and quick reflections to revisit later.</p>
+            </div>
+          </header>
+        </div>
+        <div class="desktop-notes-grid grid gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,4fr)_minmax(0,1fr)]">
+          <article class="desktop-panel card notes-editor-card border border-base-300 bg-base-200/70 shadow-sm">
             <div class="card-body gap-4">
               <div class="flex flex-col gap-3">
                 <div class="flex flex-col gap-2 mb-3">
@@ -955,7 +964,7 @@
               </div>
             </div>
           </article>
-          <aside class="card border border-base-300 bg-base-200/70 shadow-sm">
+          <aside class="desktop-panel card border border-base-300 bg-base-200/70 shadow-sm">
             <div class="card-body gap-4">
               <div>
                 <h3 class="text-base font-semibold text-base-content">Saved notes</h3>
@@ -1127,6 +1136,7 @@
       </section>
     </div>
   </main>
+  </div>
   <!-- BEGIN GPT CHANGE: live region -->
   <div id="live-status" class="sr-only" aria-live="polite" role="status"></div>
   <!-- END GPT CHANGE -->

--- a/styles/index.css
+++ b/styles/index.css
@@ -25,6 +25,290 @@ body {
   line-height: 1.6;
 }
 
+body.desktop-shell {
+  --desktop-bg: #0f172a0d;
+  --desktop-surface: #ffffff;
+  --desktop-surface-muted: #f8fafc;
+  --desktop-border-subtle: #e2e8f0;
+  --desktop-header-bg: #1e293b;
+  --desktop-header-border: #0f172a;
+  --desktop-text-main: #0f172a;
+  --desktop-text-muted: #64748b;
+  --desktop-nav-bg: #0b1120;
+  --desktop-nav-active: #1d4ed8;
+  --desktop-nav-text: #e5e7eb;
+  --desktop-nav-text-muted: #9ca3af;
+  --desktop-radius-card: 18px;
+  --desktop-radius-chip: 999px;
+  --desktop-shadow-card: 0 10px 30px rgba(15, 23, 42, 0.1);
+  --desktop-shadow-subtle: 0 2px 8px rgba(15, 23, 42, 0.06);
+
+  background: radial-gradient(circle at top, rgba(148, 163, 184, 0.12), transparent 55%), var(--desktop-bg);
+  color: var(--desktop-text-main);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  min-height: 100vh;
+}
+
+.desktop-shell .dashboard-root {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 1.25rem 1.5rem 2rem;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 1rem;
+}
+
+.desktop-shell .desktop-main {
+  padding-top: 0;
+  min-height: auto;
+}
+
+.desktop-shell .desktop-main-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 0 0.5rem 2rem;
+  width: 100%;
+}
+
+.desktop-shell .desktop-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1.25rem;
+  background: linear-gradient(135deg, var(--desktop-header-bg), #020617);
+  border-radius: 999px;
+  box-shadow: var(--desktop-shadow-subtle);
+  border: 1px solid rgba(15, 23, 42, 0.7);
+  color: #e5e7eb;
+  position: sticky;
+  top: 0.75rem;
+  z-index: 20;
+  backdrop-filter: blur(12px);
+}
+
+.desktop-shell .desktop-header-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.desktop-shell .desktop-header-brand-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  color: var(--desktop-nav-text);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.desktop-shell .desktop-header-logo {
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.desktop-shell .desktop-header-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: #cbd5f5;
+}
+
+.desktop-shell .desktop-header-subtitle {
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+
+.desktop-shell .desktop-header-nav {
+  color: var(--desktop-nav-text);
+  background: rgba(255, 255, 255, 0.04);
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.desktop-shell .desktop-header-nav .btn {
+  color: var(--desktop-nav-text-muted);
+}
+
+.desktop-shell .desktop-header-nav .btn:hover,
+.desktop-shell .desktop-header-nav .btn:focus-visible,
+.desktop-shell .desktop-header-nav .btn[aria-current="page"] {
+  color: var(--desktop-nav-text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.desktop-shell .desktop-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.desktop-shell .desktop-header-actions > *:not(:last-child) {
+  margin-right: 0.35rem;
+}
+
+.desktop-shell .desktop-header-action-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.4rem;
+}
+
+.desktop-shell .desktop-dashboard-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2.2fr) minmax(0, 1.4fr);
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+@media (max-width: 1024px) {
+  .desktop-shell .desktop-dashboard-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .desktop-shell .desktop-header {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .desktop-shell .desktop-header-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+}
+
+.desktop-shell .desktop-panel {
+  background: var(--desktop-surface);
+  border-radius: var(--desktop-radius-card);
+  border: 1px solid var(--desktop-border-subtle);
+  box-shadow: var(--desktop-shadow-card);
+  padding: 0.9rem 0.95rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.desktop-shell .desktop-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  margin-bottom: 0.2rem;
+}
+
+.desktop-shell .desktop-panel-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.desktop-shell .desktop-panel-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--desktop-text-muted);
+}
+
+.desktop-shell .desktop-panel-subtitle {
+  font-size: 0.8rem;
+  color: var(--desktop-text-muted);
+}
+
+.desktop-shell .desktop-panel-toolbar {
+  background: var(--desktop-surface-muted);
+  border-radius: calc(var(--desktop-radius-card) - 6px);
+  border: 1px solid var(--desktop-border-subtle);
+  box-shadow: var(--desktop-shadow-subtle);
+  padding: 0.5rem 0.75rem;
+}
+
+.desktop-shell .desktop-reminders-list {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 0.5rem;
+}
+
+@media (max-width: 900px) {
+  .desktop-shell .desktop-reminders-list {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.desktop-shell .reminder-item {
+  border-radius: 12px;
+  border: 1px solid var(--desktop-border-subtle);
+  background-color: var(--desktop-surface-muted);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  padding: 0.45rem 0.55rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: transform 0.12s ease, box-shadow 0.12s ease, border-color 0.12s ease;
+}
+
+.desktop-shell .reminder-item:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.12);
+  border-color: rgba(148, 163, 184, 0.9);
+}
+
+.desktop-shell .reminder-title {
+  font-weight: 600;
+  color: var(--desktop-text-main);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.desktop-shell .reminder-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--desktop-text-muted);
+}
+
+.desktop-shell .btn-primary,
+.desktop-shell .cue-btn-primary {
+  background: linear-gradient(135deg, #2563eb, #4f46e5);
+  border: none;
+  color: #f9fafb;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.4rem 0.85rem;
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.35);
+  transition: transform 0.1s ease, box-shadow 0.1s ease, filter 0.1s ease;
+}
+
+.desktop-shell .btn-primary:hover,
+.desktop-shell .cue-btn-primary:hover {
+  filter: brightness(1.06);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.45);
+}
+
+.desktop-shell .btn-ghost,
+.desktop-shell .cue-btn-ghost {
+  background: transparent;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  padding: 0.35rem 0.7rem;
+  color: var(--desktop-text-muted);
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
## Summary
- add a desktop shell wrapper and redesigned header to give the desktop dashboard a centered, pill-shaped navigation shell
- wrap reminders, planner, and notes sections in reusable desktop panel markup with refreshed actions and grids
- define desktop-specific design tokens and styling for panels, reminders, and buttons to deliver a cohesive productivity theme

## Testing
- npm test -- --runTestsByPath sample.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69186afb789c8324b410ff062382b1dd)