### PR TITLE
Add mobile notes text size control

### DIFF
--- a/app.js
+++ b/app.js
@@ -926,11 +926,22 @@ const plannerTemplateSelect = document.getElementById('planner-template-select')
 const plannerTemplateSaveButton = document.getElementById('planner-template-save-btn');
 const plannerTextSizeSelect = document.querySelector('[data-planner-text-size]');
 const plannerPanelElement = document.querySelector('.desktop-panel--planner');
+const mobileNotesTextSizeSelect = document.querySelector('[data-mobile-notes-text-size]');
+const mobileNotesPanelElement = document.querySelector('.mobile-panel--notes');
 
 const PLANNER_TEXT_SIZE_STORAGE_KEY = 'plannerTextSizePreference';
 const PLANNER_TEXT_SIZE_DEFAULT = 'default';
 const PLANNER_TEXT_SIZE_OPTIONS = new Set(['small', 'default', 'large']);
 const PLANNER_TEXT_SIZE_CLASSES = ['planner-text-small', 'planner-text-default', 'planner-text-large'];
+
+const MOBILE_NOTES_TEXT_SIZE_STORAGE_KEY = 'mobileNotesTextSizePreference';
+const MOBILE_NOTES_TEXT_SIZE_DEFAULT = 'default';
+const MOBILE_NOTES_TEXT_SIZE_OPTIONS = new Set(['small', 'default', 'large']);
+const MOBILE_NOTES_TEXT_SIZE_CLASSES = [
+  'mobile-panel--notes-size-small',
+  'mobile-panel--notes-size-default',
+  'mobile-panel--notes-size-large',
+];
 
 function isPlannerTextSizeSelect(element) {
   return typeof HTMLSelectElement !== 'undefined' && element instanceof HTMLSelectElement;
@@ -964,6 +975,45 @@ const initialPlannerTextSize = readPlannerTextSizePreference();
 applyPlannerTextSize(initialPlannerTextSize);
 if (isPlannerTextSizeSelect(plannerTextSizeSelect)) {
   plannerTextSizeSelect.value = initialPlannerTextSize;
+}
+
+function readMobileNotesTextSizePreference() {
+  if (typeof localStorage === 'undefined') {
+    return MOBILE_NOTES_TEXT_SIZE_DEFAULT;
+  }
+  const stored = localStorage.getItem(MOBILE_NOTES_TEXT_SIZE_STORAGE_KEY);
+  return stored && MOBILE_NOTES_TEXT_SIZE_OPTIONS.has(stored) ? stored : MOBILE_NOTES_TEXT_SIZE_DEFAULT;
+}
+
+function persistMobileNotesTextSizePreference(size) {
+  if (typeof localStorage === 'undefined' || !MOBILE_NOTES_TEXT_SIZE_OPTIONS.has(size)) {
+    return;
+  }
+  localStorage.setItem(MOBILE_NOTES_TEXT_SIZE_STORAGE_KEY, size);
+}
+
+function applyMobileNotesTextSize(size) {
+  if (!mobileNotesPanelElement) {
+    return;
+  }
+  const normalizedSize = MOBILE_NOTES_TEXT_SIZE_OPTIONS.has(size) ? size : MOBILE_NOTES_TEXT_SIZE_DEFAULT;
+  MOBILE_NOTES_TEXT_SIZE_CLASSES.forEach((className) => mobileNotesPanelElement.classList.remove(className));
+  mobileNotesPanelElement.classList.add(`mobile-panel--notes-size-${normalizedSize}`);
+}
+
+const initialMobileNotesTextSize = readMobileNotesTextSizePreference();
+applyMobileNotesTextSize(initialMobileNotesTextSize);
+if (mobileNotesTextSizeSelect instanceof HTMLSelectElement) {
+  mobileNotesTextSizeSelect.value = initialMobileNotesTextSize;
+  mobileNotesTextSizeSelect.addEventListener('change', (event) => {
+    const selectedSize = typeof event.target?.value === 'string' ? event.target.value : MOBILE_NOTES_TEXT_SIZE_DEFAULT;
+    if (!MOBILE_NOTES_TEXT_SIZE_OPTIONS.has(selectedSize)) {
+      mobileNotesTextSizeSelect.value = readMobileNotesTextSizePreference();
+      return;
+    }
+    persistMobileNotesTextSizePreference(selectedSize);
+    applyMobileNotesTextSize(selectedSize);
+  });
 }
 const PLANNER_DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 

--- a/mobile.html
+++ b/mobile.html
@@ -3180,14 +3180,14 @@
     </section>
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: notebook view -->
-    <section data-view="notebook" id="view-notebook" class="view-panel hidden">
+    <section data-view="notebook" id="view-notebook" class="view-panel hidden mobile-panel--notes">
       <div class="flex flex-col gap-4">
         <section class="card bg-base-100 border shadow-sm rounded-2xl">
           <div class="card-body gap-4">
             <header class="flex items-center justify-between gap-2">
               <div class="flex flex-col">
                 <h2 class="card-title text-base leading-tight">Scratch Notes</h2>
-                <p class="text-xs text-base-content/60">
+                <p class="text-xs text-base-content/60" data-note-summary>
                   Quick jot pad that syncs with your desktop notebook.
                 </p>
               </div>
@@ -3246,6 +3246,22 @@
                 </div>
               </div>
 
+              <div
+                class="flex flex-wrap items-center gap-3 rounded-2xl border border-base-200/70 bg-base-100/80 px-3 py-2 text-xs text-base-content/70"
+                data-note-toolbar
+              >
+                <span class="font-semibold text-base-content text-sm">Text size</span>
+                <select
+                  class="select select-bordered select-xs w-full max-w-[160px]"
+                  data-mobile-notes-text-size
+                  aria-label="Select scratch notes text size"
+                >
+                  <option value="small">Small</option>
+                  <option value="default" selected>Default</option>
+                  <option value="large">Large</option>
+                </select>
+              </div>
+
               <label class="flex flex-col gap-2" for="noteBodyMobile">
                 <span class="text-sm font-medium text-base-content">Body</span>
                 <div class="note-body-wrapper">
@@ -3264,7 +3280,7 @@
                 </div>
               </label>
 
-              <div class="flex items-center justify-between gap-2 text-xs text-base-content/60">
+              <div class="flex items-center justify-between gap-2 text-xs text-base-content/60" data-note-detail-list>
                 <span id="notesStatusText" class="truncate"></span>
                 <span class="flex items-center gap-1 whitespace-nowrap">
                   <span id="notesSyncStatus" class="sync-dot ready" aria-hidden="true"></span>

--- a/styles/index.css
+++ b/styles/index.css
@@ -2263,3 +2263,37 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   color: var(--planner-accent);
   font-weight: 600;
 }
