### PR TITLE
Refresh mobile reminder cards

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1842,8 +1842,192 @@
       flex: 1 1 auto;
     }
   </style>
+  <style id="mobile-reminder-card-refresh">
+    .mobile-shell #reminderList,
+    .mobile-shell .reminder-list {
+      padding: 0 0.75rem;
+      width: 100%;
+      box-sizing: border-box;
+    }
+
+    .mobile-shell #reminderList {
+      gap: 0.9rem;
+    }
+
+    .mobile-shell #reminderList.grid-cols-2 {
+      gap: 0.9rem;
+    }
+
+    .mobile-shell #reminderList.space-y-3 {
+      gap: 0;
+    }
+
+    .mobile-shell #reminderList > .reminder-card {
+      width: 100%;
+      background-color: var(--desktop-surface, var(--card-bg));
+      border-radius: 12px;
+      border: 1px solid var(--card-border);
+      border-left: 4px solid var(--card-border);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+      padding: 0.9rem 1rem;
+      padding-left: calc(1rem - 4px);
+      margin-bottom: 0.9rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+      min-height: 48px;
+      line-height: 1.4;
+      transition: transform 0.12s ease, box-shadow 0.12s ease, border-color 0.12s ease;
+      touch-action: manipulation;
+    }
+
+    .dark .mobile-shell #reminderList > .reminder-card {
+      background-color: color-mix(in srgb, var(--text-primary) 24%, rgba(15, 23, 42, 0.92) 76%);
+      border-color: color-mix(in srgb, var(--card-border) 55%, transparent);
+      box-shadow: 0 3px 14px rgba(15, 23, 42, 0.6);
+    }
+
+    .mobile-shell #reminderList.space-y-3 > .reminder-card:last-child,
+    .mobile-shell #reminderList > .reminder-card:last-child {
+      margin-bottom: 0;
+    }
+
+    .mobile-shell #reminderList > .reminder-card:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--accent-color) 55%, transparent);
+      outline-offset: 2px;
+    }
+
+    .mobile-shell #reminderList > .reminder-card:active {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.09);
+    }
+
+    @media (hover: hover) {
+      .mobile-shell #reminderList > .reminder-card:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.09);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .mobile-shell #reminderList > .reminder-card,
+      .mobile-shell #reminderList > .reminder-card:hover,
+      .mobile-shell #reminderList > .reminder-card:active {
+        transition: box-shadow 0.12s ease, border-color 0.12s ease;
+        transform: none;
+      }
+    }
+
+    .mobile-shell #reminderList > .reminder-card.priority-high {
+      border-left-color: var(--priority-high-border);
+    }
+
+    .mobile-shell #reminderList > .reminder-card.priority-medium {
+      border-left-color: var(--priority-medium-border);
+    }
+
+    .mobile-shell #reminderList > .reminder-card.priority-low {
+      border-left-color: var(--priority-low-border);
+    }
+
+    .mobile-shell #reminderList > .reminder-card .reminder-primary-row {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.6rem;
+      flex-wrap: wrap;
+    }
+
+    .mobile-shell #reminderList > .reminder-card .reminder-control-slot {
+      flex: 0 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 2.25rem;
+    }
+
+    .mobile-shell #reminderList > .reminder-card .reminder-title-slot {
+      flex: 1 1 auto;
+      min-width: 0;
+    }
+
+    .mobile-shell #reminderList > .reminder-card .reminder-title-slot > *,
+    .mobile-shell #reminderList > .reminder-card [data-reminder-title] {
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: var(--text-primary, var(--desktop-text-main));
+      line-height: 1.3;
+      margin: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+      word-break: break-word;
+    }
+
+    .mobile-shell #reminderList > .reminder-card .reminder-meta-slot,
+    .mobile-shell #reminderList > .reminder-card .reminder-secondary-row,
+    .mobile-shell #reminderList > .reminder-card .reminder-due,
+    .mobile-shell #reminderList > .reminder-card .task-meta-text,
+    .mobile-shell #reminderList > .reminder-card time {
+      font-size: 0.78rem;
+      color: var(--text-secondary, var(--desktop-text-muted));
+      line-height: 1.35;
+    }
+
+    .mobile-shell #reminderList > .reminder-card .reminder-meta-slot {
+      flex: 0 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      flex-wrap: wrap;
+      gap: 0.35rem;
+      min-width: 0;
+      text-align: right;
+    }
+
+    .mobile-shell #reminderList > .reminder-card .reminder-meta-slot.reminder-meta-slot--empty {
+      display: none;
+    }
+
+    .mobile-shell #reminderList > .reminder-card .reminder-secondary-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.4rem;
+      align-items: center;
+      width: 100%;
+    }
+
+    .mobile-shell #reminderList > .reminder-card .task-toolbar {
+      margin-left: auto;
+      display: inline-flex;
+      gap: 0.35rem;
+      align-items: center;
+    }
+
+    .mobile-shell #reminderList > .reminder-card .task-toolbar-btn {
+      min-width: 2.5rem;
+      min-height: 2.5rem;
+      border-radius: 999px;
+    }
+
+    .mobile-shell #reminderList > .reminder-card .task-notes {
+      flex-basis: 100%;
+      margin: 0;
+      padding-top: 0.35rem;
+      border-top: 1px solid color-mix(in srgb, var(--card-border) 35%, transparent);
+      font-size: 0.8rem;
+      color: var(--text-secondary, var(--desktop-text-muted));
+    }
+
+    .mobile-shell #reminderList > .reminder-card .priority-pill,
+    .mobile-shell #reminderList > .reminder-card [data-chip="priority"],
+    .mobile-shell #reminderList > .reminder-card .priority-chip-dot {
+      display: none !important;
+    }
+  </style>
 </head>
-<body class="min-h-screen bg-base-200 text-base-content show-full mobile-theme">
+<body class="min-h-screen bg-base-200 text-base-content show-full mobile-theme mobile-shell">
   <a class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-full focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-primary-content" href="#main">Skip to main content</a>
 
   <!-- Clean Mobile Header -->
@@ -2860,7 +3044,7 @@
             Press, hold, and drag a reminder card to reorder your list. Screen reader users can double-tap and hold, then drag to move a reminder.
           </p>
           <p class="text-xs text-base-content/50 mb-2 pb-2 px-4 border-b border-base-200/30">Total reminders: <span id="totalCount">0</span></p>
-          <ul id="reminderList" class="grid grid-cols-2 gap-1 w-full" aria-describedby="reminderReorderHint"></ul>
+          <ul id="reminderList" class="grid grid-cols-2 gap-1 w-full reminder-list" aria-describedby="reminderReorderHint"></ul>
         </div>
       </section>
     </section>


### PR DESCRIPTION
## Summary
- add a dedicated mobile reminder card stylesheet that gives each card a modern container, hover/press feedback, and left-stripe priority accents while improving typography for titles and metadata
- hide the legacy priority pills, ensure reminder text truncates cleanly, and add layout padding so the list stacks with generous spacing on small screens
- tag the reminder list markup and body with helper classes so the new styles only scope to the refreshed mobile shell

## Testing
- `npm test` *(fails: jest cannot execute ESM imports, e.g. "SyntaxError: Cannot use import statement outside a module" when loading js/reminders.js)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691956e8fdb88324a21915a9b43c3d89)