### PR TITLE
Add weather and news widgets to dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
   <meta
     http-equiv="Content-Security-Policy"
     content="default-src 'self';
-             connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.open-meteo.com https://api.bigdatacloud.net https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://www.googleapis.com https://cdn.jsdelivr.net;
+             connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.open-meteo.com https://api.bigdatacloud.net https://hn.algolia.com https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://www.googleapis.com https://cdn.jsdelivr.net;
              script-src 'self' https://cdn.jsdelivr.net https://esm.sh https://www.gstatic.com https://apis.google.com;
              style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;
              img-src 'self' data:;
@@ -359,27 +359,77 @@
     <main id="mainContent" class="desktop-main" tabindex="-1">
       <div class="desktop-main-inner space-y-8">
       <section data-route="dashboard" class="space-y-6 lg:space-y-12">
-        <section
-          class="desktop-panel desktop-hero dashboard-card dashboard-card--hero relative overflow-hidden bg-gradient-to-br from-primary/15 via-base-100 to-base-200/70"
-        >
-          <div class="pointer-events-none absolute -top-24 left-1/2 h-64 w-64 -translate-x-1/2 rounded-full bg-secondary/20 blur-3xl" aria-hidden="true"></div>
-          <div class="pointer-events-none absolute bottom-[-6rem] right-[-4rem] h-72 w-72 rounded-full bg-primary/30 blur-3xl" aria-hidden="true"></div>
-          <div class="dashboard-card-content relative space-y-6">
-            <div class="space-y-6">
-              <div class="space-y-4">
-                <h1 class="dashboard-card-title dashboard-card-title--hero">
-                  Settle into teaching with a focused, organised workspace
-                </h1>
-                <p class="dashboard-card-text max-w-2xl">
-                  Memory Cue keeps reminders, planning, and quick wins together so you can move from intention to action without searching across tools.
-                </p>
+        <section class="desktop-panel grid gap-4 lg:grid-cols-2">
+          <article class="dashboard-card card dashboard-card--hero relative overflow-hidden bg-gradient-to-br from-sky-100 via-base-100 to-base-200/70">
+            <div class="pointer-events-none absolute -top-24 left-1/2 h-64 w-64 -translate-x-1/2 rounded-full bg-primary/20 blur-3xl" aria-hidden="true"></div>
+            <div class="pointer-events-none absolute bottom-[-6rem] right-[-4rem] h-72 w-72 rounded-full bg-secondary/30 blur-3xl" aria-hidden="true"></div>
+            <div class="dashboard-card-content relative space-y-5">
+              <div class="flex flex-wrap items-start justify-between gap-4">
+                <div class="space-y-2">
+                  <p class="dashboard-card-eyebrow">Local weather</p>
+                  <h2 class="dashboard-card-title dashboard-card-title--hero">Plan for the elements</h2>
+                </div>
+                <span id="weatherIcon" class="text-5xl" aria-hidden="true">⛅️</span>
               </div>
-              <div class="flex flex-wrap gap-3">
-                <a href="#planner" class="btn btn-primary btn-sm sm:btn-md">Start planning</a>
-                <a href="#reminders" class="btn btn-outline btn-sm sm:btn-md">Review reminders</a>
+              <p id="weatherStatus" class="dashboard-card-text text-sm text-base-content/70" role="status" aria-live="polite">
+                Checking the latest forecast…
+              </p>
+              <div class="flex flex-wrap items-end gap-6">
+                <div>
+                  <p id="weatherTemperature" class="text-5xl font-semibold text-base-content">--°C</p>
+                  <p id="weatherDescription" class="text-base text-base-content/70">Awaiting update</p>
+                </div>
+                <dl class="grid gap-4 text-sm text-base-content/80 sm:grid-cols-2">
+                  <div>
+                    <dt class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/50">Location</dt>
+                    <dd id="weatherLocation" class="text-base-content">Locating…</dd>
+                  </div>
+                  <div>
+                    <dt class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/50">Wind</dt>
+                    <dd id="weatherWind" class="text-base-content">-- km/h</dd>
+                  </div>
+                  <div>
+                    <dt class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/50">Humidity</dt>
+                    <dd id="weatherHumidity" class="text-base-content">--%</dd>
+                  </div>
+                  <div>
+                    <dt class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/50">Feels like</dt>
+                    <dd id="weatherFeelsLike" class="text-base-content">--°C</dd>
+                  </div>
+                </dl>
               </div>
