### PR TITLE
Remove sticky desktop header

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -95,8 +95,8 @@ html[data-theme="professional"] body.desktop-shell {
 /* PROFESSIONAL DESKTOP HEADER */
 
 html[data-theme="professional"] .desktop-header-bar {
-  position: sticky;
-  top: 0;
+  position: static;
+  top: auto;
   z-index: 40;
   display: flex;
   align-items: center;
@@ -309,8 +309,8 @@ html[data-theme="professional"] .desktop-header-nav-tabs .btn:hover {
 
 @media (min-width: 1024px) {
   html[data-theme="professional"] .desktop-header-bar {
-    position: sticky;
-    top: 0;
+    position: static;
+    top: auto;
     display: flex;
     align-items: center;
   }


### PR DESCRIPTION
## Summary
- stop using sticky positioning for the desktop header so it no longer covers the page while scrolling

## Testing
- Not Run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691abb83dc788324876954d6eb4df04c)