### PR TITLE
Auto apply preferred planner template

### DIFF
--- a/js/modules/planner.js
+++ b/js/modules/planner.js
@@ -904,6 +904,7 @@ export const applyPlannerTemplate = async (weekId, templateId) => {
   if (!template) {
     return loadWeekPlan(weekId);
   }
+  rememberLastTemplateId(templateId);
   const lessons = Array.isArray(template.lessons)
     ? template.lessons.map((lesson) => ({
         dayIndex: lesson.dayIndex,


### PR DESCRIPTION
## Summary
- add a helper to automatically apply the last-used planner template when a newly loaded week has no saved lessons yet so teachers immediately see their preferred structure
- remember the last-selected template as soon as it is applied so the preference is always stored locally and in Firestore metadata

## Testing
- `npm test` *(fails: multiple suites expect CommonJS but the app modules use ESM imports, producing "Cannot use import statement outside a module")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919a6a284988324a55c2945d0f3db2b)