### PR TITLE
Standardize desktop text colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -664,7 +664,7 @@
             aria-label="Edit reminder: Submit unit overview"
           >
             <div class="flex min-w-0 flex-col gap-3">
-              <p class="desktop-reminder-title reminder-title text-sm font-semibold leading-snug text-base-content">Submit unit overview</p>
+              <p class="desktop-reminder-title reminder-title text-sm font-medium leading-snug text-base-content">Submit unit overview</p>
               <div class="desktop-reminder-meta reminder-meta flex flex-wrap items-center gap-1 text-xs text-base-content/70">
                 <span class="desktop-reminder-chip inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70" data-tone="category">
                   <span class="desktop-reminder-chip__dot h-1.5 w-1.5 rounded-full"></span>
@@ -672,7 +672,7 @@
                 </span>
               </div>
               <div class="flex justify-end">
-                <span class="badge badge-outline badge-sm text-xs text-base-content" data-tone="due">Due Friday</span>
+                <span class="badge badge-outline badge-sm text-[11px] text-base-content/80" data-tone="due">Due Friday</span>
               </div>
             </div>
             <div class="task-toolbar flex justify-end gap-2 mt-2" role="toolbar" aria-label="Reminder actions">
@@ -691,19 +691,19 @@
             aria-label="Edit reminder: Email newsletter blurb"
           >
             <div class="flex min-w-0 flex-col gap-3">
-              <p class="desktop-reminder-title reminder-title text-sm font-semibold leading-snug text-base-content">Email newsletter blurb</p>
+              <p class="desktop-reminder-title reminder-title text-sm font-medium leading-snug text-base-content">Email newsletter blurb</p>
               <div class="desktop-reminder-meta reminder-meta flex flex-wrap items-center gap-1 text-xs text-base-content/70">
-                <span class="desktop-reminder-chip inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-secondary" data-tone="category">
+                <span class="desktop-reminder-chip inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70" data-tone="category">
                   <span class="desktop-reminder-chip__dot h-1.5 w-1.5 rounded-full"></span>
                   <span class="truncate">Communications</span>
                 </span>
-                <span class="desktop-reminder-chip inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-secondary">
+                <span class="desktop-reminder-chip inline-flex max-w-full items-center gap-1 rounded-full border border-base-300/80 bg-base-200/80 px-2 py-[2px] text-[0.65rem] font-medium text-base-content/70">
                   <span class="desktop-reminder-chip__dot h-1.5 w-1.5 rounded-full"></span>
                   <span class="truncate">Scheduled</span>
                 </span>
               </div>
               <div class="flex justify-end">
-                <span class="badge badge-outline badge-sm text-xs text-base-content" data-tone="due">Due next week</span>
+                <span class="badge badge-outline badge-sm text-[11px] text-base-content/80" data-tone="due">Due next week</span>
               </div>
             </div>
             <div class="task-toolbar flex justify-end gap-2 mt-2" role="toolbar" aria-label="Reminder actions">
@@ -722,9 +722,9 @@
             aria-label="Edit reminder: Call guardians"
           >
             <div class="flex min-w-0 flex-col gap-3">
-              <p class="desktop-reminder-title reminder-title text-sm font-semibold leading-snug text-base-content">Call guardians</p>
+              <p class="desktop-reminder-title reminder-title text-sm font-medium leading-snug text-base-content">Call guardians</p>
               <div class="flex justify-end">
-                <span class="badge badge-outline badge-sm text-xs text-base-content" data-tone="due">Due tomorrow</span>
+                <span class="badge badge-outline badge-sm text-[11px] text-base-content/80" data-tone="due">Due tomorrow</span>
               </div>
             </div>
             <div class="task-toolbar flex justify-end gap-2 mt-2" role="toolbar" aria-label="Reminder actions">
@@ -804,7 +804,7 @@
             </label>
           </div>
             <p id="planner-week" class="text-sm font-semibold text-base-content/80"></p>
