### PR TITLE
Improve theme toggle to support multiple themes

### DIFF
--- a/theme-toggle.test.js
+++ b/theme-toggle.test.js
@@ -53,9 +53,10 @@ test('toggle persists theme', () => {
   const btn = document.getElementById('theme-toggle');
   // Default should be professional and not stored until the user changes it
   expect(document.documentElement.getAttribute('data-theme')).toBe('professional');
+  expect(document.documentElement.dataset.theme).toBe('professional');
   expect(localStorage.getItem('theme')).toBeNull();
   btn.click();
-  expect(localStorage.getItem('theme')).toBe('dark');
+  expect(localStorage.getItem('theme')).toBe('night');
   btn.click();
-  expect(localStorage.getItem('theme')).toBe('light');
+  expect(localStorage.getItem('theme')).toBe('professional');
 });


### PR DESCRIPTION
## Summary
- cycle the theme toggle through the supported themes and keep the root dataset in sync
- normalize legacy dark/light localStorage values to the new professional/night options
- update the unit test to reflect the new theme sequence and dataset expectation

## Testing
- `npm test -- --runInBand` *(fails: existing Jest suites that load ESM modules via vm continue to throw "Cannot use import statement outside a module" errors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b0628e7088324850131d84692c7fe)