### PR TITLE
Handle missing modal element before creating ModalController

### DIFF
--- a/app.js
+++ b/app.js
@@ -418,13 +418,22 @@ const mobileTitleInput = document.getElementById('reminderText');
 
 const modalController = (() => {
   const modalElement = document.getElementById('cue-modal') ?? document.getElementById('cue_modal');
+  if (!(modalElement instanceof HTMLElement)) {
+    return null;
+  }
+
+  const openButton = document.getElementById('openCueModal');
+  const closeButton = document.getElementById('closeCueModal');
+  const backdropButton = modalElement.querySelector('.modal-backdrop button');
+  const modalTitle = document.getElementById('modal-title');
+
   return createModalController({
     modalElement,
-    openButton: document.getElementById('openCueModal'),
-    closeButton: document.getElementById('closeCueModal'),
-    backdropButton: modalElement?.querySelector('.modal-backdrop button') ?? null,
+    openButton: openButton instanceof HTMLElement ? openButton : null,
+    closeButton: closeButton instanceof HTMLElement ? closeButton : null,
+    backdropButton: backdropButton instanceof HTMLElement ? backdropButton : null,
     titleInput,
-    modalTitle: document.getElementById('modal-title'),
+    modalTitle: modalTitle instanceof HTMLElement ? modalTitle : null,
     defaultTitle: DEFAULT_CUE_MODAL_TITLE,
     editTitle: EDIT_CUE_MODAL_TITLE
   });

--- a/js/modules/modal-controller.js
+++ b/js/modules/modal-controller.js
@@ -87,6 +87,7 @@ export class ModalController {
     this.animationHooks = options.animationHooks ?? {};
     this.enableStacking = options.enableStacking !== false;
     this.isDisabled = false;
+    this.isValid = false;
 
     this.previouslyFocusedElement = null;
     this.boundHandlers = {
@@ -104,7 +105,8 @@ export class ModalController {
 
   /** Initialise the controller and wire listeners. */
   init() {
-    if (!this.validateModal()) {
+    this.validateModal();
+    if (!this.isValid) {
       this.isDisabled = true;
       return;
     }
@@ -116,10 +118,12 @@ export class ModalController {
 
   /** Validate modal element. */
   validateModal() {
-    if (!this.modal || !(this.modal instanceof HTMLElement)) {
-      console.warn('[ModalController] Modal element is not provided or invalid.');
+    if (!(this.modal instanceof HTMLElement)) {
+      console.warn('[ModalController] Modal element is not provided or invalid.', this.modal);
+      this.isValid = false;
       return false;
     }
+    this.isValid = true;
     if (typeof this.modal.showModal !== 'function') {
       this.modal.showModal = this.modal.showModal || (() => {
         this.modal?.setAttribute('open', '');


### PR DESCRIPTION
## Summary
- guard modal controller setup by ensuring the cue modal exists before initialising
- tighten ModalController validation to mark invalid instances and avoid wiring listeners when the modal element is missing

## Testing
- npm test *(fails: legacy Jest harness cannot run ESM modules)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69187b0670a0832496f25fd17be9c22c)