### PR TITLE
Add planner navigation buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -767,9 +767,9 @@
             </div>
           </header>
           <div class="desktop-panel-toolbar flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">
-            <span class="btn btn-xs btn-secondary cursor-default">Week 7</span>
-            <button type="button" class="btn btn-xs btn-secondary">Week 8</button>
-            <button type="button" class="btn btn-xs btn-secondary">Week 9</button>
+            <button type="button" id="planner-prev" class="btn btn-xs btn-secondary" aria-label="View previous week">Prev</button>
+            <button type="button" id="planner-today" class="btn btn-xs btn-secondary" aria-label="Jump to current week">Today</button>
+            <button type="button" id="planner-next" class="btn btn-xs btn-secondary" aria-label="View next week">Next</button>
           </div>
           <p id="planner-week" class="text-sm font-semibold text-base-content/80"></p>
           <div id="plannerCards" class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"></div>


### PR DESCRIPTION
## Summary
- replace the static Week 7/8/9 controls in the planner toolbar with Prev/Today/Next buttons
- wire the new buttons with the IDs expected by the existing planner navigation listeners

## Testing
- Not Run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919570385d08324aa17f7493bd674a9)