### PR TITLE
Improve desktop notes editor styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -928,10 +928,10 @@
           </header>
         </div>
         <div class="desktop-notes-grid grid gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,4fr)_minmax(0,1fr)]">
-          <article class="desktop-panel card notes-editor-card border border-base-300 bg-base-100 text-base-content shadow-sm dark:bg-base-200 dark:text-base-content">
-            <div class="card-body gap-4">
-              <div class="flex flex-col gap-3">
-                <div class="flex flex-col gap-2 mb-3">
+          <article class="desktop-panel card notes-editor-card rounded-xl border border-base-300 bg-base-100 text-base-content shadow-sm dark:bg-base-200 dark:text-base-content">
+            <div class="card-body gap-4 p-6">
+              <div class="flex flex-col gap-4">
+                <div class="flex flex-col gap-2">
                   <label for="noteTitle" class="text-sm font-medium">Title</label>
                   <input
                     id="noteTitle"
@@ -940,18 +940,18 @@
                     placeholder="e.g. Kids basketball schedule – this weekend"
                   />
                 </div>
-                <div class="flex justify-end gap-2 mb-3">
-                  <button id="noteSaveBtn" type="button" class="btn btn-primary">Save</button>
-                  <button id="noteNewBtn" type="button" class="btn btn-outline">New note</button>
-                </div>
                 <div class="flex flex-col gap-2">
                   <label for="noteBody" class="text-sm font-medium">Body</label>
                   <textarea
                     id="noteBody"
-                    class="textarea textarea-bordered w-full resize-y min-h-[12rem] max-h-[32rem] px-4 py-2 text-base-content bg-base-100 dark:bg-base-200 dark:text-base-content"
+                    class="textarea w-full resize-y min-h-[12rem] max-h-[32rem] bg-transparent text-base-content outline-none"
                     rows="10"
                     placeholder="Write your note here…"
                   ></textarea>
+                </div>
+                <div class="flex justify-end gap-2 mt-4">
+                  <button id="noteSaveBtn" type="button" class="btn btn-primary">Save</button>
+                  <button id="noteNewBtn" type="button" class="btn btn-outline">New note</button>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- restyle the desktop notes editor card with Tailwind-friendly padding, rounded corners, and theme-aware colors
- streamline the textarea to support resizing with cleaner, transparent styling and maintained placeholder text
- space and standardize the Save/New buttons within a shared container for consistent controls

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ad78e68788324b77ab6837c7d1769)