### PR TITLE
Add subject filtering to planner

### DIFF
--- a/index.html
+++ b/index.html
@@ -814,6 +814,19 @@
             <button type="button" id="planner-template-save-btn" class="btn btn-sm btn-outline">
               Save current week as template
             </button>
+            <label class="form-control w-full max-w-xs md:w-auto">
+              <div class="label py-0">
+                <span class="label-text text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Subject filter</span>
+              </div>
+              <select
+                id="planner-subject-filter"
+                class="select select-bordered select-sm w-full md:w-48"
+                aria-label="Filter planner by subject"
+              >
+                <option value="all">All subjects</option>
+              </select>
+              <p class="mt-1 text-xs text-base-content/60">Show lessons by the subjects you teach.</p>
+            </label>
           </div>
           <p id="planner-week" class="text-sm font-semibold text-base-content/80"></p>
           <div id="plannerCards" class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"></div>
@@ -875,6 +888,16 @@
                   rows="3"
                   placeholder="What is the focus for this lesson?"
                 ></textarea>
+              </label>
+              <label class="block text-sm font-medium text-base-content">
+                Subject or class (optional)
+                <input
+                  id="planner-lesson-subject"
+                  type="text"
+                  class="input input-bordered mt-1 w-full"
+                  placeholder="e.g. Year 8 Science"
+                />
+                <span class="mt-1 block text-xs text-base-content/60">Use subjects to filter the planner by class.</span>
               </label>
               <div class="grid gap-4 md:grid-cols-2 hidden" data-planner-detail-section aria-hidden="true">
                 <label class="block text-sm font-medium text-base-content">

--- a/js/modules/planner.js
+++ b/js/modules/planner.js
@@ -207,6 +207,11 @@ const normaliseLesson = (lesson, fallback = {}) => {
     : typeof defaults.notes === 'string'
       ? defaults.notes
       : '';
+  const subject = typeof lesson?.subject === 'string'
+    ? lesson.subject.trim()
+    : typeof defaults.subject === 'string'
+      ? defaults.subject.trim()
+      : '';
   return {
     id,
     dayIndex,
@@ -215,6 +220,7 @@ const normaliseLesson = (lesson, fallback = {}) => {
     summary,
     details,
     notes,
+    subject,
     position: Number.isFinite(rawPosition) ? rawPosition : null
   };
 };
@@ -789,6 +795,7 @@ export const duplicateWeekPlan = async (sourceWeekId, targetWeekId) => {
     summary: lesson.summary,
     dayIndex: lesson.dayIndex,
     notes: typeof lesson.notes === 'string' ? lesson.notes : '',
+    subject: typeof lesson.subject === 'string' ? lesson.subject : '',
     details: (lesson.details || []).map((detail) => ({
       badge: detail.badge,
       text: detail.text
@@ -818,6 +825,7 @@ const cloneTemplateLesson = (lesson) => {
   const title = typeof lesson.title === 'string' ? lesson.title : '';
   const summary = typeof lesson.summary === 'string' ? lesson.summary : '';
   const notes = typeof lesson.notes === 'string' ? lesson.notes : '';
+  const subject = typeof lesson.subject === 'string' ? lesson.subject.trim() : '';
   const details = Array.isArray(lesson.details)
     ? lesson.details
         .map((detail) => {
@@ -833,7 +841,7 @@ const cloneTemplateLesson = (lesson) => {
         })
         .filter(Boolean)
     : [];
-  return { dayIndex, title, summary, details, notes };
+  return { dayIndex, title, summary, details, notes, subject };
 };
 
 export const loadPlannerTemplates = () => {
@@ -920,6 +928,7 @@ export const applyPlannerTemplate = async (weekId, templateId) => {
         title: lesson.title,
         summary: lesson.summary,
         notes: typeof lesson.notes === 'string' ? lesson.notes : '',
+        subject: typeof lesson.subject === 'string' ? lesson.subject : '',
         details: Array.isArray(lesson.details)
           ? lesson.details.map((detail) => ({ badge: detail.badge, text: detail.text }))
           : []


### PR DESCRIPTION
## Summary
- add a subject/class field to the planner lesson modal and persist that data in the planner store
- surface subject badges on each lesson card and add a subject filter dropdown so teachers can focus on a single class
- update planner template persistence/duplication so subjects are saved across weeks

## Testing
- `npm test` *(fails: existing Jest harness cannot load ESM modules such as js/reminders.js and mobile.js – SyntaxError: Cannot use import statement outside a module)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691aba86c0908324bcb5f66fbc3d739d)