### PR TITLE
Add planner reminder shortcut

### DIFF
--- a/index.html
+++ b/index.html
@@ -1224,6 +1224,13 @@
           Fill out the details below to save a reminder for later.
         </p>
         <form id="add-reminder-form" class="mt-4 space-y-4">
+          <div
+            id="planner-reminder-context"
+            class="hidden rounded-xl bg-base-200/80 px-4 py-3 text-sm text-base-content/80 dark:bg-base-200/20"
+            aria-live="polite"
+            aria-hidden="true"
+          ></div>
+          <input type="hidden" id="planner-reminder-lesson-id" />
           <label class="block">
             <span class="font-medium text-base-content">Title</span>
             <input

--- a/js/modules/planner.js
+++ b/js/modules/planner.js
@@ -533,6 +533,18 @@ export const getWeekIdFromOffset = (weekId, offset = 0) => {
   return formatDateKey(next);
 };
 
+export const getWeekDateForDayIndex = (weekId = getWeekIdFromDate(), dayIndex = 0) => {
+  const weekStart = parseWeekId(weekId);
+  if (!weekStart) {
+    return null;
+  }
+  const resolvedIndex = Number.isFinite(dayIndex) ? dayIndex : 0;
+  const clampedIndex = clampDayIndex(resolvedIndex);
+  const date = new Date(weekStart);
+  date.setDate(weekStart.getDate() + clampedIndex);
+  return date;
+};
+
 export const getWeekLabel = (weekId, { short = false } = {}) => {
   const start = parseWeekId(weekId);
   if (!start) {


### PR DESCRIPTION
## Summary
- add a Create reminder call-to-action to each planner lesson card and wire it up to the desktop reminder modal, prefilling the form with the lesson’s day and summary
- surface the linked lesson context inside the reminder dialog and capture the originating lesson id (`plannerLessonId`) everywhere reminders are stored or synced
- export a helper for retrieving a week’s day date so reminder due dates can default to the lesson’s day

## Testing
- npm test *(fails: existing Jest VM harness cannot import ESM modules and raises “Cannot use import statement outside a module” for the reminders/mobile suites)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919a3879d648324bd13d99413864522)