-            <div class="[&_[data-planner-lesson]]:bg-slate-900/80 [&_[data-planner-lesson]]:text-slate-100 [&_[data-planner-lesson]]:rounded-2xl [&_[data-planner-lesson]]:shadow-lg [&_[data-planner-lesson]]:px-5 [&_[data-planner-lesson]]:pt-5 [&_[data-planner-lesson]]:pb-6 [&_[data-planner-lesson]]:flex [&_[data-planner-lesson]]:flex-col [&_[data-planner-lesson]]:justify-between [&_[data-planner-lesson]]:gap-4 [&_[data-planner-lesson]>div:last-child]:flex [&_[data-planner-lesson]>div:last-child]:justify-start [&_[data-planner-lesson]>div:last-child]:gap-3 [&_[data-planner-lesson]>div:last-child]:mt-4">
+            <div class="[&_[data-planner-lesson]]:bg-base-100 [&_[data-planner-lesson]]:text-base-content [&_[data-planner-lesson]]:rounded-2xl [&_[data-planner-lesson]]:shadow-lg [&_[data-planner-lesson]]:px-5 [&_[data-planner-lesson]]:pt-5 [&_[data-planner-lesson]]:pb-6 [&_[data-planner-lesson]]:flex [&_[data-planner-lesson]]:flex-col [&_[data-planner-lesson]]:justify-between [&_[data-planner-lesson]]:gap-4 [&_[data-planner-lesson]_.badge]:text-[11px] [&_[data-planner-lesson]_.badge]:text-base-content/80 [&_[data-planner-lesson]_.label-text]:text-[11px] [&_[data-planner-lesson]_.label-text]:tracking-[0.2em] [&_[data-planner-lesson]_.label-text]:text-base-content/60 [&_[data-planner-lesson] textarea]:text-sm [&_[data-planner-lesson] textarea]:text-base-content [&_[data-planner-lesson] textarea]:placeholder:text-base-content/60 [&_[data-planner-lesson]>div:last-child]:flex [&_[data-planner-lesson]>div:last-child]:justify-start [&_[data-planner-lesson]>div:last-child]:gap-3 [&_[data-planner-lesson]>div:last-child]:mt-4">
               <div id="plannerCards" class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"></div>
             </div>
           </div>
@@ -928,19 +928,19 @@
             <div class="card-body gap-4 p-6">
               <div class="flex flex-col gap-4">
                 <div class="flex flex-col gap-2 mb-2">
-                  <label for="noteTitle" class="text-sm font-medium">Title</label>
+                  <label for="noteTitle" class="text-xs font-semibold uppercase text-base-content/70">Title</label>
                   <input
                     id="noteTitle"
                     type="text"
-                    class="input input-bordered w-full text-base"
+                    class="input input-bordered w-full text-base text-base-content placeholder:text-base-content/60"
                     placeholder="e.g. Kids basketball schedule – this weekend"
                   />
                 </div>
                 <div class="flex flex-col gap-2">
-                  <label for="noteBody" class="text-sm font-medium">Body</label>
+                  <label for="noteBody" class="text-xs font-semibold uppercase text-base-content/70">Body</label>
                   <textarea
                     id="noteBody"
-                    class="textarea textarea-bordered w-full min-h-[10rem] resize-y text-base p-3"
+                    class="textarea textarea-bordered w-full min-h-[10rem] resize-y text-sm text-base-content p-3 placeholder:text-base-content/60"
                     rows="10"
                     placeholder="Write your note here…"
                   ></textarea>
@@ -955,10 +955,10 @@
           <aside class="desktop-panel card border border-base-300 bg-base-200/70 shadow-sm">
             <div class="card-body gap-4">
               <div>
-                <h3 class="text-base font-semibold text-base-content">Saved notes</h3>
-                <p class="text-sm text-base-content/70">Select a note to load it in the editor.</p>
+                <h3 class="text-sm font-semibold text-base-content/80">Saved notes</h3>
+                <p class="text-xs text-base-content/60">Select a note to load it in the editor.</p>
               </div>
-              <ul id="notesList" class="space-y-1 max-h-80 overflow-y-auto text-sm"></ul>
+              <ul id="notesList" class="space-y-1 max-h-80 overflow-y-auto text-sm text-base-content"></ul>
             </div>
           </aside>
         </div>


### PR DESCRIPTION
## Summary
- align reminder card headings, chips, and due badges with the shared `text-base-content` tokens for clearer hierarchy
- enforce base-content colors and typography overrides on dynamically rendered planner cards via the nested utility wrapper
- refresh the notes editor and saved notes panel labels, inputs, and helper text to meet the updated contrast guidance

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691afab643848324af1f9a7a5b81fc1e)