### PR TITLE
Fix planner modal detail inputs being inert

### DIFF
--- a/app.js
+++ b/app.js
@@ -991,7 +991,24 @@ function createPlannerLessonModal() {
   const closeButtons = modal.querySelectorAll('[data-planner-modal-close]');
   const mainContent = document.getElementById('mainContent');
   const primaryNav = document.querySelector('nav[aria-label="Primary"]');
-  const backgroundTargets = [mainContent, primaryNav].filter(Boolean);
+  const backgroundTargets = (() => {
+    const targets = [];
+    if (primaryNav instanceof HTMLElement) {
+      targets.push(primaryNav);
+    }
+    if (mainContent instanceof HTMLElement) {
+      if (mainContent.contains(modal)) {
+        targets.push(
+          ...Array.from(mainContent.children).filter(
+            (child) => child instanceof HTMLElement && child !== modal
+          )
+        );
+      } else {
+        targets.push(mainContent);
+      }
+    }
+    return targets;
+  })();
 
   const focusableSelectors = [
     'a[href]',
@@ -1442,6 +1459,8 @@ function createPlannerLessonModal() {
 }
 
 const remindersCountElement = document.getElementById('remindersCount');
+const plannerLessonModalController =
+  typeof document !== 'undefined' ? createPlannerLessonModal() : null;
 const plannerCountElement = document.getElementById('plannerCount');
 const plannerSubtitleElement = document.getElementById('plannerSubtitle');
 const resourcesCountElement = document.getElementById('resourcesCount');


### PR DESCRIPTION
## Summary
- adjust the planner modal background targeting so only the surrounding UI is marked inert, keeping the modal itself interactive even when it is rendered inside `#mainContent`

## Testing
- `npm test -- --runInBand` *(fails: existing Jest suites cannot import the ESM-based reminders/mobile modules in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a5484e06883249fa14177a2fc5b70)