### PR TITLE
Align planner action buttons

### DIFF
--- a/app.js
+++ b/app.js
@@ -2474,7 +2474,7 @@ function renderPlannerLessons(plan) {
         : '';
       const moveControls = lessonId
         ? `
-            <div class="flex items-center gap-1" role="group" aria-label="Reorder lesson">
+            <div class="flex flex-wrap items-center gap-1 justify-end sm:flex-nowrap" role="group" aria-label="Reorder lesson">
               <button
                 type="button"
                 class="btn btn-ghost btn-xs"
@@ -2505,7 +2505,7 @@ function renderPlannerLessons(plan) {
                 <h2 class="text-lg font-semibold text-base-content">${escapeCueText(lesson.title || lesson.dayLabel || 'Lesson')}</h2>
                 ${summaryMarkup}
               </div>
-              <div class="flex items-center gap-1">
+              <div class="flex flex-wrap items-center justify-end gap-1">
                 ${moveControls}
                 <button type="button" class="btn btn-ghost btn-xs" data-planner-action="edit" data-lesson-id="${lessonId}">
                   Edit


### PR DESCRIPTION
## Summary
- adjust the planner card action layout so the move controls and edit/delete buttons stay grouped on the right, even when wrapping on small widths

## Testing
- `npm test` *(fails: existing Jest suite cannot execute ESM modules such as js/reminders.js and mobile.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ab9880874832485d0608e7408875a)