### PR TITLE
Add mobile reminders tabs and filtering

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -3292,6 +3292,26 @@
           </div>
           <p class="text-sm text-base-content/70">Quick capture with text or voice — everything syncs here.</p>
         </div>
+        <div class="reminders-tabs-wrapper px-4 pt-2 pb-1 -mx-4">
+          <div class="tabs tabs-boxed w-full max-w-md mx-auto text-sm">
+            <button
+              type="button"
+              class="tab flex-1 reminders-tab-active"
+              data-reminders-tab="all"
+              aria-pressed="true"
+            >
+              All
+            </button>
+            <button
+              type="button"
+              class="tab flex-1"
+              data-reminders-tab="today"
+              aria-pressed="false"
+            >
+              Today
+            </button>
+          </div>
+        </div>
         <div id="quickAddBar" class="mc-quick-add-bar w-full" aria-label="Quick add reminder">
           <div class="mc-quick-add-inner space-y-1.5 w-full">
             <div class="mc-quick-status flex items-center gap-2 text-xs text-base-content/60">


### PR DESCRIPTION
## Summary
- add the All/Today tab bar to the mobile reminders screen markup
- cache the mobile reminder snapshot, filter it for the Today tab, and keep the rendering logic in sync with the selected tab
- wire the new tab buttons so switching tabs re-renders the filtered list and keeps aria/tab state accurate

## Testing
- `npm test -- reminders.quick-add.test.js` *(fails: Jest runs the CommonJS harness but `js/reminders.js` now uses native `import` at the top, causing the pre-existing "Cannot use import statement outside a module" SyntaxError)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bf84933488324b362c24b394e3520)