### PR TITLE
Soften notes editor styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,6 +192,14 @@
 
     [data-route="notes"] .notes-editor-card textarea {
       min-height: 22rem;
+      color: #1f2a24;
+      border-color: #e5dec9;
+      background-color: #fffcf5;
+    }
+
+    [data-route="notes"] .notes-editor-card {
+      border-color: #e8e0cc;
+      background-color: #fbf9f2;
     }
 
     @media (max-width: 639px) {


### PR DESCRIPTION
## Summary
- soften the notes editor card background and border so the page no longer appears stark white
- update the notes textarea styling to retain the dark text while using a warmer off-white fill and softer border

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691abe54f3f08324b30a3f2034dfb04a)