### PR TITLE
Polish mobile saved notes panel

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -342,6 +342,41 @@
     overflow: hidden;
   }
 
+  .mobile-shell #notesListMobile {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .mobile-shell #notesListMobile .note-item-mobile {
+    margin: 0;
+  }
+
+  .mobile-shell #notesListMobile .saved-note-row {
+    border: 1px solid color-mix(in srgb, var(--card-border) 85%, transparent);
+    background-color: color-mix(in srgb, var(--card-bg) 90%, rgba(148, 163, 184, 0.08));
+    padding: 0.35rem 0.65rem;
+    border-radius: 999px;
+    transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  }
+
+  .mobile-shell #notesListMobile .saved-note-row:hover {
+    background-color: color-mix(in srgb, var(--card-bg) 92%, rgba(148, 163, 184, 0.18));
+    border-color: color-mix(in srgb, var(--accent-color) 35%, var(--card-border));
+  }
+
+  .mobile-shell #notesListMobile .saved-note-row:active {
+    transform: translateY(1px);
+  }
+
+  .mobile-shell #notesListMobile .saved-note-row .open-note-btn {
+    padding: 0;
+  }
+
+  .mobile-shell #notesListMobile .delete-note-btn {
+    border-radius: 999px;
+  }
+
   .mobile-shell #savedNotesSheet {
     transition: opacity 0.25s ease;
     opacity: 0;
@@ -3362,13 +3397,6 @@
               </div>
             </div>
 
-            <div class="flex items-center justify-between gap-2 text-xs text-base-content/60" data-note-detail-list>
-              <span id="notesStatusText" class="truncate"></span>
-              <span class="flex items-center gap-1 whitespace-nowrap">
-                <span id="notesSyncStatus" class="sync-dot ready" aria-hidden="true"></span>
-              </span>
-            </div>
-
             <div id="scratch-notes-actions" class="flex justify-end gap-2 pt-1">
               <button
                 id="noteNewMobile"
@@ -3383,61 +3411,68 @@
             </div>
           </div>
         </div>
+        <div
+          id="savedNotesSheet"
+          class="fixed inset-0 z-40 hidden bg-base-300/40 backdrop-blur-sm"
+          aria-hidden="true"
+          aria-modal="true"
+          role="dialog"
+          aria-labelledby="savedNotesSheetTitle"
+          data-open="false"
+        >
+          <div
+            id="saved-notes-panel"
+            class="saved-notes-panel mt-4 bg-base-100 border border-base-300 rounded-2xl shadow-sm px-4 py-3 space-y-2 fixed inset-x-0 bottom-0 z-40 max-w-md mx-auto rounded-t-3xl shadow-xl border-t border-base-300 pt-3 pb-4 transition-transform flex flex-col max-h-[80vh]"
+          >
+            <div class="flex items-start justify-between gap-3">
+              <div id="saved-notes-header" class="space-y-1 mb-1">
+                <h3 id="savedNotesSheetTitle" class="text-sm font-semibold text-base-content/90">Saved notes</h3>
+                <p class="text-xs text-base-content/70">Tap a note to load it here.</p>
+              </div>
+              <button
+                type="button"
+                class="btn btn-ghost btn-circle"
+                data-action="close-saved-notes"
+                aria-label="Close saved notes"
+              >
+                ✕
+              </button>
+            </div>
+
+            <div class="flex items-center justify-between gap-2 text-[11px] text-base-content/60" data-note-detail-list>
+              <p id="notesStatusText" class="text-[11px] text-base-content/60 truncate"></p>
+              <span class="flex items-center gap-1 whitespace-nowrap">
+                <span id="notesSyncStatus" class="sync-dot ready" aria-hidden="true"></span>
+              </span>
+            </div>
+
+            <div class="space-y-2 border border-base-200/70 rounded-2xl bg-base-100/80 px-3 py-3">
+              <label class="sr-only" for="notesFilterMobile">Filter notes</label>
+              <input
+                id="notesFilterMobile"
+                type="search"
+                class="input input-bordered input-sm w-full text-sm text-base-content bg-base-200/80 placeholder:text-base-content/70 placeholder:opacity-80"
+                placeholder="Search saved notes…"
+              />
+              <div class="flex items-center justify-between text-xs font-semibold text-base-content/70">
+                <span class="text-base-content/60 font-medium">Showing</span>
+                <span id="notesCountMobile" class="text-sm font-semibold whitespace-nowrap"></span>
+              </div>
+            </div>
+
+            <div class="mt-1 max-h-56 overflow-y-auto flex-1 w-full">
+              <ul
+                id="notesListMobile"
+                class="space-y-1 text-sm"
+                aria-label="Saved scratch notes"
+              ></ul>
+            </div>
+          </div>
+        </div>
       </div>
     </section>
     <!-- END GPT CHANGE -->
     </main>
-  </div>
-
-  <div
-    id="savedNotesSheet"
-    class="fixed inset-0 z-40 hidden bg-base-300/40 backdrop-blur-sm"
-    aria-hidden="true"
-    aria-modal="true"
-    role="dialog"
-    aria-labelledby="savedNotesSheetTitle"
-    data-open="false"
-  >
-    <div
-      class="saved-notes-panel fixed bottom-0 left-0 right-0 mx-auto w-full max-w-md bg-base-100 rounded-t-xl shadow-lg p-4 space-y-4 max-h-[80vh] overflow-y-auto transition-transform z-40 flex flex-col"
-    >
-      <header class="flex items-start justify-between gap-3 pb-3 border-b border-base-200/70">
-        <div class="flex flex-col gap-0.5">
-          <h3 id="savedNotesSheetTitle" class="text-base font-semibold">Saved notes</h3>
-          <p class="text-xs text-base-content/60">Tap a note to load it here.</p>
-        </div>
-        <button
-          type="button"
-          class="btn btn-ghost btn-circle"
-          data-action="close-saved-notes"
-          aria-label="Close saved notes"
-        >
-          ✕
-        </button>
-      </header>
-
-      <div class="space-y-3 border-b border-base-200/60 pb-4">
-        <label class="sr-only" for="notesFilterMobile">Filter notes</label>
-        <input
-          id="notesFilterMobile"
-          type="search"
-          class="input input-bordered input-sm w-full text-base-content bg-base-200 placeholder:text-base-content/70 placeholder:opacity-80"
-          placeholder="Search saved notes…"
-        />
-        <div class="flex items-center justify-between text-xs font-semibold text-base-content/70">
-          <span class="text-base-content/50 font-medium">Showing</span>
-          <span id="notesCountMobile" class="text-sm font-semibold whitespace-nowrap"></span>
-        </div>
-      </div>
-
-      <div class="flex-1 overflow-y-auto pb-2">
-        <ul
-          id="notesListMobile"
-          class="space-y-3 pb-12"
-          aria-label="Saved scratch notes"
-        ></ul>
-      </div>
-    </div>
   </div>
 
   <div class="fixed bottom-0 left-0 right-0 z-40 px-4 pb-safe-bottom pointer-events-none">


### PR DESCRIPTION
## Summary
- restyled the mobile saved notes bottom sheet into a tidy panel with a structured header, helper text, status line, filter controls, and a compact scrollable list
- updated the saved notes list container and pill row styling so each saved note renders with modern spacing and hover/active feedback

## Testing
- Not Run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bba97055c8324814f020ab3a0bcbd)