### PR TITLE
Align desktop dashboard containers

### DIFF
--- a/index.html
+++ b/index.html
@@ -358,178 +358,186 @@
       <div class="desktop-main-inner space-y-8">
       <section data-route="dashboard" class="space-y-6 lg:space-y-12">
         <div class="max-w-6xl mx-auto my-10 px-6 py-6 md:px-8 md:py-7 space-y-6">
-          <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
-            <div class="lg:col-span-1">
-              <div class="bg-base-100/90 border border-base-300 rounded-3xl shadow-lg px-5 py-4 space-y-3">
-                <div class="flex items-start justify-between gap-3">
-                  <div class="space-y-1">
-                    <p class="text-sm font-semibold tracking-wide text-base-content/80">Weather</p>
-                    <p id="weatherStatus" class="text-xs text-base-content/60" role="status" aria-live="polite">
-                      Checking the latest forecast…
-                    </p>
-                  </div>
-                  <span id="weatherIcon" class="text-3xl" aria-hidden="true">⛅️</span>
+          <section class="desktop-hero">
+            <div class="hero-content">
+              <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
+                <div class="lg:col-span-1">
+                  <article class="dashboard-card dashboard-card--hero h-full">
+                    <div class="dashboard-card-content">
+                      <div class="flex items-start justify-between gap-3">
+                        <div class="space-y-1">
+                          <p class="dashboard-card-eyebrow">Weather</p>
+                          <p id="weatherStatus" class="text-xs text-base-content/60" role="status" aria-live="polite">
+                            Checking the latest forecast…
+                          </p>
+                        </div>
+                        <span id="weatherIcon" class="text-3xl" aria-hidden="true">⛅️</span>
+                      </div>
+                      <div class="flex flex-wrap items-end gap-4">
+                        <p id="weatherTemperature" class="dashboard-card-metric">--°C</p>
+                        <p id="weatherDescription" class="dashboard-card-text">Awaiting update</p>
+                      </div>
+                      <dl class="grid gap-3 sm:grid-cols-2">
+                        <div>
+                          <dt class="text-[11px] font-semibold tracking-wide uppercase text-base-content/60">Location</dt>
+                          <dd id="weatherLocation" class="text-xs text-base-content/80">Locating…</dd>
+                        </div>
+                        <div>
+                          <dt class="text-[11px] font-semibold tracking-wide uppercase text-base-content/60">Wind</dt>
+                          <dd id="weatherWind" class="text-xs text-base-content/80">-- km/h</dd>
+                        </div>
+                        <div>
+                          <dt class="text-[11px] font-semibold tracking-wide uppercase text-base-content/60">Humidity</dt>
+                          <dd id="weatherHumidity" class="text-xs text-base-content/80">--%</dd>
+                        </div>
+                        <div>
+                          <dt class="text-[11px] font-semibold tracking-wide uppercase text-base-content/60">Feels like</dt>
+                          <dd id="weatherFeelsLike" class="text-xs text-base-content/80">--°C</dd>
+                        </div>
+                      </dl>
+                      <p id="weatherFootnote" class="text-xs text-base-content/60">We use your approximate location to calculate these details.</p>
+                      <div class="weather-radar" aria-label="Live radar" role="group">
+                        <p class="weather-radar__message text-xs text-base-content/60">
+                          Live radar opens in a new tab due to browser security settings.
+                        </p>
+                        <a
+                          class="btn btn-primary btn-sm mt-2"
+                          href="https://www.windy.com/-Weather-radar-radar"
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          Open Windy radar
+                        </a>
+                      </div>
+                    </div>
+                  </article>
                 </div>
