### PR TITLE
Fix planner card layout structure

### DIFF
--- a/app.js
+++ b/app.js
@@ -2769,13 +2769,13 @@ function renderPlannerLessons(plan) {
                 >
                   Delete
                 </button>
+              </div>
             </div>
-          </div>
-          ${detailsSection}
-          ${notesSection}
-          <div class="flex flex-wrap gap-2">
-            <button
-              type="button"
+            ${detailsSection}
+            ${notesSection}
+            <div class="flex flex-wrap gap-2">
+              <button
+                type="button"
                 class="btn btn-sm btn-primary"
                 data-planner-action="create-reminder"
                 data-open-reminder-modal="true"


### PR DESCRIPTION
## Summary
- keep the planner card content inside the `.card-body` container so the layout spacing renders correctly

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bec2ad42c8324a7666eb6e52638ab)