### PR TITLE
Add planner module and dynamic weekly view

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -718,88 +718,12 @@
             <button type="button" class="rounded-full px-3 py-1 text-base-content/70 hover:bg-base-100">Week 9</button>
           </div>
           <div class="flex flex-wrap items-center gap-2">
-            <button type="button" class="btn btn-sm btn-outline" disabled title="Coming soon">Duplicate plan</button>
-            <button type="button" class="btn btn-sm btn-primary" disabled title="Coming soon">New lesson</button>
+            <button type="button" id="planner-duplicate-btn" class="btn btn-sm btn-outline">Duplicate plan</button>
+            <button type="button" id="planner-new-lesson-btn" class="btn btn-sm btn-primary">New lesson</button>
           </div>
         </div>
-        <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-          <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow">
-            <div class="card-body gap-4">
-              <div>
-                <h2 class="text-lg font-semibold text-base-content">Monday</h2>
-                <p class="text-sm text-base-content/70">Co-teach literacy rotations with Mia. Collect exit slips.</p>
-              </div>
-              <ul class="space-y-2 text-sm text-base-content/70">
-                <li class="flex items-center gap-2">
-                  <span class="badge badge-outline badge-sm text-primary">Workshop</span>
-                  Shared reading focus · 45 mins
-                </li>
-                <li class="flex items-center gap-2">
-                  <span class="badge badge-outline badge-sm text-secondary">Prep</span>
-                  Print small group checklists
-                </li>
-              </ul>
-              <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Add detail</button>
-            </div>
-          </article>
-          <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow">
-            <div class="card-body gap-4">
-              <div>
-                <h2 class="text-lg font-semibold text-base-content">Tuesday</h2>
-                <p class="text-sm text-base-content/70">STEM lab – robotics challenges for groups A &amp; B.</p>
-              </div>
-              <ul class="space-y-2 text-sm text-base-content/70">
-                <li class="flex items-center gap-2">
-                  <span class="badge badge-outline badge-sm text-accent">Lab</span>
-                  Calibrate sensors before class
-                </li>
-                <li class="flex items-center gap-2">
-                  <span class="badge badge-outline badge-sm text-warning">Check-in</span>
-                  Collect student reflections in Notes
-                </li>
-              </ul>
-              <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Add detail</button>
-            </div>
-          </article>
-          <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow">
-            <div class="card-body gap-4">
-              <div>
-                <h2 class="text-lg font-semibold text-base-content">Wednesday</h2>
-                <p class="text-sm text-base-content/70">Parent interviews from 3 PM. Prepare student snapshots.</p>
-              </div>
-              <ul class="space-y-2 text-sm text-base-content/70">
-                <li class="flex items-center gap-2">
-                  <span class="badge badge-outline badge-sm text-secondary">Families</span>
-                  Finalise progress highlights
-                </li>
-                <li class="flex items-center gap-2">
-                  <span class="badge badge-outline badge-sm text-primary">Reminder</span>
-                  Email timetable to staff
-                </li>
-              </ul>
-              <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Add detail</button>
-            </div>
-          </article>
-          <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow">
-            <div class="card-body gap-4">
-              <div>
-                <h2 class="text-lg font-semibold text-base-content">Thursday</h2>
-                <p class="text-sm text-base-content/70">Lesson study · co-design inquiry prompts with team.</p>
-              </div>
-              <ul class="space-y-2 text-sm text-base-content/70">
-                <li class="flex items-center gap-2">
-                  <span class="badge badge-outline badge-sm text-success">Collab</span>
-                  Align goals with team rubric
-                </li>
-                <li class="flex items-center gap-2">
-                  <span class="badge badge-outline badge-sm text-info">Resource</span>
-                  Attach planning template
-                </li>
-              </ul>
-              <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Add detail</button>
-            </div>
-          </article>
-        </div>
+        <p id="planner-week" class="text-sm font-semibold text-base-content/80"></p>
+        <div id="plannerCards" class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"></div>
       </section>
 
       <section data-route="notes" class="space-y-6" style="display: none;">