-                <div class="flex flex-wrap items-end gap-4">
-                  <p id="weatherTemperature" class="text-3xl font-semibold text-base-content">--°C</p>
-                  <p id="weatherDescription" class="text-sm text-base-content/80">Awaiting update</p>
-                </div>
-                <dl class="grid gap-3 sm:grid-cols-2">
-                  <div>
-                    <dt class="text-[11px] font-semibold tracking-wide uppercase text-base-content/60">Location</dt>
-                    <dd id="weatherLocation" class="text-xs text-base-content/80">Locating…</dd>
-                  </div>
-                  <div>
-                    <dt class="text-[11px] font-semibold tracking-wide uppercase text-base-content/60">Wind</dt>
-                    <dd id="weatherWind" class="text-xs text-base-content/80">-- km/h</dd>
-                  </div>
-                  <div>
-                    <dt class="text-[11px] font-semibold tracking-wide uppercase text-base-content/60">Humidity</dt>
-                    <dd id="weatherHumidity" class="text-xs text-base-content/80">--%</dd>
-                  </div>
-                  <div>
-                    <dt class="text-[11px] font-semibold tracking-wide uppercase text-base-content/60">Feels like</dt>
-                    <dd id="weatherFeelsLike" class="text-xs text-base-content/80">--°C</dd>
-                  </div>
-                </dl>
-                <p id="weatherFootnote" class="text-xs text-base-content/60">We use your approximate location to calculate these details.</p>
-                <div class="weather-radar space-y-2 rounded-xl border border-dashed border-base-300/80 bg-base-200/40 p-3" aria-label="Live radar" role="group">
-                  <p class="weather-radar__message text-xs text-base-content/60">
-                    Live radar opens in a new tab due to browser security settings.
-                  </p>
-                  <a
-                    class="btn btn-primary btn-sm mt-2"
-                    href="https://www.windy.com/-Weather-radar-radar"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Open Windy radar
-                  </a>
+                <div class="lg:col-span-2">
+                  <article class="dashboard-card dashboard-card--hero h-full">
+                    <div class="dashboard-card-content">
+                      <div class="space-y-1">
+                        <p class="dashboard-card-eyebrow">Top educational news</p>
+                        <h2 class="dashboard-card-title dashboard-card-title--hero">Start conversations informed</h2>
+                      </div>
+                      <p id="newsStatus" class="dashboard-card-text" role="status" aria-live="polite">
+                        Gathering the top educational news…
+                      </p>
+                      <div id="newsContent" class="hidden space-y-4">
+                        <a
+                          id="newsPrimaryLink"
+                          href="#"
+                          class="block rounded-2xl border border-base-300 bg-base-100/90 p-4 text-left transition hover:border-primary/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          <p class="text-xs font-semibold tracking-wide uppercase text-base-content/60">Lead story</p>
+                          <p id="newsHeadline" class="mt-2 text-sm font-semibold text-primary hover:underline"></p>
+                          <p id="newsSource" class="mt-1 text-sm text-base-content/80"></p>
+                        </a>
+                        <div>
+                          <p class="text-xs font-semibold tracking-wide uppercase text-base-content/60">More to skim</p>
+                          <ul id="newsTopStories" class="mt-3 space-y-1 text-sm"></ul>
+                        </div>
+                      </div>
+                      <p id="newsFootnote" class="text-xs text-base-content/60" aria-live="polite"></p>
+                    </div>
+                  </article>
                 </div>
               </div>
             </div>
-            <div class="lg:col-span-2">
-              <div class="bg-base-100/90 border border-base-300 rounded-3xl shadow-lg px-5 py-4 space-y-3">
-                <div class="space-y-1">
-                  <p class="text-xs font-semibold tracking-wide uppercase text-base-content/60">Top educational news</p>
-                  <h2 class="text-lg font-semibold tracking-wide text-base-content">Start conversations informed</h2>
-                </div>
-                <p id="newsStatus" class="text-sm text-base-content/80" role="status" aria-live="polite">
-                  Gathering the top educational news…
-                </p>
-                <div id="newsContent" class="hidden space-y-4">
-                  <a
-                    id="newsPrimaryLink"
-                    href="#"
-                    class="block rounded-2xl border border-base-300 bg-base-100/90 p-4 text-left transition hover:border-primary/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    <p class="text-xs font-semibold tracking-wide uppercase text-base-content/60">Lead story</p>
-                    <p id="newsHeadline" class="mt-2 text-sm font-semibold text-primary hover:underline"></p>
-                    <p id="newsSource" class="mt-1 text-sm text-base-content/80"></p>
-                  </a>
-                  <div>
-                    <p class="text-xs font-semibold tracking-wide uppercase text-base-content/60">More to skim</p>
-                    <ul id="newsTopStories" class="mt-3 space-y-1 text-sm"></ul>
-                  </div>
-                </div>
-                <p id="newsFootnote" class="text-xs text-base-content/60" aria-live="polite"></p>
-              </div>
-            </div>
-          </div>
+          </section>
           <div class="grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
