### PR TITLE
Adjust mobile quick add layout

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2591,21 +2591,24 @@
       border-bottom: none;
       backdrop-filter: none;
       margin: 0.25rem 0 0.25rem;
+      width: 100%;
     }
 
     .mc-quick-add-inner {
-      max-width: 28rem;
-      margin: 0 auto;
-      padding: 0.4rem 0.85rem;
+      width: 100%;
+      max-width: none;
+      margin: 0;
+      padding: 0;
       display: flex;
-      align-items: center;
-      justify-content: space-between;
+      flex-direction: column;
+      align-items: stretch;
+      justify-content: flex-start;
       gap: 0.75rem;
-      border-radius: 999px;
-      background: var(--mobile-quick-surface);
-      border: 1px solid color-mix(in srgb, var(--card-border) 80%, transparent);
-      box-shadow: var(--mobile-quick-shadow);
-      backdrop-filter: blur(14px);
+      border-radius: 0;
+      background: transparent;
+      border: none;
+      box-shadow: none;
+      backdrop-filter: none;
     }
 
     .mc-quick-status {


### PR DESCRIPTION
## Summary
- remove the pill-style background from the mobile quick-add container so the add-reminder controls sit directly on the page
- let the quick-add row stretch to the full screen width for better alignment on all phone sizes and tighten its spacing on compact breakpoints

## Testing
- not run (UI change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b042b2a7883249bc7db080e314c13)