### PR TITLE
Simplify dashboard weather card

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,16 +384,12 @@
     <main id="mainContent" class="desktop-main" tabindex="-1">
       <div class="desktop-main-inner space-y-8">
       <section data-route="dashboard" class="space-y-6 lg:space-y-12">
-        <section class="desktop-panel desktop-hero grid gap-4 lg:grid-cols-2">
+        <section class="desktop-panel desktop-hero grid gap-4 lg:grid-cols-[1fr_3fr]">
           <article class="dashboard-card card dashboard-card--hero relative overflow-hidden bg-gradient-to-br from-sky-100 via-base-100 to-base-200/70">
             <div class="pointer-events-none absolute -top-24 left-1/2 h-64 w-64 -translate-x-1/2 rounded-full bg-primary/20 blur-3xl" aria-hidden="true"></div>
             <div class="pointer-events-none absolute bottom-[-6rem] right-[-4rem] h-72 w-72 rounded-full bg-secondary/30 blur-3xl" aria-hidden="true"></div>
             <div class="dashboard-card-content hero-content relative space-y-5">
-              <div class="flex flex-wrap items-start justify-between gap-4">
-                <div class="space-y-2">
-                  <p class="dashboard-card-eyebrow">Local weather</p>
-                  <h2 class="dashboard-card-title dashboard-card-title--hero">Plan for the elements</h2>
-                </div>
+              <div class="flex justify-end">
                 <span id="weatherIcon" class="text-5xl" aria-hidden="true">⛅️</span>
               </div>
               <p id="weatherStatus" class="dashboard-card-text text-sm text-base-content/70" role="status" aria-live="polite">


### PR DESCRIPTION
## Summary
- remove the dashboard hero eyebrow/title so the weather widget only presents the live data
- adjust the dashboard hero grid so the weather card only occupies half of its previous width

## Testing
- `npm test -- --runInBand` *(fails: existing SyntaxError: Cannot use import statement outside a module in multiple reminders/mobile Jest suites)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69193f39f21083249ac243a628fd5fae)