### PR TITLE
Tighten professional hero width and reminders grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -388,11 +388,11 @@
     <main id="mainContent" class="desktop-main" tabindex="-1">
       <div class="desktop-main-inner space-y-8">
       <section data-route="dashboard" class="space-y-6 lg:space-y-12">
-        <section class="desktop-panel grid gap-4 lg:grid-cols-2">
+        <section class="desktop-panel desktop-hero grid gap-4 lg:grid-cols-2">
           <article class="dashboard-card card dashboard-card--hero relative overflow-hidden bg-gradient-to-br from-sky-100 via-base-100 to-base-200/70">
             <div class="pointer-events-none absolute -top-24 left-1/2 h-64 w-64 -translate-x-1/2 rounded-full bg-primary/20 blur-3xl" aria-hidden="true"></div>
             <div class="pointer-events-none absolute bottom-[-6rem] right-[-4rem] h-72 w-72 rounded-full bg-secondary/30 blur-3xl" aria-hidden="true"></div>
-            <div class="dashboard-card-content relative space-y-5">
+            <div class="dashboard-card-content hero-content relative space-y-5">
               <div class="flex flex-wrap items-start justify-between gap-4">
                 <div class="space-y-2">
                   <p class="dashboard-card-eyebrow">Local weather</p>

--- a/styles/index.css
+++ b/styles/index.css
@@ -314,13 +314,22 @@ html[data-theme="professional"] .desktop-shell .desktop-panel {
 }
 
 html[data-theme="professional"] .desktop-shell .desktop-hero {
-  padding-block: 1.5rem;
+  width: 100%;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: clamp(2rem, 3vw, 4rem) 1.5rem;
+  box-sizing: border-box;
   background: radial-gradient(
       circle at top left,
       rgba(99, 102, 241, 0.16),
       rgba(14, 165, 233, 0.12) 45%,
       var(--desktop-surface)
     );
+}
+
+html[data-theme="professional"] .desktop-shell .desktop-hero .hero-content {
+  max-width: 65ch;
+  margin: 0 auto;
 }
 
 html[data-theme="professional"] .desktop-shell .desktop-hero h1 {
@@ -364,13 +373,29 @@ html[data-theme="professional"] .desktop-shell .desktop-panel-toolbar {
 
 html[data-theme="professional"] .desktop-shell .desktop-reminders-list {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1.25rem;
+  margin: 0 auto;
+  width: 100%;
+  max-width: 1180px;
+  padding: 0 1.5rem;
+  box-sizing: border-box;
 }
 
-@media (max-width: 900px) {
+@media (min-width: 1440px) {
+  html[data-theme="professional"] .desktop-shell .desktop-hero {
+    padding: clamp(3rem, 4vw, 6rem) 2rem;
+  }
+
   html[data-theme="professional"] .desktop-shell .desktop-reminders-list {
-    grid-template-columns: minmax(0, 1fr);
+    max-width: 1440px;
+    gap: 1.5rem;
+  }
+}
+
+@media (max-width: 1024px) {
+  html[data-theme="professional"] .desktop-shell .desktop-reminders-list {
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   }
 }
 
@@ -379,19 +404,19 @@ html[data-theme="professional"] .desktop-shell .reminder-item {
   border: 1px solid var(--desktop-border-subtle);
   background-color: var(--desktop-surface-muted);
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
-  padding: 0.45rem 0.55rem;
+  padding: 0.6rem 0.75rem;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
   font-size: 0.8rem;
+  min-width: 0;
   cursor: pointer;
-  transition: transform 0.12s ease, box-shadow 0.12s ease, border-color 0.12s ease;
+  transition: box-shadow 0.15s ease, transform 0.15s ease;
 }
 
 html[data-theme="professional"] .desktop-shell .reminder-item:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 6px 16px rgba(79, 70, 229, 0.18);
-  border-color: color-mix(in srgb, var(--desktop-border-subtle) 45%, var(--desktop-nav-active) 55%);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
 }
 
 html[data-theme="professional"] .desktop-shell .reminder-title {


### PR DESCRIPTION
## Summary
- limit the professional desktop hero container and its inner content so text stays readable on wide screens
- realign the reminders grid with fluid widths, shared max-widths, and hover treatments that match the hero section

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69193a2c892c8324acc5381281347c46)