### PR TITLE
Clean up CSS imports in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,19 +56,7 @@
   <link rel="icon" href="./icons/icon-192.svg" type="image/svg+xml" />
   <link rel="stylesheet" href="./styles/tokens.css" />
   <link rel="stylesheet" href="./styles/a11y.css" />
-  <link rel="stylesheet" href="./styles/tailwind.css" />
   <link rel="stylesheet" href="./styles/index.css" />
-  <!-- BEGIN GPT CHANGE: styles moved to styles/index.css -->
-  <!-- END GPT CHANGE -->
-  <link
-    rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/daisyui@4.12.10/dist/full.min.css"
-    integrity="sha384-yxrQVVFFRZdq4Z/YbeTDzSYbn1W6VnVonm2vAgnxtxUMehcccE4k2NufOz2tJnOe"
-    crossorigin="anonymous"
-  />
-  <link rel="stylesheet" href="./styles/daisy-themes.css" />
-  <!-- BEGIN GPT CHANGE: styles moved to styles/index.css -->
-  <!-- END GPT CHANGE -->
   <style>
     :root {
       --vh: 1vh;


### PR DESCRIPTION
## Summary
- remove the redundant Tailwind and DaisyUI CDN stylesheet links from index.html now that the professional theme is provided by the compiled bundle
- ensure only tokens.css, a11y.css, and the compiled styles/index.css are loaded in the head

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ad65421b083248ff34e6505ddb158)