### PR TITLE
Reduce footer height on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -1260,8 +1260,8 @@
       <span class="sr-only">New lesson plan</span>
     </button>
   </nav>
-  <footer class="border-t border-base-300 bg-base-200/80 py-10">
-    <div class="mx-auto flex max-w-7xl flex-col gap-6 px-4 text-sm text-base-content/80 sm:px-6 lg:px-8">
+  <footer class="border-t border-base-300 bg-base-200/80 py-6 sm:py-8">
+    <div class="mx-auto flex max-w-7xl flex-col gap-4 px-4 text-sm text-base-content/80 sm:px-6 lg:px-8">
       <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div class="max-w-lg space-y-2">
           <p class="text-base font-semibold text-base-content">Memory Cue</p>
@@ -1288,7 +1288,7 @@
           </div>
         </div>
       </div>
-      <div class="flex flex-col gap-2 border-t border-base-300/60 pt-4 text-xs text-base-content/60 sm:flex-row sm:items-center sm:justify-between">
+      <div class="flex flex-col gap-2 border-t border-base-300/60 pt-3 text-xs text-base-content/60 sm:flex-row sm:items-center sm:justify-between">
         <p>© <span id="year"></span> Memory Cue. All rights reserved.</p>
         <p>Crafted with care for classrooms everywhere.</p>
       </div>


### PR DESCRIPTION
## Summary
- reduce the footer's vertical padding and internal spacing so it takes up less space on desktop screens
- slightly lower the divider padding to keep the legal text compact

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b0ee64888832483fc7020410f07cf)