### PR TITLE
Add focus-visible outline for mobile delete buttons

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -274,6 +274,11 @@
     background-color: rgba(15, 23, 42, 0.08);
   }
 
+  .mobile-shell #notesListMobile .note-item-mobile button[data-role="delete-note"]:focus-visible {
+    outline: 2px solid var(--delete-color);
+    outline-offset: 2px;
+  }
+
   .mobile-shell #notesListMobile .line-clamp-2 {
     display: -webkit-box;
     -webkit-line-clamp: 2;


### PR DESCRIPTION
## Summary
- add a focus-visible outline style for the delete-note buttons in the mobile notebook view to improve keyboard accessibility

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919acf1b86c8324b545ed24312ee82f)