### PR TITLE
Add planner move controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -2241,6 +2241,28 @@ function renderPlannerLessons(plan) {
       const summaryMarkup = lesson.summary
         ? `<p class="text-sm text-base-content/70">${escapeCueText(lesson.summary)}</p>`
         : '';
+      const moveControls = lessonId
+        ? `
+            <div class="flex items-center gap-1" role="group" aria-label="Reorder lesson">
+              <button
+                type="button"
+                class="btn btn-ghost btn-xs"
+                data-planner-action="move-up"
+                data-lesson-id="${lessonId}"
+              >
+                Move up
+              </button>
+              <button
+                type="button"
+                class="btn btn-ghost btn-xs"
+                data-planner-action="move-down"
+                data-lesson-id="${lessonId}"
+              >
+                Move down
+              </button>
+            </div>
+          `
+        : '';
       return `
         <article class="card border border-base-300 bg-base-200/70 shadow-sm transition hover:-translate-y-1 hover:shadow" ${selectionAttributes}>
           <div class="card-body gap-4">
@@ -2253,22 +2275,7 @@ function renderPlannerLessons(plan) {
                 ${summaryMarkup}
               </div>
               <div class="flex items-center gap-1">
-                <button
-                  type="button"
-                  class="btn btn-ghost btn-xs"
-                  data-planner-action="move-up"
-                  data-lesson-id="${lessonId}"
-                >
-                  Move up
-                </button>
-                <button
-                  type="button"
-                  class="btn btn-ghost btn-xs"
-                  data-planner-action="move-down"
-                  data-lesson-id="${lessonId}"
-                >
-                  Move down
-                </button>
+                ${moveControls}
                 <button type="button" class="btn btn-ghost btn-xs" data-planner-action="edit" data-lesson-id="${lessonId}">
                   Edit
                 </button>

--- a/js/modules/planner.js
+++ b/js/modules/planner.js
@@ -706,22 +706,23 @@ export const movePlannerLesson = async (weekId, lessonId, direction) => {
     return plan;
   }
   const currentLesson = lessons[lessonIndex];
-  const dayLessons = sortLessons(lessons).filter((lesson) => lesson.dayIndex === currentLesson.dayIndex);
-  const currentDayIndex = dayLessons.findIndex((lesson) => lesson.id === lessonId);
+  const dayLessons = lessons.filter((lesson) => lesson.dayIndex === currentLesson.dayIndex);
+  if (dayLessons.length <= 1) {
+    return plan;
+  }
+  const orderedDayLessons = sortLessons(dayLessons);
+  const dayOrderIds = orderedDayLessons.map((lesson) => lesson.id);
+  const currentDayIndex = dayOrderIds.indexOf(lessonId);
   if (currentDayIndex === -1) {
     return plan;
   }
   const targetDayIndex = currentDayIndex + offset;
-  if (targetDayIndex < 0 || targetDayIndex >= dayLessons.length) {
+  if (targetDayIndex < 0 || targetDayIndex >= dayOrderIds.length) {
     return plan;
   }
-  const reordered = [...dayLessons];
-  const [movedLesson] = reordered.splice(currentDayIndex, 1);
-  reordered.splice(targetDayIndex, 0, movedLesson);
-  const updatedPositions = new Map();
-  reordered.forEach((lesson, index) => {
-    updatedPositions.set(lesson.id, index);
-  });
+  const [movedLessonId] = dayOrderIds.splice(currentDayIndex, 1);
+  dayOrderIds.splice(targetDayIndex, 0, movedLessonId);
+  const updatedPositions = new Map(dayOrderIds.map((id, index) => [id, index]));
   const nextLessons = lessons.map((lesson) => {
     if (lesson.dayIndex !== currentLesson.dayIndex) {
       return lesson;


### PR DESCRIPTION
## Summary
- add move-up/move-down controls to planner lesson cards so teachers can reorder their plans
- implement planner lesson move logic that keeps the lessons within their day and emits the usual planner updated event

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919a80004f88324a7d651f0bcf93121)