### PR TITLE
Fix planner detail modal background targeting

### DIFF
--- a/app.js
+++ b/app.js
@@ -991,7 +991,31 @@ function createPlannerLessonModal() {
   const closeButtons = modal.querySelectorAll('[data-planner-modal-close]');
   const mainContent = document.getElementById('mainContent');
   const primaryNav = document.querySelector('nav[aria-label="Primary"]');
-  const backgroundTargets = [mainContent, primaryNav].filter(Boolean);
+  const backgroundTargets = (() => {
+    const targets = [];
+    const modalParent = modal.parentElement;
+    if (primaryNav instanceof HTMLElement) {
+      targets.push(primaryNav);
+    }
+    if (modalParent instanceof HTMLElement) {
+      targets.push(
+        ...Array.from(modalParent.children).filter(
+          (child) => child instanceof HTMLElement && child !== modal
+        )
+      );
+    } else if (mainContent instanceof HTMLElement) {
+      if (mainContent.contains(modal)) {
+        targets.push(
+          ...Array.from(mainContent.children).filter(
+            (child) => child instanceof HTMLElement && !child.contains(modal)
+          )
+        );
+      } else {
+        targets.push(mainContent);
+      }
+    }
+    return targets;
+  })();
 
   const focusableSelectors = [
     'a[href]',
@@ -1442,6 +1466,8 @@ function createPlannerLessonModal() {
 }
 
 const remindersCountElement = document.getElementById('remindersCount');
+const plannerLessonModalController =
+  typeof document !== 'undefined' ? createPlannerLessonModal() : null;
 const plannerCountElement = document.getElementById('plannerCount');
 const plannerSubtitleElement = document.getElementById('plannerSubtitle');
 const resourcesCountElement = document.getElementById('resourcesCount');


### PR DESCRIPTION
## Summary
- stop inerting the planner modal’s parent container so only true siblings and the primary navigation are disabled while the lesson modal is open, keeping the add lesson and add detail forms interactive

## Testing
- `npm test -- --runInBand` *(fails: Jest cannot run because several suites try to import the ESM-based reminders/mobile modules and throw "Cannot use import statement outside a module" syntax errors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a5484e06883249fa14177a2fc5b70)