+              <p id="weatherFootnote" class="text-xs text-base-content/60">We use your approximate location to calculate these details.</p>
             </div>
-          </div>
+          </article>
+          <article class="dashboard-card card border border-base-300 bg-base-100/90 shadow-sm">
+            <div class="dashboard-card-content card-body gap-5">
+              <div class="space-y-2">
+                <p class="dashboard-card-eyebrow">Top stories</p>
+                <h2 class="dashboard-card-title">Start conversations informed</h2>
+              </div>
+              <p id="newsStatus" class="dashboard-card-text text-sm text-base-content/70" role="status" aria-live="polite">
+                Gathering the latest headlines…
+              </p>
+              <div id="newsContent" class="hidden space-y-4">
+                <a
+                  id="newsPrimaryLink"
+                  href="#"
+                  class="block rounded-2xl border border-base-200 bg-base-200/60 p-4 text-left transition hover:border-primary/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <p class="text-xs font-semibold uppercase tracking-[0.3em] text-primary">Lead story</p>
+                  <p id="newsHeadline" class="mt-2 text-lg font-semibold text-base-content"></p>
+                  <p id="newsSource" class="mt-1 text-sm text-base-content/70"></p>
+                </a>
+                <div>
+                  <p class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/50">More to skim</p>
+                  <ul id="newsTopStories" class="mt-3 space-y-3 text-sm text-base-content/80"></ul>
+                </div>
+              </div>
+              <p id="newsFootnote" class="text-xs text-base-content/60" aria-live="polite"></p>
+            </div>
+          </article>
         </section>
 
         <section class="dashboard-kpis" aria-labelledby="kpi-heading">
@@ -1212,6 +1262,7 @@
     </div>
   </div>
   <script src="./js/router.js" defer></script>
+  <script type="module" src="./js/dashboard-insights.js" defer></script>
   <script type="module" src="./app.js" defer></script>
   <script src="./js/update-footer-year.js" defer></script>
   <script type="module" src="./js/supabase-auth-init.js" defer></script>

