### PR TITLE
Add workspace status rail and relocate quick actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,21 +288,6 @@
         </div>
       </div>
       <div class="desktop-header-right">
-        <p id="sync-status" class="sync-status hidden text-xs text-base-content" data-compact="true"></p>
-        <div
-          id="user-badge"
-          class="hidden items-center gap-3 rounded-full border border-base-200 bg-base-100/80 px-3 py-1.5 text-sm shadow-sm backdrop-blur"
-        >
-          <span
-            id="user-badge-initial"
-            class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-primary text-primary-content text-base font-semibold"
-            aria-hidden="true"
-          >T</span>
-          <div class="text-left leading-tight">
-            <p id="user-badge-email" class="text-sm font-semibold text-base-content"></p>
-            <p class="text-xs text-base-content/60">Reminders syncing</p>
-          </div>
-        </div>
         <div id="auth-feedback" class="text-xs text-base-content/70" role="status" aria-live="polite"></div>
       </div>
     </header>
@@ -380,7 +365,36 @@
             </div>
           </div>
         </aside>
-        <div class="desktop-workspace space-y-8" data-workspace>
+        <div class="desktop-workspace-region">
+          <div class="workspace-status-rail" role="region" aria-label="Workspace status">
+            <div class="workspace-status-rail__breadcrumbs">
+              <nav id="workspace-breadcrumbs" aria-label="Workspace breadcrumbs">
+                <ol class="workspace-breadcrumbs__list" data-breadcrumb-list>
+                  <li class="workspace-breadcrumb">
+                    <span class="badge workspace-breadcrumb__current" aria-current="page">Dashboard</span>
+                  </li>
+                </ol>
+              </nav>
+            </div>
+            <div class="workspace-status-rail__meta">
+              <p id="sync-status" class="sync-status hidden text-xs text-base-content" data-compact="true"></p>
+              <div
+                id="user-badge"
+                class="hidden items-center gap-3 rounded-full border border-base-200 bg-base-100/80 px-3 py-1.5 text-sm shadow-sm backdrop-blur"
+              >
+                <span
+                  id="user-badge-initial"
+                  class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-primary text-primary-content text-base font-semibold"
+                  aria-hidden="true"
+                >T</span>
+                <div class="text-left leading-tight">
+                  <p id="user-badge-email" class="text-sm font-semibold text-base-content"></p>
+                  <p class="text-xs text-base-content/60">Reminders syncing</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="desktop-workspace space-y-8" data-workspace>
       <section data-route="dashboard" class="space-y-6 lg:space-y-12">
         <div class="max-w-6xl mx-auto space-y-6">
           <section class="desktop-hero">
@@ -1370,48 +1384,49 @@
         </form>
       </section>
         </div>
+        </div>
       </div>
     </main>
+    <nav
+      id="quick-action-toolbar"
+      aria-label="Quick actions"
+      class="flex flex-col items-end gap-2"
+    >
+      <button
+        type="button"
+        data-quick-action="reminder"
+        class="quick-action-btn bg-gradient-to-r from-purple-600 via-indigo-500 to-blue-500 text-xl text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-purple-300"
+        title="Add reminder"
+        aria-label="Add reminder"
+      >
+        <span aria-hidden="true">🔔</span>
+        <span class="sr-only">Add reminder</span>
+      </button>
+      <button
+        type="button"
+        data-quick-action="note"
+        class="quick-action-btn bg-white/90 text-xl text-gray-900 dark:text-gray-100 shadow-md backdrop-blur focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-300 hover:bg-white dark:bg-gray-800/70 dark:text-gray-100 dark:hover:bg-gray-700/80 dark:focus-visible:outline-gray-500 border border-white/60 dark:border-gray-700/60"
+        title="Create note"
+        aria-label="Create note"
+      >
+        <span aria-hidden="true">📝</span>
+        <span class="sr-only">Create note</span>
+      </button>
+      <button
+        type="button"
+        data-quick-action="planner"
+        class="quick-action-btn bg-emerald-500 text-xl text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 hover:bg-emerald-600"
+        title="New lesson plan"
+        aria-label="New lesson plan"
+      >
+        <span aria-hidden="true">🗓️</span>
+        <span class="sr-only">New lesson plan</span>
+      </button>
+    </nav>
   </div>
   <!-- BEGIN GPT CHANGE: live region -->
   <div id="live-status" class="sr-only" aria-live="polite" role="status"></div>
   <!-- END GPT CHANGE -->
