### PR TITLE
Maintain focus after toggling daily tasks

### DIFF
--- a/app.js
+++ b/app.js
@@ -4023,18 +4023,34 @@ dailyTasksContainer?.addEventListener('change', async (event) => {
   if (!Array.isArray(currentDailyTasks) || Number.isNaN(index) || !currentDailyTasks[index]) {
     return;
   }
+  const wasTargetFocused = document.activeElement === target;
+  const refocusCheckbox = () => {
+    if (!wasTargetFocused) {
+      return;
+    }
+    const nextCheckbox = dailyTasksContainer?.querySelector(`input[data-task-index="${index}"]`);
+    if (nextCheckbox instanceof HTMLInputElement) {
+      try {
+        nextCheckbox.focus({ preventScroll: true });
+      } catch {
+        nextCheckbox.focus();
+      }
+    }
+  };
   const previousState = currentDailyTasks.map((task) => ({ ...task }));
   const updatedTasks = previousState.map((task, taskIndex) =>
     taskIndex === index ? { ...task, completed: target.checked } : task
   );
   currentDailyTasks = updatedTasks;
   renderDailyTasks(updatedTasks);
+  refocusCheckbox();
   try {
     await saveDailyTasks(updatedTasks);
   } catch (error) {
     console.error('Failed to update task completion state', error);
     currentDailyTasks = previousState;
     renderDailyTasks(previousState);
+    refocusCheckbox();
   }
 });
 


### PR DESCRIPTION
## Summary
- keep track of whether the toggled daily task checkbox was focused before re-rendering
- after each render, re-focus the checkbox for the same task index so keyboard users remain on the same task

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module in reminders/mobile test suites)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c0254145483249ea2ad6addc44bba)