### PR TITLE
Rework desktop layout to add navigation rail

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,22 +267,6 @@
           </a>
         </div>
       </div>
-      <nav class="desktop-header-nav-tabs nav-desktop hidden lg:flex" aria-label="Primary">
-        <ul class="menu menu-horizontal gap-1 nav-pill-glass text-sm">
-          <li>
-            <a href="#dashboard" data-nav="dashboard" id="nav-dashboard" class="btn btn-sm btn-ghost">Dashboard</a>
-          </li>
-          <li>
-            <a href="#reminders" data-nav="reminders" id="nav-reminders" class="btn btn-sm btn-ghost">Reminders</a>
-          </li>
-          <li>
-            <a href="#planner" data-nav="planner" id="nav-planner" class="btn btn-sm btn-ghost">Planner</a>
-          </li>
-          <li>
-            <a href="#notes" data-nav="notes" id="nav-notes" class="btn btn-sm btn-ghost">Notes</a>
-          </li>
-        </ul>
-      </nav>
       <div class="desktop-header-right">
         <p id="sync-status" class="sync-status hidden text-xs text-base-content" data-compact="true"></p>
         <div
@@ -299,63 +283,84 @@
             <p class="text-xs text-base-content/60">Reminders syncing</p>
           </div>
         </div>
-        <div class="desktop-header-action-bar flex w-full flex-wrap items-center justify-end gap-3 sm:w-auto">
-          <button
-            id="theme-toggle"
-            type="button"
-            class="btn btn-sm btn-ghost text-base-content"
-            data-icon-dark="🌙"
-            data-icon-light="☀️"
-          ></button>
-          <div
-            class="desktop-account-controls w-full sm:w-auto"
-            data-account-panel-container
-            data-account-collapsed="true"
-          >
-            <button
-              id="desktopAccountToggle"
-              type="button"
-              class="desktop-account-toggle btn btn-sm btn-ghost"
-              aria-expanded="false"
-              aria-controls="desktopAccountPanel"
-              data-collapsed-label="Account"
-              data-expanded-label="Account"
-              data-collapsed-aria="Show account controls"
-              data-expanded-aria="Hide account controls"
-            >
-              <span class="desktop-account-toggle__label" data-account-toggle-label aria-hidden="true">Account</span>
-              <span class="sr-only" data-account-toggle-a11y>Show account controls</span>
-              <span class="desktop-account-toggle__chevron" aria-hidden="true"></span>
-            </button>
-            <div
-              id="desktopAccountPanel"
-              class="desktop-account-panel"
-              aria-hidden="true"
-              data-account-panel
-              inert
-            >
-              <div class="flex w-full flex-wrap items-center justify-end gap-2 sm:w-auto sm:flex-nowrap">
-                <div
-                  id="googleUserName"
-                  class="google-user-chip text-xs sm:text-sm font-medium text-base-content/80 rounded-full border border-base-200 bg-base-100/80 px-3 py-1"
-                ></div>
-                <button id="googleSignInBtn" type="button" class="btn btn-sm btn-primary w-full sm:w-auto">Sign in</button>
+        <div id="auth-feedback" class="text-xs text-base-content/70" role="status" aria-live="polite"></div>
+      </div>
+    </header>
+    <main id="mainContent" class="desktop-main" tabindex="-1">
+      <div class="desktop-main-inner">
+        <aside class="desktop-rail" aria-label="Workspace navigation">
+          <div class="desktop-rail-sticky">
+            <nav class="desktop-rail-nav" aria-label="Primary">
+              <ul class="menu menu-vertical gap-1 nav-pill-glass text-sm">
+                <li>
+                  <a href="#dashboard" data-nav="dashboard" id="nav-dashboard" class="btn btn-sm btn-ghost">Dashboard</a>
+                </li>
+                <li>
+                  <a href="#reminders" data-nav="reminders" id="nav-reminders" class="btn btn-sm btn-ghost">Reminders</a>
+                </li>
+                <li>
+                  <a href="#planner" data-nav="planner" id="nav-planner" class="btn btn-sm btn-ghost">Planner</a>
+                </li>
+                <li>
+                  <a href="#notes" data-nav="notes" id="nav-notes" class="btn btn-sm btn-ghost">Notes</a>
+                </li>
+              </ul>
+            </nav>
+            <div class="desktop-rail-controls">
+              <button
+                id="theme-toggle"
+                type="button"
+                class="btn btn-sm btn-ghost text-base-content"
+                data-icon-dark="🌙"
+                data-icon-light="☀️"
+              ></button>
+              <div
+                class="desktop-account-controls w-full sm:w-auto"
+                data-account-panel-container
+                data-account-collapsed="true"
+              >
                 <button
-                  id="googleSignOutBtn"
+                  id="desktopAccountToggle"
                   type="button"
-                  class="hidden btn btn-sm btn-outline border-base-300 bg-base-100/80 text-base-content w-full sm:w-auto"
+                  class="desktop-account-toggle btn btn-sm btn-ghost"
+                  aria-expanded="false"
+                  aria-controls="desktopAccountPanel"
+                  data-collapsed-label="Account"
+                  data-expanded-label="Account"
+                  data-collapsed-aria="Show account controls"
+                  data-expanded-aria="Hide account controls"
                 >
-                  Sign out
+                  <span class="desktop-account-toggle__label" data-account-toggle-label aria-hidden="true">Account</span>
+                  <span class="sr-only" data-account-toggle-a11y>Show account controls</span>
+                  <span class="desktop-account-toggle__chevron" aria-hidden="true"></span>
                 </button>
