### PR TITLE
Restore mobile reminder title clamp

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -3265,8 +3265,18 @@ export async function initReminders(sel = {}) {
       if (summary.done) {
         titleEl.classList.add('line-through', 'text-base-content/60');
       }
+      if (isMobile) {
+        titleEl.dataset.reminderTitle = 'true';
+      }
       titleEl.textContent = reminder.title;
-      content.appendChild(titleEl);
+
+      let titleSlot = titleEl;
+      if (isMobile) {
+        titleSlot = document.createElement('div');
+        titleSlot.className = 'reminder-title-slot';
+        titleSlot.appendChild(titleEl);
+      }
+      content.appendChild(titleSlot);
 
       const metaRow = document.createElement('div');
       metaRow.className = isMobile


### PR DESCRIPTION
## Summary
- mark mobile reminder titles with the data-reminder-title selector again and wrap them in a reminder-title-slot container so the mobile stylesheet can target them
- ensure the wrapper is only used in the mobile card path so desktop layout stays unchanged

## Testing
- npm test -- --runTestsByPath sample.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691add0516f48324aff1d385d03c4504)