### PR TITLE
Improve mobile notes hero layout

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2791,6 +2791,58 @@
     }
   </style>
 
+  <style>
+    .notes-hero {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      padding: clamp(1rem, 4vw, 1.4rem);
+      border-radius: 1.5rem;
+      background: var(--mobile-quick-surface);
+      border: 1px solid color-mix(in srgb, var(--card-border) 85%, transparent);
+      box-shadow: var(--mobile-quick-shadow);
+    }
+
+    .notes-hero-top {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 0.75rem;
+    }
+
+    .notes-hero-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 0.65rem;
+    }
+
+    .notes-hero-buttons {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 0.5rem;
+    }
+
+    .notes-hero-buttons .btn {
+      width: 100%;
+    }
+
+    @media (min-width: 640px) {
+      .notes-hero {
+        flex-direction: row;
+        align-items: center;
+        gap: 1.25rem;
+      }
+
+      .notes-hero-actions {
+        flex: 0 0 260px;
+      }
+
+      .notes-hero-top {
+        max-width: 380px;
+      }
+    }
+  </style>
+
   <header class="sticky top-0 z-20 text-black shadow-md bg-white/80 backdrop-blur">
     <div class="mx-auto max-w-md px-3 py-3 flex items-center justify-between gap-3">
       <div class="header-action-group">
@@ -3184,28 +3236,47 @@
       <div class="flex flex-col gap-4">
         <section class="card bg-base-100 border shadow-sm rounded-2xl">
           <div class="card-body gap-4">
-            <header class="flex items-center justify-between gap-2">
-              <div class="flex flex-col">
-                <h2 class="card-title text-base leading-tight">Scratch Notes</h2>
-                <p class="text-xs text-base-content/60" data-note-summary>
-                  Quick jot pad that syncs with your desktop notebook.
-                </p>
-              </div>
-              <div class="flex items-center gap-2">
+            <header class="notes-hero">
+              <div class="notes-hero-top">
+                <div class="flex flex-col">
+                  <span class="text-xs uppercase tracking-wide text-base-content/50">Scratch Notes</span>
+                  <h2 class="text-lg font-semibold leading-snug">Capture quick thoughts on the go</h2>
+                  <p class="text-xs text-base-content/60" data-note-summary>
+                    Quick jot pad that syncs with your desktop notebook.
+                  </p>
+                </div>
                 <button
                   type="button"
-                  class="btn btn-ghost btn-sm rounded-full px-4"
+                  class="btn btn-ghost btn-xs sm:btn-sm rounded-full px-4"
                   data-jump-view="reminders"
                 >
                   Back
                 </button>
+              </div>
+              <div class="notes-hero-actions">
                 <button
+                  id="noteSaveMobile"
+                  class="btn btn-primary btn-md w-full shadow-md shadow-primary/20"
                   type="button"
-                  class="btn btn-outline btn-sm rounded-full px-4"
-                  data-action="open-saved-notes"
                 >
-                  Saved notes
+                  Save note
                 </button>
+                <div class="notes-hero-buttons">
+                  <button
+                    id="noteNewMobile"
+                    type="button"
+                    class="btn btn-outline btn-sm"
+                  >
+                    New note
+                  </button>
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-sm"
+                    data-action="open-saved-notes"
+                  >
+                    Saved notes
+                  </button>
+                </div>
               </div>
             </header>
 
@@ -3219,32 +3290,6 @@
                   placeholder="e.g. Kids basketball schedule – this weekend"
                 />
               </label>
-
-              <div class="flex flex-col gap-2">
-                <button
-                  id="noteSaveMobile"
-                  class="btn btn-primary btn-md w-full shadow-md shadow-primary/20"
-                  type="button"
-                >
-                  Save note
-                </button>
-                <div class="grid grid-cols-2 gap-2 w-full">
-                  <button
-                    id="noteNewMobile"
-                    type="button"
-                    class="btn btn-outline btn-sm col-span-2 sm:col-span-1"
-                  >
-                    New note
-                  </button>
-                  <button
-                    type="button"
-                    class="btn btn-ghost btn-sm col-span-2 sm:col-span-1"
-                    data-action="open-saved-notes"
-                  >
-                    Saved notes
-                  </button>
-                </div>
-              </div>
 
               <div
                 class="flex flex-wrap items-center gap-3 rounded-2xl border border-base-200/70 bg-base-100/80 px-3 py-2 text-xs text-base-content/70"


### PR DESCRIPTION
## Summary
- move the Save note, New note, and Saved notes controls into a dedicated hero header so each button only appears once
- add styling for the new notes hero to better match the refreshed mobile shell

## Testing
- Not Run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691abe052da88324b245cf3cce99c576)