### PR TITLE
Update notes textarea styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,6 +192,8 @@
 
     [data-route="notes"] .notes-editor-card textarea {
       min-height: 22rem;
+      background-color: #ffffff;
+      color: #1f2a24;
     }
 
     @media (max-width: 639px) {


### PR DESCRIPTION
## Summary
- ensure the desktop notes textarea uses a solid white background with dark text to match the requested appearance

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691abe54f3f08324b30a3f2034dfb04a)