-            <div class="md:col-span-1">
-              <div class="bg-base-100/90 border border-base-300 rounded-3xl shadow-lg px-5 py-4 space-y-3">
-                <div class="flex items-center justify-between gap-2">
-                  <h2 class="text-sm font-semibold tracking-wide text-base-content/80 uppercase">
-                    Today’s reminders
-                  </h2>
-                  <!-- Optional simple icon -->
-                  <span class="text-lg" aria-hidden="true">⏰</span>
+            <div class="md:col-span-1 h-full">
+              <article class="dashboard-card dashboard-card--compact h-full">
+                <div class="dashboard-card-content">
+                  <div class="flex items-center justify-between gap-2">
+                    <p class="dashboard-card-eyebrow">Today’s reminders</p>
+                    <span class="text-lg" aria-hidden="true">⏰</span>
+                  </div>
+
+                  <p class="dashboard-card-text">
+                    A quick snapshot of what you’ve scheduled for today.
+                  </p>
+
+                  <div class="flex items-baseline gap-2">
+                    <span class="dashboard-card-metric" id="dashboard-reminders-today-count" aria-live="polite">
+                      –
+                    </span>
+                    <span class="text-xs text-base-content/70 uppercase tracking-wide">
+                      reminders today
+                    </span>
+                  </div>
+
+                  <ul class="space-y-1 text-sm text-base-content/80">
+                    <li class="flex items-center gap-2">
+                      <span class="w-1.5 h-1.5 rounded-full bg-primary/70"></span>
+                      <span>Use quick-add in Reminders to capture new tasks.</span>
+                    </li>
+                    <li class="flex items-center gap-2">
+                      <span class="w-1.5 h-1.5 rounded-full bg-primary/30"></span>
+                      <span>Mark tasks complete from the Reminders tab when they’re done.</span>
+                    </li>
+                  </ul>
+
+                  <div class="pt-1">
+                    <button class="btn btn-outline btn-sm" type="button" data-route-target="reminders">
+                      Open Reminders
+                    </button>
+                  </div>
                 </div>
-
-                <p class="text-sm text-base-content/80">
-                  A quick snapshot of what you’ve scheduled for today.
-                </p>
-
-                <div class="flex items-baseline gap-2">
-                  <span class="text-3xl font-semibold text-base-content" id="dashboard-reminders-today-count" aria-live="polite">
-                    –
-                  </span>
-                  <span class="text-xs text-base-content/70 uppercase tracking-wide">
-                    reminders today
-                  </span>
-                </div>
-
-                <ul class="space-y-1 text-sm text-base-content/80">
-                  <li class="flex items-center gap-2">
-                    <span class="w-1.5 h-1.5 rounded-full bg-primary/70"></span>
-                    <span>Use quick-add in Reminders to capture new tasks.</span>
-                  </li>
-                  <li class="flex items-center gap-2">
-                    <span class="w-1.5 h-1.5 rounded-full bg-primary/30"></span>
-                    <span>Mark tasks complete from the Reminders tab when they’re done.</span>
-                  </li>
-                </ul>
-
-                <div class="pt-1">
-                  <button class="btn btn-outline btn-sm" type="button" data-route-target="reminders">
-                    Open Reminders
-                  </button>
-                </div>
-              </div>
+              </article>
             </div>
-            <div class="md:col-span-1">
-              <div class="bg-base-100/90 border border-base-300 rounded-3xl shadow-lg px-5 py-4 space-y-3">
-                <div class="flex items-center justify-between gap-2">
-                  <h2 class="text-sm font-semibold tracking-wide text-base-content/80 uppercase">
-                    Next lesson
-                  </h2>
-                  <span class="text-lg" aria-hidden="true">🗓️</span>
-                </div>
+            <div class="md:col-span-1 h-full">
+              <article class="dashboard-card dashboard-card--compact h-full">
+                <div class="dashboard-card-content">
+                  <div class="flex items-center justify-between gap-2">
+                    <p class="dashboard-card-eyebrow">Next lesson</p>
+                    <span class="text-lg" aria-hidden="true">🗓️</span>
+                  </div>
 
-                <p class="text-sm text-base-content/80">
-                  Jot down the key focus for your upcoming class so it’s top of mind.
-                </p>
+                  <p class="dashboard-card-text">
+                    Jot down the key focus for your upcoming class so it’s top of mind.
+                  </p>
 
