### PR TITLE
Refresh planner theme

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -55,6 +55,15 @@ html[data-theme="caramellatte"] {
   --page-bg-highlight: rgba(188, 108, 37, 0.2);
 }
 
+html[data-theme="professional"] {
+  --planner-accent: #3bafda;
+  --planner-accent-muted: #b6e4f3;
+  --planner-bg: #f0faff;
+  --planner-card-bg: #ffffff;
+  --planner-card-border: #b6e4f3;
+  --planner-card-hover: #4cc3ee;
+}
+
 html[data-theme="professional"] body.desktop-shell {
   background:
     radial-gradient(circle at 18% 0%, rgba(99, 102, 241, 0.18), transparent 60%),
@@ -2166,4 +2175,61 @@ section[data-route="dashboard"] .dashboard-shortcuts {
 [data-priority-pill],
 .priority-pill {
   display: none !important;
+}
+
+[data-route="planner"] {
+  background: var(--planner-bg);
+}
+
+[data-route="planner"] .lesson-card,
+[data-route="planner"] .planner-lesson,
+[data-route="planner"] [data-planner-lesson] {
+  background: var(--planner-card-bg);
+  border: 1px solid var(--planner-card-border);
+  border-radius: 12px;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+[data-route="planner"] .lesson-card:hover,
+[data-route="planner"] .planner-lesson:hover,
+[data-route="planner"] [data-planner-lesson]:hover,
+[data-route="planner"] [data-planner-selected="true"] {
+  border-color: var(--planner-card-hover);
+  background: color-mix(in srgb, var(--planner-card-hover) 8%, #ffffff);
+  box-shadow: 0 12px 30px rgba(59, 175, 218, 0.2);
+}
+
+[data-route="planner"] .day-column-header {
+  background: var(--planner-accent);
+  color: white;
+  font-weight: 600;
+}
+
+[data-route="planner"] [data-planner-lesson] .card-body .tracking-[0.3em] {
+  background: var(--planner-accent);
+  color: #ffffff;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  letter-spacing: 0.2em;
+}
+
+[data-route="planner"] .timeline-marker,
+[data-route="planner"] .lesson-chip,
+[data-route="planner"] .planner-badge {
+  background: var(--planner-accent);
+  color: #ffffff;
+  border-radius: 999px;
+}
+
+[data-route="planner"] [data-planner-lesson] .badge {
+  background: var(--planner-accent);
+  border-color: transparent;
+  color: #ffffff;
+}
+
+[data-route="planner"] #planner-week {
+  color: var(--planner-accent);
+  font-weight: 600;
 }


### PR DESCRIPTION
## Summary
- add planner-specific CSS variables to the professional theme so the new color accents can be reused across the view
- scope new layout and hover overrides to `[data-route="planner"]` to brighten the planner UI without affecting other routes
- extend the planner overrides to the actual `[data-planner-lesson]` cards, badges, and week header so the brighter palette is visible in the live planner

## Testing
- `npm test` *(fails: Jest still cannot import the ESM reminders/mobile modules and aborts before running the suites)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691aad1e3c30832490b6ce04cc161acd)