### PR TITLE
Add context-aware subtitle to mobile reminders header

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -554,6 +554,32 @@ export async function initReminders(sel = {}) {
   let mobileRemindersFilterMode = 'all';
   let mobileRemindersCache = [];
 
+  // Returns a short, user-facing label for "today", e.g. "Tue 18 Nov"
+  function getTodayLabelForHeader() {
+    const now = new Date();
+    return now.toLocaleDateString(undefined, {
+      weekday: 'short',
+      day: 'numeric',
+      month: 'short',
+    });
+  }
+
+  function updateMobileRemindersHeaderSubtitle() {
+    if (variant !== 'mobile' || typeof document === 'undefined') {
+      return;
+    }
+    const subtitleEl = document.getElementById('mobileRemindersHeaderSubtitle');
+    if (!subtitleEl) {
+      return;
+    }
+    const todayLabel = getTodayLabelForHeader();
+    if (mobileRemindersFilterMode === 'today') {
+      subtitleEl.textContent = `Today\u2019s reminders \u2022 ${todayLabel}`;
+    } else {
+      subtitleEl.textContent = `All reminders \u2022 ${todayLabel}`;
+    }
+  }
+
   const LAST_DEFAULTS_KEY = 'mc:lastDefaults';
 
   const clearPlannerReminderContext = () => {
@@ -2535,6 +2561,7 @@ export async function initReminders(sel = {}) {
     if(!userId){
       hydrateOfflineReminders();
       render();
+      updateMobileRemindersHeaderSubtitle();
       persistItems();
       rescheduleAllReminders();
       return;
@@ -2567,6 +2594,7 @@ export async function initReminders(sel = {}) {
       });
       items = ensureOrderIndicesInitialized(remoteItems);
       render();
+      updateMobileRemindersHeaderSubtitle();
       persistItems();
       rescheduleAllReminders();
     }, (error)=>{
@@ -3277,6 +3305,7 @@ export async function initReminders(sel = {}) {
     };
 
     syncTabUiState();
+    updateMobileRemindersHeaderSubtitle();
 
     tabButtons.forEach((button) => {
       button.addEventListener('click', () => {
@@ -3289,6 +3318,7 @@ export async function initReminders(sel = {}) {
         if (Array.isArray(mobileRemindersCache)) {
           render();
         }
+        updateMobileRemindersHeaderSubtitle();
       });
     });
   }
@@ -3364,6 +3394,7 @@ export async function initReminders(sel = {}) {
     if (variant === 'mobile') {
       mobileRemindersCache = rows.slice();
       rows = filterMobileReminderRows(mobileRemindersCache, mobileRemindersFilterMode, todayRange);
+      updateMobileRemindersHeaderSubtitle();
     }
 
     const highlightToday = true;

--- a/mobile.html
+++ b/mobile.html
@@ -3283,6 +3283,12 @@
     <section data-view="reminders" id="view-reminders" class="view-panel">
       <div class="reminders-header-card bg-base-100 border border-base-300 rounded-2xl shadow-sm w-full px-4 py-3 space-y-3">
         <div class="space-y-1">
+          <p
+            id="mobileRemindersHeaderSubtitle"
+            class="mt-1 text-xs text-base-content/70"
+          >
+            All reminders • Today
+          </p>
           <div class="flex items-baseline justify-between gap-2">
                  <div class="reminders-tabs-wrapper px-4 pt-2 pb-1 -mx-4">
           <div class="tabs tabs-boxed w-full max-w-md mx-auto text-sm">


### PR DESCRIPTION
## Summary
- add a subtitle element to the mobile reminders header so it can show the current context and day label
- add helpers that compute today’s label and update the subtitle on initial render, snapshot refreshes, and tab switches

## Testing
- npm test -- --runInBand *(fails: existing Jest harness cannot import the ESM bundles, e.g. "SyntaxError: Cannot use import statement outside a module")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c094c136083249bbfce04051198e4)