### PR TITLE
Adjust mobile notebook padding

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -175,9 +175,11 @@
   .mobile-shell #view-notebook .card {
     border-radius: 1.1rem;
     box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
+    padding-inline: 0;
   }
 
   .mobile-shell #view-notebook .card-body {
+    padding-inline: 0;
     padding-bottom: 0.5rem;
   }
 
@@ -3311,7 +3313,7 @@
               </label>
 
               <div
-                class="flex flex-wrap items-center gap-3 rounded-2xl border border-base-200/70 bg-base-100/80 px-3 py-2 text-xs text-base-content/70"
+                class="flex flex-wrap items-center gap-3 rounded-2xl border border-base-200/70 bg-base-100/80 px-0 md:px-3 py-2 text-xs text-base-content/70"
                 data-note-toolbar
               >
                 <span class="font-semibold text-base-content text-sm">Text size</span>


### PR DESCRIPTION
## Summary
- remove the horizontal padding from the notebook card/card body when the mobile shell is active so the hero, title, and body inputs reach the screen edge
- keep the note toolbar flush on phones by only applying its horizontal padding at desktop breakpoints

## Testing
- not run (CSS-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b097d601883248e1124cae54d489f)