### PR TITLE
Make reminder notes textarea white

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,6 +181,11 @@
       color: var(--delete-color);
     }
 
+    #add-reminder-modal #reminder-notes {
+      background-color: #ffffff;
+      color: #1f2a24;
+    }
+
     [data-route="notes"] .notes-editor-card .card-body {
       padding: clamp(1.5rem, 4vw, 2.25rem);
     }


### PR DESCRIPTION
## Summary
- ensure the add-reminder modal’s notes field has a white background with readable text

## Testing
- npm test -- sample.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691abae6922c8324b98827030f2751d5)