### PR TITLE
Add mobile reminders header scroll shadow

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2828,6 +2828,11 @@
         min-height: 3.2rem;
       }
     }
+
+    /* Header shadow when scrolled */
+    .header-shadow {
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+    }
   </style>
 
   <header class="sticky top-0 z-20 text-black shadow-md bg-white/80 backdrop-blur">
@@ -3153,7 +3158,7 @@
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: reminders view -->
     <section data-view="reminders" id="view-reminders" class="view-panel">
-      <header class="px-4 pt-safe-top pb-3 space-y-2 bg-base-100/90 backdrop-blur-md border-b border-base-300">
+      <header class="px-4 pt-safe-top pb-3 space-y-2 bg-base-100/90 backdrop-blur-md border-b border-base-300 transition-shadow">
         <div class="flex items-center justify-between gap-3">
           <h2 class="text-base font-semibold tracking-wide text-base-content">Reminders</h2>
           <button
@@ -5499,6 +5504,32 @@
           e.preventDefault(); // Prevent double-tap zoom
         }, { passive: false });
       }
+    })();
+  </script>
+
+  <script>
+    (function() {
+      // Identify reminders view container and header
+      const remindersSection = document.querySelector('section[data-view="reminders"]');
+      if (!remindersSection) return;
+
+      const header = remindersSection.querySelector('header');
+      const scrollContainer =
+        remindersSection.querySelector('.reminders-scroll-container') ||
+        remindersSection.querySelector('#reminders-list') ||
+        remindersSection;
+
+      // SAFETY:
+      // Do NOT rename elements. We check multiple fallbacks.
+      // Whichever scrollable container exists will trigger the shadow.
+
+      scrollContainer.addEventListener('scroll', function() {
+        if (scrollContainer.scrollTop > 2) {
+          header.classList.add('header-shadow');
+        } else {
+          header.classList.remove('header-shadow');
+        }
+      });
     })();
   </script>
 


### PR DESCRIPTION
## Summary
- add the transition-shadow helper class to the mobile reminders header and define the header-shadow effect in the inline mobile styles
- attach a scroll listener that toggles the new class when the reminders list container scrolls so the header gains a subtle drop shadow in context

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691af91044308324ad42c57cfac33341)