### PR TITLE
Shrink weather dashboard card

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -1197,7 +1197,7 @@ section[data-route="dashboard"] .dashboard-card--compact .card-body {
 }
 
 section[data-route="dashboard"] .dashboard-card--hero .dashboard-card-content {
-  padding: clamp(2.25rem, 3vw, 3rem);
+  padding: clamp(1.7rem, 2.25vw, 2.25rem);
 }
 
 section[data-route="dashboard"] .dashboard-card-title {
@@ -1208,9 +1208,47 @@ section[data-route="dashboard"] .dashboard-card-title {
 }
 
 section[data-route="dashboard"] .dashboard-card-title--hero {
-  font-size: clamp(2.1rem, 4vw, 2.85rem);
+  font-size: clamp(1.575rem, 3vw, 2.1375rem);
   line-height: 1.1;
   color: hsl(var(--bc));
+}
+
+section[data-route="dashboard"] .dashboard-card--hero .dashboard-card-eyebrow {
+  font-size: 0.5625rem;
+  letter-spacing: 0.24em;
+}
+
+section[data-route="dashboard"] .dashboard-card--hero #weatherIcon,
+section[data-route="dashboard"] .dashboard-card--hero #weatherTemperature {
+  font-size: 2.25rem;
+}
+
+section[data-route="dashboard"] .dashboard-card--hero #weatherStatus {
+  font-size: 0.65625rem;
+}
+
+section[data-route="dashboard"] .dashboard-card--hero #weatherDescription {
+  font-size: 0.75rem;
+}
+
+section[data-route="dashboard"] .dashboard-card--hero dl {
+  gap: 0.75rem;
+}
+
+section[data-route="dashboard"] .dashboard-card--hero dt {
+  font-size: 0.5625rem;
+  letter-spacing: 0.24em;
+}
+
+section[data-route="dashboard"] .dashboard-card--hero #weatherLocation,
+section[data-route="dashboard"] .dashboard-card--hero #weatherWind,
+section[data-route="dashboard"] .dashboard-card--hero #weatherHumidity,
+section[data-route="dashboard"] .dashboard-card--hero #weatherFeelsLike {
+  font-size: 0.75rem;
+}
+
+section[data-route="dashboard"] .dashboard-card--hero #weatherFootnote {
+  font-size: 0.5625rem;
 }
 
 section[data-route="dashboard"] .dashboard-card-text {


### PR DESCRIPTION
## Summary
- reduce the hero weather card padding and typography to make it roughly 75% of its previous size
- tighten spacing and supporting text styles so the widget no longer dominates the dashboard

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69193d4225848324afc0cc440ae53e35)