-                <div class="space-y-1">
-                  <label class="text-xs font-semibold tracking-wide text-base-content/60 uppercase" for="dashboard-next-lesson-title">
-                    Lesson title
-                  </label>
-                  <input
-                    id="dashboard-next-lesson-title"
-                    type="text"
-                    class="input input-bordered input-sm w-full text-sm text-base-content"
-                    placeholder="e.g. Yr7 English – Two Wolves chapter 5"
-                  >
-                </div>
+                  <div class="space-y-1">
+                    <label class="text-xs font-semibold tracking-wide text-base-content/60 uppercase" for="dashboard-next-lesson-title">
+                      Lesson title
+                    </label>
+                    <input
+                      id="dashboard-next-lesson-title"
+                      type="text"
+                      class="input input-bordered input-sm w-full text-sm text-base-content"
+                      placeholder="e.g. Yr7 English – Two Wolves chapter 5"
+                    >
+                  </div>
 
-                <div class="space-y-1">
-                  <label class="text-xs font-semibold tracking-wide text-base-content/60 uppercase" for="dashboard-next-lesson-focus">
-                    Focus / key point
-                  </label>
-                  <textarea
-                    id="dashboard-next-lesson-focus"
-                    class="textarea textarea-bordered w-full min-h-[4rem] text-sm text-base-content"
-                    placeholder="Main activity, checkpoint, or behaviour focus for this lesson."
-                  ></textarea>
-                </div>
+                  <div class="space-y-1">
+                    <label class="text-xs font-semibold tracking-wide text-base-content/60 uppercase" for="dashboard-next-lesson-focus">
+                      Focus / key point
+                    </label>
+                    <textarea
+                      id="dashboard-next-lesson-focus"
+                      class="textarea textarea-bordered w-full min-h-[4rem] text-sm text-base-content"
+                      placeholder="Main activity, checkpoint, or behaviour focus for this lesson."
+                    ></textarea>
+                  </div>
 
-                <div class="flex justify-end gap-2 pt-1">
-                  <button class="btn btn-outline btn-sm" type="button">
-                    Copy to planner
-                  </button>
+                  <div class="flex justify-end gap-2 pt-1">
+                    <button class="btn btn-outline btn-sm" type="button">
+                      Copy to planner
+                    </button>
+                  </div>
                 </div>
-              </div>
+              </article>
             </div>
           </div>
         </div>
 
-        <section class="dashboard-kpis" aria-labelledby="kpi-heading">
+        <div class="desktop-dashboard-grid">
+          <section class="dashboard-kpis" aria-labelledby="kpi-heading">
           <h2 id="kpi-heading" class="sr-only">Key metrics</h2>
           <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            <article class="bg-base-100 border border-base-300 rounded-2xl shadow-sm px-4 py-3 flex flex-col gap-1.5">
+            <article class="dashboard-kpi-tile px-4 py-3 flex flex-col gap-1.5">
               <div class="flex items-center justify-between">
                 <p class="text-xs font-medium tracking-wide text-base-content/70 uppercase">Reminders</p>
                 <span aria-hidden="true">🔔</span>
@@ -537,7 +545,7 @@
               <p class="text-xl font-semibold text-base-content"><span id="remindersCount">0</span></p>
               <p class="text-[11px] text-base-content/60"><span id="remindersSubtitle"></span></p>
             </article>
-            <article class="bg-base-100 border border-base-300 rounded-2xl shadow-sm px-4 py-3 flex flex-col gap-1.5">
+            <article class="dashboard-kpi-tile px-4 py-3 flex flex-col gap-1.5">
               <div class="flex items-center justify-between">
                 <p class="text-xs font-medium tracking-wide text-base-content/70 uppercase">Planner</p>
                 <span aria-hidden="true">🗂️</span>
@@ -545,7 +553,7 @@
               <p class="text-xl font-semibold text-base-content"><span id="plannerCount">0</span></p>
               <p class="text-[11px] text-base-content/60"><span id="plannerSubtitle"></span></p>
             </article>
