### PR TITLE
Widen professional dashboard and add Windy radar modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,9 +392,18 @@
               <div class="flex justify-end">
                 <span id="weatherIcon" class="text-5xl" aria-hidden="true">⛅️</span>
               </div>
-              <p id="weatherStatus" class="dashboard-card-text text-sm text-base-content/70" role="status" aria-live="polite">
-                Checking the latest forecast…
-              </p>
+              <div class="weather-status-row">
+                <p id="weatherStatus" class="dashboard-card-text text-sm text-base-content/70" role="status" aria-live="polite">
+                  Checking the latest forecast…
+                </p>
+                <button
+                  type="button"
+                  class="cue-btn-ghost cue-btn-sm"
+                  data-action="open-windy-map"
+                >
+                  View radar
+                </button>
+              </div>
               <div class="flex flex-wrap items-end gap-6">
                 <div>
                   <p id="weatherTemperature" class="text-5xl font-semibold text-base-content">--°C</p>
@@ -1292,6 +1301,15 @@
             </div>
           </form>
         </div>
+      </div>
+    </div>
+  </div>
+  <div class="modal" id="windyWeatherModal" hidden>
+    <div class="modal-box" role="dialog" aria-modal="true" aria-labelledby="windyWeatherModalTitle">
+      <h3 id="windyWeatherModalTitle" class="font-semibold mb-2">Weather radar</h3>
+      <div class="windy-embed-wrapper" data-loaded="false"></div>
+      <div class="modal-action">
+        <button type="button" class="cue-btn-ghost" data-action="close-windy-map">Close</button>
       </div>
     </div>
   </div>

--- a/js/dashboard-insights.js
+++ b/js/dashboard-insights.js
@@ -262,6 +262,68 @@ async function updateNewsCard() {
   }
 }
 
+function initWindyModal() {
+  const openBtn = document.querySelector('[data-action="open-windy-map"]');
+  const closeBtn = document.querySelector('[data-action="close-windy-map"]');
+  const modal = document.getElementById('windyWeatherModal');
+
+  if (!openBtn || !modal) {
+    return;
+  }
+
+  const wrapper = modal.querySelector('.windy-embed-wrapper');
+
+  const loadIframe = () => {
+    if (!wrapper || wrapper.dataset.loaded === 'true') {
+      return;
+    }
+
+    wrapper.innerHTML = `
+        <!-- TODO: Use the Windy "Embed" tool to generate this URL for your preferred zoom/location and paste it here. -->
+        <iframe
+          title="Windy weather map"
+          style="width:100%;height:360px;border:0;border-radius:12px;"
+          src="YOUR_WINDY_EMBED_URL_HERE"
+          loading="lazy"
+        ></iframe>`;
+    wrapper.dataset.loaded = 'true';
+  };
+
+  function hideModal() {
+    modal.hidden = true;
+    modal.setAttribute('aria-hidden', 'true');
+    document.removeEventListener('keydown', handleEscape, true);
+  }
+
+  function handleEscape(event) {
+    if (event.key === 'Escape' && !modal.hidden) {
+      hideModal();
+    }
+  }
+
+  const showModal = () => {
+    modal.hidden = false;
+    modal.removeAttribute('aria-hidden');
+    loadIframe();
+    document.addEventListener('keydown', handleEscape, true);
+    if (closeBtn) {
+      closeBtn.focus();
+    }
+  };
+
+  openBtn.addEventListener('click', showModal);
+
+  if (closeBtn) {
+    closeBtn.addEventListener('click', hideModal);
+  }
+
+  modal.addEventListener('click', (event) => {
+    if (event.target === modal) {
+      hideModal();
+    }
+  });
+}
+
 function initDashboardInsights() {
   if (typeof document === 'undefined') {
     return;
@@ -274,6 +336,8 @@ function initDashboardInsights() {
   if (newsElements.status) {
     updateNewsCard();
   }
+
+  initWindyModal();
 }
 
 if (document.readyState === 'loading') {

--- a/styles/index.css
+++ b/styles/index.css
@@ -282,12 +282,21 @@ html[data-theme="professional"] .desktop-header-nav-tabs .btn:hover {
 
 
 html[data-theme="professional"] .desktop-shell .dashboard-root {
-  max-width: 1180px;
+  max-width: 1320px;
   margin: 0 auto;
-  padding: 1.25rem 1.5rem 2rem;
+  padding: 1.25rem 2.25rem 2.5rem;
   display: grid;
   grid-template-rows: auto 1fr;
   gap: 1rem;
+}
+
+html[data-theme="professional"] .desktop-shell .desktop-hero,
+html[data-theme="professional"] .desktop-shell .desktop-panel,
+html[data-theme="professional"] .desktop-shell .desktop-dashboard-grid {
+  width: 100%;
+  max-width: 1320px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 html[data-theme="professional"] .desktop-shell .desktop-main {
@@ -335,7 +344,7 @@ html[data-theme="professional"] .desktop-shell .desktop-panel-body {
 
 html[data-theme="professional"] .desktop-shell .desktop-hero {
   width: 100%;
-  max-width: 1180px;
+  max-width: 1320px;
   margin: 0 auto;
   padding: clamp(1.4rem, 2vw, 2.5rem);
   box-sizing: border-box;
@@ -559,7 +568,7 @@ html[data-theme="professional"] .desktop-shell .desktop-reminders-list {
   gap: 1.25rem;
   margin: 0 auto;
   width: 100%;
-  max-width: 1180px;
+  max-width: 1320px;
   padding: 0 1.5rem;
   box-sizing: border-box;
 }
@@ -644,6 +653,12 @@ html[data-theme="professional"] .desktop-shell .cue-btn-ghost {
   font-size: 0.8rem;
   padding: 0.35rem 0.7rem;
   color: var(--desktop-nav-text-muted);
+}
+
+html[data-theme="professional"] .desktop-shell .cue-btn-sm {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.85rem;
+  line-height: 1.2;
 }
 
 h1,
@@ -1403,6 +1418,19 @@ section[data-route="dashboard"] .dashboard-card--hero .dashboard-card-eyebrow {
 section[data-route="dashboard"] .dashboard-card--hero #weatherIcon,
 section[data-route="dashboard"] .dashboard-card--hero #weatherTemperature {
   font-size: 2.25rem;
+}
+
+section[data-route="dashboard"] .weather-status-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+section[data-route="dashboard"] .weather-status-row #weatherStatus {
+  flex: 1 1 auto;
+  min-width: 220px;
 }
 
 section[data-route="dashboard"] .dashboard-card--hero #weatherStatus {


### PR DESCRIPTION
## Summary
- increase the professional desktop dashboard container widths to 1320px and keep hero/panel/grid sections centered with refreshed padding so the content uses more horizontal space
- add a dedicated weather status row plus a "View radar" ghost button and modal markup so the hero card can open a Windy radar view without changing the Open-Meteo summary
- initialize a Windy modal controller that lazy-loads the iframe, manages close interactions, and provides a placeholder URL for the eventual embed configuration

## Testing
- `npm test` *(fails: existing Jest suites throw "Cannot use import statement outside a module" when loading reminders.js/mobile.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69196482b8e08324a24868091f93ef9c)