+
+.mobile-panel--notes {
+  --mobile-notes-text-scale: 1;
+  --mobile-notes-detail-base: 0.75rem;
+  --mobile-notes-textarea-base: 1rem;
+}
+
+.mobile-panel--notes-size-small {
+  --mobile-notes-text-scale: 0.9;
+}
+
+.mobile-panel--notes-size-default {
+  --mobile-notes-text-scale: 1;
+}
+
+.mobile-panel--notes-size-large {
+  --mobile-notes-text-scale: 1.15;
+}
+
+.mobile-panel--notes [data-note-summary],
+.mobile-panel--notes [data-note-detail-list],
+.mobile-panel--notes [data-note-detail-list] > * {
+  font-size: calc(var(--mobile-notes-detail-base, 0.75rem) * var(--mobile-notes-text-scale, 1));
+  line-height: calc(1.35 * var(--mobile-notes-text-scale, 1));
+}
+
+.mobile-panel--notes .note-body-field textarea {
+  font-size: calc(var(--mobile-notes-textarea-base, 1rem) * var(--mobile-notes-text-scale, 1));
+  line-height: calc(1.45 * var(--mobile-notes-text-scale, 1));
+}
+
+.mobile-panel--notes .note-body-field textarea::placeholder {
+  font-size: inherit;
+}


### PR DESCRIPTION
## Summary
- add a text size selector and supporting data attributes to the mobile notes toolbar
- persist the selected size in localStorage via app.js and toggle modifier classes on the mobile notes panel
- add CSS overrides so summary text, status rows, and the textarea scale consistently for each size option

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module when jest loads ESM files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ab02964f883249b123d5f26dfade9)