--- a/js/dashboard-insights.js
+++ b/js/dashboard-insights.js
@@ -1,0 +1,283 @@
+const WEATHER_FALLBACK = {
+  latitude: -33.8688,
+  longitude: 151.2093,
+  label: 'Sydney, AU'
+};
+
+const WEATHER_CODE_MAP = {
+  0: { label: 'Clear skies', icon: '☀️' },
+  1: { label: 'Mainly clear', icon: '🌤️' },
+  2: { label: 'Partly cloudy', icon: '⛅️' },
+  3: { label: 'Overcast', icon: '☁️' },
+  45: { label: 'Foggy', icon: '🌫️' },
+  48: { label: 'Freezing fog', icon: '🌫️' },
+  51: { label: 'Light drizzle', icon: '🌦️' },
+  53: { label: 'Drizzle', icon: '🌦️' },
+  55: { label: 'Heavy drizzle', icon: '🌧️' },
+  61: { label: 'Light rain', icon: '🌦️' },
+  63: { label: 'Rain', icon: '🌧️' },
+  65: { label: 'Heavy rain', icon: '🌧️' },
+  71: { label: 'Light snow', icon: '🌨️' },
+  73: { label: 'Snow', icon: '🌨️' },
+  75: { label: 'Heavy snow', icon: '❄️' },
+  77: { label: 'Snow grains', icon: '🌨️' },
+  80: { label: 'Rain showers', icon: '🌦️' },
+  81: { label: 'Heavy showers', icon: '🌧️' },
+  82: { label: 'Violent showers', icon: '🌧️' },
+  85: { label: 'Snow showers', icon: '🌨️' },
+  86: { label: 'Heavy snow showers', icon: '🌨️' },
+  95: { label: 'Thunderstorm', icon: '⛈️' },
+  96: { label: 'Storm with hail', icon: '⛈️' },
+  99: { label: 'Heavy hail', icon: '⛈️' }
+};
+
+const weatherElements = {
+  status: document.getElementById('weatherStatus'),
+  temperature: document.getElementById('weatherTemperature'),
+  description: document.getElementById('weatherDescription'),
+  location: document.getElementById('weatherLocation'),
+  wind: document.getElementById('weatherWind'),
+  humidity: document.getElementById('weatherHumidity'),
+  feelsLike: document.getElementById('weatherFeelsLike'),
+  footnote: document.getElementById('weatherFootnote'),
+  icon: document.getElementById('weatherIcon')
+};
+
+const newsElements = {
+  status: document.getElementById('newsStatus'),
+  content: document.getElementById('newsContent'),
+  headline: document.getElementById('newsHeadline'),
+  source: document.getElementById('newsSource'),
+  topStories: document.getElementById('newsTopStories'),
+  primaryLink: document.getElementById('newsPrimaryLink'),
+  footnote: document.getElementById('newsFootnote')
+};
+
+function safeText(target, value) {
+  if (target) {
+    target.textContent = value;
+  }
+}
+
+function formatTimeLabel(dateLike) {
+  const date = dateLike instanceof Date ? dateLike : new Date(dateLike);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+}
+
+function resolveWeatherDescription(code) {
+  return WEATHER_CODE_MAP[code] || { label: 'Latest weather', icon: '⛅️' };
+}
+
+async function fetchWeather(latitude, longitude) {
+  const url = new URL('https://api.open-meteo.com/v1/forecast');
+  url.searchParams.set('latitude', latitude.toFixed(3));
+  url.searchParams.set('longitude', longitude.toFixed(3));
+  url.searchParams.set('current', 'temperature_2m,apparent_temperature,weather_code,relative_humidity_2m,wind_speed_10m');
+  url.searchParams.set('timezone', 'auto');
+  url.searchParams.set('wind_speed_unit', 'kmh');
+
+  const response = await fetch(url.toString());
+  if (!response.ok) {
+    throw new Error('Unable to fetch weather');
+  }
+  return response.json();
+}
+
+async function fetchLocationName(latitude, longitude) {
+  const endpoint = new URL('https://api.bigdatacloud.net/data/reverse-geocode-client');
+  endpoint.searchParams.set('latitude', latitude);
+  endpoint.searchParams.set('longitude', longitude);
+  endpoint.searchParams.set('localityLanguage', 'en');
+
+  const response = await fetch(endpoint.toString());
+  if (!response.ok) {
+    throw new Error('Unable to resolve location');
+  }
+
+  const data = await response.json();
+  const locality = data.locality || data.city || data.principalSubdivision || data.countryName;
+  const country = data.countryCode ? data.countryCode.toUpperCase() : '';
+  if (locality && country) {
+    return `${locality}, ${country}`;
+  }
+  return locality || country || null;
+}
+
+async function updateWeatherSummary(coords) {
+  if (!weatherElements.status) {
+    return;
+  }
+
+  safeText(weatherElements.status, 'Loading local weather…');
+
+  try {
+    const [weatherData, prettyLocation] = await Promise.all([
+      fetchWeather(coords.latitude, coords.longitude),
+      fetchLocationName(coords.latitude, coords.longitude).catch(() => coords.label || null)
+    ]);
+
+    const current = weatherData.current || {};
+    const description = resolveWeatherDescription(current.weather_code);
+
+    safeText(weatherElements.temperature, `${Math.round(current.temperature_2m ?? 0)}°C`);
+    safeText(weatherElements.description, description.label);
+    safeText(weatherElements.location, prettyLocation || coords.label || 'Your area');
+    safeText(weatherElements.wind, `${Math.round(current.wind_speed_10m ?? 0)} km/h`);
+    safeText(weatherElements.humidity, `${Math.round(current.relative_humidity_2m ?? 0)}%`);
+    safeText(weatherElements.feelsLike, `${Math.round(current.apparent_temperature ?? current.temperature_2m ?? 0)}°C`);
+    safeText(weatherElements.status, `Updated at ${formatTimeLabel(current.time)}.`);
+    safeText(weatherElements.footnote, 'Powered by Open-Meteo');
+
+    if (weatherElements.icon) {
+      weatherElements.icon.textContent = description.icon;
+    }
+  } catch (error) {
+    safeText(weatherElements.status, 'Unable to load weather right now. Try again later.');
+    console.error('Memory Cue weather', error);
+  }
+}
+
+function requestWeather() {
+  if (!weatherElements.status) {
+    return;
+  }
+
+  if (!navigator.geolocation) {
+    updateWeatherSummary(WEATHER_FALLBACK);
+    return;
+  }
+
+  navigator.geolocation.getCurrentPosition(
+    (position) => {
+      updateWeatherSummary({
+        latitude: position.coords.latitude,
+        longitude: position.coords.longitude
+      });
+    },
+    () => {
+      updateWeatherSummary(WEATHER_FALLBACK);
+    },
+    {
+      enableHighAccuracy: false,
+      timeout: 10000,
+      maximumAge: 5 * 60 * 1000
+    }
+  );
+}
+
+function buildStoryLink(story, index) {
+  const listItem = document.createElement('li');
+  const link = document.createElement('a');
+  const order = document.createElement('span');
+  const body = document.createElement('div');
+  const title = document.createElement('p');
+  const source = document.createElement('p');
+
+  const storyUrl = story.url || `https://news.ycombinator.com/item?id=${story.objectID}`;
+  link.href = storyUrl;
+  link.target = '_blank';
+  link.rel = 'noreferrer';
+  link.className = 'flex items-start gap-3 rounded-xl border border-transparent px-3 py-2 transition hover:border-base-300 hover:text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary';
+
+  order.className = 'text-xs font-semibold uppercase tracking-[0.3em] text-base-content/50';
+  order.textContent = `${index + 1}`.padStart(2, '0');
+
+  title.className = 'font-medium text-base-content';
+  title.textContent = story.title || 'Untitled story';
+
+  source.className = 'text-xs text-base-content/60';
+  source.textContent = extractHostname(storyUrl);
+
+  body.className = 'space-y-1';
+  body.append(title, source);
+
+  link.append(order, body);
+  listItem.append(link);
+  return listItem;
+}
+
+function extractHostname(url) {
+  try {
+    const hostname = new URL(url).hostname;
+    return hostname.replace(/^www\./, '');
+  } catch (error) {
+    return 'news.ycombinator.com';
+  }
+}
+
+async function fetchTopStories() {
+  const response = await fetch('https://hn.algolia.com/api/v1/search?tags=front_page');
+  if (!response.ok) {
+    throw new Error('Unable to fetch news');
+  }
+  return response.json();
+}
+
+async function updateNewsCard() {
+  if (!newsElements.status) {
+    return;
+  }
+
+  safeText(newsElements.status, 'Loading top stories…');
+
+  try {
+    const data = await fetchTopStories();
+    const stories = Array.isArray(data.hits) ? data.hits.slice(0, 4) : [];
+
+    if (!stories.length) {
+      throw new Error('No news stories returned');
+    }
+
+    const leadStory = stories[0];
+    const leadUrl = leadStory.url || `https://news.ycombinator.com/item?id=${leadStory.objectID}`;
+    safeText(newsElements.headline, leadStory.title || 'Top story');
+    safeText(newsElements.source, extractHostname(leadUrl));
+
+    if (newsElements.primaryLink) {
+      newsElements.primaryLink.href = leadUrl;
+    }
+
+    if (newsElements.topStories) {
+      newsElements.topStories.textContent = '';
+      stories.slice(1, 4).forEach((story, index) => {
+        newsElements.topStories.appendChild(buildStoryLink(story, index + 1));
+      });
+    }
+
+    if (newsElements.content) {
+      newsElements.content.classList.remove('hidden');
+    }
+
+    safeText(newsElements.status, 'Latest headlines are ready.');
+    safeText(newsElements.footnote, `Updated ${formatTimeLabel(new Date())}`);
+  } catch (error) {
+    safeText(newsElements.status, 'Unable to load headlines right now.');
+    if (newsElements.content) {
+      newsElements.content.classList.add('hidden');
+    }
+    console.error('Memory Cue news', error);
+  }
+}
+
+function initDashboardInsights() {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  if (weatherElements.status) {
+    requestWeather();
+  }
+
+  if (newsElements.status) {
+    updateNewsCard();
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initDashboardInsights, { once: true });
+} else {
+  initDashboardInsights();
+}


### PR DESCRIPTION
## Summary
- replace the dashboard hero card with two insight cards dedicated to local weather and a curated list of top news stories
- add a dashboard-insights module that fetches geolocation-aware weather data from Open-Meteo/BigDataCloud and top stories from the Hacker News front page, updating the new cards in real time
- extend the CSP connect-src directive and load the new module on the page so the data sources are allowed and initialised

## Testing
- `npm test` *(fails: existing Jest harness cannot run ESM-based modules such as js/reminders.js and mobile.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918e0e4cd7c8324ae2fb3b14d66898e)