### PR TITLE
Improve notes pane contrast

### DIFF
--- a/css/teacher.css
+++ b/css/teacher.css
@@ -768,10 +768,11 @@ input::placeholder, textarea::placeholder {
   outline: none;
   line-height: 1.6;
   color: var(--text-primary);
+  background: var(--bg-secondary);
 }
 
 .notes-content:focus {
-  background: var(--bg-primary);
+  background: var(--bg-tertiary);
 }
 
 /* Resource List */


### PR DESCRIPTION
## Summary
- lighten the notes editor background so the desktop writing pane is easier to read
- provide a slightly darker highlight colour while the notes pane has focus for contrast

## Testing
- `npm test -- --runInBand` *(fails: existing Jest suites cannot load ES module style imports in reminders.js and mobile.js, causing "Cannot use import statement outside a module" errors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691936c81b8c8324b738ec2978ad0066)