### PR TITLE
Refine desktop layout spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,10 +357,10 @@
     <main id="mainContent" class="desktop-main" tabindex="-1">
       <div class="desktop-main-inner space-y-8">
       <section data-route="dashboard" class="space-y-6 lg:space-y-12">
-        <div class="max-w-6xl mx-auto my-10 px-6 space-y-8">
+        <div class="max-w-6xl mx-auto my-10 px-6 py-6 md:px-8 md:py-7 space-y-6">
           <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
             <div class="lg:col-span-1">
-              <div class="bg-base-100/90 border border-base-300 rounded-3xl shadow-lg px-5 py-4 space-y-2">
+              <div class="bg-base-100/90 border border-base-300 rounded-3xl shadow-lg px-5 py-4 space-y-3">
                 <div class="flex items-start justify-between gap-3">
                   <div class="space-y-1">
                     <p class="text-sm font-semibold tracking-wide text-base-content/80">Weather</p>
@@ -700,34 +700,34 @@
       </section>
 
       <section data-route="reminders" class="space-y-6" style="display: none;">
-        <div class="max-w-6xl mx-auto my-10 bg-base-100/75 border border-base-300 rounded-[2rem] shadow-xl px-8 pt-8 pb-10 space-y-6 backdrop-blur-sm">
+        <div class="max-w-6xl mx-auto my-10 bg-base-100/75 border border-base-300 rounded-[2rem] shadow-xl px-6 py-6 md:px-8 md:py-7 space-y-6 backdrop-blur-sm">
           <div class="desktop-panel desktop-panel--reminders">
-            <header class="desktop-panel-header flex flex-wrap items-start justify-between gap-4">
-              <div class="mb-4">
+            <header class="desktop-panel-header">
+              <div class="flex items-center justify-between gap-3 mb-2">
                 <div class="space-y-1">
-                  <h2 class="desktop-panel-title text-2xl font-semibold tracking-wide text-base-content">Reminders</h2>
-                  <p class="desktop-panel-subtitle text-sm text-base-content/70">Keep track of tasks, family updates, and prep work in one organised list.</p>
+                  <h2 class="text-2xl font-semibold tracking-wide text-base-content">Reminders</h2>
+                </div>
+                <div class="desktop-panel-actions">
+                  <button
+                    type="button"
+                    class="btn btn-primary btn-sm"
+                    data-open-reminder-modal
+                    aria-haspopup="dialog"
+                    aria-controls="add-reminder-modal"
+                  >
+                    Add reminder
+                  </button>
                 </div>
               </div>
-              <div class="desktop-panel-actions">
-                <button
-                  type="button"
-                  class="btn btn-primary btn-sm"
-                  data-open-reminder-modal
-                  aria-haspopup="dialog"
-                  aria-controls="add-reminder-modal"
-                >
-                  Add reminder
-                </button>
-              </div>
+              <p class="text-sm text-base-content/70 mb-4">Keep track of tasks, family updates, and prep work in one organised list.</p>
             </header>
-          <div class="desktop-panel-toolbar flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">
+          <div class="flex flex-wrap items-center gap-2 mb-4 text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">
             <span class="btn btn-ghost btn-xs cursor-default" title="Filtering not available yet">All</span>
             <button type="button" class="btn btn-ghost btn-xs" disabled title="Filtering not available yet">Today</button>
             <button type="button" class="btn btn-ghost btn-xs" disabled title="Filtering not available yet">This week</button>
             <button type="button" class="btn btn-ghost btn-xs" disabled title="Filtering not available yet">Later</button>
           </div>
-          <ul id="reminders-list" class="desktop-reminders-list list-none grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 px-6">
+          <ul id="reminders-list" class="desktop-reminders-list list-none grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 px-6 space-y-2">
           <li
             class="reminder-item task-item desktop-task-card reminder-card bg-base-100 border border-base-300 rounded-2xl shadow-sm p-4 flex flex-col justify-between gap-3 transition hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
             role="button"
@@ -813,70 +813,64 @@
       </section>
 
       <section data-route="planner" class="space-y-6" style="display: none;">
-        <div class="max-w-6xl mx-auto my-10 bg-base-100/75 border border-base-300 rounded-[2rem] shadow-xl px-8 pt-8 pb-10 space-y-6 backdrop-blur-sm">
+        <div class="max-w-6xl mx-auto my-10 bg-base-100/75 border border-base-300 rounded-[2rem] shadow-xl px-6 py-6 md:px-8 md:py-7 space-y-6 backdrop-blur-sm">
           <div class="desktop-panel desktop-panel--planner">
