### PR TITLE
Improve daily task checkbox accessibility

### DIFF
--- a/app.js
+++ b/app.js
@@ -3508,15 +3508,16 @@ function renderDailyTasks(tasks) {
     .map((task, index) => {
       const safeText = escapeCueText(task?.text || '');
       const completed = Boolean(task?.completed);
+      const checkboxId = `daily-task-${index}`;
       const textClasses = ['ml-3', 'flex-1', 'text-sm', 'sm:text-base', 'text-base-content'];
       if (completed) {
         textClasses.push('line-through', 'text-opacity-50');
       }
       return `
-        <div class="flex items-center p-3 border-b border-base-200" data-task-index="${index}">
-          <input type="checkbox" class="checkbox checkbox-sm" data-task-index="${index}" data-task-text="${safeText}" ${completed ? 'checked' : ''} />
+        <label class="flex items-center p-3 border-b border-base-200" data-task-index="${index}" for="${checkboxId}">
+          <input id="${checkboxId}" type="checkbox" class="checkbox checkbox-sm" data-task-index="${index}" ${completed ? 'checked' : ''} />
           <span class="${textClasses.join(' ')}">${safeText}</span>
-        </div>
+        </label>
       `;
     })
     .join('');


### PR DESCRIPTION
## Summary
- wrap each daily task row in a label so the task text provides the checkbox's accessible name
- add stable IDs to the daily task checkboxes and remove the unused task text data attribute

## Testing
- `npm test -- --runInBand` *(fails: existing Jest suites cannot import ESM modules such as js/reminders.js, causing "Cannot use import statement outside a module" errors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c080fadd483249039b34d526585ff)