### PR TITLE
Update planner count sync to planner data

### DIFF
--- a/js/modules/planner.js
+++ b/js/modules/planner.js
@@ -410,6 +410,21 @@ export const getWeekLabel = (weekId, { short = false } = {}) => {
   return `${startLabel} – ${endLabel}, ${yearLabel}`;
 };
 
+export const getPlannerLessonsForWeek = (weekId = getWeekIdFromDate()) => {
+  if (!weekId) {
+    return [];
+  }
+  const cached = plannerCache.get(weekId);
+  if (cached && Array.isArray(cached.lessons)) {
+    return [...cached.lessons];
+  }
+  const localPlan = getLocalPlan(weekId);
+  if (Array.isArray(localPlan?.lessons)) {
+    return [...localPlan.lessons];
+  }
+  return [];
+};
+
 export const loadWeekPlan = async (weekId = getWeekIdFromDate()) => {
   if (!weekId) {
     return null;


### PR DESCRIPTION
## Summary
- expose a synchronous getter from the planner module so other components can read the latest lessons for the current week
- refactor the dashboard’s `plannerCount` helper to consume planner lessons instead of daily tasks and drop the old `trackPlannerCountFromPromise` coupling
- trigger planner count refreshes from planner events/mutations and leave the daily list logic focused solely on task rendering

## Testing
- `npm test` *(fails: existing Jest suites that load ESM modules via `vm.runInNewContext` error with "SyntaxError: Cannot use import statement outside a module" when importing `js/reminders.js` / `mobile.js`)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69193badf5108324872e2ec86fd13091)