### PR TITLE
Refresh desktop color palette for readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,16 +220,16 @@
     }
 
     #quick-action-toolbar {
-      opacity: 0.9;
-      backdrop-filter: blur(10px);
-      background-color: rgba(15, 23, 42, 0.55);
+      opacity: 0.95;
+      backdrop-filter: blur(14px);
+      background-color: color-mix(in srgb, var(--desktop-header-bg) 88%, transparent);
       border-radius: 1.25rem;
       padding: 0.5rem;
-      box-shadow: 0 8px 20px rgba(15, 23, 42, 0.22);
+      box-shadow: 0 12px 28px rgba(79, 70, 229, 0.22);
     }
 
     #quick-action-toolbar .quick-action-btn {
-      box-shadow: 0 3px 8px rgba(15, 23, 42, 0.35);
+      box-shadow: 0 4px 12px rgba(79, 70, 229, 0.25);
     }
 
     .google-user-chip {
@@ -255,7 +255,7 @@
 
     /* Dashboard: emphasise Today's focus card */
     .dashboard-today-focus {
-      background: linear-gradient(to right, rgba(59, 130, 246, 0.04), rgba(15, 23, 42, 0.02));
+      background: linear-gradient(to right, rgba(79, 70, 229, 0.08), rgba(14, 165, 233, 0.05));
     }
 
     /* Dashboard layout tweaks */
@@ -270,8 +270,8 @@
     /* Dashboard: lighter action shortcuts card */
     .dashboard-shortcuts {
       border-radius: 0.75rem;
-      border: 1px solid rgba(148, 163, 184, 0.35);
-      background-color: rgba(15, 23, 42, 0.015);
+      border: 1px solid color-mix(in srgb, var(--desktop-border-subtle) 70%, transparent);
+      background-color: color-mix(in srgb, var(--desktop-header-bg) 50%, transparent);
       box-shadow: none;
     }
 

--- a/styles/daisy-themes.css
+++ b/styles/daisy-themes.css
@@ -47,22 +47,22 @@
   default: false;
   prefersdark: false;
   color-scheme: "light";
-  --color-base-100: #f8fafc;
-  --color-base-200: #e2e8f0;
-  --color-base-300: #cbd5f5;
-  --color-base-content: #0f172a;
-  --color-primary: #2563eb;
+  --color-base-100: #f5f7ff;
+  --color-base-200: #e6edff;
+  --color-base-300: #d0dcff;
+  --color-base-content: #1f2937;
+  --color-primary: #4f46e5;
   --color-primary-content: #f8fafc;
-  --color-secondary: #1e293b;
-  --color-secondary-content: #e2e8f0;
-  --color-accent: #38bdf8;
-  --color-accent-content: #0f172a;
-  --color-neutral: #0b1120;
-  --color-neutral-content: #e2e8f0;
-  --color-info: #1d4ed8;
+  --color-secondary: #1d4ed8;
+  --color-secondary-content: #f8fafc;
+  --color-accent: #0ea5e9;
+  --color-accent-content: #06263a;
+  --color-neutral: #1f2937;
+  --color-neutral-content: #f5f7ff;
+  --color-info: #2563eb;
   --color-info-content: #f8fafc;
-  --color-success: #22c55e;
-  --color-success-content: #052e16;
+  --color-success: #059669;
+  --color-success-content: #f0fdfa;
   --color-warning: #f59e0b;
   --color-warning-content: #3b2100;
   --color-error: #ef4444;
@@ -76,26 +76,26 @@
   --depth: 0;
   --noise: 0;
 
-  --background-color: #0f172a0d;
-  --card-border: #e2e8f0;
-  --accent-color: #2563eb;
+  --background-color: #eef2ff;
+  --card-border: #d7def1;
+  --accent-color: #4f46e5;
 
-  --desktop-bg: #0f172a0d;
+  --desktop-bg: #eef2ff;
   --desktop-surface: #ffffff;
-  --desktop-surface-muted: #f8fafc;
-  --desktop-border-subtle: #e2e8f0;
-  --desktop-header-bg: #1e293b;
-  --desktop-header-border: #0f172a;
-  --desktop-text-main: #0f172a;
-  --desktop-text-muted: #64748b;
-  --desktop-nav-bg: #0b1120;
-  --desktop-nav-active: #1d4ed8;
-  --desktop-nav-text: #e5e7eb;
-  --desktop-nav-text-muted: #9ca3af;
+  --desktop-surface-muted: #f6f7ff;
+  --desktop-border-subtle: #d7def1;
+  --desktop-header-bg: #e3e9ff;
+  --desktop-header-border: #c0ccf2;
+  --desktop-text-main: #1f2a44;
+  --desktop-text-muted: #55607a;
+  --desktop-nav-bg: #e6ecff;
+  --desktop-nav-active: #4f46e5;
+  --desktop-nav-text: #1f2a44;
+  --desktop-nav-text-muted: #6b7694;
   --desktop-radius-card: 18px;
   --desktop-radius-chip: 999px;
-  --desktop-shadow-card: 0 10px 30px rgba(15, 23, 42, 0.10);
-  --desktop-shadow-subtle: 0 2px 8px rgba(15, 23, 42, 0.06);
+  --desktop-shadow-card: 0 12px 30px rgba(79, 70, 229, 0.12);
+  --desktop-shadow-subtle: 0 4px 14px rgba(79, 70, 229, 0.08);
 }
 
 @plugin "daisyui/theme" {
@@ -205,22 +205,22 @@
 :root[data-theme="professional"],
 [data-theme="professional"] {
   color-scheme: light;
-  --color-base-100: #f8fafc;
-  --color-base-200: #e2e8f0;
-  --color-base-300: #cbd5f5;
-  --color-base-content: #0f172a;
-  --color-primary: #2563eb;
+  --color-base-100: #f5f7ff;
+  --color-base-200: #e6edff;
+  --color-base-300: #d0dcff;
+  --color-base-content: #1f2937;
+  --color-primary: #4f46e5;
   --color-primary-content: #f8fafc;
-  --color-secondary: #1e293b;
-  --color-secondary-content: #e2e8f0;
-  --color-accent: #38bdf8;
-  --color-accent-content: #0f172a;
-  --color-neutral: #0b1120;
-  --color-neutral-content: #e2e8f0;
-  --color-info: #1d4ed8;
+  --color-secondary: #1d4ed8;
+  --color-secondary-content: #f8fafc;
+  --color-accent: #0ea5e9;
+  --color-accent-content: #06263a;
+  --color-neutral: #1f2937;
+  --color-neutral-content: #f5f7ff;
+  --color-info: #2563eb;
   --color-info-content: #f8fafc;
-  --color-success: #22c55e;
-  --color-success-content: #052e16;
+  --color-success: #059669;
+  --color-success-content: #f0fdfa;
   --color-warning: #f59e0b;
   --color-warning-content: #3b2100;
   --color-error: #ef4444;
@@ -234,26 +234,26 @@
   --depth: 0;
   --noise: 0;
 
-  --background-color: #0f172a0d;
-  --card-border: #e2e8f0;
-  --accent-color: #2563eb;
+  --background-color: #eef2ff;
+  --card-border: #d7def1;
+  --accent-color: #4f46e5;
 
-  --desktop-bg: #0f172a0d;
+  --desktop-bg: #eef2ff;
   --desktop-surface: #ffffff;
-  --desktop-surface-muted: #f8fafc;
-  --desktop-border-subtle: #e2e8f0;
-  --desktop-header-bg: #1e293b;
-  --desktop-header-border: #0f172a;
-  --desktop-text-main: #0f172a;
-  --desktop-text-muted: #64748b;
-  --desktop-nav-bg: #0b1120;
-  --desktop-nav-active: #1d4ed8;
-  --desktop-nav-text: #e5e7eb;
-  --desktop-nav-text-muted: #9ca3af;
+  --desktop-surface-muted: #f6f7ff;
+  --desktop-border-subtle: #d7def1;
+  --desktop-header-bg: #e3e9ff;
+  --desktop-header-border: #c0ccf2;
+  --desktop-text-main: #1f2a44;
+  --desktop-text-muted: #55607a;
+  --desktop-nav-bg: #e6ecff;
+  --desktop-nav-active: #4f46e5;
+  --desktop-nav-text: #1f2a44;
+  --desktop-nav-text-muted: #6b7694;
   --desktop-radius-card: 18px;
   --desktop-radius-chip: 999px;
-  --desktop-shadow-card: 0 10px 30px rgba(15, 23, 42, 0.10);
-  --desktop-shadow-subtle: 0 2px 8px rgba(15, 23, 42, 0.06);
+  --desktop-shadow-card: 0 12px 30px rgba(79, 70, 229, 0.12);
+  --desktop-shadow-subtle: 0 4px 14px rgba(79, 70, 229, 0.08);
 }
 
 :root[data-theme="dracula"],

--- a/styles/index.css
+++ b/styles/index.css
@@ -26,7 +26,12 @@ body {
 }
 
 html[data-theme="professional"] body.desktop-shell {
-  background: radial-gradient(circle at top, rgba(148, 163, 184, 0.12), transparent 55%), var(--desktop-bg);
+  background: radial-gradient(
+      circle at top,
+      rgba(99, 102, 241, 0.14),
+      rgba(14, 165, 233, 0.08) 55%
+    ),
+    var(--desktop-bg);
   color: var(--desktop-text-main);
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   min-height: 100vh;
@@ -45,11 +50,11 @@ html[data-theme="professional"] .desktop-header-bar {
   padding: 0.45rem 1.25rem;
   margin: 0 auto 0.75rem;
   max-width: 1180px;
-  background: rgba(248, 250, 252, 0.92);
+  background: color-mix(in srgb, var(--desktop-header-bg) 92%, transparent);
   backdrop-filter: blur(14px);
   border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+  border: 1px solid color-mix(in srgb, var(--desktop-border-subtle) 75%, transparent);
+  box-shadow: 0 18px 38px rgba(79, 70, 229, 0.16);
 }
 
 html[data-theme="professional"] .desktop-header-left {
@@ -87,14 +92,14 @@ html[data-theme="professional"] .desktop-header-brand-link {
   gap: 0.6rem;
   padding: 0.35rem 0.75rem;
   border-radius: 999px;
-  background: rgba(15, 23, 42, 0.04);
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: color-mix(in srgb, var(--desktop-header-bg) 60%, transparent);
+  border: 1px solid color-mix(in srgb, var(--desktop-border-subtle) 65%, transparent);
   color: var(--desktop-text-main);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9);
 }
 
 html[data-theme="professional"] .desktop-header-brand-link:hover {
-  background: rgba(15, 23, 42, 0.08);
+  background: color-mix(in srgb, var(--desktop-header-bg) 80%, transparent);
 }
 
 html[data-theme="professional"] .desktop-header-logo {
@@ -137,14 +142,9 @@ html[data-theme="professional"] .desktop-header-nav-tabs {
   gap: 0.25rem;
   padding: 0.3rem;
   border-radius: 999px;
-  background: radial-gradient(
-      circle at top left,
-      rgba(59, 130, 246, 0.09),
-      rgba(125, 211, 252, 0.08) 45%,
-      rgba(248, 250, 252, 0.98)
-    );
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.18);
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.16), rgba(14, 165, 233, 0.12));
+  box-shadow: 0 16px 32px rgba(79, 70, 229, 0.18);
+  border: 1px solid color-mix(in srgb, var(--desktop-border-subtle) 70%, transparent);
 }
 
 html[data-theme="professional"] .desktop-header-nav-tabs .btn {
@@ -154,20 +154,20 @@ html[data-theme="professional"] .desktop-header-nav-tabs .btn {
   padding: 0.3rem 0.85rem;
   border-width: 0;
   background: transparent;
-  color: var(--desktop-text-muted);
+  color: var(--desktop-nav-text-muted);
   box-shadow: none;
 }
 
 html[data-theme="professional"] .desktop-header-nav-tabs .btn[aria-current="page"],
 html[data-theme="professional"] .desktop-header-nav-tabs .btn.btn-active {
-  background: linear-gradient(135deg, #22c55e, #38bdf8);
-  color: #0f172a;
-  box-shadow: 0 6px 16px rgba(34, 197, 94, 0.35);
+  background: linear-gradient(135deg, #4f46e5, #22d3ee);
+  color: #ffffff;
+  box-shadow: 0 10px 22px rgba(79, 70, 229, 0.28);
 }
 
 html[data-theme="professional"] .desktop-header-nav-tabs .btn:hover {
-  background: rgba(148, 163, 184, 0.14);
-  color: var(--desktop-text-main);
+  background: color-mix(in srgb, var(--desktop-nav-active) 18%, transparent);
+  color: var(--desktop-nav-text);
 }
 
 @media (max-width: 960px) {
@@ -236,9 +236,9 @@ html[data-theme="professional"] .desktop-shell .desktop-hero {
   padding-block: 1.5rem;
   background: radial-gradient(
       circle at top left,
-      rgba(129, 140, 248, 0.18),
-      rgba(244, 114, 182, 0.12) 40%,
-      #f8fafc
+      rgba(99, 102, 241, 0.16),
+      rgba(14, 165, 233, 0.12) 45%,
+      var(--desktop-surface)
     );
 }
 
@@ -309,8 +309,8 @@ html[data-theme="professional"] .desktop-shell .reminder-item {
 
 html[data-theme="professional"] .desktop-shell .reminder-item:hover {
   transform: translateY(-1px);
-  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.12);
-  border-color: rgba(148, 163, 184, 0.9);
+  box-shadow: 0 6px 16px rgba(79, 70, 229, 0.18);
+  border-color: color-mix(in srgb, var(--desktop-border-subtle) 45%, var(--desktop-nav-active) 55%);
 }
 
 html[data-theme="professional"] .desktop-shell .reminder-title {
@@ -331,14 +331,14 @@ html[data-theme="professional"] .desktop-shell .reminder-meta {
 
 html[data-theme="professional"] .desktop-shell .btn-primary,
 html[data-theme="professional"] .desktop-shell .cue-btn-primary {
-  background: linear-gradient(135deg, #2563eb, #4f46e5);
+  background: linear-gradient(135deg, #4f46e5, #22d3ee);
   border: none;
-  color: #f9fafb;
+  color: #ffffff;
   border-radius: 999px;
   font-size: 0.8rem;
   font-weight: 600;
   padding: 0.4rem 0.85rem;
-  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.35);
+  box-shadow: 0 10px 24px rgba(79, 70, 229, 0.35);
   transition: transform 0.1s ease, box-shadow 0.1s ease, filter 0.1s ease;
 }
 
@@ -346,7 +346,7 @@ html[data-theme="professional"] .desktop-shell .btn-primary:hover,
 html[data-theme="professional"] .desktop-shell .cue-btn-primary:hover {
   filter: brightness(1.06);
   transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.45);
+  box-shadow: 0 14px 28px rgba(79, 70, 229, 0.4);
 }
 
 html[data-theme="professional"] .desktop-shell .btn-ghost,
@@ -355,7 +355,7 @@ html[data-theme="professional"] .desktop-shell .cue-btn-ghost {
   border-radius: 999px;
   font-size: 0.8rem;
   padding: 0.35rem 0.7rem;
-  color: var(--desktop-text-muted);
+  color: var(--desktop-nav-text-muted);
 }
 
 h1,


### PR DESCRIPTION
## Summary
- soften the professional desktop theme palette variables for improved legibility on desktop
- update desktop header, hero, reminders, and shortcut styling to use the lighter palette
- refresh primary button and quick action toolbar treatments to align with the new colors

## Testing
- npm test -- --runTestsByPath sample.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69188011e6c4832488fa15f354a06aed)