### PR TITLE
Set desktop default theme to professional

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,7 +281,7 @@
   </style>
   <script src="./js/runtime-env-shim.js" defer></script>
 </head>
-<body id="top" class="bg-base-100 text-base-content antialiased leading-7 min-h-screen desktop-shell">
+<body id="top" class="desktop-shell">
   <a class="skip-link" href="#mainContent">Skip to main content</a>
   <div class="dashboard-root">
     <header class="desktop-header desktop-header-bar" aria-label="Primary">

--- a/js/main.js
+++ b/js/main.js
@@ -9,7 +9,7 @@ initViewportHeight();
   }
 
   const THEME_STORAGE_KEY = 'theme';
-  const DEFAULT_THEME = 'light';
+  const DEFAULT_THEME = 'professional';
 
   function safeGetItem(key) {
     try {
@@ -52,12 +52,7 @@ initViewportHeight();
     if (stored) {
       return stored;
     }
-    const prefersDark = typeof window !== 'undefined'
-      && typeof window.matchMedia === 'function'
-      && window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const theme = prefersDark ? 'dark' : DEFAULT_THEME;
-    safeSetItem(THEME_STORAGE_KEY, theme);
-    return theme;
+    return DEFAULT_THEME;
   }
 
   function updateThemeButton(button, theme) {

--- a/theme-toggle.test.js
+++ b/theme-toggle.test.js
@@ -51,8 +51,9 @@ beforeEach(() => {
 
 test('toggle persists theme', () => {
   const btn = document.getElementById('theme-toggle');
-  // Default should be light
-  expect(localStorage.getItem('theme')).toBe('light');
+  // Default should be professional and not stored until the user changes it
+  expect(document.documentElement.getAttribute('data-theme')).toBe('professional');
+  expect(localStorage.getItem('theme')).toBeNull();
   btn.click();
   expect(localStorage.getItem('theme')).toBe('dark');
   btn.click();


### PR DESCRIPTION
## Summary
- set the desktop shell markup to use the professional theme
- default the theme initialisation logic to the professional theme without overriding explicit choices
- update the theme toggle test expectations for the new default

## Testing
- npm test -- theme-toggle.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69187aad7ca88324a7ec016715ada302)