### PR TITLE
Refresh mobile scratch notes UI

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -228,50 +228,75 @@
     transform: translateY(-2px);
   }
 
-  .mobile-shell #notesListMobile .note-item-mobile button[data-role="open-note"] {
-    border-radius: 0.9rem;
-    background-color: var(--desktop-surface-muted, #f8fafc);
-    transition: transform 160ms ease, background-color 160ms ease, border-color 160ms ease;
+  #savedNotesSheet {
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
   }
 
-  .mobile-shell #notesListMobile .note-item-mobile button[data-role="open-note"]:focus-visible {
-    outline: 2px solid var(--accent-color);
-    outline-offset: 2px;
+  #savedNotesSheet[data-open="true"] {
+    opacity: 1;
+    pointer-events: auto;
   }
 
-  .mobile-shell #notesListMobile .note-item-mobile button[data-role="open-note"]:active {
-    transform: scale(0.99);
+  #savedNotesSheet .saved-notes-panel {
+    transform: translateY(100%);
+    transition: transform 0.35s cubic-bezier(0.25, 0.8, 0.25, 1);
+  }
+
+  #savedNotesSheet[data-open="true"] .saved-notes-panel {
+    transform: translateY(0);
+  }
+
+  .note-body-field {
+    position: relative;
+    border-radius: 1.25rem;
+    border: 1px solid color-mix(in srgb, var(--card-border) 85%, transparent);
+    background: color-mix(in srgb, var(--card-bg) 94%, rgba(148, 163, 184, 0.12));
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+    overflow: hidden;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .note-body-field:focus-within {
+    border-color: color-mix(in srgb, var(--accent-color) 70%, var(--card-border));
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-color) 20%, transparent);
+  }
+
+  .note-body-field::before {
+    content: attr(data-placeholder);
+    position: absolute;
+    inset: 0;
+    padding: 1rem 1.25rem;
+    font-size: 0.85rem;
+    color: color-mix(in srgb, var(--text-secondary) 70%, transparent);
+    opacity: 0.9;
+    pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+  }
+
+  .note-body-field[data-has-content="true"]::before,
+  .note-body-field:focus-within::before {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+
+  .note-body-field textarea {
+    position: relative;
+    z-index: 1;
+    background: transparent;
+    border: none;
+    box-shadow: none;
+  }
+
+  .note-body-field textarea::placeholder {
+    color: transparent;
   }
 
   .mobile-shell #notesListMobile .note-item-mobile button[data-role="open-note"][data-state="active"] {
     border-color: var(--accent-color);
-    background: linear-gradient(135deg, rgba(37, 99, 235, 0.06), rgba(56, 189, 248, 0.03));
-  }
-
-  .mobile-shell #savedNotesSheet {
-    opacity: 0;
-    transition: opacity 0.2s ease;
-  }
-
-  .mobile-shell #savedNotesSheet[data-open="true"] {
-    opacity: 1;
-  }
-
-  .mobile-shell #savedNotesSheet > div {
-    transform: translateY(100%);
-    transition: transform 0.25s ease-out;
-  }
-
-  .mobile-shell #savedNotesSheet[data-open="true"] > div {
-    transform: translateY(0);
-  }
-
-  .mobile-shell #notesListMobile .note-item-mobile button[data-role="delete-note"] {
-    background-color: rgba(15, 23, 42, 0.04);
-  }
-
-  .mobile-shell #notesListMobile .note-item-mobile button[data-role="delete-note"]:active {
-    background-color: rgba(15, 23, 42, 0.08);
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(56, 189, 248, 0.05));
+    box-shadow: 0 12px 26px rgba(37, 99, 235, 0.12);
   }
 
   .mobile-shell #notesListMobile .note-item-mobile button[data-role="delete-note"]:focus-visible {
@@ -287,7 +312,7 @@
   }
 
   .mobile-shell #savedNotesSheet {
-    transition: opacity 0.2s ease;
+    transition: opacity 0.25s ease;
     opacity: 0;
   }
 
@@ -295,13 +320,13 @@
     opacity: 1;
   }
 
-  .mobile-shell #savedNotesSheet[data-open="true"] > div {
-    transform: translateY(0);
+  .mobile-shell #savedNotesSheet .saved-notes-panel {
+    transform: translateY(100%);
+    transition: transform 0.35s cubic-bezier(0.25, 0.8, 0.25, 1);
   }
 
