### PR TITLE
Improve planner notes feedback

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -436,11 +436,33 @@ html[data-theme="professional"] .desktop-shell .desktop-panel {
   background: color-mix(in srgb, var(--planner-card-bg) 85%, #ffffff 15%);
   border-color: color-mix(in srgb, var(--planner-card-border) 80%, transparent);
   color: var(--desktop-text-main);
+  background-repeat: no-repeat;
+  background-position: right 0.85rem center;
+  background-size: 1.15rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
 
 .desktop-panel.desktop-panel--planner textarea[data-planner-notes]:focus {
   border-color: color-mix(in srgb, var(--desktop-nav-active, #4f46e5) 55%, var(--planner-card-border) 45%);
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--planner-card-highlight) 65%, transparent);
+}
+
+.desktop-panel.desktop-panel--planner textarea[data-planner-notes][data-notes-status="saving"] {
+  border-color: color-mix(in srgb, #fbbf24 55%, transparent);
+  background-color: color-mix(in srgb, #fef3c7 50%, var(--planner-card-bg) 50%);
+  background-image: url("data:image/svg+xml,%3Csvg%20width='16'%20height='16'%20viewBox='0%200%2016%2016'%20fill='none'%20xmlns='http://www.w3.org/2000/svg'%3E%3Cpath%20d='M8%203a5%205%200%201%201-3.54%201.46'%20stroke='%23d97706'%20stroke-width='1.6'%20stroke-linecap='round'%20/%3E%3Cpath%20d='M3.5%204.5V7h2.5'%20stroke='%23d97706'%20stroke-width='1.6'%20stroke-linecap='round'%20stroke-linejoin='round'/%3E%3C/svg%3E");
+}
+
+.desktop-panel.desktop-panel--planner textarea[data-planner-notes][data-notes-status="saved"] {
+  border-color: color-mix(in srgb, #4ade80 65%, transparent);
+  background-color: color-mix(in srgb, #dcfce7 60%, var(--planner-card-bg) 40%);
+  background-image: url("data:image/svg+xml,%3Csvg%20width='16'%20height='16'%20viewBox='0%200%2016%2016'%20fill='none'%20xmlns='http://www.w3.org/2000/svg'%3E%3Cpath%20d='M3.2%208.2l2.7%202.8L12.8%204'%20stroke='%2316a34a'%20stroke-width='1.6'%20stroke-linecap='round'%20stroke-linejoin='round'/%3E%3C/svg%3E");
+}
+
+.desktop-panel.desktop-panel--planner textarea[data-planner-notes][data-notes-status="error"] {
+  border-color: color-mix(in srgb, #f87171 65%, transparent);
+  background-color: color-mix(in srgb, #fee2e2 55%, var(--planner-card-bg) 45%);
+  background-image: url("data:image/svg+xml,%3Csvg%20width='16'%20height='16'%20viewBox='0%200%2016%2016'%20fill='none'%20xmlns='http://www.w3.org/2000/svg'%3E%3Cpath%20d='M4.2%204.2l7.6%207.6M11.8%204.2L4.2%2011.8'%20stroke='%23dc2626'%20stroke-width='1.6'%20stroke-linecap='round'%20/%3E%3C/svg%3E");
 }
 
 html[data-theme="professional"] .desktop-shell .desktop-panel-body {
@@ -2264,10 +2286,33 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   transition: font-size 0.2s ease, line-height 0.2s ease;
 }
 
+.desktop-panel--planner [data-planner-lesson] .badge {
+  font-size: calc(0.7rem * var(--planner-text-scale));
+  line-height: 1.1;
+  padding: calc(0.1rem * var(--planner-text-scale)) calc(0.55rem * var(--planner-text-scale));
+  transition: font-size 0.2s ease, padding 0.2s ease;
+}
+
 .desktop-panel--planner textarea[data-planner-notes] {
   font-size: calc(1rem * var(--planner-text-scale));
   line-height: calc(1.5rem * var(--planner-text-scale));
   transition: font-size 0.2s ease, line-height 0.2s ease;
+}
+
+.desktop-panel--planner [data-notes-status-text] {
+  transition: color 0.2s ease;
+}
+
+.desktop-panel--planner [data-notes-status-text][data-status="saving"] {
+  color: color-mix(in srgb, #b45309 80%, transparent);
+}
+
+.desktop-panel--planner [data-notes-status-text][data-status="saved"] {
+  color: color-mix(in srgb, #15803d 85%, transparent);
+}
+
+.desktop-panel--planner [data-notes-status-text][data-status="error"] {
+  color: color-mix(in srgb, #dc2626 85%, transparent);
 }
 
 .planner-notes-collapse {


### PR DESCRIPTION
## Summary
- show save status text under each lesson notes textarea and reuse helper logic to flip both the attribute and the human-friendly copy when saves start, complete, or fail
- add planner text scaling refinements so badges and the notes helper text respond to the selected size while lesson notes areas now surface clear status colors/icons for saving, saved, and error states

## Testing
- npm test -- --runTestsByPath sample.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ab710d66083249076ae2f8d306ec1)