### PR TITLE
Embed weather radar in desktop dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -396,13 +396,6 @@
                 <p id="weatherStatus" class="dashboard-card-text text-sm text-base-content/70" role="status" aria-live="polite">
                   Checking the latest forecast…
                 </p>
-                <button
-                  type="button"
-                  class="cue-btn-ghost cue-btn-sm"
-                  data-action="open-windy-map"
-                >
-                  View radar
-                </button>
               </div>
               <div class="flex flex-wrap items-end gap-6">
                 <div>
@@ -429,6 +422,15 @@
                 </dl>
               </div>
               <p id="weatherFootnote" class="text-xs text-base-content/60">We use your approximate location to calculate these details.</p>
+              <div class="weather-radar" aria-label="Live radar preview" role="group">
+                <iframe
+                  title="Windy weather radar"
+                  src="https://embed.windy.com/embed2.html?lat=39.8283&lon=-98.5795&detailLat=39.8283&detailLon=-98.5795&width=650&height=450&zoom=4&level=surface&overlay=radar&product=radar&menu=&message=true&marker=false&calendar=now&pressure=true&type=map&location=coordinates&detail=true&metricWind=kmh&metricTemp=default&radarRange=-1"
+                  loading="lazy"
+                  referrerpolicy="no-referrer-when-downgrade"
+                  allowfullscreen="false"
+                ></iframe>
+              </div>
             </div>
           </article>
           <article class="dashboard-card card border border-base-300 bg-base-100/90 shadow-sm">
@@ -1348,15 +1350,6 @@
             </div>
           </form>
         </div>
-      </div>
-    </div>
-  </div>
-  <div class="modal" id="windyWeatherModal" hidden>
-    <div class="modal-box" role="dialog" aria-modal="true" aria-labelledby="windyWeatherModalTitle">
-      <h3 id="windyWeatherModalTitle" class="font-semibold mb-2">Weather radar</h3>
-      <div class="windy-embed-wrapper" data-loaded="false"></div>
-      <div class="modal-action">
-        <button type="button" class="cue-btn-ghost" data-action="close-windy-map">Close</button>
       </div>
     </div>
   </div>

--- a/js/dashboard-insights.js
+++ b/js/dashboard-insights.js
@@ -262,68 +262,6 @@ async function updateNewsCard() {
   }
 }
 
-function initWindyModal() {
-  const openBtn = document.querySelector('[data-action="open-windy-map"]');
-  const closeBtn = document.querySelector('[data-action="close-windy-map"]');
-  const modal = document.getElementById('windyWeatherModal');
-
-  if (!openBtn || !modal) {
-    return;
-  }
-
-  const wrapper = modal.querySelector('.windy-embed-wrapper');
-
-  const loadIframe = () => {
-    if (!wrapper || wrapper.dataset.loaded === 'true') {
-      return;
-    }
-
-    wrapper.innerHTML = `
-        <!-- TODO: Use the Windy "Embed" tool to generate this URL for your preferred zoom/location and paste it here. -->
-        <iframe
-          title="Windy weather map"
-          style="width:100%;height:360px;border:0;border-radius:12px;"
-          src="YOUR_WINDY_EMBED_URL_HERE"
-          loading="lazy"
-        ></iframe>`;
-    wrapper.dataset.loaded = 'true';
-  };
-
-  function hideModal() {
-    modal.hidden = true;
-    modal.setAttribute('aria-hidden', 'true');
-    document.removeEventListener('keydown', handleEscape, true);
-  }
-
-  function handleEscape(event) {
-    if (event.key === 'Escape' && !modal.hidden) {
-      hideModal();
-    }
-  }
-
-  const showModal = () => {
-    modal.hidden = false;
-    modal.removeAttribute('aria-hidden');
-    loadIframe();
-    document.addEventListener('keydown', handleEscape, true);
-    if (closeBtn) {
-      closeBtn.focus();
-    }
-  };
-
-  openBtn.addEventListener('click', showModal);
-
-  if (closeBtn) {
-    closeBtn.addEventListener('click', hideModal);
-  }
-
-  modal.addEventListener('click', (event) => {
-    if (event.target === modal) {
-      hideModal();
-    }
-  });
-}
-
 function initDashboardInsights() {
   if (typeof document === 'undefined') {
     return;
@@ -336,8 +274,6 @@ function initDashboardInsights() {
   if (newsElements.status) {
     updateNewsCard();
   }
-
-  initWindyModal();
 }
 
 if (document.readyState === 'loading') {

--- a/styles/index.css
+++ b/styles/index.css
@@ -1467,6 +1467,21 @@ section[data-route="dashboard"] .dashboard-card--hero #weatherFootnote {
   font-size: 0.5625rem;
 }
 
+section[data-route="dashboard"] .dashboard-card--hero .weather-radar {
+  margin-top: 1rem;
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 10px 25px hsl(var(--bc) / 0.08);
+  border: 1px solid hsl(var(--b2) / 0.3);
+}
+
+section[data-route="dashboard"] .dashboard-card--hero .weather-radar iframe {
+  width: 100%;
+  height: 240px;
+  border: 0;
+  display: block;
+}
+
 section[data-route="dashboard"] .dashboard-card-text {
   font-size: clamp(0.95rem, 1.3vw, 1.05rem);
   color: hsl(var(--bc) / 0.72);


### PR DESCRIPTION
## Summary
- embed a Windy radar iframe directly inside the desktop weather hero card so the radar is always visible
- remove the unused modal markup/script and add styling for the inline radar container

## Testing
- npm test *(fails: existing Jest suites error when loading ESM modules like js/reminders.js – SyntaxError: Cannot use import statement outside a module)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919a87c9ae883248d62e16599b8c7a8)