### PR TITLE
Add planner lesson modal workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -776,6 +776,96 @@
         </div>
       </section>
 
+      <div id="planner-lesson-modal" class="fixed inset-0 z-50 hidden" aria-hidden="true" inert>
+        <div class="min-h-dvh w-full bg-black/50 flex items-center justify-center px-4" data-planner-modal-backdrop>
+          <div
+            class="w-full max-w-2xl rounded-2xl bg-base-100 p-6 shadow-xl"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="planner-modal-title"
+            aria-describedby="planner-modal-description"
+            tabindex="-1"
+            data-planner-modal-dialog
+          >
+            <div class="flex items-start justify-between gap-4">
+              <div>
+                <p class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Planner</p>
+                <h3 id="planner-modal-title" class="text-xl font-semibold text-base-content">Plan lesson</h3>
+                <p id="planner-modal-description" class="text-sm text-base-content/70">
+                  Capture the lesson details you want to remember this week.
+                </p>
+              </div>
+              <button
+                type="button"
+                class="btn btn-ghost btn-sm"
+                aria-label="Close planner modal"
+                data-planner-modal-close
+              >
+                ✕
+              </button>
+            </div>
+            <form id="planner-lesson-form" class="mt-6 space-y-4" novalidate>
+              <div class="grid gap-4 md:grid-cols-2" data-planner-lesson-section>
+                <label class="block text-sm font-medium text-base-content">
+                  Day
+                  <select id="planner-lesson-day" class="select select-bordered mt-1 w-full" required>
+                    <option value="Monday">Monday</option>
+                    <option value="Tuesday">Tuesday</option>
+                    <option value="Wednesday">Wednesday</option>
+                    <option value="Thursday">Thursday</option>
+                    <option value="Friday">Friday</option>
+                    <option value="Saturday">Saturday</option>
+                    <option value="Sunday">Sunday</option>
+                  </select>
+                </label>
+                <label class="block text-sm font-medium text-base-content">
+                  Title
+                  <input id="planner-lesson-title" type="text" class="input input-bordered mt-1 w-full" required />
+                </label>
+              </div>
+              <label class="block text-sm font-medium text-base-content" data-planner-summary-section>
+                Summary
+                <textarea
+                  id="planner-lesson-summary"
+                  class="textarea textarea-bordered mt-1 w-full"
+                  rows="3"
+                  placeholder="What is the focus for this lesson?"
+                ></textarea>
+              </label>
+              <div class="grid gap-4 md:grid-cols-2 hidden" data-planner-detail-section aria-hidden="true">
+                <label class="block text-sm font-medium text-base-content">
+                  Detail badge (optional)
+                  <input id="planner-detail-badge" type="text" class="input input-bordered mt-1 w-full" />
+                </label>
+                <label class="block text-sm font-medium text-base-content">
+                  Detail text
+                  <textarea
+                    id="planner-detail-text"
+                    class="textarea textarea-bordered mt-1 w-full"
+                    rows="2"
+                    placeholder="Add a quick reminder, resource, or checkpoint."
+                  ></textarea>
+                </label>
+              </div>
+              <div class="space-y-2 hidden" data-planner-duplicate-section aria-hidden="true">
+                <label class="block text-sm font-medium text-base-content">
+                  Week starting Monday (YYYY-MM-DD)
+                  <input id="planner-duplicate-week" type="date" class="input input-bordered mt-1 w-full" />
+                </label>
+                <p class="text-sm text-base-content/70">
+                  Choose the Monday date for the week that should receive a copy of this plan.
+                </p>
+              </div>
+              <p id="planner-modal-error" class="hidden text-sm text-error" aria-live="assertive" aria-hidden="true"></p>
+              <div class="flex flex-wrap items-center justify-end gap-3 pt-2">
+                <button type="button" class="btn" data-planner-modal-close>Cancel</button>
+                <button type="submit" id="planner-modal-submit" class="btn btn-primary">Save lesson</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+
       <section data-route="notes" class="space-y-6" style="display: none;">
         <div class="desktop-panel desktop-panel--notes-intro">
           <header class="desktop-panel-header">


### PR DESCRIPTION
## Summary
- add a dedicated planner lesson modal with fields for day, title, summary, details, and duplication targets
- create a modal controller that manages focus, validation, and submission for add, edit, detail, and duplicate flows
- replace the previous prompt/alert interactions with the new modal-based workflows and keep dashboard rendering in sync

## Testing
- npm test *(fails: existing reminders/mobile vm harness cannot import ESM modules, see failure logs in npm test output)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69195aca4f448324b6830ae35449ef8f)