### PR TITLE
Refine workspace scaffold routing

### DIFF
--- a/index.html
+++ b/index.html
@@ -380,7 +380,7 @@
             </div>
           </div>
         </aside>
-        <div class="desktop-workspace space-y-8" data-workspace>
+        <div class="desktop-workspace space-y-8">
       <section data-route="dashboard" class="space-y-6 lg:space-y-12">
         <div class="max-w-6xl mx-auto space-y-6">
           <section class="desktop-hero">
@@ -959,7 +959,7 @@
             <h2 class="text-2xl font-semibold tracking-wide text-base-content">Reminders, planner, and notes</h2>
             <p class="text-sm text-base-content/70">Stay in one focused surface while you triage tasks, prepare lessons, and capture reflections.</p>
           </div>
-          <div class="flex flex-col gap-6 lg:flex-row" data-workspace-shell data-workspace-active="reminders">
+          <div class="flex flex-col gap-6 lg:flex-row" data-workspace data-workspace-active="reminders">
             <div class="flex flex-row gap-2 overflow-x-auto rounded-2xl border border-base-300/70 bg-base-100/80 p-4 lg:flex-col lg:w-56" role="tablist" aria-label="Workspace panels">
               <button
                 type="button"

--- a/js/router.js
+++ b/js/router.js
@@ -4,12 +4,24 @@ const workspaceRoutes = new Set(['reminders', 'planner', 'notes']);
 function renderRoute() {
   const rawRoute = (window.location.hash || '#dashboard').replace('#', '');
   const activeRoute = rawRoute === '' ? 'dashboard' : rawRoute;
-  const displayRoute = workspaceRoutes.has(activeRoute) || activeRoute === 'workspace' ? 'workspace' : activeRoute;
+  const isWorkspaceRoute = workspaceRoutes.has(activeRoute) || activeRoute === 'workspace';
   const routeNodes = document.querySelectorAll('[data-route]');
   routeNodes.forEach((node) => {
-    const isDashboardFallback = rawRoute === '' && node.dataset.route === 'dashboard';
-    const shouldShow = node.dataset.route === displayRoute || isDashboardFallback;
+    const nodeRoute = node.dataset.route;
+    const isDashboardFallback = rawRoute === '' && nodeRoute === 'dashboard';
+    let shouldShow = false;
+
+    if (nodeRoute === 'workspace') {
+      shouldShow = isWorkspaceRoute;
+    } else if (!isWorkspaceRoute) {
+      shouldShow = nodeRoute === activeRoute || isDashboardFallback;
+    } else if (isDashboardFallback) {
+      shouldShow = true;
+    }
+
     node.style.display = shouldShow ? '' : 'none';
+    node.hidden = !shouldShow;
+    node.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
   });
 
   syncWorkspacePanels(activeRoute);
@@ -50,7 +62,7 @@ function renderRoute() {
 }
 
 function syncWorkspacePanels(route) {
-  const workspace = document.querySelector('[data-workspace-shell]');
+  const workspace = document.querySelector('[data-workspace]');
   if (!workspace) {
     return;
   }
@@ -139,7 +151,7 @@ function initMobileNavHandlers() {
 }
 
 function initWorkspaceTabs() {
-  const workspace = document.querySelector('[data-workspace-shell]');
+  const workspace = document.querySelector('[data-workspace]');
   if (!workspace) {
     return;
   }


### PR DESCRIPTION
## Summary
- attach the reminders/planner/notes scaffold to a single `[data-workspace]` container so the panes stay mounted
- update the router to switch workspace panes via the shared container while keeping navigation state intact

## Testing
- `npm test --silent` *(fails: SyntaxError: Cannot use import statement outside a module when Jest loads `js/reminders.js` via vm)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b1a3264548324b8f87df5625cfa9f)