+                <div
+                  id="desktopAccountPanel"
+                  class="desktop-account-panel"
+                  aria-hidden="true"
+                  data-account-panel
+                  inert
+                >
+                  <div class="flex w-full flex-wrap items-center justify-end gap-2 sm:w-auto sm:flex-nowrap">
+                    <div
+                      id="googleUserName"
+                      class="google-user-chip text-xs sm:text-sm font-medium text-base-content/80 rounded-full border border-base-200 bg-base-100/80 px-3 py-1"
+                    ></div>
+                    <button id="googleSignInBtn" type="button" class="btn btn-sm btn-primary w-full sm:w-auto">Sign in</button>
+                    <button
+                      id="googleSignOutBtn"
+                      type="button"
+                      class="hidden btn btn-sm btn-outline border-base-300 bg-base-100/80 text-base-content w-full sm:w-auto"
+                    >
+                      Sign out
+                    </button>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-        <div id="auth-feedback" class="text-xs text-base-content/70" role="status" aria-live="polite"></div>
-      </div>
-  </header>
-    <main id="mainContent" class="desktop-main" tabindex="-1">
-      <div class="desktop-main-inner space-y-8">
+        </aside>
+        <div class="desktop-workspace space-y-8" data-workspace>
       <section data-route="dashboard" class="space-y-6 lg:space-y-12">
         <div class="max-w-6xl mx-auto my-10 px-6 py-6 md:px-8 md:py-7 space-y-6">
           <section class="desktop-hero">
@@ -1218,8 +1223,9 @@
           </aside>
         </form>
       </section>
-    </div>
-  </main>
+        </div>
+      </div>
+    </main>
   </div>
   <!-- BEGIN GPT CHANGE: live region -->
   <div id="live-status" class="sr-only" aria-live="polite" role="status"></div>

--- a/js/router.js
+++ b/js/router.js
@@ -2,7 +2,9 @@ const groupedRoutes = new Set(['notes', 'resources', 'templates']);
 
 function renderRoute() {
   const route = (window.location.hash || '#dashboard').replace('#', '');
-  document.querySelectorAll('[data-route]').forEach((node) => {
+  const workspace = document.querySelector('[data-workspace]');
+  const routeNodes = workspace ? workspace.querySelectorAll('[data-route]') : document.querySelectorAll('[data-route]');
+  routeNodes.forEach((node) => {
     const isDashboardFallback = route === '' && node.dataset.route === 'dashboard';
     node.style.display = node.dataset.route === route || isDashboardFallback ? '' : 'none';
   });

--- a/styles/index.css
+++ b/styles/index.css
@@ -365,12 +365,80 @@ html[data-theme="professional"] .desktop-shell .desktop-main {
   min-height: auto;
 }
 
+html[data-theme="professional"] .desktop-shell {
+  --desktop-shell-gutter: clamp(1rem, 4vw, 2rem);
+  --desktop-rail-width: clamp(230px, 18vw, 280px);
+  --desktop-rail-sticky-offset: 1.25rem;
+}
+
 html[data-theme="professional"] .desktop-shell .desktop-main-inner {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--desktop-shell-gutter);
+  align-items: flex-start;
+  padding: 0 var(--desktop-shell-gutter) 2.5rem;
+  width: 100%;
+}
+
+@media (min-width: 1024px) {
+  html[data-theme="professional"] .desktop-shell .desktop-main-inner {
+    grid-template-columns: var(--desktop-rail-width) minmax(0, 1fr);
+  }
+}
+
+html[data-theme="professional"] .desktop-shell .desktop-rail {
+  align-self: flex-start;
+}
+
+html[data-theme="professional"] .desktop-shell .desktop-rail-sticky {
+  position: sticky;
+  top: var(--desktop-rail-sticky-offset);
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  padding: 0 0.5rem 2rem;
+  gap: 1.25rem;
+  padding: 1.25rem;
+  border-radius: 1.5rem;
+  border: 1px solid color-mix(in srgb, var(--desktop-border-subtle, #d7def1) 70%, transparent);
+  background: color-mix(in srgb, var(--desktop-header-bg, #e6edff) 65%, transparent);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+}
+
+html[data-theme="professional"] .desktop-shell .desktop-rail-nav .menu {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+html[data-theme="professional"] .desktop-shell .desktop-rail-nav .btn {
   width: 100%;
+  justify-content: flex-start;
+}
+
+html[data-theme="professional"] .desktop-shell .desktop-rail-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid color-mix(in srgb, var(--desktop-border-subtle, #d7def1) 70%, transparent);
+}
+
+@media (max-width: 1023px) {
+  html[data-theme="professional"] .desktop-shell .desktop-main-inner {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  html[data-theme="professional"] .desktop-shell .desktop-rail-sticky {
+    position: static;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  html[data-theme="professional"] .desktop-shell .desktop-rail-controls {
+    border-top: 0;
+    padding-top: 0.5rem;
+  }
 }
 
 html[data-theme="professional"] .desktop-shell .desktop-dashboard-grid {


### PR DESCRIPTION
## Summary
- restructure the desktop shell so navigation and account controls live in a sticky rail and the content resides in a dedicated workspace container
- update the desktop CSS to use a two-column grid with a fixed-width rail, sticky behavior, and shared gutters
- scope the client-side router to panels inside the new workspace container to keep scroll position stable when switching routes

## Testing
- npm test *(fails: existing Jest suites cannot import ES modules in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b1065acd08324a0b36138240dce8b)