### PR TITLE
Make dashboard widgets full width

### DIFF
--- a/docs/styles/index.css
+++ b/docs/styles/index.css
@@ -1063,11 +1063,19 @@ html {
   .dashboard-widgets-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
+  .dashboard-widgets-grid > .dashboard-widget {
+    grid-column: span 2;
+  }
 }
 
 @media (min-width: 1024px) {
   .dashboard-widgets-grid {
     grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  .dashboard-widgets-grid > .dashboard-widget {
+    grid-column: span 6;
   }
 }
 
@@ -1084,11 +1092,11 @@ html {
   }
 
   .dashboard-widget--primary {
-    grid-column: span 3;
+    grid-column: span 6;
   }
 
   .dashboard-widget--secondary {
-    grid-column: span 3;
+    grid-column: span 6;
   }
 }
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -1695,11 +1695,19 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   .dashboard-widgets-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
+  .dashboard-widgets-grid > .dashboard-widget {
+    grid-column: span 2;
+  }
 }
 
 @media (min-width: 1024px) {
   .dashboard-widgets-grid {
     grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  .dashboard-widgets-grid > .dashboard-widget {
+    grid-column: span 6;
   }
 }
 
@@ -1716,11 +1724,11 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   }
 
   .dashboard-widget--primary {
-    grid-column: span 3;
+    grid-column: span 6;
   }
 
   .dashboard-widget--secondary {
-    grid-column: span 3;
+    grid-column: span 6;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure every dashboard widget spans the full grid width on tablet and desktop breakpoints so the panels share a consistent size
- keep the reminders and notes experiences consistent by mirroring the CSS change in the generated docs bundle

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919387016f48324aa7d3221ac5b71e8)