### PR TITLE
Update dashboard news section to focus on education

### DIFF
--- a/index.html
+++ b/index.html
@@ -429,11 +429,11 @@
           <article class="dashboard-card card border border-base-300 bg-base-100/90 shadow-sm">
             <div class="dashboard-card-content card-body gap-5">
               <div class="space-y-2">
-                <p class="dashboard-card-eyebrow">Top stories</p>
+                <p class="dashboard-card-eyebrow">Top educational news</p>
                 <h2 class="dashboard-card-title">Start conversations informed</h2>
               </div>
               <p id="newsStatus" class="dashboard-card-text text-sm text-base-content/70" role="status" aria-live="polite">
-                Gathering the latest headlines…
+                Gathering the top educational news…
               </p>
               <div id="newsContent" class="hidden space-y-4">
                 <a

--- a/js/dashboard-insights.js
+++ b/js/dashboard-insights.js
@@ -251,7 +251,7 @@ async function updateNewsCard() {
       newsElements.content.classList.remove('hidden');
     }
 
-    safeText(newsElements.status, 'Latest headlines are ready.');
+    safeText(newsElements.status, 'Top educational news is ready.');
     safeText(newsElements.footnote, `Updated ${formatTimeLabel(new Date())}`);
   } catch (error) {
     safeText(newsElements.status, 'Unable to load headlines right now.');


### PR DESCRIPTION
## Summary
- retitle the dashboard news card to "Top educational news" and adjust its loading message
- update the news status text shown after headlines load to mention educational news

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69193ec1e3c483248a2a87c9a9b99988)