-  <nav
-    id="quick-action-toolbar"
-    aria-label="Quick actions"
-    class="fixed bottom-5 right-5 z-40 flex flex-col items-end gap-2 max-sm:bottom-3 max-sm:right-3"
-  >
-    <button
-      type="button"
-      data-quick-action="reminder"
-      class="quick-action-btn bg-gradient-to-r from-purple-600 via-indigo-500 to-blue-500 text-xl text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-purple-300"
-      title="Add reminder"
-      aria-label="Add reminder"
-    >
-      <span aria-hidden="true">🔔</span>
-      <span class="sr-only">Add reminder</span>
-    </button>
-    <button
-      type="button"
-      data-quick-action="note"
-      class="quick-action-btn bg-white/90 text-xl text-gray-900 dark:text-gray-100 shadow-md backdrop-blur focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-300 hover:bg-white dark:bg-gray-800/70 dark:text-gray-100 dark:hover:bg-gray-700/80 dark:focus-visible:outline-gray-500 border border-white/60 dark:border-gray-700/60"
-      title="Create note"
-      aria-label="Create note"
-    >
-      <span aria-hidden="true">📝</span>
-      <span class="sr-only">Create note</span>
-    </button>
-    <button
-      type="button"
-      data-quick-action="planner"
-      class="quick-action-btn bg-emerald-500 text-xl text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 hover:bg-emerald-600"
-      title="New lesson plan"
-      aria-label="New lesson plan"
-    >
-      <span aria-hidden="true">🗓️</span>
-      <span class="sr-only">New lesson plan</span>
-    </button>
-  </nav>
   <footer class="border-t border-base-300 bg-base-200/80 py-6 sm:py-8">
     <div class="mx-auto flex max-w-7xl flex-col gap-4 px-4 text-sm text-base-content/80 sm:px-6 lg:px-8">
       <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">

--- a/js/router.js
+++ b/js/router.js
@@ -1,5 +1,58 @@
 const groupedRoutes = new Set(['notes', 'resources', 'templates']);
 const workspaceRoutes = new Set(['reminders', 'planner', 'notes']);
