### PR TITLE
Add header add reminder button

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -334,6 +334,15 @@
       </nav>
       <div class="desktop-header-right">
         <div class="desktop-header-action-bar">
+          <button
+            class="btn btn-primary btn-sm"
+            type="button"
+            data-open-reminder-modal
+            aria-haspopup="dialog"
+            aria-controls="add-reminder-form"
+          >
+            Add reminder
+          </button>
           <div id="auth-feedback" class="text-xs text-base-content/70" role="status" aria-live="polite"></div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -364,6 +364,15 @@
       </nav>
       <div class="desktop-header-right">
         <div class="desktop-header-action-bar">
+          <button
+            class="btn btn-primary btn-sm"
+            type="button"
+            data-open-reminder-modal
+            aria-haspopup="dialog"
+            aria-controls="add-reminder-form"
+          >
+            Add reminder
+          </button>
           <div id="auth-feedback" class="text-xs text-base-content/70" role="status" aria-live="polite"></div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add the existing “Add reminder” button to the desktop header action bar for quick access
- wire the button to the reminder modal so it behaves the same as other entry points

## Testing
- `npm test` *(fails: existing Jest environment cannot import ESM modules in js/reminders.js and mobile.js — SyntaxError: Cannot use import statement outside a module)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bd8623c988324ac2848e07474ebc2)