### PR TITLE
Polish mobile notebook chrome

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -3342,9 +3342,17 @@
     <!-- BEGIN GPT CHANGE: notebook view -->
     <section data-view="notebook" id="view-notebook" class="view-panel hidden mobile-panel--notes">
       <div class="flex flex-col gap-4">
+        <div id="notebook-view-header" class="mb-3">
+          <div class="flex items-baseline justify-between gap-2">
+            <h1 class="text-base font-semibold text-base-content">Notebook</h1>
+            <span class="text-[11px] text-base-content/60">
+              Scratch ideas first, then refine later.
+            </span>
+          </div>
+        </div>
         <div
           id="scratch-notes-card"
-          class="bg-base-100 border border-base-300 rounded-2xl shadow-sm px-4 py-4 space-y-3"
+          class="mt-1 bg-base-100 border border-base-300 rounded-2xl shadow-sm px-4 py-4 space-y-3"
         >
           <div class="flex items-start justify-between gap-3">
             <div>


### PR DESCRIPTION
## Summary
- add a dedicated header for the mobile notebook view to give the screen a clearer identity
- tighten spacing by adding a modest top margin to the scratch notes card while preserving the saved notes panel rhythm

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691befedb3c88324b3b71f08eea27b47)