### PR TITLE
Ensure planner cards render in three columns

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -413,7 +413,21 @@ html[data-theme="professional"] .desktop-shell .desktop-panel {
 }
 
 .desktop-panel.desktop-panel--planner #plannerCards {
+  display: grid;
   gap: clamp(1rem, 2.5vw, 1.5rem);
+  grid-template-columns: minmax(0, 1fr);
+}
+
+@media (min-width: 768px) {
+  .desktop-panel.desktop-panel--planner #plannerCards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .desktop-panel.desktop-panel--planner #plannerCards {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }
 
 .desktop-panel.desktop-panel--planner .card {


### PR DESCRIPTION
## Summary
- force the desktop planner cards container to use a CSS grid so cards align consistently
- add responsive breakpoints so the planner shows one column on small screens, two on tablets, and three cards across on desktop just like before

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b0bdc3dac8324a51905beb555d165)