--- a/index.html
+++ b/index.html
@@ -770,8 +770,8 @@
               <p class="desktop-panel-subtitle">Draft the key lessons, checkpoints, and resources your classes need this week.</p>
             </div>
             <div class="desktop-panel-actions flex flex-wrap items-center gap-2">
-              <button type="button" class="btn btn-sm btn-outline" disabled title="Coming soon">Duplicate plan</button>
-              <button type="button" class="btn btn-sm btn-primary" disabled title="Coming soon">New lesson</button>
+              <button type="button" id="planner-duplicate-btn" class="btn btn-sm btn-outline">Duplicate plan</button>
+              <button type="button" id="planner-new-lesson-btn" class="btn btn-sm btn-primary">New lesson</button>
             </div>
           </header>
           <div class="desktop-panel-toolbar flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">
@@ -779,84 +779,8 @@
             <button type="button" class="btn btn-xs btn-secondary">Week 8</button>
             <button type="button" class="btn btn-xs btn-secondary">Week 9</button>
           </div>
-          <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-            <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow">
-            <div class="card-body gap-4">
-              <div>
-                <h2 class="text-lg font-semibold text-base-content">Monday</h2>
-                <p class="text-sm text-base-content/70">Co-teach literacy rotations with Mia. Collect exit slips.</p>
-              </div>
-              <ul class="space-y-2 text-sm text-base-content/70">
-                <li class="flex items-center gap-2">
-                  <span class="badge badge-outline badge-sm text-primary">Workshop</span>
-                  Shared reading focus · 45 mins
-                </li>
-                <li class="flex items-center gap-2">
-                  <span class="badge badge-outline badge-sm text-secondary">Prep</span>
-                  Print small group checklists
-                </li>
-              </ul>
-              <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Add detail</button>
-            </div>
-          </article>
-          <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow">
-            <div class="card-body gap-4">
-              <div>
-                <h2 class="text-lg font-semibold text-base-content">Tuesday</h2>
-                <p class="text-sm text-base-content/70">STEM lab – robotics challenges for groups A &amp; B.</p>
-              </div>
-              <ul class="space-y-2 text-sm text-base-content/70">
-                <li class="flex items-center gap-2">
-                  <span class="badge badge-outline badge-sm text-accent">Lab</span>
-                  Calibrate sensors before class
-                </li>
-                <li class="flex items-center gap-2">
-                  <span class="badge badge-outline badge-sm text-warning">Check-in</span>
-                  Collect student reflections in Notes
-                </li>
-              </ul>
-              <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Add detail</button>
-            </div>
-          </article>
-          <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow">
-            <div class="card-body gap-4">
-              <div>
-                <h2 class="text-lg font-semibold text-base-content">Wednesday</h2>
-                <p class="text-sm text-base-content/70">Parent interviews from 3 PM. Prepare student snapshots.</p>
-              </div>
-              <ul class="space-y-2 text-sm text-base-content/70">
-                <li class="flex items-center gap-2">
-                  <span class="badge badge-outline badge-sm text-secondary">Families</span>
-                  Finalise progress highlights
-                </li>
-                <li class="flex items-center gap-2">
-                  <span class="badge badge-outline badge-sm text-primary">Reminder</span>
-                  Email timetable to staff
-                </li>
-              </ul>
-              <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Add detail</button>
-            </div>
-          </article>
-          <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow">
-            <div class="card-body gap-4">
-              <div>
-                <h2 class="text-lg font-semibold text-base-content">Thursday</h2>
-                <p class="text-sm text-base-content/70">Lesson study · co-design inquiry prompts with team.</p>
-              </div>
-              <ul class="space-y-2 text-sm text-base-content/70">
-                <li class="flex items-center gap-2">
-                  <span class="badge badge-outline badge-sm text-success">Collab</span>
-                  Align goals with team rubric
-                </li>
-                <li class="flex items-center gap-2">
-                  <span class="badge badge-outline badge-sm text-info">Resource</span>
-                  Attach planning template
-                </li>
-              </ul>
-              <button class="btn btn-sm btn-outline" type="button" disabled title="Coming soon">Add detail</button>
-            </div>
-          </article>
-          </div>
+          <p id="planner-week" class="text-sm font-semibold text-base-content/80"></p>
+          <div id="plannerCards" class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"></div>
         </div>
       </section>
 

