### PR TITLE
Wrap reminder controls in task toolbar

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -3291,14 +3291,16 @@ export async function initReminders(sel = {}) {
       itemEl.appendChild(content);
 
       const controls = document.createElement('div');
-      controls.className = 'flex items-start gap-1';
+      controls.className = 'task-toolbar flex items-start gap-1';
+      controls.setAttribute('role', 'toolbar');
+      controls.setAttribute('aria-label', 'Reminder actions');
       if (isMobile) {
         controls.classList.add('flex-shrink-0');
       }
 
       const toggleBtn = document.createElement('button');
       toggleBtn.type = 'button';
-      toggleBtn.className = 'btn btn-ghost btn-circle btn-xs';
+      toggleBtn.className = 'btn btn-ghost btn-circle btn-xs task-toolbar-btn';
       if (summary.done) {
         toggleBtn.classList.add('text-base-content/60');
         toggleBtn.innerHTML = '<span aria-hidden="true">↺</span>';
@@ -3319,7 +3321,7 @@ export async function initReminders(sel = {}) {
 
       const deleteBtn = document.createElement('button');
       deleteBtn.type = 'button';
-      deleteBtn.className = 'btn btn-ghost btn-circle btn-xs text-error';
+      deleteBtn.className = 'btn btn-ghost btn-circle btn-xs text-error task-toolbar-btn';
       deleteBtn.innerHTML = '<span aria-hidden="true">🗑️</span>';
       deleteBtn.setAttribute('aria-label', `Delete reminder: ${reminder.title}`);
       deleteBtn.setAttribute('data-reminder-control', 'delete');


### PR DESCRIPTION
## Summary
- wrap the reminder item controls in the existing `.task-toolbar` container so the toggle and delete buttons align with the content column
- add the `.task-toolbar-btn` class to both buttons to restore the intended spacing and minimum touch target sizing on mobile

## Testing
- npm test -- --runTestsByPath sample.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691adc1072848324a919b17c8620fe77)