-            <article class="bg-base-100 border border-base-300 rounded-2xl shadow-sm px-4 py-3 flex flex-col gap-1.5">
+            <article class="dashboard-kpi-tile px-4 py-3 flex flex-col gap-1.5">
               <div class="flex items-center justify-between">
                 <p class="text-xs font-medium tracking-wide text-base-content/70 uppercase">Resources</p>
                 <span aria-hidden="true">📁</span>
@@ -553,7 +561,7 @@
               <p class="text-xl font-semibold text-base-content"><span id="resourcesCount">0</span></p>
               <p class="text-[11px] text-base-content/60"><span id="resourcesSubtitle"></span></p>
             </article>
-            <article class="bg-base-100 border border-base-300 rounded-2xl shadow-sm px-4 py-3 flex flex-col gap-1.5">
+            <article class="dashboard-kpi-tile px-4 py-3 flex flex-col gap-1.5">
               <div class="flex items-center justify-between">
                 <p class="text-xs font-medium tracking-wide text-base-content/70 uppercase">Templates</p>
                 <span aria-hidden="true">🧩</span>
@@ -562,79 +570,82 @@
               <p class="text-[11px] text-base-content/60"><span id="templatesSubtitle"></span></p>
             </article>
           </div>
-        </section>
-
-        <div class="grid gap-6 lg:grid-cols-2">
-          <section class="dashboard-card relative backdrop-blur">
-            <div class="dashboard-card-content">
-              <h2
-                id="daily-snapshot-heading"
-                class="dashboard-card-title"
-              >
-                Daily snapshot
-              </h2>
-              <ul
-                id="dailySnapshotList"
-                class="mt-5 space-y-4 dashboard-card-text"
-                role="list"
-                aria-labelledby="daily-snapshot-heading"
-              ></ul>
-              <div class="mt-6 rounded-2xl border border-dashed border-base-200 bg-base-200/60 p-4">
-                <p class="dashboard-card-eyebrow">Shortcut</p>
-                <p class="dashboard-card-text mt-1">Press <kbd class="kbd kbd-sm">Shift</kbd><span class="mx-1">+</span><kbd class="kbd kbd-sm">K</kbd> for quick actions anywhere in the app.</p>
-              </div>
-            </div>
           </section>
 
-          <section class="bg-base-100 border border-base-300 rounded-2xl shadow-sm px-4 py-4 flex flex-col gap-2">
-            <div class="flex flex-wrap items-start justify-between gap-4">
-              <div class="space-y-3">
-                <h2 id="todays-focus-heading" class="text-sm font-semibold text-base-content/80">Today's focus</h2>
-                <p class="text-sm text-base-content/90">
-                  Keep literacy collaborative, celebrate small wins, and capture anything that needs follow up before the afternoon rush.
-                </p>
-                <dl class="flex flex-wrap gap-3 text-xs text-base-content/60">
-                  <div class="flex items-center gap-2">
-                    <dt class="font-semibold uppercase tracking-[0.3em]">Focus area</dt>
-                    <dd class="badge badge-outline badge-xs text-[11px]">Literacy workshops</dd>
-                  </div>
-                  <div class="flex items-center gap-2">
-                    <dt class="font-semibold uppercase tracking-[0.3em]">Time block</dt>
-                    <dd class="badge badge-outline badge-xs text-[11px]">Period 2 · 45 mins</dd>
-                  </div>
-                  <div class="flex items-center gap-2">
-                    <dt class="font-semibold uppercase tracking-[0.3em]">Support</dt>
-                    <dd class="badge badge-outline badge-xs text-[11px]">Co-teach with Mia</dd>
-                  </div>
-                </dl>
+          <div class="flex flex-col gap-6">
+            <section class="dashboard-card relative backdrop-blur">
+              <div class="dashboard-card-content">
+                <h2
+                  id="daily-snapshot-heading"
+                  class="dashboard-card-title"
+                >
+                  Daily snapshot
+                </h2>
+                <ul
+                  id="dailySnapshotList"
+                  class="mt-5 space-y-4 dashboard-card-text"
+                  role="list"
+                  aria-labelledby="daily-snapshot-heading"
+                ></ul>
+                <div class="mt-6 rounded-2xl border border-dashed border-base-200 bg-base-200/60 p-4">
+                  <p class="dashboard-card-eyebrow">Shortcut</p>
+                  <p class="dashboard-card-text mt-1">Press <kbd class="kbd kbd-sm">Shift</kbd><span class="mx-1">+</span><kbd class="kbd kbd-sm">K</kbd> for quick actions anywhere in the app.</p>
+                </div>
               </div>
