### PR TITLE
Improve planner notes status feedback

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -2299,6 +2299,33 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   transition: font-size 0.2s ease, line-height 0.2s ease;
 }
 
+.desktop-panel--planner textarea[data-planner-notes][data-notes-status="saving"] {
+  border-color: color-mix(in srgb, #fbbf24 55%, transparent);
+  background-color: color-mix(in srgb, #fef3c7 50%, var(--planner-card-bg, #ffffff) 50%);
+  background-image: url("data:image/svg+xml,%3Csvg%20width='16'%20height='16'%20viewBox='0%200%2016%2016'%20fill='none'%20xmlns='http://www.w3.org/2000/svg'%3E%3Cpath%20d='M8%203a5%205%200%201%201-3.54%201.46'%20stroke='%23d97706'%20stroke-width='1.6'%20stroke-linecap='round'%20/%3E%3Cpath%20d='M3.5%204.5V7h2.5'%20stroke='%23d97706'%20stroke-width='1.6'%20stroke-linecap='round'%20stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.85rem center;
+  background-size: 1.15rem;
+}
+
+.desktop-panel--planner textarea[data-planner-notes][data-notes-status="saved"] {
+  border-color: color-mix(in srgb, #4ade80 65%, transparent);
+  background-color: color-mix(in srgb, #dcfce7 60%, var(--planner-card-bg, #ffffff) 40%);
+  background-image: url("data:image/svg+xml,%3Csvg%20width='16'%20height='16'%20viewBox='0%200%2016%2016'%20fill='none'%20xmlns='http://www.w3.org/2000/svg'%3E%3Cpath%20d='M3.2%208.2l2.7%202.8L12.8%204'%20stroke='%2316a34a'%20stroke-width='1.6'%20stroke-linecap='round'%20stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.85rem center;
+  background-size: 1.15rem;
+}
+
+.desktop-panel--planner textarea[data-planner-notes][data-notes-status="error"] {
+  border-color: color-mix(in srgb, #f87171 65%, transparent);
+  background-color: color-mix(in srgb, #fee2e2 55%, var(--planner-card-bg, #ffffff) 45%);
+  background-image: url("data:image/svg+xml,%3Csvg%20width='16'%20height='16'%20viewBox='0%200%2016%2016'%20fill='none'%20xmlns='http://www.w3.org/2000/svg'%3E%3Cpath%20d='M4.2%204.2l7.6%207.6M11.8%204.2L4.2%2011.8'%20stroke='%23dc2626'%20stroke-width='1.6'%20stroke-linecap='round'%20/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.85rem center;
+  background-size: 1.15rem;
+}
+
 .desktop-panel--planner [data-notes-status-text] {
   transition: color 0.2s ease;
 }


### PR DESCRIPTION
## Summary
- add state-specific styles for planner note fields so visual feedback remains consistent across layouts
- render a dedicated status text span next to the helper copy for lesson notes
- update the note persistence flow so the aria-live text mirrors the current save state

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ab8e0d5888324868713d869358418)