### PR TITLE
Update mobile footer styling

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -3513,7 +3513,7 @@
 
   <div id="mobile-nav-shell" class="fixed inset-x-0 bottom-3 z-50 flex justify-center pointer-events-none">
     <nav
-      class="btm-nav bg-base-100/90 border border-base-300 rounded-full shadow-lg px-4 py-1.5 flex items-center justify-around gap-2 max-w-md w-full mx-auto pointer-events-auto backdrop-blur-md"
+      class="btm-nav bg-base-100 border border-base-300 rounded-full shadow-lg px-3 py-1 flex items-center justify-around gap-2 max-w-md w-3/4 mx-auto pointer-events-auto"
       aria-label="Primary navigation"
     >
       <button
@@ -3521,14 +3521,12 @@
         aria-current="page"
         class="active flex flex-col items-center justify-center gap-0.5 px-2 py-1 rounded-full text-[11px] font-medium text-base-content/70 transition"
       >
-        <span class="text-lg leading-none">⏰</span>
         <span class="leading-tight">Reminders</span>
       </button>
       <button
         type="button"
         class="flex flex-col items-center justify-center gap-0.5 px-2 py-1 rounded-full text-[11px] font-medium text-base-content/70 transition"
       >
-        <span class="text-lg leading-none">📝</span>
         <span class="leading-tight">Notebook</span>
       </button>
     </nav>


### PR DESCRIPTION
## Summary
- make the mobile footer background opaque and reduce its footprint
- remove the reminder and notebook icons from the footer buttons

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c13896bf48324bc92944f7736f427)