+const staticBreadcrumbs = new Map([
+  ['dashboard', [{ label: 'Dashboard', href: '#dashboard' }]],
+  ['workspace', [{ label: 'Workspace', href: '#workspace' }]],
+  ['resources', [{ label: 'Resources', href: '#resources' }]],
+  ['templates', [{ label: 'Templates', href: '#templates' }]],
+]);
+
+function getBreadcrumbsForRoute(route) {
+  if (workspaceRoutes.has(route)) {
+    const capitalised = route.charAt(0).toUpperCase() + route.slice(1);
+    return [
+      { label: 'Workspace', href: '#workspace' },
+      { label: capitalised, href: `#${route}` },
+    ];
+  }
+  if (staticBreadcrumbs.has(route)) {
+    return staticBreadcrumbs.get(route);
+  }
+  if (groupedRoutes.has(route)) {
+    const capitalised = route.charAt(0).toUpperCase() + route.slice(1);
+    return [{ label: capitalised, href: `#${route}` }];
+  }
+  return [{ label: 'Dashboard', href: '#dashboard' }];
+}
+
+function updateWorkspaceBreadcrumbs(route) {
+  const breadcrumbList = document.querySelector('[data-breadcrumb-list]');
+  if (!breadcrumbList) {
+    return;
+  }
+
+  breadcrumbList.innerHTML = '';
+  const crumbs = getBreadcrumbsForRoute(route);
+  crumbs.forEach((crumb, index) => {
+    const listItem = document.createElement('li');
+    listItem.className = 'workspace-breadcrumb';
+    const isCurrent = index === crumbs.length - 1;
+    if (isCurrent) {
+      const current = document.createElement('span');
+      current.className = 'badge workspace-breadcrumb__current';
+      current.textContent = crumb.label;
+      current.setAttribute('aria-current', 'page');
+      listItem.appendChild(current);
+    } else {
+      const link = document.createElement('a');
+      link.className = 'badge workspace-breadcrumb__link';
+      link.textContent = crumb.label;
+      link.href = crumb.href || '#';
+      listItem.appendChild(link);
+    }
+    breadcrumbList.appendChild(listItem);
+  });
+}
 
 function renderRoute() {
   const rawRoute = (window.location.hash || '#dashboard').replace('#', '');
@@ -47,6 +100,8 @@ function renderRoute() {
     moreSummary.setAttribute('aria-expanded', moreDetails.open ? 'true' : 'false');
     moreSummary.classList.toggle('more-active', moreDetails.open);
   }
+
+  updateWorkspaceBreadcrumbs(activeRoute);
 }
 
 function syncWorkspacePanels(route) {

--- a/styles/index.css
+++ b/styles/index.css
@@ -380,6 +380,85 @@ html[data-theme="professional"] .desktop-shell .desktop-main-inner {
   width: 100%;
 }
 
+html[data-theme="professional"] .desktop-shell .desktop-workspace-region {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 2vw, 1.5rem);
+  min-width: 0;
+}
+
+html[data-theme="professional"] .desktop-shell .workspace-status-rail {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.85rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--desktop-border-subtle, #d7def1) 65%, transparent);
+  background: color-mix(in srgb, var(--desktop-header-bg, #e6edff) 78%, transparent);
+  box-shadow: 0 18px 34px rgba(79, 70, 229, 0.12);
+}
+
+html[data-theme="professional"] .desktop-shell .workspace-status-rail__meta {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+html[data-theme="professional"] .desktop-shell .workspace-breadcrumbs__list {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+html[data-theme="professional"] .desktop-shell .workspace-breadcrumb {
+  display: flex;
+}
+
+html[data-theme="professional"] .desktop-shell .workspace-breadcrumb__link,
+html[data-theme="professional"] .desktop-shell .workspace-breadcrumb__current {
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.25rem 0.85rem;
+  border-width: 1px;
+  border-style: solid;
+}
+
+html[data-theme="professional"] .desktop-shell .workspace-breadcrumb__link {
+  text-decoration: none;
+  background: color-mix(in srgb, var(--desktop-header-bg, #e6edff) 55%, transparent);
+  color: var(--desktop-text-main, #0f172a);
+  border-color: color-mix(in srgb, var(--desktop-border-subtle, #d7def1) 55%, transparent);
+}
+
+html[data-theme="professional"] .desktop-shell .workspace-breadcrumb__link:hover,
+html[data-theme="professional"] .desktop-shell .workspace-breadcrumb__link:focus-visible {
+  background: color-mix(in srgb, var(--desktop-header-bg, #e6edff) 75%, transparent);
+  border-color: color-mix(in srgb, var(--desktop-border-subtle, #d7def1) 70%, transparent);
+}
+
+html[data-theme="professional"] .desktop-shell .workspace-breadcrumb__current {
+  background: var(--color-primary, #4f46e5);
+  color: var(--color-primary-content, #ffffff);
+  border-color: transparent;
+}
+
+@media (max-width: 640px) {
+  html[data-theme="professional"] .desktop-shell .workspace-status-rail {
+    border-radius: 1.25rem;
+    padding: 0.75rem 1rem;
+  }
+}
+
 @media (min-width: 1024px) {
   html[data-theme="professional"] .desktop-shell .desktop-main-inner {
     grid-template-columns: var(--desktop-rail-width) minmax(0, 1fr);
@@ -1789,6 +1868,24 @@ section[data-route="dashboard"] .dashboard-shortcuts {
 
 .dashboard-highlight {
   animation: dashboard-highlight 0.85s ease-out;
+}
+
+#quick-action-toolbar {
+  position: fixed;
+  right: clamp(0.75rem, 2vw, 1.5rem);
+  bottom: clamp(0.75rem, 2vw, 1.5rem);
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+}
+
+@media (max-width: 640px) {
+  #quick-action-toolbar {
+    right: 0.75rem;
+    bottom: 0.75rem;
+  }
 }
 
 .quick-action-btn {


### PR DESCRIPTION
## Summary
- add a workspace status rail that surfaces breadcrumbs, sync state, and the user badge above the desktop panes
- teach the router to update the new breadcrumb rail whenever routes or workspace panels change
- relocate the quick action toolbar inside the desktop shell and give it global fixed positioning so it stays above the workspace

## Testing
- npm test -- --runTestsByPath sample.test.js theme-toggle.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b18bd1a848324b2dc356a10d7696b)