### PR TITLE
Refine workspace routing

### DIFF
--- a/index.html
+++ b/index.html
@@ -983,7 +983,8 @@
                 <span class="ml-2">Notes</span>
               </button>
             </div>
-            <div class="flex-1 min-w-0">
+            <div class="flex-1 min-w-0" data-workspace-region>
+              <div class="space-y-10" data-workspace-panels>
               <div
                 id="workspace-panel-reminders"
                 data-workspace-panel="reminders"
@@ -1212,6 +1213,7 @@
                     </div>
                   </aside>
                 </div>
+              </div>
               </div>
             </div>
           </div>

--- a/js/router.js
+++ b/js/router.js
@@ -57,20 +57,13 @@ function updateWorkspaceBreadcrumbs(route) {
 function renderRoute() {
   const rawRoute = (window.location.hash || '#dashboard').replace('#', '');
   const activeRoute = rawRoute === '' ? 'dashboard' : rawRoute;
-  const isWorkspaceRoute = workspaceRoutes.has(activeRoute) || activeRoute === 'workspace';
+  const isWorkspaceView = workspaceRoutes.has(activeRoute) || activeRoute === 'workspace';
+  const activeSectionRoute = isWorkspaceView ? 'workspace' : activeRoute;
   const routeNodes = document.querySelectorAll('[data-route]');
   routeNodes.forEach((node) => {
     const nodeRoute = node.dataset.route;
     const isDashboardFallback = rawRoute === '' && nodeRoute === 'dashboard';
-    let shouldShow = false;
-
-    if (nodeRoute === 'workspace') {
-      shouldShow = isWorkspaceRoute;
-    } else if (!isWorkspaceRoute) {
-      shouldShow = nodeRoute === activeRoute || isDashboardFallback;
-    } else if (isDashboardFallback) {
-      shouldShow = true;
-    }
+    const shouldShow = nodeRoute === activeSectionRoute || isDashboardFallback;
 
     node.style.display = shouldShow ? '' : 'none';
     node.hidden = !shouldShow;


### PR DESCRIPTION
## Summary
- wrap the reminders, planner, and notes panes in a dedicated workspace region so the shared scaffold remains mounted while tabs toggle visibility
- update the router so workspace sub-routes only flip the active panel inside the workspace instead of expecting separate sections

## Testing
- `npm test` *(fails: Jest cannot execute ESM-only modules such as js/reminders.js, producing "Cannot use import statement outside a module" errors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b7fcc70988324929b66d4d49af303)