-              <div class="flex flex-wrap items-center gap-2">
-                  <button
-                    class="btn btn-primary btn-sm sm:btn-md"
-                    type="button"
-                    data-open-reminder-modal
-                    aria-haspopup="dialog"
-                    aria-controls="add-reminder-modal"
-                  >
-                    Add reminder
-                  </button>
-                  <div class="join hidden sm:inline-flex">
-                    <button class="btn btn-sm join-item btn-outline" type="button">Low</button>
-                    <button class="btn btn-sm join-item btn-outline" type="button">Medium</button>
-                    <button class="btn btn-sm join-item btn-outline" type="button">High</button>
+            </section>
+
+            <section class="dashboard-card card dashboard-card--compact flex flex-col gap-2">
+              <div class="dashboard-card-content">
+                <div class="flex flex-wrap items-start justify-between gap-4">
+                  <div class="space-y-3">
+                    <h2 id="todays-focus-heading" class="dashboard-card-title">Today's focus</h2>
+                    <p class="dashboard-card-text">
+                      Keep literacy collaborative, celebrate small wins, and capture anything that needs follow up before the afternoon rush.
+                    </p>
+                    <dl class="flex flex-wrap gap-3 text-xs text-base-content/60">
+                      <div class="flex items-center gap-2">
+                        <dt class="font-semibold uppercase tracking-[0.3em]">Focus area</dt>
+                        <dd class="badge badge-outline badge-xs text-[11px]">Literacy workshops</dd>
+                      </div>
+                      <div class="flex items-center gap-2">
+                        <dt class="font-semibold uppercase tracking-[0.3em]">Time block</dt>
+                        <dd class="badge badge-outline badge-xs text-[11px]">Period 2 · 45 mins</dd>
+                      </div>
+                      <div class="flex items-center gap-2">
+                        <dt class="font-semibold uppercase tracking-[0.3em]">Support</dt>
+                        <dd class="badge badge-outline badge-xs text-[11px]">Co-teach with Mia</dd>
+                      </div>
+                    </dl>
                   </div>
+                  <div class="flex flex-wrap items-center gap-2">
+                      <button
+                        class="btn btn-primary btn-sm sm:btn-md"
+                        type="button"
+                        data-open-reminder-modal
+                        aria-haspopup="dialog"
+                        aria-controls="add-reminder-modal"
+                      >
+                        Add reminder
+                      </button>
+                      <div class="join hidden sm:inline-flex">
+                        <button class="btn btn-sm join-item btn-outline" type="button">Low</button>
+                        <button class="btn btn-sm join-item btn-outline" type="button">Medium</button>
+                        <button class="btn btn-sm join-item btn-outline" type="button">High</button>
+                      </div>
+                  </div>
+                </div>
+                <ol
+                  id="todaysFocusList"
+                  class="space-y-3"
+                  role="list"
+                  aria-labelledby="todays-focus-heading"
+                ></ol>
               </div>
-            </div>
-            <ol
-              id="todaysFocusList"
-              class="space-y-3"
-              role="list"
-              aria-labelledby="todays-focus-heading"
-            ></ol>
-          </section>
+            </section>
+          </div>
         </div>
 
-        <div class="grid gap-6 lg:grid-cols-2">
+        <div class="desktop-dashboard-grid">
           <section class="dashboard-card card h-full">
             <div class="card-body dashboard-card-body gap-5">
               <div class="flex flex-wrap items-center justify-between gap-3">
@@ -655,44 +666,46 @@
           </section>
 
           <div class="flex flex-col gap-6">
-            <div id="pinnedNotesCard" class="h-full">
-              <section class="bg-base-100 border border-base-300 rounded-2xl shadow-sm px-4 py-4 flex flex-col gap-2">
+            <section id="pinnedNotesCard" class="dashboard-card card dashboard-card--compact h-full">
+              <div class="card-body dashboard-card-body gap-3">
                 <div class="flex flex-wrap items-center justify-between gap-3">
-                  <h2 class="text-sm font-semibold text-base-content/80">Pinned notes</h2>
+                  <h2 class="dashboard-card-title">Pinned notes</h2>
                   <button class="btn btn-sm btn-primary" type="button" disabled title="Coming soon">New note</button>
                 </div>
                 <ul id="pinnedNotesList" class="space-y-3 text-sm text-base-content/90"></ul>
