### PR TITLE
Descope desktop shell layout

### DIFF
--- a/docs/styles/index.css
+++ b/docs/styles/index.css
@@ -82,7 +82,7 @@ html[data-theme="professional"] {
   --planner-card-hover: #4cc3ee;
 }
 
- body.desktop-shell {
+.desktop-shell {
   background:
     radial-gradient(circle at 18% 0%, rgba(99, 102, 241, 0.18), transparent 60%),
     radial-gradient(circle at 82% 0%, rgba(14, 165, 233, 0.18), transparent 55%),

--- a/styles/index.css
+++ b/styles/index.css
@@ -82,7 +82,7 @@ html[data-theme="professional"] {
   --planner-card-hover: #4cc3ee;
 }
 
- body.desktop-shell {
+.desktop-shell {
   background:
     radial-gradient(circle at 18% 0%, rgba(99, 102, 241, 0.18), transparent 60%),
     radial-gradient(circle at 82% 0%, rgba(14, 165, 233, 0.18), transparent 55%),


### PR DESCRIPTION
## Summary
- generalize the `.desktop-shell` base styling in both CSS bundles so the desktop layout applies regardless of the host element

## Testing
- not run (CSS-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bc8550104832487d8c72481dd25bf)