### PR TITLE
Add planner template storage and UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -780,6 +780,23 @@
             <button type="button" id="planner-today" class="btn btn-xs btn-secondary" aria-label="Jump to current week">Today</button>
             <button type="button" id="planner-next" class="btn btn-xs btn-secondary" aria-label="View next week">Next</button>
           </div>
+          <div class="flex flex-wrap items-end gap-3 text-sm text-base-content/80">
+            <label class="form-control w-full max-w-xs md:w-auto">
+              <div class="label py-0">
+                <span class="label-text text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Template</span>
+              </div>
+              <select
+                id="planner-template-select"
+                class="select select-bordered select-sm w-full md:w-56"
+                aria-label="Choose a planner template"
+              >
+                <option value="">No templates saved</option>
+              </select>
+            </label>
+            <button type="button" id="planner-template-save-btn" class="btn btn-sm btn-outline">
+              Save current week as template
+            </button>
+          </div>
           <p id="planner-week" class="text-sm font-semibold text-base-content/80"></p>
           <div id="plannerCards" class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"></div>
         </div>


### PR DESCRIPTION
## Summary
- add a local planner template store along with helpers for persisting template choices with week plans and propagating template IDs to Firestore/local storage
- expose template management in the planner view with a selector for applying saved templates and a button to capture the current week as a reusable template

## Testing
- `npm test` *(fails: existing reminders/mobile Jest suites cannot run because they execute browser modules with `import` statements via `vm.runInNewContext`, leading to "SyntaxError: Cannot use import statement outside a module" before this change as well)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69199befcb208324bb9e9a12f6cfdcc2)