-            <header class="desktop-panel-header">
-              <div class="mb-4">
-                <div class="space-y-1">
-                  <h2 class="desktop-panel-title text-2xl font-semibold tracking-wide text-base-content">Weekly planner</h2>
-                  <p class="desktop-panel-subtitle text-sm text-base-content/70">Draft the key lessons, checkpoints, and resources your classes need this week.</p>
-                </div>
-              </div>
-            </header>
-            <div class="flex justify-end gap-2 mb-4">
-              <button type="button" id="planner-duplicate-btn" class="btn btn-outline btn-sm">Duplicate plan</button>
-              <button type="button" id="planner-new-lesson-btn" class="btn btn-primary btn-sm">New lesson</button>
+            <div class="space-y-1 mb-4">
+              <h2 class="text-2xl font-semibold tracking-wide text-base-content">Weekly planner</h2>
+              <p class="text-sm text-base-content/70">Draft the key lessons, checkpoints, and resources your classes need this week.</p>
             </div>
-            <div class="desktop-panel-toolbar flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">
-              <button type="button" id="planner-prev" class="btn btn-ghost btn-xs" aria-label="View previous week">Prev</button>
-              <button type="button" id="planner-today" class="btn btn-ghost btn-xs" aria-label="Jump to current week">Today</button>
-              <button type="button" id="planner-next" class="btn btn-ghost btn-xs" aria-label="View next week">Next</button>
-              <label class="flex items-center gap-2 text-[0.65rem] tracking-[0.2em] text-base-content/70" aria-label="Choose planner text size">
-                <span class="hidden sm:inline">Text size</span>
-              <select
-                class="select select-bordered select-xs w-auto"
-                data-planner-text-size
-                aria-label="Planner text size"
-              >
-                <option value="small">Small</option>
-                <option value="default">Default</option>
-                <option value="large">Large</option>
-              </select>
-            </label>
-          </div>
-          <div class="flex flex-wrap items-end gap-3 text-sm text-base-content/80">
-            <label class="form-control w-full max-w-xs md:w-auto">
-              <div class="label py-0">
-                <span class="label-text text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Template</span>
+            <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
+              <div class="flex items-center gap-2">
+                <button type="button" id="planner-prev" class="btn btn-ghost btn-xs" aria-label="View previous week">Prev</button>
+                <button type="button" id="planner-today" class="btn btn-ghost btn-xs" aria-label="Jump to current week">Today</button>
+                <button type="button" id="planner-next" class="btn btn-ghost btn-xs" aria-label="View next week">Next</button>
+                <label class="flex items-center gap-2 text-[0.65rem] tracking-[0.2em] text-base-content/70" aria-label="Choose planner text size">
+                  <span class="hidden sm:inline">Text size</span>
+                  <select
+                    class="select select-bordered select-xs w-auto"
+                    data-planner-text-size
+                    aria-label="Planner text size"
+                  >
+                    <option value="small">Small</option>
+                    <option value="default">Default</option>
+                    <option value="large">Large</option>
+                  </select>
+                </label>
               </div>
-              <select
-                id="planner-template-select"
-                class="select select-bordered select-sm w-full md:w-56"
-                aria-label="Choose a planner template"
-              >
-                <option value="">No templates saved</option>
-              </select>
-            </label>
-            <button type="button" id="planner-template-save-btn" class="btn btn-outline btn-sm">
-              Save current week as template
-            </button>
-            <label class="form-control w-full max-w-xs md:w-auto">
-              <div class="label py-0">
-                <span class="label-text text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Subject filter</span>
+              <div class="flex flex-wrap items-center gap-2">
+                <button type="button" id="planner-duplicate-btn" class="btn btn-outline btn-sm">Duplicate plan</button>
+                <button type="button" id="planner-new-lesson-btn" class="btn btn-primary btn-sm">New lesson</button>
+                <label class="form-control w-full max-w-xs md:w-auto">
+                  <div class="label py-0">
+                    <span class="label-text text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Template</span>
+                  </div>
+                  <select
+                    id="planner-template-select"
+                    class="select select-bordered select-sm w-full md:w-56"
+                    aria-label="Choose a planner template"
+                  >
+                    <option value="">No templates saved</option>
+                  </select>
+                </label>
+                <button type="button" id="planner-template-save-btn" class="btn btn-outline btn-sm">Save current week as template</button>
+                <label class="form-control w-full max-w-xs md:w-auto">
+                  <div class="label py-0">
+                    <span class="label-text text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Subject filter</span>
+                  </div>
+                  <select
+                    id="planner-subject-filter"
+                    class="select select-bordered select-sm w-full md:w-48"
+                    aria-label="Filter planner by subject"
+                  >
+                    <option value="all">All subjects</option>
+                  </select>
+                  <p class="mt-1 text-xs text-base-content/60">Show lessons by the subjects you teach.</p>
+                </label>
               </div>
