### PR TITLE
Register professional DaisyUI theme

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,22 @@ module.exports = {
   },
   plugins: [require("daisyui")],
   daisyui: {
-    themes: ["light", "dark"], // add more later if desired
+    themes: [
+      {
+        professional: {
+          primary: "#4f46e5",
+          secondary: "#fcd34d",
+          accent: "#f472b6",
+          neutral: "#3d4451",
+          "base-100": "#ffffff",
+          info: "#3abff8",
+          success: "#36d399",
+          warning: "#fbbd23",
+          error: "#f87272",
+        },
+      },
+      "light",
+      "dark",
+    ],
   },
 };


### PR DESCRIPTION
## Summary
- register the existing professional color palette as a DaisyUI theme in the Tailwind config so it is available during builds
- ensure the desktop HTML already specifies `data-theme="professional"` so the theme applies on load

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ad523c1f88324a9552fd43e075ee6)