### PR TITLE
Add planner quick action handler

### DIFF
--- a/app.js
+++ b/app.js
@@ -531,6 +531,59 @@ if (settingsSaveButton && settingsSaveConfirmation) {
   });
 }
 
+function handlePlannerQuickAction(event) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  event.preventDefault();
+
+  const targetRoute = 'planner';
+  const targetHash = '#planner';
+
+  if (window.location.hash !== targetHash) {
+    window.location.hash = targetHash;
+  }
+
+  if (typeof window.renderRoute === 'function') {
+    window.renderRoute();
+  }
+
+  scheduleRouteFocus(targetRoute);
+
+  if (liveStatusRegion) {
+    liveStatusRegion.textContent = 'Opening planner to add a new lesson.';
+  }
+
+  initPlannerView();
+
+  window.requestAnimationFrame(() => {
+    const result = handlePlannerNewLesson();
+    if (result && typeof result.catch === 'function') {
+      result.catch((error) => {
+        console.error('Planner quick action failed to start new lesson flow', error);
+      });
+    }
+  });
+}
+
+function initPlannerQuickActions() {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const plannerQuickActions = document.querySelectorAll('[data-quick-action="planner"]');
+  if (!plannerQuickActions.length) {
+    return;
+  }
+
+  plannerQuickActions.forEach((action) => {
+    action.addEventListener('click', handlePlannerQuickAction);
+  });
+}
+
+initPlannerQuickActions();
+
 const titleInput = document.getElementById('reminder-title');
 const mobileTitleInput = document.getElementById('reminderText');
 


### PR DESCRIPTION
## Summary
- add a planner quick-action listener that switches the hash router to the planner route, announces the jump, and triggers the existing new-lesson workflow
- ensure the planner view is initialised before invoking the new-lesson prompts so the quick action fulfils its label

## Testing
- npm test -- --runInBand *(fails: existing Jest suites cannot import ESM modules such as js/reminders.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69193cf09f4083249e304773a54377ab)