-              <select
-                id="planner-subject-filter"
-                class="select select-bordered select-sm w-full md:w-48"
-                aria-label="Filter planner by subject"
-              >
-                <option value="all">All subjects</option>
-              </select>
-              <p class="mt-1 text-xs text-base-content/60">Show lessons by the subjects you teach.</p>
-            </label>
-          </div>
-            <p id="planner-week" class="text-sm font-semibold text-base-content/80"></p>
-            <div class="[&_[data-planner-lesson]]:bg-base-100 [&_[data-planner-lesson]]:text-base-content [&_[data-planner-lesson]]:rounded-2xl [&_[data-planner-lesson]]:shadow-lg [&_[data-planner-lesson]]:px-5 [&_[data-planner-lesson]]:pt-5 [&_[data-planner-lesson]]:pb-6 [&_[data-planner-lesson]]:flex [&_[data-planner-lesson]]:flex-col [&_[data-planner-lesson]]:justify-between [&_[data-planner-lesson]]:gap-4 [&_[data-planner-lesson]_.badge]:text-[11px] [&_[data-planner-lesson]_.badge]:text-base-content/80 [&_[data-planner-lesson]_.label-text]:text-[11px] [&_[data-planner-lesson]_.label-text]:tracking-[0.2em] [&_[data-planner-lesson]_.label-text]:text-base-content/60 [&_[data-planner-lesson] textarea]:text-sm [&_[data-planner-lesson] textarea]:text-base-content [&_[data-planner-lesson] textarea]:placeholder:text-base-content/60 [&_[data-planner-lesson]>div:last-child]:flex [&_[data-planner-lesson]>div:last-child]:justify-start [&_[data-planner-lesson]>div:last-child]:gap-3 [&_[data-planner-lesson]>div:last-child]:mt-4">
-              <div id="plannerCards" class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"></div>
+            </div>
+            <p id="planner-week" class="text-sm font-semibold text-base-content/80 mb-3"></p>
+            <div class="[&_[data-planner-lesson]]:bg-base-100 [&_[data-planner-lesson]]:text-base-content [&_[data-planner-lesson]]:rounded-2xl [&_[data-planner-lesson]]:shadow-lg [&_[data-planner-lesson]]:px-4 [&_[data-planner-lesson]]:py-4 [&_[data-planner-lesson]]:flex [&_[data-planner-lesson]]:flex-col [&_[data-planner-lesson]]:justify-between [&_[data-planner-lesson]]:space-y-2 [&_[data-planner-lesson]_.badge]:text-[11px] [&_[data-planner-lesson]_.badge]:text-base-content/80 [&_[data-planner-lesson]_.label-text]:text-[11px] [&_[data-planner-lesson]_.label-text]:tracking-[0.2em] [&_[data-planner-lesson]_.label-text]:text-base-content/60 [&_[data-planner-lesson] textarea]:text-sm [&_[data-planner-lesson] textarea]:text-base-content [&_[data-planner-lesson] textarea]:placeholder:text-base-content/60 [&_[data-planner-lesson]>div:last-child]:flex [&_[data-planner-lesson]>div:last-child]:justify-start [&_[data-planner-lesson]>div:last-child]:gap-2 [&_[data-planner-lesson]>div:last-child]:mt-3">
+              <div id="plannerCards" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"></div>
             </div>
           </div>
         </div>
@@ -983,57 +977,51 @@
       </div>
 
       <section data-route="notes" class="space-y-6" style="display: none;">
-        <div class="max-w-6xl mx-auto my-10 bg-base-100/75 border border-base-300 rounded-[2rem] shadow-xl px-8 pt-8 pb-10 space-y-6 backdrop-blur-sm">
-          <div class="desktop-panel desktop-panel--notes-intro">
-            <header class="desktop-panel-header">
-              <div class="mb-4">
-                <div class="space-y-1">
-                  <h2 class="desktop-panel-title text-2xl font-semibold tracking-wide text-base-content">Notes</h2>
-                  <p class="desktop-panel-subtitle text-sm text-base-content/70">Capture observations, behaviour wins, and quick reflections to revisit later.</p>
-                </div>
-              </div>
-            </header>
+        <div class="max-w-6xl mx-auto my-10 bg-base-100/75 border border-base-300 rounded-[2rem] shadow-xl px-6 py-6 md:px-8 md:py-7 space-y-6 backdrop-blur-sm">
+          <div class="space-y-1 mb-4">
+            <h2 class="text-2xl font-semibold tracking-wide text-base-content">Notes</h2>
+            <p class="text-sm text-base-content/70">Capture observations, behaviour wins, and quick reflections to revisit later.</p>
           </div>