-  .mobile-shell #savedNotesSheet > div {
-    transform: translateY(100%);
-    transition: transform 0.25s ease-out;
+  .mobile-shell #savedNotesSheet[data-open="true"] .saved-notes-panel {
+    transform: translateY(0);
   }
 
   .quick-actions-panel {
@@ -3205,17 +3230,17 @@
                   Quick jot pad that syncs with your desktop notebook.
                 </p>
               </div>
-              <div class="flex items-center gap-1">
+              <div class="flex items-center gap-2">
                 <button
                   type="button"
-                  class="btn btn-ghost btn-xs"
+                  class="btn btn-ghost btn-sm rounded-full px-4"
                   data-jump-view="reminders"
                 >
                   Back
                 </button>
                 <button
                   type="button"
-                  class="btn btn-ghost btn-xs"
+                  class="btn btn-outline btn-sm rounded-full px-4"
                   data-action="open-saved-notes"
                 >
                   Saved notes
@@ -3223,47 +3248,62 @@
               </div>
             </header>
 
-            <div class="flex flex-col gap-4">
+            <div class="flex flex-col gap-5">
               <label class="flex flex-col gap-2" for="noteTitleMobile">
                 <span class="text-sm font-medium text-base-content">Title</span>
                 <input
                   id="noteTitleMobile"
                   type="text"
-                  class="input input-bordered input-sm w-full"
+                  class="input input-bordered input-sm w-full rounded-2xl focus-visible:outline-none focus-visible:ring focus-visible:ring-primary/30"
                   placeholder="e.g. Kids basketball schedule – this weekend"
                 />
               </label>
 
-              <div class="flex flex-wrap items-center gap-2">
-                <button id="noteSaveMobile" class="btn btn-primary btn-sm flex-1 min-w-[6rem]" type="button">
-                  Save
-                </button>
+              <div class="flex flex-col gap-2">
                 <button
-                  id="noteNewMobile"
+                  id="noteSaveMobile"
+                  class="btn btn-primary btn-md w-full shadow-md shadow-primary/20"
                   type="button"
-                  class="btn btn-ghost btn-sm flex-1 min-w-[6rem]"
                 >
-                  New note
+                  Save note
                 </button>
-                <button
-                  type="button"
-                  class="btn btn-ghost btn-xs"
-                  data-action="open-saved-notes"
-                >
-                  Saved notes
-                </button>
+                <div class="grid grid-cols-2 gap-2 w-full">
+                  <button
+                    id="noteNewMobile"
+                    type="button"
+                    class="btn btn-outline btn-sm col-span-2 sm:col-span-1"
+                  >
+                    New note
+                  </button>
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-sm col-span-2 sm:col-span-1"
+                    data-action="open-saved-notes"
+                  >
+                    Saved notes
+                  </button>
+                </div>
               </div>
 
               <label class="flex flex-col gap-2" for="noteBodyMobile">
                 <span class="text-sm font-medium text-base-content">Body</span>
-                <textarea
-                  id="noteBodyMobile"
-                  class="textarea textarea-bordered textarea-sm w-full min-h-[160px] leading-snug"
-                  placeholder="Write your note here…"
-                ></textarea>
+                <div class="note-body-wrapper">
+                  <div
+                    class="note-body-field"
+                    data-role="note-body-field"
+                    data-placeholder="Start typing your scratch note…"
+                    data-has-content="false"
+                  >
+                    <textarea
+                      id="noteBodyMobile"
+                      class="textarea textarea-sm w-full min-h-[200px] leading-relaxed resize-none bg-transparent px-4 py-3 text-base-content focus-visible:outline-none focus-visible:ring-0"
+                      placeholder="Start typing your scratch note…"
+                    ></textarea>
+                  </div>
+                </div>
               </label>
 
-              <div class="flex items-center justify-between gap-2 text-[0.7rem] text-base-content/60">
+              <div class="flex items-center justify-between gap-2 text-xs text-base-content/60">
                 <span id="notesStatusText" class="truncate"></span>
                 <span class="flex items-center gap-1 whitespace-nowrap">
                   <span id="notesSyncStatus" class="sync-dot ready" aria-hidden="true"></span>
@@ -3288,39 +3328,41 @@
     data-open="false"
   >
     <div
-      class="absolute inset-x-0 bottom-0 max-h-[80vh] bg-base-100 rounded-t-2xl shadow-2xl flex flex-col"
+      class="saved-notes-panel absolute inset-x-0 bottom-0 max-h-[85vh] bg-base-100 rounded-t-3xl border border-base-200/70 shadow-2xl flex flex-col"
     >
-      <header class="flex items-center justify-between px-4 pt-3 pb-2 border-b border-base-200/70">
-        <div class="flex flex-col">
-          <h3 id="savedNotesSheetTitle" class="text-sm font-semibold">Saved notes</h3>
-          <p class="text-[0.7rem] text-base-content/60">Tap a note to load it here.</p>
+      <header class="flex items-start justify-between gap-3 px-5 pt-4 pb-3 border-b border-base-200/70">
+        <div class="flex flex-col gap-0.5">
+          <h3 id="savedNotesSheetTitle" class="text-base font-semibold">Saved notes</h3>
+          <p class="text-xs text-base-content/60">Tap a note to load it here.</p>
         </div>
         <button
           type="button"
-          class="btn btn-ghost btn-xs"
+          class="btn btn-ghost btn-circle"
           data-action="close-saved-notes"
+          aria-label="Close saved notes"
         >
-          Close
+          ✕
         </button>
       </header>
 
-      <div class="px-4 pt-2 pb-3 border-b border-base-200/60 space-y-2">
+      <div class="px-5 pt-3 pb-4 border-b border-base-200/60 space-y-3">
         <label class="sr-only" for="notesFilterMobile">Filter notes</label>
         <input
           id="notesFilterMobile"
           type="search"
-          class="input input-bordered input-xs w-full text-[0.75rem]"
-          placeholder="Filter by title or text…"
+          class="input input-sm input-bordered w-full rounded-2xl"
+          placeholder="Search saved notes…"
         />
-        <div class="text-[0.7rem] text-base-content/60 text-right">
-          <span id="notesCountMobile" class="whitespace-nowrap"></span>
+        <div class="flex items-center justify-between text-xs font-semibold text-base-content/70">
+          <span class="text-base-content/50 font-medium">Showing</span>
+          <span id="notesCountMobile" class="text-sm font-semibold whitespace-nowrap"></span>
         </div>
       </div>
 
-      <div class="flex-1 overflow-y-auto px-3 pb-4 pt-1">
+      <div class="flex-1 overflow-y-auto px-4 pb-6 pt-3">
         <ul
           id="notesListMobile"
-          class="flex flex-col gap-1.5"
+          class="flex flex-col gap-3 pb-10"
           aria-label="Saved scratch notes"
         ></ul>
       </div>

--- a/mobile.js
+++ b/mobile.js
@@ -307,6 +307,7 @@ const initMobileNotes = () => {
 
   const titleInput = document.getElementById('noteTitleMobile');
   const bodyInput = document.getElementById('noteBodyMobile');
+  const bodyInputWrapper = bodyInput?.closest('[data-role="note-body-field"]');
   const saveButton = document.getElementById('noteSaveMobile');
   const newButton = document.getElementById('noteNewMobile');
   const listElement = document.getElementById('notesListMobile');
@@ -319,6 +320,17 @@ const initMobileNotes = () => {
   if (!titleInput || !bodyInput || !saveButton) {
     return;
   }
+
+  const syncBodyPlaceholderState = () => {
+    if (!bodyInputWrapper || !bodyInput) {
+      return;
+    }
+    const hasContent = typeof bodyInput.value === 'string' && bodyInput.value.trim().length > 0;
+    bodyInputWrapper.setAttribute('data-has-content', hasContent ? 'true' : 'false');
+  };
+
+  syncBodyPlaceholderState();
+  bodyInput.addEventListener('input', syncBodyPlaceholderState);
 
   const debounce = (fn, delay = 200) => {
     let timeoutId;
@@ -419,6 +431,7 @@ const initMobileNotes = () => {
       bodyInput.value = '';
       delete titleInput.dataset.noteOriginalTitle;
       delete bodyInput.dataset.noteOriginalBody;
+      syncBodyPlaceholderState();
       return;
     }
     currentNoteId = note.id;
@@ -426,6 +439,7 @@ const initMobileNotes = () => {
     bodyInput.value = note.body || '';
     titleInput.dataset.noteOriginalTitle = note.title || '';
     bodyInput.dataset.noteOriginalBody = note.body || '';
+    syncBodyPlaceholderState();
   };
 
   const updateListSelection = () => {
@@ -584,12 +598,16 @@ const initMobileNotes = () => {
 
     if (countElement) {
       const totalSaved = allNotes.length;
-      countElement.textContent = `${totalSaved} saved`;
+      const visibleCount = notes.length;
+      countElement.textContent = totalSaved
+        ? `${visibleCount} of ${totalSaved} saved`
+        : 'No saved notes yet';
     }
 
     if (!notes.length) {
       const emptyItem = document.createElement('li');
-      emptyItem.className = 'text-xs italic text-base-content/60 px-1';
+      emptyItem.className =
+        'text-xs italic text-base-content/60 px-3 py-4 text-center rounded-2xl border border-dashed border-base-200/80 bg-base-100/50';
       emptyItem.textContent =
         allNotes.length && getNormalizedFilterQuery()
           ? 'No notes match this filter.'
@@ -600,36 +618,36 @@ const initMobileNotes = () => {
 
     notes.forEach((note) => {
       const listItem = document.createElement('li');
-      listItem.className = 'note-item-mobile';
+      listItem.className = 'note-item-mobile w-full';
 
       const row = document.createElement('div');
-      row.className = 'flex items-stretch gap-1';
+      row.className = 'flex items-center gap-2';
 
       const button = document.createElement('button');
       button.type = 'button';
       button.dataset.noteId = note.id;
       button.dataset.role = 'open-note';
       button.className =
-        'flex-1 text-left rounded-xl border border-base-200/70 bg-base-100 px-3 py-2.5 flex flex-col gap-0.5 active:scale-[0.99] transition-transform';
+        'note-card group flex-1 text-left rounded-2xl border border-base-200/70 bg-base-100 px-4 py-3 flex flex-col gap-1 shadow-sm transition-all duration-200 active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30';
 
       const headerRow = document.createElement('div');
       headerRow.className = 'flex items-center justify-between gap-2';
 
       const titleSpan = document.createElement('span');
-      titleSpan.className = 'text-[0.82rem] font-medium truncate';
+      titleSpan.className = 'text-sm font-semibold truncate text-base-content';
       titleSpan.textContent = note.title || 'Untitled note';
       headerRow.appendChild(titleSpan);
 
       const timestampText = formatNoteTimestamp(note.updatedAt || note.createdAt);
       if (timestampText) {
         const dateSpan = document.createElement('span');
-        dateSpan.className = 'text-[0.7rem] text-base-content/50 whitespace-nowrap';
+        dateSpan.className = 'text-[0.7rem] text-base-content/50 whitespace-nowrap font-medium';
         dateSpan.textContent = timestampText;
         headerRow.appendChild(dateSpan);
       }
 
       const preview = document.createElement('p');
-      preview.className = 'text-[0.75rem] text-base-content/60 line-clamp-2';
+      preview.className = 'text-xs text-base-content/70 line-clamp-2 leading-snug';
       const bodyText =
         typeof note.body === 'string' ? note.body.replace(/\s+/g, ' ').trim() : '';
       preview.textContent = bodyText || 'No body text yet.';
@@ -642,7 +660,7 @@ const initMobileNotes = () => {
       deleteButton.dataset.noteId = note.id;
       deleteButton.dataset.role = 'delete-note';
       deleteButton.className =
-        'shrink-0 w-9 h-9 rounded-full flex items-center justify-center bg-base-200/80 text-base-content/60 text-xs active:scale-95';
+        'btn btn-ghost btn-circle btn-sm shrink-0 text-error/70 hover:text-error focus-visible:outline-none focus-visible:ring focus-visible:ring-error/30';
       deleteButton.setAttribute('aria-label', 'Delete note');
       deleteButton.textContent = '✕';
 


### PR DESCRIPTION
## Summary
- restyle the mobile scratch notes editor with larger inputs, a clear primary save button, and a pseudo-placeholder overlay for the note body
- modernize the saved notes sheet with a sliding panel, refined filter/count UI, and card-like entries that highlight the active note
- update the notes script to keep the new placeholder state in sync, render the refreshed card layout, and display a dynamic "shown vs. total" count

## Testing
- `npm test -- --runInBand` *(fails: existing Jest harness cannot import ES modules such as js/reminders.js and mobile.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919b1be813883248264618823ee6591)