### PR TITLE
Add collapsible planner notes UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -2179,6 +2179,57 @@ let selectedPlannerLessonId = null;
 let plannerTemplates = loadPlannerTemplates();
 const plannerNotesSaveTimers = new Map();
 const PLANNER_NOTES_SAVE_DELAY = 800;
+const PLANNER_NOTES_OPEN_STATE_STORAGE_KEY = 'plannerNotesOpenState';
+let plannerNotesOpenState = loadPlannerNotesOpenState();
+
+function loadPlannerNotesOpenState() {
+  if (typeof localStorage === 'undefined') {
+    return {};
+  }
+  try {
+    const stored = localStorage.getItem(PLANNER_NOTES_OPEN_STATE_STORAGE_KEY);
+    if (!stored) {
+      return {};
+    }
+    const parsed = JSON.parse(stored);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch (error) {
+    console.warn('Unable to load planner notes state', error);
+    return {};
+  }
+}
+
+function persistPlannerNotesOpenState() {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+  try {
+    localStorage.setItem(PLANNER_NOTES_OPEN_STATE_STORAGE_KEY, JSON.stringify(plannerNotesOpenState));
+  } catch (error) {
+    console.warn('Unable to persist planner notes state', error);
+  }
+}
+
+function isPlannerLessonNotesOpen(lessonId) {
+  if (!lessonId) {
+    return false;
+  }
+  return Boolean(plannerNotesOpenState?.[lessonId]);
+}
+
+function setPlannerLessonNotesOpenState(lessonId, isOpen) {
+  if (!lessonId) {
+    return;
+  }
+  if (isOpen) {
+    plannerNotesOpenState = { ...plannerNotesOpenState, [lessonId]: true };
+  } else if (plannerNotesOpenState?.[lessonId]) {
+    const nextState = { ...plannerNotesOpenState };
+    delete nextState[lessonId];
+    plannerNotesOpenState = nextState;
+  }
+  persistPlannerNotesOpenState();
+}
 
 const updatePlannerCountDisplay = (sourceLessons) => {
   if (!plannerCountElement) {
@@ -2326,23 +2377,35 @@ function renderPlannerLessons(plan) {
         ? `<p class="text-sm text-base-content/70">${escapeCueText(lesson.summary)}</p>`
         : '';
       const notesValue = typeof lesson.notes === 'string' ? lesson.notes : '';
+      const notesOpen = isPlannerLessonNotesOpen(lessonId);
       const notesSection = lessonId
         ? `
-            <label class="form-control w-full gap-1">
-              <div class="label py-1">
+            <details
+              class="planner-notes-collapse"
+              data-planner-notes-collapse="true"
+              data-lesson-id="${lessonId}"
+              ${notesOpen ? 'open' : ''}
+            >
+              <summary class="planner-notes-summary">
                 <span class="label-text text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Lesson notes</span>
+                <span class="planner-notes-summary-indicator" aria-hidden="true"></span>
+              </summary>
+              <div class="planner-notes-panel">
+                <label class="form-control w-full gap-1">
+                  <textarea
+                    class="textarea textarea-bordered w-full min-h-[6rem] text-base-content"
+                    data-planner-notes="true"
+                    data-lesson-id="${lessonId}"
+                    placeholder="Write lesson notes"
+                    spellcheck="true"
+                    aria-label="Lesson notes"
+                  >${escapeCueText(notesValue)}</textarea>
+                  <div class="label py-1">
+                    <span class="label-text-alt text-xs text-base-content/60">Notes save automatically.</span>
+                  </div>
+                </label>
               </div>
-              <textarea
-                class="textarea textarea-bordered w-full min-h-[6rem] text-base-content"
-                data-planner-notes="true"
-                data-lesson-id="${lessonId}"
-                placeholder="Write lesson notes"
-                spellcheck="true"
-              >${escapeCueText(notesValue)}</textarea>
-              <div class="label py-1">
-                <span class="label-text-alt text-xs text-base-content/60">Notes save automatically.</span>
-              </div>
-            </label>
+            </details>
           `
         : '';
       const moveControls = lessonId
@@ -2579,6 +2642,19 @@ function handlePlannerNotesFocusOut(event) {
   }
   clearPlannerNotesTimer(lessonId);
   persistPlannerLessonNotes(lessonId, textarea.value, textarea);
+}
+
+function handlePlannerNotesToggle(event) {
+  const details = event.target instanceof HTMLDetailsElement ? event.target : null;
+  if (!details || !details.hasAttribute('data-planner-notes-collapse')) {
+    return;
+  }
+  const lessonId = details.getAttribute('data-lesson-id');
+  if (!lessonId) {
+    return;
+  }
+  const isOpen = details.hasAttribute('open');
+  setPlannerLessonNotesOpenState(lessonId, isOpen);
 }
 
 function renderPlannerForWeek(weekId) {
@@ -2876,6 +2952,7 @@ function initPlannerView() {
   plannerCardsContainer.addEventListener('click', handlePlannerCardAction);
   plannerCardsContainer.addEventListener('input', handlePlannerNotesInput);
   plannerCardsContainer.addEventListener('focusout', handlePlannerNotesFocusOut);
+  plannerCardsContainer.addEventListener('toggle', handlePlannerNotesToggle);
   plannerNewLessonButton?.addEventListener('click', handlePlannerNewLesson);
   plannerDuplicateButton?.addEventListener('click', handlePlannerDuplicatePlan);
   plannerTemplateSelect?.addEventListener('change', handlePlannerTemplateChange);

--- a/styles/index.css
+++ b/styles/index.css
@@ -2207,6 +2207,87 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   transition: font-size 0.2s ease, line-height 0.2s ease;
 }
 
+.planner-notes-collapse {
+  border-radius: 0.75rem;
+  border: 1px solid color-mix(in srgb, currentColor 12%, transparent);
+  background: color-mix(in srgb, var(--planner-card-bg, #ffffff) 75%, transparent);
+  padding: 0.75rem 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.planner-notes-collapse:hover,
+.planner-notes-collapse:focus-within {
+  border-color: color-mix(in srgb, var(--planner-card-hover, #4cc3ee) 55%, transparent);
+  box-shadow: 0 8px 20px rgba(59, 175, 218, 0.18);
+}
+
+.planner-notes-summary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.2rem 0;
+  user-select: none;
+}
+
+.planner-notes-summary::-webkit-details-marker {
+  display: none;
+}
+
+.planner-notes-summary-indicator {
+  flex-shrink: 0;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease;
+}
+
+.planner-notes-summary-indicator::before {
+  content: '';
+  width: 0.4rem;
+  height: 0.4rem;
+  border: 2px solid currentColor;
+  border-top: 0;
+  border-left: 0;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.planner-notes-collapse[open] .planner-notes-summary-indicator {
+  transform: rotate(180deg);
+}
+
+.planner-notes-collapse[open] .planner-notes-summary-indicator::before {
+  transform: rotate(-135deg);
+}
+
+.planner-notes-panel {
+  overflow: hidden;
+  max-height: 0;
+  opacity: 0;
+  transition: max-height 0.25s ease, opacity 0.2s ease;
+}
+
+.planner-notes-collapse[open] .planner-notes-panel {
+  max-height: 800px;
+  opacity: 1;
+  overflow: visible;
+}
+
+.planner-notes-panel textarea:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--planner-card-hover, #4cc3ee) 80%, transparent);
+  outline-offset: 2px;
+}
+
 [data-route="planner"] {
   background: var(--planner-bg);
 }


### PR DESCRIPTION
## Summary
- add a collapsible details element around planner lesson notes so the summary stays visible while the textarea is hidden by default
- persist the open state per lesson in localStorage so teachers do not have to reopen frequently used notes
- introduce supporting styles for the collapse animation, indicator, and focus handling

## Testing
- `npm test -- --runInBand` *(fails: existing reminders/mobile test suites cannot import ESM modules inside the vm harness)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ab07b86088324b3706d22d9be0757)