### PR TITLE
Adjust footer background and remove quick action icons

### DIFF
--- a/404.html
+++ b/404.html
@@ -1549,42 +1549,7 @@
   <!-- BEGIN GPT CHANGE: live region -->
   <div id="live-status" class="sr-only" aria-live="polite" role="status"></div>
   <!-- END GPT CHANGE -->
-  <nav
-    id="quick-action-toolbar"
-    aria-label="Quick actions"
-    class="fixed bottom-5 right-5 z-40 flex flex-col items-end gap-2 max-sm:bottom-3 max-sm:right-3"
-  >
-    <button
-      type="button"
-      data-quick-action="reminder"
-      class="quick-action-btn bg-gradient-to-r from-purple-600 via-indigo-500 to-blue-500 text-xl text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-purple-300"
-      title="Add reminder"
-      aria-label="Add reminder"
-    >
-      <span aria-hidden="true">🔔</span>
-      <span class="sr-only">Add reminder</span>
-    </button>
-    <button
-      type="button"
-      data-quick-action="note"
-      class="quick-action-btn bg-white/90 text-xl text-gray-900 dark:text-gray-100 shadow-md backdrop-blur focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-300 hover:bg-white dark:bg-gray-800/70 dark:text-gray-100 dark:hover:bg-gray-700/80 dark:focus-visible:outline-gray-500 border border-white/60 dark:border-gray-700/60"
-      title="Create note"
-      aria-label="Create note"
-    >
-      <span aria-hidden="true">📝</span>
-      <span class="sr-only">Create note</span>
-    </button>
-    <button
-      type="button"
-      data-quick-action="planner"
-      class="quick-action-btn bg-emerald-500 text-xl text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 hover:bg-emerald-600"
-      title="New lesson plan"
-      aria-label="New lesson plan"
-    >
-      <span aria-hidden="true">🗓️</span>
-      <span class="sr-only">New lesson plan</span>
-    </button>
-  </nav>
+  <nav id="quick-action-toolbar" aria-label="Quick actions" hidden></nav>
   <footer class="bg-gray-900 text-white py-8">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex flex-col sm:flex-row justify-between items-center gap-4">

--- a/docs/404.html
+++ b/docs/404.html
@@ -1549,42 +1549,7 @@
   <!-- BEGIN GPT CHANGE: live region -->
   <div id="live-status" class="sr-only" aria-live="polite" role="status"></div>
   <!-- END GPT CHANGE -->
-  <nav
-    id="quick-action-toolbar"
-    aria-label="Quick actions"
-    class="fixed bottom-5 right-5 z-40 flex flex-col items-end gap-2 max-sm:bottom-3 max-sm:right-3"
-  >
-    <button
-      type="button"
-      data-quick-action="reminder"
-      class="quick-action-btn bg-gradient-to-r from-purple-600 via-indigo-500 to-blue-500 text-xl text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-purple-300"
-      title="Add reminder"
-      aria-label="Add reminder"
-    >
-      <span aria-hidden="true">🔔</span>
-      <span class="sr-only">Add reminder</span>
-    </button>
-    <button
-      type="button"
-      data-quick-action="note"
-      class="quick-action-btn bg-white/90 text-xl text-gray-900 dark:text-gray-100 shadow-md backdrop-blur focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-300 hover:bg-white dark:bg-gray-800/70 dark:text-gray-100 dark:hover:bg-gray-700/80 dark:focus-visible:outline-gray-500 border border-white/60 dark:border-gray-700/60"
-      title="Create note"
-      aria-label="Create note"
-    >
-      <span aria-hidden="true">📝</span>
-      <span class="sr-only">Create note</span>
-    </button>
-    <button
-      type="button"
-      data-quick-action="planner"
-      class="quick-action-btn bg-emerald-500 text-xl text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 hover:bg-emerald-600"
-      title="New lesson plan"
-      aria-label="New lesson plan"
-    >
-      <span aria-hidden="true">🗓️</span>
-      <span class="sr-only">New lesson plan</span>
-    </button>
-  </nav>
+  <nav id="quick-action-toolbar" aria-label="Quick actions" hidden></nav>
   <footer class="bg-gray-900 text-white py-8">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex flex-col sm:flex-row justify-between items-center gap-4">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1495,47 +1495,12 @@
         </div>
       </div>
     </main>