-          <div class="desktop-notes-grid grid gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,4fr)_minmax(0,1fr)]">
-          <article class="desktop-panel card notes-editor-card rounded-xl border border-base-300 bg-base-100 text-base-content shadow-sm dark:bg-base-200 dark:text-base-content">
-            <div class="card-body gap-4 p-6">
-              <div class="flex flex-col gap-4">
-                <div class="flex flex-col gap-2 mb-2">
-                  <label for="noteTitle" class="text-xs font-semibold uppercase text-base-content/70">Title</label>
-                  <input
-                    id="noteTitle"
-                    type="text"
-                    class="input input-bordered w-full text-base text-base-content placeholder:text-base-content/60"
-                    placeholder="e.g. Kids basketball schedule – this weekend"
-                  />
-                </div>
-                <div class="flex flex-col gap-2">
-                  <label for="noteBody" class="text-xs font-semibold uppercase text-base-content/70">Body</label>
-                  <textarea
-                    id="noteBody"
-                    class="textarea textarea-bordered w-full min-h-[10rem] resize-y text-sm text-base-content p-3 placeholder:text-base-content/60"
-                    rows="10"
-                    placeholder="Write your note here…"
-                  ></textarea>
-                </div>
-                <div class="flex justify-end gap-2 mt-4">
-                  <button id="noteSaveBtn" type="button" class="btn btn-primary btn-sm">Save</button>
-                  <button id="noteNewBtn" type="button" class="btn btn-outline btn-sm">New note</button>
+          <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
+            <article class="desktop-panel card notes-editor-card rounded-xl border border-base-300 bg-base-100 text-base-content shadow-sm dark:bg-base-200 dark:text-base-content">
+              <div class="card-body gap-4 p-6">
+                <div class="space-y-4">
+                  <div class="space-y-1 mb-3">
+                    <label for="noteTitle" class="text-xs font-semibold uppercase text-base-content/70">Title</label>
+                    <input
+                      id="noteTitle"
+                      type="text"
+                      class="input input-bordered w-full text-base text-base-content placeholder:text-base-content/60"
+                      placeholder="e.g. Kids basketball schedule – this weekend"
+                    />
+                  </div>
+                  <div class="space-y-1 mb-3">
+                    <label for="noteBody" class="text-xs font-semibold uppercase text-base-content/70">Body</label>
+                    <textarea
+                      id="noteBody"
+                      class="textarea textarea-bordered w-full min-h-[10rem] resize-y text-sm text-base-content p-3 placeholder:text-base-content/60"
+                      rows="10"
+                      placeholder="Write your note here…"
+                    ></textarea>
+                  </div>
+                  <div class="flex justify-end gap-2 mt-2">
+                    <button id="noteSaveBtn" type="button" class="btn btn-primary btn-sm">Save</button>
+                    <button id="noteNewBtn" type="button" class="btn btn-outline btn-sm">New note</button>
+                  </div>
                 </div>
               </div>
-            </div>
-          </article>
-          <aside class="desktop-panel card border border-base-300 bg-base-200/70 shadow-sm">
-            <div class="card-body gap-4">
-              <div>
-                <h3 class="text-sm font-semibold text-base-content/80">Saved notes</h3>
-                <p class="text-xs text-base-content/60">Select a note to load it in the editor.</p>
+            </article>
+            <aside class="desktop-panel card border border-base-300 bg-base-200/70 shadow-sm">
+              <div class="card-body gap-4">
+                <div class="space-y-1 mb-3">
+                  <h3 class="text-sm font-semibold text-base-content/80">Saved notes</h3>
+                  <p class="text-xs text-base-content/60">Select a note to load it in the editor.</p>
+                </div>
+                <ul id="notesList" class="space-y-1 text-sm text-base-content max-h-80 overflow-y-auto"></ul>
               </div>
-              <ul id="notesList" class="space-y-1 max-h-80 overflow-y-auto text-sm text-base-content"></ul>
-            </div>
-          </aside>
+            </aside>
+          </div>
         </div>
-      </div>
       </section>
 
       <section data-route="resources" class="space-y-6" style="display: none;">


### PR DESCRIPTION
## Summary
- standardize padding on the main dashboard cards and ensure each widget stack has consistent spacing for its content
- refresh the Reminders, Planner, and Notes sections with the requested wrappers, gap utilities, and responsive grid tweaks

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b03502bb88324b582524525293655)