### PR TITLE
Force professional theme on desktop shell

### DIFF
--- a/app.js
+++ b/app.js
@@ -2052,6 +2052,7 @@ initDesktopNotes();
 const THEME_STORAGE_KEY = 'theme';
 const DEFAULT_THEME = 'professional';
 const THEME_CHANGE_EVENT = 'memoryCue:theme-change';
+const DESKTOP_THEME = 'professional';
 const themeMenu = document.getElementById('theme-menu');
 const themeOptionSelector = '[data-theme-name],[data-theme-option]';
 
@@ -2143,6 +2144,15 @@ function setTheme(themeName, { persist = true, notify = true } = {}) {
 }
 
 function loadSavedTheme() {
+  const isDesktopShell = typeof document !== 'undefined'
+    && document.body instanceof HTMLElement
+    && document.body.classList.contains('desktop-shell');
+
+  if (isDesktopShell) {
+    setTheme(DESKTOP_THEME, { persist: true, notify: true });
+    return;
+  }
+
   let storedTheme = '';
   try {
     storedTheme = localStorage.getItem(THEME_STORAGE_KEY) || '';


### PR DESCRIPTION
## Summary
- ensure desktop shell always applies the professional theme and persists it to storage

## Testing
- npm test -- theme-toggle.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69187c3d8c308324b151fe6dfaab3ff6)