### PR TITLE
Restore microphone icon to mobile quick add

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -2001,7 +2001,8 @@
             class="mc-quick-voice"
             aria-label="Use voice to add reminder"
           >
-            🎤
+            <span aria-hidden="true">🎤</span>
+            <span class="sr-only">Use voice to add reminder</span>
           </button>
           <button
             id="viewToggle"

--- a/mobile.html
+++ b/mobile.html
@@ -2910,7 +2910,10 @@
             type="button"
             class="mc-quick-voice"
             aria-label="Use voice to add reminder"
-          ></button>
+          >
+            <span aria-hidden="true">🎤</span>
+            <span class="sr-only">Use voice to add reminder</span>
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- restore a visible microphone icon inside the mobile quick add voice button so it is obvious the feature is available again
- mirror the same markup in `docs/mobile.html`, including an accessible screen reader label

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691aae0143ec832492e17b27a0531a95)