### PR TITLE
Revamp mobile saved notes panel

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -300,12 +300,6 @@
     opacity: 0.8;
   }
 
-  .mobile-shell #notesListMobile .note-item-mobile button[data-role="open-note"][data-state="active"] {
-    border-color: var(--accent-color);
-    background: color-mix(in srgb, var(--accent-color) 12%, transparent);
-    box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent-color) 25%, transparent);
-  }
-
   .mobile-shell #notesListMobile .note-item-mobile button[data-role="delete-note"]:focus-visible {
     outline: 2px solid var(--accent-color, #2563eb);
     outline-offset: 2px;
@@ -3329,9 +3323,9 @@
     data-open="false"
   >
     <div
-      class="saved-notes-panel absolute inset-x-0 bottom-0 max-h-[85vh] bg-base-100 rounded-t-3xl border border-base-200/70 shadow-2xl flex flex-col"
+      class="saved-notes-panel fixed bottom-0 left-0 right-0 mx-auto w-full max-w-md bg-base-100 rounded-t-xl shadow-lg p-4 space-y-4 max-h-[80vh] overflow-y-auto transition-transform z-40 flex flex-col"
     >
-      <header class="flex items-start justify-between gap-3 px-5 pt-4 pb-3 border-b border-base-200/70">
+      <header class="flex items-start justify-between gap-3 pb-3 border-b border-base-200/70">
         <div class="flex flex-col gap-0.5">
           <h3 id="savedNotesSheetTitle" class="text-base font-semibold">Saved notes</h3>
           <p class="text-xs text-base-content/60">Tap a note to load it here.</p>
@@ -3346,12 +3340,12 @@
         </button>
       </header>
 
-      <div class="px-5 pt-3 pb-4 border-b border-base-200/60 space-y-3">
+      <div class="space-y-3 border-b border-base-200/60 pb-4">
         <label class="sr-only" for="notesFilterMobile">Filter notes</label>
         <input
           id="notesFilterMobile"
           type="search"
-          class="input input-sm input-bordered w-full rounded-2xl"
+          class="input input-bordered input-sm w-full text-base-content bg-base-200 placeholder:text-base-content/70 placeholder:opacity-80"
           placeholder="Search saved notes…"
         />
         <div class="flex items-center justify-between text-xs font-semibold text-base-content/70">
@@ -3360,10 +3354,10 @@
         </div>
       </div>
 
-      <div class="flex-1 overflow-y-auto px-4 pb-6 pt-3">
+      <div class="flex-1 overflow-y-auto pb-2">
         <ul
           id="notesListMobile"
-          class="flex flex-col gap-3 pb-10"
+          class="space-y-3 pb-12"
           aria-label="Saved scratch notes"
         ></ul>
       </div>

--- a/mobile.js
+++ b/mobile.js
@@ -316,6 +316,7 @@ const initMobileNotes = () => {
   const savedNotesSheet = document.getElementById('savedNotesSheet');
   const openSavedNotesButton = document.querySelector('[data-action="open-saved-notes"]');
   const closeSavedNotesButton = document.querySelector('[data-action="close-saved-notes"]');
+  const ACTIVE_NOTE_SHADOW_CLASS = 'shadow-[0_0_0_3px_var(--accent-color)]';
 
   if (!titleInput || !bodyInput || !saveButton) {
     return;
@@ -459,6 +460,11 @@ const initMobileNotes = () => {
       } else {
         button.removeAttribute('data-state');
       }
+      button.classList.toggle('active', isActive);
+      button.classList.toggle('outline', isActive);
+      button.classList.toggle('outline-2', isActive);
+      button.classList.toggle('outline-accent', isActive);
+      button.classList.toggle(ACTIVE_NOTE_SHADOW_CLASS, isActive);
       button.setAttribute('aria-current', isActive ? 'true' : 'false');
     });
   };
@@ -621,14 +627,15 @@ const initMobileNotes = () => {
       listItem.className = 'note-item-mobile w-full';
 
       const row = document.createElement('div');
-      row.className = 'flex items-center gap-2';
+      row.className =
+        'saved-note-row flex items-center justify-between gap-3 rounded-lg bg-base-200 p-3 text-sm text-base-content hover:bg-base-300 transition-colors';
 
       const button = document.createElement('button');
       button.type = 'button';
       button.dataset.noteId = note.id;
       button.dataset.role = 'open-note';
       button.className =
-        'note-card group flex-1 text-left rounded-2xl border border-base-200/70 bg-base-100 px-4 py-3 flex flex-col gap-1 shadow-sm transition-all duration-200 active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30';
+        'open-note-btn flex-1 text-left flex flex-col gap-1 text-sm text-base-content focus-visible:outline-none active:scale-[0.99] transition-transform duration-200';
 
       const headerRow = document.createElement('div');
       headerRow.className = 'flex items-center justify-between gap-2';
@@ -641,13 +648,13 @@ const initMobileNotes = () => {
       const timestampText = formatNoteTimestamp(note.updatedAt || note.createdAt);
       if (timestampText) {
         const dateSpan = document.createElement('span');
-        dateSpan.className = 'text-[0.7rem] text-base-content/50 whitespace-nowrap font-medium';
+        dateSpan.className = 'text-xs text-base-content/60 whitespace-nowrap font-medium';
         dateSpan.textContent = timestampText;
         headerRow.appendChild(dateSpan);
       }
 
       const preview = document.createElement('p');
-      preview.className = 'text-xs text-base-content/70 line-clamp-2 leading-snug';
+      preview.className = 'text-sm text-base-content/70 line-clamp-2 leading-snug';
       const bodyText =
         typeof note.body === 'string' ? note.body.replace(/\s+/g, ' ').trim() : '';
       preview.textContent = bodyText || 'No body text yet.';
@@ -660,7 +667,7 @@ const initMobileNotes = () => {
       deleteButton.dataset.noteId = note.id;
       deleteButton.dataset.role = 'delete-note';
       deleteButton.className =
-        'btn btn-ghost btn-circle btn-sm shrink-0 text-error/70 hover:text-error focus-visible:outline-none focus-visible:ring focus-visible:ring-error/30';
+        'delete-note-btn btn btn-ghost btn-xs text-error shrink-0 focus-visible:outline-none focus-visible:ring-0';
       deleteButton.setAttribute('aria-label', 'Delete note');
       deleteButton.textContent = '✕';
 


### PR DESCRIPTION
## Summary
- restyle the Saved Notes bottom sheet on mobile with theme-aware spacing, typography, and layout tweaks for better readability
- update the saved note entries to use new row, button, and delete button styles along with improved placeholder colors
- adjust the mobile notes list logic so active notes receive the new accent outline classes

## Testing
- npm test *(fails: SyntaxError: Cannot use import statement outside a module in several reminders and mobile Jest suites)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ada19278483248edbf50c364f927f)