### PR TITLE
Improve mobile reminder cards

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -3198,12 +3198,13 @@ export async function initReminders(sel = {}) {
         done: Boolean(reminder.done),
       };
 
+      const desktopCardClasses =
+        'reminder-item task-item reminder-card desktop-task-card grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-4 text-sm shadow-sm transition hover:border-base-300 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60';
+      const mobileCardClasses =
+        'reminder-item task-item reminder-card w-full bg-base-100 rounded-xl border border-base-200 border-l-4 shadow-sm p-4 mb-3 flex items-start justify-between gap-2 text-sm text-base-content transition hover:border-base-300 hover:bg-base-100 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 active:scale-[.98]';
+
       const itemEl = document.createElement(elementTag);
-      itemEl.className =
-        'task-item reminder-card desktop-task-card grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-4 text-sm shadow-sm transition hover:border-base-300 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60';
-      if (isMobile) {
-        itemEl.classList.add('w-full');
-      }
+      itemEl.className = isMobile ? mobileCardClasses : desktopCardClasses;
       itemEl.dataset.id = summary.id;
       itemEl.dataset.category = summary.category;
       itemEl.dataset.title = summary.title;
@@ -3248,10 +3249,15 @@ export async function initReminders(sel = {}) {
       }
 
       const content = document.createElement('div');
-      content.className = 'flex min-w-0 flex-col gap-2';
+      content.className = 'flex min-w-0 flex-1 flex-col gap-2';
+      if (isMobile) {
+        content.classList.add('text-sm', 'text-base-content');
+      }
 
       const titleEl = document.createElement('p');
-      titleEl.className = 'text-lg font-bold leading-snug text-base-content';
+      titleEl.className = isMobile
+        ? 'text-base font-semibold leading-tight text-base-content'
+        : 'text-lg font-bold leading-snug text-base-content';
       titleEl.classList.add('desktop-reminder-title');
       if (!isMobile) {
         titleEl.classList.add('sm:text-[0.95rem]');
@@ -3263,7 +3269,9 @@ export async function initReminders(sel = {}) {
       content.appendChild(titleEl);
 
       const metaRow = document.createElement('div');
-      metaRow.className = 'desktop-reminder-meta flex flex-wrap items-center gap-1 text-xs text-base-content/70';
+      metaRow.className = isMobile
+        ? 'desktop-reminder-meta reminder-meta flex flex-wrap items-center gap-1 text-sm text-base-content/70'
+        : 'desktop-reminder-meta reminder-meta flex flex-wrap items-center gap-1 text-xs text-base-content/70';
 
       const dueLabelRaw = formatDesktopDue(reminder);
       const dueLabel = dueLabelRaw && dueLabelRaw !== 'No due date' ? dueLabelRaw : '';
@@ -3284,6 +3292,9 @@ export async function initReminders(sel = {}) {
 
       const controls = document.createElement('div');
       controls.className = 'flex items-start gap-1';
+      if (isMobile) {
+        controls.classList.add('flex-shrink-0');
+      }
 
       const toggleBtn = document.createElement('button');
       toggleBtn.type = 'button';

--- a/mobile.html
+++ b/mobile.html
@@ -36,6 +36,9 @@
       --priority-medium-bg: color-mix(in srgb, var(--priority-medium-border) 16%, #FFFFFF);
       --priority-low-border: #6B8F71; /* Digital Sage */
       --priority-low-bg: color-mix(in srgb, var(--priority-low-border) 16%, #FFFFFF);
+      --priority-high-color: #ef4444; /* Tailwind red-500 */
+      --priority-medium-color: #eab308; /* Tailwind yellow-500 */
+      --priority-low-color: #22c55e; /* Tailwind green-500 */
       --shadow-sm: 0 1px 3px var(--shadow-color);
       --shadow-md: 0 4px 12px var(--shadow-color);
       --transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -2038,25 +2041,9 @@
     .mobile-shell .reminder-card {
       position: relative;
       width: 100%;
-      background: var(--surface-bg, var(--desktop-surface, var(--card-bg)));
-      border-radius: 14px;
-      border: 1px solid color-mix(in srgb, var(--card-border) 35%, transparent);
-      padding: 0.85rem 1rem;
-      box-shadow: 3px 3px 8px rgba(15, 23, 42, 0.06), -2px -2px 6px rgba(255, 255, 255, 0.9);
-      margin-bottom: 0.9rem;
-      display: flex;
-      flex-direction: column;
-      gap: 0.35rem;
       min-height: 48px;
       line-height: 1.4;
-      transition: transform 0.15s ease, box-shadow 0.15s ease;
       touch-action: manipulation;
-    }
-
-    .dark .mobile-shell .reminder-card {
-      background: color-mix(in srgb, var(--text-primary) 18%, rgba(15, 23, 42, 0.92) 82%);
-      border-color: color-mix(in srgb, var(--card-border) 55%, transparent);
-      box-shadow: 3px 3px 10px rgba(15, 23, 42, 0.65), -2px -2px 5px rgba(255, 255, 255, 0.04);
     }
 
     .mobile-shell #reminderList.space-y-3 > .reminder-card:last-child,
@@ -2069,37 +2056,25 @@
       outline-offset: 2px;
     }
 
-    .mobile-shell .reminder-card:active {
-      transform: translateY(-1px);
-      box-shadow: 1px 1px 4px rgba(15, 23, 42, 0.1), -1px -1px 4px rgba(255, 255, 255, 0.95);
-    }
-
-    @media (hover: hover) {
-      .mobile-shell .reminder-card:hover {
-        transform: translateY(-1px);
-        box-shadow: 1px 1px 4px rgba(15, 23, 42, 0.1), -1px -1px 4px rgba(255, 255, 255, 0.95);
-      }
-    }
-
     @media (prefers-reduced-motion: reduce) {
       .mobile-shell .reminder-card,
       .mobile-shell .reminder-card:hover,
       .mobile-shell .reminder-card:active {
-        transition: box-shadow 0.12s ease, border-color 0.12s ease;
-        transform: none;
+        transition: none !important;
+        transform: none !important;
       }
     }
 
     .mobile-shell #reminderList > .reminder-card.priority-high {
-      border-left-color: var(--priority-high-border);
+      border-left-color: var(--priority-high-color, var(--priority-high-border));
     }
 
     .mobile-shell #reminderList > .reminder-card.priority-medium {
-      border-left-color: var(--priority-medium-border);
+      border-left-color: var(--priority-medium-color, var(--priority-medium-border));
     }
 
     .mobile-shell #reminderList > .reminder-card.priority-low {
-      border-left-color: var(--priority-low-border);
+      border-left-color: var(--priority-low-color, var(--priority-low-border));
     }
 
     .mobile-shell #reminderList > .reminder-card .reminder-primary-row {


### PR DESCRIPTION
## Summary
- add dedicated Tailwind-friendly styling hooks for mobile reminder cards and updated priority stripe colors
- update the reminder renderer so mobile items adopt the new flex card layout, typography, and hover/tap affordances

## Testing
- npm test -- reminders.categories.test.js *(fails: Jest cannot execute modules that use ES module syntax in the current test harness)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ad7ea4e2483249eab312285449b64)