### PR TITLE
Fix planner detail buttons

### DIFF
--- a/app.js
+++ b/app.js
@@ -1442,6 +1442,8 @@ function createPlannerLessonModal() {
 }
 
 const remindersCountElement = document.getElementById('remindersCount');
+const plannerLessonModalController =
+  typeof document !== 'undefined' ? createPlannerLessonModal() : null;
 const plannerCountElement = document.getElementById('plannerCount');
 const plannerSubtitleElement = document.getElementById('plannerSubtitle');
 const resourcesCountElement = document.getElementById('resourcesCount');


### PR DESCRIPTION
## Summary
- instantiate the planner lesson modal controller on load so the modal flows can be triggered from the planner actions
- ensure the controller is available for add detail, add lesson, and duplicate week operations

## Testing
- `npm test -- --runInBand` *(fails: existing Jest suites cannot import the ESM-based reminders/mobile modules in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a5484e06883249fa14177a2fc5b70)