-              </section>
-            </div>
+              </div>
+            </section>
 
-            <section class="bg-base-100 border border-base-300 rounded-2xl shadow-sm px-4 py-4 flex flex-col gap-3">
-              <div class="flex flex-wrap items-center justify-between gap-2">
-                <h2 class="text-sm font-semibold text-base-content/80">Action shortcuts</h2>
-                <span class="text-xs font-medium text-base-content/70">Jump back in</span>
-              </div>
-              <div class="grid gap-2 sm:grid-cols-2">
-                <a href="#reminders" class="btn btn-ghost btn-sm justify-start gap-2 text-sm text-base-content/80" data-nav="reminders">
-                  <span aria-hidden="true">🔔</span>
-                  Open reminders
-                </a>
-                <a href="#planner" class="btn btn-ghost btn-sm justify-start gap-2 text-sm text-base-content/80" data-nav="planner">
-                  <span aria-hidden="true">🗓️</span>
-                  Weekly planner
-                </a>
-                <a href="#notes" class="btn btn-ghost btn-sm justify-start gap-2 text-sm text-base-content/80" data-nav="notes">
-                  <span aria-hidden="true">📝</span>
-                  Daily notes
-                </a>
-                <a href="#resources" class="btn btn-ghost btn-sm justify-start gap-2 text-sm text-base-content/80" data-nav="resources">
-                  <span aria-hidden="true">📚</span>
-                  Resource library
-                </a>
-              </div>
-              <div class="rounded-2xl border border-dashed border-base-300 bg-base-100/70 p-4">
-                <p class="text-sm font-semibold text-base-content/90">Need inspiration?</p>
-                <p class="text-sm text-base-content/70 mt-1">
-                  Open the activity ideas modal from the quick action toolbar to gather ready-to-run activities tailored to your class context.
-                </p>
+            <section class="dashboard-card card dashboard-card--compact flex flex-col gap-3">
+              <div class="card-body dashboard-card-body gap-4">
+                <div class="flex flex-wrap items-center justify-between gap-2">
+                  <h2 class="dashboard-card-title">Action shortcuts</h2>
+                  <span class="text-xs font-medium text-base-content/70">Jump back in</span>
+                </div>
+                <div class="grid gap-2 sm:grid-cols-2">
+                  <a href="#reminders" class="btn btn-ghost btn-sm justify-start gap-2 text-sm text-base-content/80" data-nav="reminders">
+                    <span aria-hidden="true">🔔</span>
+                    Open reminders
+                  </a>
+                  <a href="#planner" class="btn btn-ghost btn-sm justify-start gap-2 text-sm text-base-content/80" data-nav="planner">
+                    <span aria-hidden="true">🗓️</span>
+                    Weekly planner
+                  </a>
+                  <a href="#notes" class="btn btn-ghost btn-sm justify-start gap-2 text-sm text-base-content/80" data-nav="notes">
+                    <span aria-hidden="true">📝</span>
+                    Daily notes
+                  </a>
+                  <a href="#resources" class="btn btn-ghost btn-sm justify-start gap-2 text-sm text-base-content/80" data-nav="resources">
+                    <span aria-hidden="true">📚</span>
+                    Resource library
+                  </a>
+                </div>
+                <div class="rounded-2xl border border-dashed border-base-300 bg-base-100/70 p-4">
+                  <p class="text-sm font-semibold text-base-content/90">Need inspiration?</p>
+                  <p class="text-sm text-base-content/70 mt-1">
+                    Open the activity ideas modal from the quick action toolbar to gather ready-to-run activities tailored to your class context.
+                  </p>
+                </div>
               </div>
             </section>
           </div>


### PR DESCRIPTION
## Summary
- wrap the weather and news hero block in the `desktop-hero` section and use the dashboard helper classes so the shared typography and padding rules apply
- convert the reminder, lesson, KPI, pinned note, and action shortcut cards to the dashboard helper variants and place the KPI/action stack inside the `desktop-dashboard-grid` layout container for the intended desktop spacing

## Testing
- `npm test` *(fails: existing Jest suites cannot import ES modules such as js/reminders.js in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b0ac3ba2083249353df7bf175b4d6)