### PR TITLE
Refine mobile header layout and styling

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2945,12 +2945,15 @@
   </style>
 
   <header class="sticky top-0 z-40 w-full">
-    <div class="mx-auto flex w-full max-w-md items-center justify-between gap-3 px-4 py-2 bg-base-100/95 border-b border-base-200 shadow-sm backdrop-blur">
-      <div class="flex items-center gap-3 min-w-0">
+    <div
+      class="mx-auto flex w-full max-w-md items-center justify-between gap-3 px-4 py-2 flex-nowrap backdrop-blur"
+      style="background: var(--mobile-header-bg); border-bottom: 1px solid var(--mobile-header-border); box-shadow: var(--mobile-header-shadow); color: var(--mobile-header-text);"
+    >
+      <div class="flex items-center gap-3 min-w-0 flex-nowrap">
         <button
           id="btn-open-drawer"
           type="button"
-          class="header-icon-btn inline-flex items-center justify-center w-10 h-10 rounded-full border border-base-200/70 bg-base-100 text-base-content shadow-sm transition"
+          class="header-icon-btn inline-flex items-center justify-center w-10 h-10 rounded-full transition"
           aria-label="Open navigation menu"
           aria-expanded="false"
         >
@@ -2962,11 +2965,11 @@
         </div>
       </div>
 
-      <div class="flex items-center gap-2 flex-shrink-0">
+      <div class="flex items-center gap-2 flex-shrink-0 flex-nowrap">
         <button
           id="addReminderBtn"
           type="button"
-          class="mc-add-btn btn btn-primary btn-sm gap-1"
+          class="mc-add-btn btn btn-primary btn-sm gap-1 whitespace-nowrap"
           data-open-add-task
         >
           <span class="mc-add-btn-icon" aria-hidden="true">＋</span>
@@ -2976,7 +2979,7 @@
           <button
             id="overflowMenuBtn"
             type="button"
-            class="header-icon-btn inline-flex items-center justify-center w-10 h-10 rounded-full border border-base-200/70 bg-base-100 text-base-content shadow-sm transition"
+            class="header-icon-btn inline-flex items-center justify-center w-10 h-10 rounded-full transition"
             aria-label="Open quick settings"
             aria-haspopup="menu"
             aria-controls="overflowMenu"


### PR DESCRIPTION
## Summary
- prevent the mobile header content from wrapping by keeping the layout in a single flex row
- remove the default white background so the themed header background and shadow are visible and ensure the icon buttons inherit the new styling

## Testing
- npm test -- --runTestsByPath sample.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bf585faf08324ae62c0fa511bc4f5)