### PR TITLE
Polish mobile reminders and notebook layouts

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -3270,17 +3270,22 @@
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: reminders view -->
     <section data-view="reminders" id="view-reminders" class="view-panel">
-      <div class="reminders-header-card bg-base-100 border border-base-300 rounded-2xl shadow-sm w-full px-4 py-3 space-y-3">
-        <div class="space-y-1">
-          <p
-            id="mobileRemindersHeaderSubtitle"
-            class="mt-1 text-xs text-base-content/70"
-          >
-            All reminders • Today
-          </p>
-          <div class="flex items-baseline justify-between gap-2">
-                 <div class="reminders-tabs-wrapper px-4 pt-2 pb-1 -mx-4">
-          <div class="tabs tabs-boxed w-full max-w-md mx-auto text-sm">
+      <div class="mobile-view-inner mx-auto w-full max-w-md px-4 pt-4 pb-4 space-y-3">
+        <header class="mobile-header flex flex-col gap-1">
+          <div class="reminders-header-card bg-base-100 border border-base-300 rounded-2xl shadow-sm w-full px-4 py-3 space-y-3">
+            <div class="space-y-1">
+              <p
+                id="mobileRemindersHeaderSubtitle"
+                class="mt-1 text-xs text-base-content/70"
+              >
+                All reminders • Today
+              </p>
+            </div>
+          </div>
+        </header>
+
+        <div class="reminders-tabs-wrapper pt-1">
+          <div class="tabs tabs-boxed w-full text-sm">
             <button
               type="button"
               class="tab flex-1 reminders-tab-active"
@@ -3298,7 +3303,9 @@
               Today
             </button>
           </div>
-                <div id="quickAddBar" class="mc-quick-add-bar w-full" aria-label="Quick add reminder">
+        </div>
+
+        <div id="quickAddBar" class="reminders-quick-add mc-quick-add-bar w-full rounded-xl bg-base-100 shadow-sm px-3 py-2 flex items-center gap-2" aria-label="Quick add reminder">
           <div class="mc-quick-add-inner space-y-1.5 w-full">
             <div class="mc-quick-add-row flex flex-col items-center gap-2 w-full mt-1">
               <div class="mc-quick-input-group w-full">
@@ -3332,35 +3339,41 @@
             </div>
           </div>
         </div>
+
+        <div id="remindersListMobile" class="space-y-2">
           <section
-        id="reminderListSection"
-        class="w-full relative"
-      >
-        <div class="w-full" id="remindersWrapper">
-          <div id="emptyState" class="hidden text-center text-base-content/60 py-8 sm:px-4"></div>
-          <p id="reminderReorderHint" class="sr-only">
-            Press, hold, and drag a reminder card to reorder your list. Screen reader users can double-tap and hold, then drag to move a reminder.
-          </p>
-          <p class="text-xs text-base-content/50 mb-2 pb-2 border-b border-base-200/30 sm:px-4">Total reminders: <span id="totalCount">0</span></p>
-          <ul id="reminderList" class="grid grid-cols-2 gap-1 w-full overflow-x-hidden reminder-list" aria-describedby="reminderReorderHint"></ul>
+            id="reminderListSection"
+            class="w-full relative"
+          >
+            <div class="w-full" id="remindersWrapper">
+              <div id="emptyState" class="hidden text-center text-base-content/60 py-8 sm:px-4"></div>
+              <p id="reminderReorderHint" class="sr-only">
+                Press, hold, and drag a reminder card to reorder your list. Screen reader users can double-tap and hold, then drag to move a reminder.
+              </p>
+              <p class="text-xs text-base-content/50 mb-2 pb-2 border-b border-base-200/30 sm:px-4">Total reminders: <span id="totalCount">0</span></p>
+              <ul id="reminderList" class="grid grid-cols-2 gap-1 w-full overflow-x-hidden reminder-list" aria-describedby="reminderReorderHint"></ul>
+            </div>
+          </section>
         </div>
-      </section>
+      </div>
     </section>
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: notebook view -->
     <section data-view="notebook" id="view-notebook" class="view-panel hidden mobile-panel--notes">
-      <div class="flex flex-col gap-4">
-        <div id="notebook-view-header" class="mb-3">
-          <div class="flex items-baseline justify-between gap-2">
-            <h1 class="text-base font-semibold text-base-content">Notebook</h1>
-            <span class="text-[11px] text-base-content/60">
-              Scratch ideas first, then refine later.
-            </span>
+      <div class="mobile-view-inner mx-auto w-full max-w-md px-4 pt-4 pb-4 space-y-3">
+        <header class="mobile-header flex flex-col gap-1">
+          <div id="notebook-view-header" class="space-y-1">
+            <div class="flex items-baseline justify-between gap-2">
+              <h1 class="text-base font-semibold text-base-content">Notebook</h1>
+              <span class="text-[11px] text-base-content/60">
+                Scratch ideas first, then refine later.
+              </span>
+            </div>
           </div>
-        </div>
+        </header>
         <div
           id="scratch-notes-card"
-          class="mt-1 bg-base-100 border border-base-300 rounded-2xl shadow-sm px-4 py-4 space-y-3"
+          class="scratch-notes-card bg-base-100 border border-base-300 rounded-xl shadow-sm p-3 space-y-2"
         >
           <div class="flex items-start justify-between gap-3">
             <div>
@@ -3499,7 +3512,7 @@
             <div class="mt-1 max-h-56 overflow-y-auto flex-1 w-full">
               <ul
                 id="notesListMobile"
-                class="space-y-1 text-sm"
+                class="space-y-2 text-sm"
                 aria-label="Saved scratch notes"
               ></ul>
             </div>


### PR DESCRIPTION
## Summary
- wrap the reminders view content in the new `mobile-view-inner` container, refresh the tabs/quick-add spacing, and add the `remindersListMobile` wrapper to keep the column width consistent
- apply the same `mobile-view-inner` structure to the notebook view, updating the scratch notes card and saved-notes list spacing for the shared mobile visual rhythm

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c16b36b648324a3db0a2ac745ffe2)