--- a/js/modules/planner.js
+++ b/js/modules/planner.js
@@ -1,0 +1,559 @@
+const PLANNER_STORAGE_KEY = 'memoryCue:plannerPlans';
+const PLANNER_UPDATED_EVENT = 'memoryCue:plannerUpdated';
+const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+const DEFAULT_WEEK_TEMPLATE = [
+  {
+    dayIndex: 1,
+    title: 'Monday',
+    summary: 'Co-teach literacy rotations with Mia. Collect exit slips.',
+    details: [
+      { badge: 'Workshop', text: 'Shared reading focus · 45 mins' },
+      { badge: 'Prep', text: 'Print small group checklists' }
+    ]
+  },
+  {
+    dayIndex: 2,
+    title: 'Tuesday',
+    summary: 'STEM lab – robotics challenges for groups A & B.',
+    details: [
+      { badge: 'Lab', text: 'Calibrate sensors before class' },
+      { badge: 'Check-in', text: 'Collect student reflections in Notes' }
+    ]
+  },
+  {
+    dayIndex: 3,
+    title: 'Wednesday',
+    summary: 'Parent interviews from 3 PM. Prepare student snapshots.',
+    details: [
+      { badge: 'Families', text: 'Finalise progress highlights' },
+      { badge: 'Reminder', text: 'Email timetable to staff' }
+    ]
+  },
+  {
+    dayIndex: 4,
+    title: 'Thursday',
+    summary: 'Lesson study · co-design inquiry prompts with team.',
+    details: [
+      { badge: 'Collab', text: 'Align goals with team rubric' },
+      { badge: 'Resource', text: 'Attach planning template' }
+    ]
+  }
+];
+
+const hasLocalStorage = () => {
+  try {
+    return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+  } catch {
+    return false;
+  }
+};
+
+const safeParseJson = (value) => {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+};
+
+const generateId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `planner-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+const clampDayIndex = (index) => {
+  if (!Number.isFinite(index)) {
+    return 0;
+  }
+  if (index < 0) {
+    return 0;
+  }
+  if (index > 6) {
+    return 6;
+  }
+  return index;
+};
+
+const getWeekStart = (date) => {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return null;
+  }
+  const clone = new Date(date);
+  const day = clone.getDay();
+  const diff = (day + 6) % 7; // Monday as the first day.
+  clone.setHours(0, 0, 0, 0);
+  clone.setDate(clone.getDate() - diff);
+  return clone;
+};
+
+const formatDateKey = (date) => {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return '';
+  }
+  const year = String(date.getFullYear());
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const parseWeekId = (weekId) => {
+  if (typeof weekId !== 'string') {
+    return null;
+  }
+  const [yearRaw, monthRaw, dayRaw] = weekId.split('-');
+  const year = Number.parseInt(yearRaw, 10);
+  const month = Number.parseInt(monthRaw, 10);
+  const day = Number.parseInt(dayRaw, 10);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+    return null;
+  }
+  const date = new Date(year, month - 1, day);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  date.setHours(0, 0, 0, 0);
+  return date;
+};
+
+const resolveDayIndexFromName = (value) => {
+  if (typeof value !== 'string') {
+    return 0;
+  }
+  const target = value.trim().toLowerCase();
+  const matchIndex = DAY_NAMES.findIndex((name) => name.toLowerCase() === target);
+  return matchIndex >= 0 ? matchIndex : 0;
+};
+
+const normaliseDetail = (detail) => {
+  if (!detail || typeof detail !== 'object') {
+    return null;
+  }
+  const text = typeof detail.text === 'string' ? detail.text.trim() : '';
+  if (!text) {
+    return null;
+  }
+  const badge = typeof detail.badge === 'string' ? detail.badge.trim() : '';
+  const id = typeof detail.id === 'string' && detail.id.trim() ? detail.id : generateId();
+  return { id, badge, text };
+};
+
+const normaliseLesson = (lesson, fallback = {}) => {
+  const defaults = typeof fallback === 'object' && fallback ? fallback : {};
+  const rawDayIndex = Number.isFinite(lesson?.dayIndex)
+    ? lesson.dayIndex
+    : Number.isFinite(defaults.dayIndex)
+      ? defaults.dayIndex
+      : resolveDayIndexFromName(lesson?.dayName || defaults.dayName || defaults.dayLabel);
+  const dayIndex = clampDayIndex(rawDayIndex);
+  const titleSource = typeof lesson?.title === 'string' && lesson.title.trim().length
+    ? lesson.title.trim()
+    : typeof defaults.title === 'string' && defaults.title.trim().length
+      ? defaults.title.trim()
+      : DAY_NAMES[dayIndex];
+  const summary = typeof lesson?.summary === 'string'
+    ? lesson.summary.trim()
+    : typeof defaults.summary === 'string'
+      ? defaults.summary
+      : '';
+  const detailsSource = Array.isArray(lesson?.details)
+    ? lesson.details
+    : Array.isArray(defaults.details)
+      ? defaults.details
+      : [];
+  const details = detailsSource.map((detail) => normaliseDetail(detail)).filter(Boolean);
+  const id = typeof lesson?.id === 'string' && lesson.id.trim()
+    ? lesson.id
+    : typeof defaults.id === 'string' && defaults.id.trim()
+      ? defaults.id
+      : generateId();
+  return {
+    id,
+    dayIndex,
+    dayLabel: DAY_NAMES[dayIndex] || 'Lesson',
+    title: titleSource,
+    summary,
+    details
+  };
+};
+
+const sortLessons = (lessons) => {
+  return [...lessons].sort((a, b) => {
+    if (a.dayIndex !== b.dayIndex) {
+      return a.dayIndex - b.dayIndex;
+    }
+    return a.title.localeCompare(b.title);
+  });
+};
+
+const normalisePlan = (plan, fallbackWeekId) => {
+  const targetWeekId = typeof plan?.weekId === 'string' && plan.weekId ? plan.weekId : fallbackWeekId;
+  const weekStartDate = parseWeekId(targetWeekId);
+  const lessons = Array.isArray(plan?.lessons) ? plan.lessons.map((lesson) => normaliseLesson(lesson)).filter(Boolean) : [];
+  return {
+    weekId: targetWeekId,
+    startDate: weekStartDate ? weekStartDate.toISOString() : '',
+    lessons: sortLessons(lessons),
+    updatedAt: typeof plan?.updatedAt === 'string' ? plan.updatedAt : new Date().toISOString()
+  };
+};
+
+const readLocalPlans = () => {
+  if (!hasLocalStorage()) {
+    return {};
+  }
+  try {
+    const stored = window.localStorage.getItem(PLANNER_STORAGE_KEY);
+    if (typeof stored !== 'string' || !stored.length) {
+      return {};
+    }
+    const parsed = safeParseJson(stored);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch (error) {
+    console.warn('Unable to read planner data from storage', error);
+    return {};
+  }
+};
+
+const writeLocalPlans = (map) => {
+  if (!hasLocalStorage()) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(PLANNER_STORAGE_KEY, JSON.stringify(map));
+  } catch (error) {
+    console.warn('Unable to persist planner data locally', error);
+  }
+};
+
+const getLocalPlan = (weekId) => {
+  if (!weekId) {
+    return null;
+  }
+  const map = readLocalPlans();
+  const plan = map[weekId];
+  if (!plan) {
+    return null;
+  }
+  return normalisePlan(plan, weekId);
+};
+
+const setLocalPlan = (weekId, plan) => {
+  if (!weekId || !plan) {
+    return plan;
+  }
+  const map = readLocalPlans();
+  map[weekId] = plan;
+  writeLocalPlans(map);
+  return plan;
+};
+
+const plannerCache = new Map();
+let ensureFirestoreFn = null;
+let plannerFirestorePromise = null;
+let shouldUseLocalPlanner = false;
+
+const isPermissionDeniedError = (error) => {
+  const code = typeof error?.code === 'string' ? error.code.toLowerCase() : '';
+  if (code && (code.includes('permission-denied') || code.includes('insufficient-permission'))) {
+    return true;
+  }
+  const message = typeof error?.message === 'string' ? error.message.toLowerCase() : '';
+  return Boolean(message && message.includes('permission'));
+};
+
+const dispatchPlannerUpdated = (plan) => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  try {
+    const event = new CustomEvent(PLANNER_UPDATED_EVENT, { detail: { plan } });
+    document.dispatchEvent(event);
+  } catch (error) {
+    console.warn('Unable to dispatch planner update event', error);
+  }
+};
+
+const ensurePlannerFirestore = async () => {
+  if (!ensureFirestoreFn) {
+    return null;
+  }
+  if (plannerFirestorePromise) {
+    return plannerFirestorePromise;
+  }
+  plannerFirestorePromise = ensureFirestoreFn()
+    .then((base) => {
+      const { db, getCollection } = base || {};
+      const plannerCollection = typeof getCollection === 'function' && db ? getCollection(db, 'plannerPlans') : null;
+      return { ...base, plannerCollection };
+    })
+    .catch((error) => {
+      console.error('Failed to initialise Firestore for planner', error);
+      throw error;
+    });
+  return plannerFirestorePromise;
+};
+
+const getPlannerDocRef = (firestore, weekId) => {
+  if (!firestore) {
+    throw new Error('Planner Firestore context is unavailable');
+  }
+  const { doc, plannerCollection, db } = firestore;
+  if (typeof doc !== 'function') {
+    throw new Error('Firestore document helper is unavailable');
+  }
+  if (plannerCollection) {
+    return doc(plannerCollection, weekId);
+  }
+  return doc(db, 'plannerPlans', weekId);
+};
+
+const cachePlan = (plan) => {
+  if (plan && typeof plan === 'object' && typeof plan.weekId === 'string') {
+    plannerCache.set(plan.weekId, plan);
+  }
+  return plan;
+};
+
+const createDefaultPlan = (weekId) => {
+  const currentWeekId = getWeekIdFromDate();
+  const templateLessons = weekId === currentWeekId ? DEFAULT_WEEK_TEMPLATE : [];
+  return normalisePlan({ weekId, lessons: templateLessons }, weekId);
+};
+
+const ensureLocalPlan = (weekId) => {
+  const existing = getLocalPlan(weekId);
+  if (existing) {
+    cachePlan(existing);
+    return existing;
+  }
+  const fallback = createDefaultPlan(weekId);
+  setLocalPlan(weekId, fallback);
+  cachePlan(fallback);
+  return fallback;
+};
+
+const persistPlan = async (plan) => {
+  if (!plan?.weekId) {
+    return plan;
+  }
+  const normalised = normalisePlan(plan, plan.weekId);
+  setLocalPlan(normalised.weekId, normalised);
+  cachePlan(normalised);
+  if (shouldUseLocalPlanner || !ensureFirestoreFn) {
+    return normalised;
+  }
+  try {
+    const firestore = await ensurePlannerFirestore();
+    if (!firestore) {
+      return normalised;
+    }
+    const ref = getPlannerDocRef(firestore, normalised.weekId);
+    if (typeof firestore.setDoc === 'function') {
+      await firestore.setDoc(ref, normalised, { merge: true });
+    } else {
+      await firestore.updateDoc(ref, normalised);
+    }
+    return normalised;
+  } catch (error) {
+    if (isPermissionDeniedError(error)) {
+      console.warn('Persisting planner data locally due to permission issue', error);
+      shouldUseLocalPlanner = true;
+      return normalised;
+    }
+    console.error('Failed to persist planner plan', error);
+    return normalised;
+  }
+};
+
+export const initPlannerStore = (options = {}) => {
+  if (typeof options.ensureFirestore === 'function') {
+    ensureFirestoreFn = options.ensureFirestore;
+  }
+  if (typeof options.forceLocal === 'boolean') {
+    shouldUseLocalPlanner = options.forceLocal;
+  }
+};
+
+export const getWeekIdFromDate = (date = new Date()) => {
+  const start = getWeekStart(date);
+  return formatDateKey(start);
+};
+
+export const getWeekIdFromOffset = (weekId, offset = 0) => {
+  const base = parseWeekId(weekId);
+  if (!base || !Number.isFinite(offset)) {
+    return weekId;
+  }
+  const next = new Date(base);
+  next.setDate(base.getDate() + offset * 7);
+  return formatDateKey(next);
+};
+
+export const getWeekLabel = (weekId, { short = false } = {}) => {
+  const start = parseWeekId(weekId);
+  if (!start) {
+    return '';
+  }
+  const end = new Date(start);
+  end.setDate(start.getDate() + 6);
+  const monthDayFormatter = new Intl.DateTimeFormat(undefined, { month: 'long', day: 'numeric' });
+  const startLabel = monthDayFormatter.format(start);
+  const endLabel = monthDayFormatter.format(end);
+  const sameYear = start.getFullYear() === end.getFullYear();
+  if (short) {
+    return `Week of ${startLabel}`;
+  }
+  const yearLabel = sameYear ? start.getFullYear() : `${start.getFullYear()} – ${end.getFullYear()}`;
+  return `${startLabel} – ${endLabel}, ${yearLabel}`;
+};
+
+export const loadWeekPlan = async (weekId = getWeekIdFromDate()) => {
+  if (!weekId) {
+    return null;
+  }
+  if (plannerCache.has(weekId)) {
+    return plannerCache.get(weekId);
+  }
+  if (shouldUseLocalPlanner || !ensureFirestoreFn) {
+    return ensureLocalPlan(weekId);
+  }
+  try {
+    const firestore = await ensurePlannerFirestore();
+    if (!firestore) {
+      return ensureLocalPlan(weekId);
+    }
+    const ref = getPlannerDocRef(firestore, weekId);
+    const snapshot = await firestore.getDoc(ref);
+    if (snapshot.exists()) {
+      const data = snapshot.data();
+      const plan = normalisePlan({ ...data, weekId }, weekId);
+      setLocalPlan(weekId, plan);
+      cachePlan(plan);
+      shouldUseLocalPlanner = false;
+      return plan;
+    }
+    const fallback = ensureLocalPlan(weekId);
+    if (typeof firestore.setDoc === 'function') {
+      await firestore.setDoc(ref, fallback, { merge: true });
+    }
+    return fallback;
+  } catch (error) {
+    if (isPermissionDeniedError(error)) {
+      console.warn('Falling back to local planner data due to permission issue', error);
+      shouldUseLocalPlanner = true;
+      return ensureLocalPlan(weekId);
+    }
+    console.error('Failed to load planner data', error);
+    return ensureLocalPlan(weekId);
+  }
+};
+
+export const addLessonToWeek = async (weekId, lessonInput) => {
+  if (!weekId) {
+    return null;
+  }
+  const plan = await loadWeekPlan(weekId);
+  const nextLesson = normaliseLesson(lessonInput);
+  const nextPlan = {
+    ...plan,
+    lessons: sortLessons([...(plan?.lessons || []), nextLesson]),
+    updatedAt: new Date().toISOString()
+  };
+  const persisted = await persistPlan(nextPlan);
+  dispatchPlannerUpdated(persisted);
+  return persisted;
+};
+
+export const updateLessonInWeek = async (weekId, lessonId, updates = {}) => {
+  if (!weekId || !lessonId) {
+    return null;
+  }
+  const plan = await loadWeekPlan(weekId);
+  const lessons = [...(plan?.lessons || [])];
+  const index = lessons.findIndex((lesson) => lesson.id === lessonId);
+  if (index === -1) {
+    return plan;
+  }
+  const updatedLesson = normaliseLesson({ ...lessons[index], ...updates, id: lessonId }, lessons[index]);
+  lessons[index] = updatedLesson;
+  const nextPlan = {
+    ...plan,
+    lessons: sortLessons(lessons),
+    updatedAt: new Date().toISOString()
+  };
+  const persisted = await persistPlan(nextPlan);
+  dispatchPlannerUpdated(persisted);
+  return persisted;
+};
+
+export const deleteLessonFromWeek = async (weekId, lessonId) => {
+  if (!weekId || !lessonId) {
+    return null;
+  }
+  const plan = await loadWeekPlan(weekId);
+  const remaining = (plan?.lessons || []).filter((lesson) => lesson.id !== lessonId);
+  const nextPlan = {
+    ...plan,
+    lessons: sortLessons(remaining),
+    updatedAt: new Date().toISOString()
+  };
+  const persisted = await persistPlan(nextPlan);
+  dispatchPlannerUpdated(persisted);
+  return persisted;
+};
+
+export const addLessonDetail = async (weekId, lessonId, detailInput) => {
+  if (!weekId || !lessonId) {
+    return null;
+  }
+  const plan = await loadWeekPlan(weekId);
+  const lessons = [...(plan?.lessons || [])];
+  const index = lessons.findIndex((lesson) => lesson.id === lessonId);
+  if (index === -1) {
+    return plan;
+  }
+  const detail = normaliseDetail(detailInput);
+  if (!detail) {
+    return plan;
+  }
+  const currentLesson = lessons[index];
+  const nextLesson = {
+    ...currentLesson,
+    details: [...(currentLesson.details || []), detail]
+  };
+  lessons[index] = nextLesson;
+  const nextPlan = {
+    ...plan,
+    lessons: sortLessons(lessons),
+    updatedAt: new Date().toISOString()
+  };
+  const persisted = await persistPlan(nextPlan);
+  dispatchPlannerUpdated(persisted);
+  return persisted;
+};
+
+export const duplicateWeekPlan = async (sourceWeekId, targetWeekId) => {
+  if (!sourceWeekId || !targetWeekId) {
+    return null;
+  }
+  const sourcePlan = await loadWeekPlan(sourceWeekId);
+  const duplicatedLessons = (sourcePlan?.lessons || []).map((lesson) => ({
+    title: lesson.title,
+    summary: lesson.summary,
+    dayIndex: lesson.dayIndex,
+    details: (lesson.details || []).map((detail) => ({
+      badge: detail.badge,
+      text: detail.text
+    }))
+  }));
+  const nextPlan = normalisePlan({ weekId: targetWeekId, lessons: duplicatedLessons }, targetWeekId);
+  nextPlan.updatedAt = new Date().toISOString();
+  const persisted = await persistPlan(nextPlan);
+  dispatchPlannerUpdated(persisted);
+  return persisted;
+};
+
+export { PLANNER_UPDATED_EVENT };


### PR DESCRIPTION
## Summary
- add a planner storage module that mirrors the daily list fallback logic and exposes helpers to load, mutate, and duplicate week plans
- wire the new module into the dashboard by rendering planner cards dynamically, handling CRUD operations, and updating the planner metrics only when planner data is available
- replace the hard-coded planner markup in the main and docs builds with dynamic containers and enable the toolbar buttons

## Testing
- `npm test` *(fails: existing Jest suite cannot import the ESM reminders/mobile modules and aborts with "SyntaxError: Cannot use import statement outside a module")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69193818a37c8324bcc3adede3e6fb6c)