-    <nav
-      id="quick-action-toolbar"
-      aria-label="Quick actions"
-      class="flex flex-col items-end gap-2"
-    >
-      <button
-        type="button"
-        data-quick-action="reminder"
-        class="quick-action-btn bg-gradient-to-r from-purple-600 via-indigo-500 to-blue-500 text-xl text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-purple-300"
-        title="Add reminder"
-        aria-label="Add reminder"
-      >
-        <span aria-hidden="true">🔔</span>
-        <span class="sr-only">Add reminder</span>
-      </button>
-      <button
-        type="button"
-        data-quick-action="note"
-        class="quick-action-btn bg-white/90 text-xl text-gray-900 dark:text-gray-100 shadow-md backdrop-blur focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-300 hover:bg-white dark:bg-gray-800/70 dark:text-gray-100 dark:hover:bg-gray-700/80 dark:focus-visible:outline-gray-500 border border-white/60 dark:border-gray-700/60"
-        title="Create note"
-        aria-label="Create note"
-      >
-        <span aria-hidden="true">📝</span>
-        <span class="sr-only">Create note</span>
-      </button>
-      <button
-        type="button"
-        data-quick-action="planner"
-        class="quick-action-btn bg-emerald-500 text-xl text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 hover:bg-emerald-600"
-        title="New lesson plan"
-        aria-label="New lesson plan"
-      >
-        <span aria-hidden="true">🗓️</span>
-        <span class="sr-only">New lesson plan</span>
-      </button>
-    </nav>
+    <nav id="quick-action-toolbar" aria-label="Quick actions" hidden></nav>
   </div>
   <!-- BEGIN GPT CHANGE: live region -->
   <div id="live-status" class="sr-only" aria-live="polite" role="status"></div>
   <!-- END GPT CHANGE -->
-  <footer class="border-t border-base-300 bg-base-200/80 py-6 sm:py-8">
+  <footer class="border-t border-base-300 bg-base-200 py-[18px] sm:py-6">
     <div class="mx-auto flex max-w-7xl flex-col gap-4 px-4 text-sm text-base-content/80 sm:px-6 lg:px-8">
       <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div class="max-w-lg space-y-2">
@@ -1563,7 +1528,7 @@
           </div>
         </div>
       </div>
-      <div class="flex flex-col gap-2 border-t border-base-300/60 pt-3 text-xs text-base-content/60 sm:flex-row sm:items-center sm:justify-between">
+      <div class="flex flex-col gap-2 border-t border-base-300/60 pt-[9px] text-xs text-base-content/60 sm:flex-row sm:items-center sm:justify-between">
         <p>© <span id="year"></span> Memory Cue. All rights reserved.</p>
         <p>Crafted with care for classrooms everywhere.</p>
       </div>

--- a/index.html
+++ b/index.html
@@ -1484,47 +1484,12 @@
         </div>
       </div>
     </main>
-    <nav
-      id="quick-action-toolbar"
-      aria-label="Quick actions"
-      class="flex flex-col items-end gap-2"
-    >
-      <button
-        type="button"
-        data-quick-action="reminder"
-        class="quick-action-btn bg-gradient-to-r from-purple-600 via-indigo-500 to-blue-500 text-xl text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-purple-300"
-        title="Add reminder"
-        aria-label="Add reminder"
-      >
-        <span aria-hidden="true">🔔</span>
-        <span class="sr-only">Add reminder</span>
-      </button>
-      <button
-        type="button"
-        data-quick-action="note"
-        class="quick-action-btn bg-white/90 text-xl text-gray-900 dark:text-gray-100 shadow-md backdrop-blur focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-300 hover:bg-white dark:bg-gray-800/70 dark:text-gray-100 dark:hover:bg-gray-700/80 dark:focus-visible:outline-gray-500 border border-white/60 dark:border-gray-700/60"
-        title="Create note"
-        aria-label="Create note"
-      >
-        <span aria-hidden="true">📝</span>
-        <span class="sr-only">Create note</span>
-      </button>
-      <button
-        type="button"
-        data-quick-action="planner"
-        class="quick-action-btn bg-emerald-500 text-xl text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 hover:bg-emerald-600"
-        title="New lesson plan"
-        aria-label="New lesson plan"
-      >
-        <span aria-hidden="true">🗓️</span>
-        <span class="sr-only">New lesson plan</span>
-      </button>
-    </nav>
+    <nav id="quick-action-toolbar" aria-label="Quick actions" hidden></nav>
   </div>
   <!-- BEGIN GPT CHANGE: live region -->
   <div id="live-status" class="sr-only" aria-live="polite" role="status"></div>
   <!-- END GPT CHANGE -->
-  <footer class="border-t border-base-300 bg-base-200/80 py-6 sm:py-8">
+  <footer class="border-t border-base-300 bg-base-200 py-[18px] sm:py-6">
     <div class="mx-auto flex max-w-7xl flex-col gap-4 px-4 text-sm text-base-content/80 sm:px-6 lg:px-8">
       <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div class="max-w-lg space-y-2">
@@ -1552,7 +1517,7 @@
           </div>
         </div>
       </div>
-      <div class="flex flex-col gap-2 border-t border-base-300/60 pt-3 text-xs text-base-content/60 sm:flex-row sm:items-center sm:justify-between">
+      <div class="flex flex-col gap-2 border-t border-base-300/60 pt-[9px] text-xs text-base-content/60 sm:flex-row sm:items-center sm:justify-between">
         <p>© <span id="year"></span> Memory Cue. All rights reserved.</p>
         <p>Crafted with care for classrooms everywhere.</p>
       </div>


### PR DESCRIPTION
## Summary
- hide the quick action icon toolbar so the footer area is icon-free across the main and 404 pages
- make the footer background fully opaque and trim its vertical padding to roughly 75% of its previous height
- mirror the same markup updates in the generated docs HTML files

## Testing
- `npm test` *(fails: current Jest setup cannot execute the ESM modules imported by reminders.js/mobile.js and raises "Cannot use import statement outside a module" errors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c0e17768483249d5f572e4d128d36)