### PR TITLE
Fix mobile priority chip selection

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -3011,12 +3011,12 @@
                 <option value="Medium" selected>Medium</option>
                 <option value="Low">Low</option>
               </select>
-              <!-- BEGIN GPT CHANGE: priority s -->
-               <fieldset id="prioritys" aria-label="Priority" class="chip-row">
+              <!-- BEGIN GPT CHANGE: priority chips -->
+               <fieldset id="priorityChips" aria-label="Priority" class="chip-row">
                 <label><input type="radio" name="priority" value="High"> High</label>
                 <label><input type="radio" name="priority" value="Medium" checked> Medium</label>
                 <label><input type="radio" name="priority" value="Low"> Low</label>
-              </fieldset>             
+              </fieldset>
               <!-- END GPT CHANGE: priority chips -->
             </div>
             <label class="form-control">


### PR DESCRIPTION
## Summary
- align the mobile priority radio group id with the reminder module expectations so selected priorities persist and update card styling
- adjust the inline comment label to reflect the corrected priority chips block

## Testing
- `npm test -- --runTestsByPath js/__tests__/reminders.save-click.test.js` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69187dd5b14483249d6efd2390e233f6)