### PR TITLE
Adjust dashboard hero grid layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -388,7 +388,7 @@
     <main id="mainContent" class="desktop-main" tabindex="-1">
       <div class="desktop-main-inner space-y-8">
       <section data-route="dashboard" class="space-y-6 lg:space-y-12">
-        <section class="desktop-panel grid gap-4 lg:grid-cols-2">
+        <section class="desktop-panel grid gap-4 sm:grid-cols-2">
           <article class="dashboard-card card dashboard-card--hero relative overflow-hidden bg-gradient-to-br from-sky-100 via-base-100 to-base-200/70">
             <div class="pointer-events-none absolute -top-24 left-1/2 h-64 w-64 -translate-x-1/2 rounded-full bg-primary/20 blur-3xl" aria-hidden="true"></div>
             <div class="pointer-events-none absolute bottom-[-6rem] right-[-4rem] h-72 w-72 rounded-full bg-secondary/30 blur-3xl" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- ensure the dashboard hero widget grid uses two columns starting at the small breakpoint so weather and top stories sit next to each other

## Testing
- `npm test -- --runTestsByPath sample.test.js`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69193a54887c8324ad60bf15a708ed1a)