### PR TITLE
Restructure desktop workspace layout grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -341,7 +341,7 @@
 </head>
 <body id="top" class="desktop-shell">
   <a class="skip-link" href="#mainContent">Skip to main content</a>
-  <div class="dashboard-root">
+  <div class="dashboard-root desktop-layout">
     <header class="desktop-header desktop-header-bar" aria-label="Primary">
       <div class="desktop-header-left">
         <div class="desktop-header-brand">
@@ -377,88 +377,87 @@
         </div>
       </div>
     </header>
-    <main id="mainContent" class="desktop-main" tabindex="-1">
-      <div class="desktop-main-inner">
-        <aside class="desktop-rail" aria-label="Workspace navigation">
-          <div class="desktop-rail-sticky">
-            <nav class="desktop-rail-nav" aria-label="Primary">
-              <ul class="menu menu-vertical gap-1 nav-pill-glass text-sm">
-                <li>
-                  <a href="#dashboard" data-nav="dashboard" id="nav-dashboard" class="btn btn-sm btn-ghost">Dashboard</a>
-                </li>
-                <li>
-                  <a href="#reminders" data-nav="reminders" id="nav-reminders" class="btn btn-sm btn-ghost">Reminders</a>
-                </li>
-                <li>
-                  <a href="#planner" data-nav="planner" id="nav-planner" class="btn btn-sm btn-ghost">Planner</a>
-                </li>
-                <li>
-                  <a href="#notes" data-nav="notes" id="nav-notes" class="btn btn-sm btn-ghost">Notes</a>
-                </li>
-              </ul>
-            </nav>
-            <div class="desktop-rail-controls">
-              <button
-                id="theme-toggle"
-                type="button"
-                class="btn btn-sm btn-ghost text-base-content"
-                data-icon-dark="🌙"
-                data-icon-light="☀️"
-              ></button>
-              <div
-                class="desktop-account-controls w-full sm:w-auto"
-                data-account-panel-container
-                data-account-collapsed="true"
-              >
-                <button
-                  id="desktopAccountToggle"
-                  type="button"
-                  class="desktop-account-toggle btn btn-sm btn-ghost"
-                  aria-expanded="false"
-                  aria-controls="desktopAccountPanel"
-                  data-collapsed-label="Account"
-                  data-expanded-label="Account"
-                  data-collapsed-aria="Show account controls"
-                  data-expanded-aria="Hide account controls"
-                >
-                  <span class="desktop-account-toggle__label" data-account-toggle-label aria-hidden="true">Account</span>
-                  <span class="sr-only" data-account-toggle-a11y>Show account controls</span>
-                  <span class="desktop-account-toggle__chevron" aria-hidden="true"></span>
-                </button>
+    <aside class="desktop-rail desktop-sidebar" aria-label="Workspace navigation">
+      <div class="desktop-rail-sticky">
+        <nav class="desktop-rail-nav" aria-label="Primary">
+          <ul class="menu menu-vertical gap-1 nav-pill-glass text-sm">
+            <li>
+              <a href="#dashboard" data-nav="dashboard" id="nav-dashboard" class="btn btn-sm btn-ghost">Dashboard</a>
+            </li>
+            <li>
+              <a href="#reminders" data-nav="reminders" id="nav-reminders" class="btn btn-sm btn-ghost">Reminders</a>
+            </li>
+            <li>
+              <a href="#planner" data-nav="planner" id="nav-planner" class="btn btn-sm btn-ghost">Planner</a>
+            </li>
+            <li>
+              <a href="#notes" data-nav="notes" id="nav-notes" class="btn btn-sm btn-ghost">Notes</a>
+            </li>
+          </ul>
+        </nav>
+        <div class="desktop-rail-controls">
+          <button
+            id="theme-toggle"
+            type="button"
+            class="btn btn-sm btn-ghost text-base-content"
+            data-icon-dark="🌙"
+            data-icon-light="☀️"
+          ></button>
+          <div
+            class="desktop-account-controls w-full sm:w-auto"
+            data-account-panel-container
+            data-account-collapsed="true"
+          >
+            <button
+              id="desktopAccountToggle"
+              type="button"
+              class="desktop-account-toggle btn btn-sm btn-ghost"
+              aria-expanded="false"
+              aria-controls="desktopAccountPanel"
+              data-collapsed-label="Account"
+              data-expanded-label="Account"
+              data-collapsed-aria="Show account controls"
+              data-expanded-aria="Hide account controls"
+            >
+              <span class="desktop-account-toggle__label" data-account-toggle-label aria-hidden="true">Account</span>
+              <span class="sr-only" data-account-toggle-a11y>Show account controls</span>
+              <span class="desktop-account-toggle__chevron" aria-hidden="true"></span>
+            </button>
+            <div
+              id="desktopAccountPanel"
+              class="desktop-account-panel"
+              aria-hidden="true"
+              data-account-panel
+              inert
+            >
+              <div class="flex w-full flex-wrap items-center justify-end gap-2 sm:w-auto sm:flex-nowrap">
                 <div
-                  id="desktopAccountPanel"
-                  class="desktop-account-panel"
-                  aria-hidden="true"
-                  data-account-panel
-                  inert
+                  id="googleUserName"
+                  class="google-user-chip text-xs sm:text-sm font-medium text-base-content/80 rounded-full border border-base-200 bg-base-100/80 px-3 py-1"
+                ></div>
+                <button id="googleSignInBtn" type="button" class="btn btn-sm btn-primary w-full sm:w-auto">Sign in</button>
+                <button
+                  id="googleSignOutBtn"
+                  type="button"
+                  class="hidden btn btn-sm btn-outline border-base-300 bg-base-100/80 text-base-content w-full sm:w-auto"
                 >
-                  <div class="flex w-full flex-wrap items-center justify-end gap-2 sm:w-auto sm:flex-nowrap">
-                    <div
-                      id="googleUserName"
-                      class="google-user-chip text-xs sm:text-sm font-medium text-base-content/80 rounded-full border border-base-200 bg-base-100/80 px-3 py-1"
-                    ></div>
-                    <button id="googleSignInBtn" type="button" class="btn btn-sm btn-primary w-full sm:w-auto">Sign in</button>
-                    <button
-                      id="googleSignOutBtn"
-                      type="button"
-                      class="hidden btn btn-sm btn-outline border-base-300 bg-base-100/80 text-base-content w-full sm:w-auto"
-                    >
-                      Sign out
-                    </button>
-                  </div>
-                </div>
+                  Sign out
+                </button>
               </div>
             </div>
           </div>
-        </aside>
-        <div class="desktop-workspace desktop-workspace-region space-y-8">
+        </div>
+      </div>
+    </aside>
+    <main id="mainContent" class="desktop-main desktop-workspace" tabindex="-1">
+      <div class="desktop-main-inner">
+        <div class="desktop-workspace-region space-y-8">
       <section data-route="dashboard" class="space-y-6 lg:space-y-12">
         <div class="max-w-6xl mx-auto space-y-6">
           <section class="desktop-hero">
             <div class="hero-content max-w-none w-full">
-              <div class="desktop-dashboard-grid">
-                <div class="space-y-6">
-                  <article class="dashboard-card dashboard-card--hero h-full">
+              <div class="desktop-dashboard-grid dashboard-grid">
+                <article class="dashboard-card dashboard-card--hero h-full">
                     <div class="dashboard-card-content">
                       <div class="flex items-start justify-between gap-3">
                         <div class="space-y-1">
@@ -508,7 +507,7 @@
                     </div>
                   </article>
 
-                  <article class="dashboard-card dashboard-card--compact h-full">
+                <article class="dashboard-card dashboard-card--compact h-full">
                     <div class="dashboard-card-content">
                       <div class="flex items-center justify-between gap-2">
                         <p class="dashboard-card-eyebrow">Today’s reminders</p>
@@ -546,9 +545,7 @@
                       </div>
                     </div>
                   </article>
-                </div>
-                <div class="space-y-6">
-                  <article class="dashboard-card dashboard-card--hero h-full">
+                <article class="dashboard-card dashboard-card--hero h-full">
                     <div class="dashboard-card-content">
                       <div class="space-y-1">
                         <p class="dashboard-card-eyebrow">Top educational news</p>
@@ -577,8 +574,7 @@
                       <p id="newsFootnote" class="text-xs text-base-content/60" aria-live="polite"></p>
                     </div>
                   </article>
-
-                  <article class="dashboard-card dashboard-card--compact h-full">
+                <article class="dashboard-card dashboard-card--compact h-full">
                     <div class="dashboard-card-content">
                       <div class="flex items-center justify-between gap-2">
                         <p class="dashboard-card-eyebrow">Next lesson</p>
@@ -618,14 +614,12 @@
                         </button>
                       </div>
                     </div>
-                  </article>
-                </div>
+                    </article>
               </div>
-            </div>
           </section>
         </div>
 
-        <div class="desktop-dashboard-grid">
+        <div class="desktop-dashboard-grid dashboard-grid">
           <section
             class="dashboard-card card dashboard-card--compact"
             aria-labelledby="kpi-heading"
@@ -855,7 +849,7 @@
           </section>
         </div>
 
-        <div class="desktop-dashboard-grid">
+        <div class="desktop-dashboard-grid dashboard-grid">
           <section class="dashboard-card card h-full">
             <div class="card-body dashboard-card-body gap-5">
               <div class="flex flex-wrap items-center justify-between gap-3">
@@ -1086,9 +1080,10 @@
                     <h3 class="desktop-panel-title text-2xl font-semibold tracking-wide text-base-content" data-primary-heading>Reminders</h3>
                     <p class="desktop-panel-subtitle text-sm text-base-content/70">Keep track of tasks, family updates, and prep work in one organised list.</p>
                   </div>
-                  <div class="desktop-reminders-layout gap-6">
-                    <div class="desktop-reminders-column workspace-pane desktop-panel card border border-base-300/80 bg-base-100 text-base-content shadow-sm">
-                      <div class="desktop-panel-body card-body flex h-full flex-col gap-3">
+                  <div class="desktop-reminders-layout workspace-columns">
+                    <div class="workspace-column column-primary">
+                      <div class="desktop-reminders-column workspace-pane desktop-panel card border border-base-300/80 bg-base-100 text-base-content shadow-sm">
+                        <div class="desktop-panel-body card-body flex h-full flex-col gap-3">
                         <div class="desktop-panel-toolbar flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">
                           <span class="btn btn-ghost btn-xs cursor-default" title="Filtering not available yet">All</span>
                           <button type="button" class="btn btn-ghost btn-xs" disabled title="Filtering not available yet">Today</button>
@@ -1098,10 +1093,12 @@
                         <div class="desktop-panel-body workspace-pane__body desktop-reminders-scroll">
                           <ul id="reminders-list" class="desktop-reminders-list list-none"></ul>
                         </div>
+                        </div>
                       </div>
                     </div>
-                    <div class="desktop-reminders-detail workspace-pane desktop-panel card border border-base-300/80 bg-base-100 text-base-content shadow-sm">
-                      <div class="desktop-panel-body card-body flex h-full flex-col gap-5">
+                    <div class="workspace-column column-secondary">
+                      <div class="desktop-reminders-detail workspace-pane desktop-panel card border border-base-300/80 bg-base-100 text-base-content shadow-sm">
+                        <div class="desktop-panel-body card-body flex h-full flex-col gap-5">
                         <div class="desktop-panel-header flex flex-wrap items-start justify-between gap-3">
                           <div class="space-y-1">
                             <p class="desktop-panel-title text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Quick add</p>
@@ -1175,6 +1172,7 @@
                             </div>
                           </form>
                         </div>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1191,9 +1189,10 @@
                     <h3 class="desktop-panel-title text-2xl font-semibold tracking-wide text-base-content" data-primary-heading>Weekly planner</h3>
                     <p class="desktop-panel-subtitle text-sm text-base-content/70">Draft the key lessons, checkpoints, and resources your classes need this week.</p>
                   </div>
-                  <div class="grid gap-6 lg:grid-cols-[minmax(0,22rem)_minmax(0,1fr)]">
-                    <div class="workspace-pane desktop-panel desktop-panel--planner card border border-base-300/80 bg-base-100 text-base-content shadow-sm">
-                      <div class="desktop-panel-body card-body flex h-full flex-col gap-4">
+                  <div class="workspace-columns">
+                    <div class="workspace-column column-primary">
+                      <div class="workspace-pane desktop-panel desktop-panel--planner card border border-base-300/80 bg-base-100 text-base-content shadow-sm">
+                        <div class="desktop-panel-body card-body flex h-full flex-col gap-4">
                         <div class="desktop-panel-toolbar flex flex-wrap items-center gap-2">
                           <button type="button" id="planner-prev" class="btn btn-ghost btn-xs" aria-label="View previous week">Prev</button>
                           <button type="button" id="planner-today" class="btn btn-ghost btn-xs" aria-label="Jump to current week">Today</button>
@@ -1234,8 +1233,9 @@
                         <p id="planner-week" class="text-sm font-semibold text-base-content/80"></p>
                       </div>
                     </div>
-                    <div class="workspace-pane desktop-panel desktop-panel--planner card border border-base-300/80 bg-base-100 text-base-content shadow-sm">
-                      <div class="desktop-panel-body workspace-pane__body h-full overflow-y-auto px-6 py-4">
+                    <div class="workspace-column column-secondary">
+                      <div class="workspace-pane desktop-panel desktop-panel--planner card border border-base-300/80 bg-base-100 text-base-content shadow-sm">
+                        <div class="desktop-panel-body workspace-pane__body h-full overflow-y-auto px-6 py-4">
                         <div class="[&_[data-planner-lesson]]:rounded-2xl [&_[data-planner-lesson]]:bg-base-100 [&_[data-planner-lesson]]:px-4 [&_[data-planner-lesson]]:py-4 [&_[data-planner-lesson]]:text-base-content [&_[data-planner-lesson]]:shadow-lg [&_[data-planner-lesson]]:space-y-2 [&_[data-planner-lesson]]:flex [&_[data-planner-lesson]]:flex-col [&_[data-planner-lesson]]:justify-between [&_[data-planner-lesson]_.badge]:text-[11px] [&_[data-planner-lesson]_.badge]:text-base-content/80 [&_[data-planner-lesson]_.label-text]:text-[11px] [&_[data-planner-lesson]_.label-text]:tracking-[0.2em] [&_[data-planner-lesson]_.label-text]:text-base-content/60 [&_[data-planner-lesson] textarea]:text-sm [&_[data-planner-lesson] textarea]:text-base-content [&_[data-planner-lesson] textarea]:placeholder:text-base-content/60 [&_[data-planner-lesson]>div:last-child]:mt-3 [&_[data-planner-lesson]>div:last-child]:flex [&_[data-planner-lesson]>div:last-child]:gap-2 [&_[data-planner-lesson]>div:last-child]:justify-start">
                           <div id="plannerCards" class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"></div>
                         </div>
@@ -1255,9 +1255,10 @@
                     <h3 class="desktop-panel-title text-2xl font-semibold tracking-wide text-base-content" data-primary-heading>Notes</h3>
                     <p class="desktop-panel-subtitle text-sm text-base-content/70">Capture observations, behaviour wins, and quick reflections to revisit later.</p>
                   </div>
-                  <div class="grid gap-6 lg:grid-cols-2">
-                    <article class="workspace-pane desktop-panel card notes-editor-card border border-base-300 bg-base-100 text-base-content shadow-sm">
-                      <div class="desktop-panel-body workspace-pane__body card-body flex h-full flex-col gap-4">
+                  <div class="workspace-columns">
+                    <div class="workspace-column column-primary">
+                      <article class="workspace-pane desktop-panel card notes-editor-card border border-base-300 bg-base-100 text-base-content shadow-sm">
+                        <div class="desktop-panel-body workspace-pane__body card-body flex h-full flex-col gap-4">
                         <div class="space-y-1">
                           <label for="noteTitle" class="text-xs font-semibold uppercase text-base-content/70">Title</label>
                           <input
@@ -1280,10 +1281,12 @@
                           <button id="noteSaveBtn" type="button" class="btn btn-primary btn-sm">Save</button>
                           <button id="noteNewBtn" type="button" class="btn btn-outline btn-sm">New note</button>
                         </div>
-                      </div>
-                    </article>
-                    <aside class="workspace-pane desktop-panel card border border-base-300 bg-base-200/70 text-base-content shadow-sm">
-                      <div class="desktop-panel-body card-body flex h-full flex-col gap-3">
+                        </div>
+                      </article>
+                    </div>
+                    <div class="workspace-column column-secondary">
+                      <aside class="workspace-pane desktop-panel card border border-base-300 bg-base-200/70 text-base-content shadow-sm">
+                        <div class="desktop-panel-body card-body flex h-full flex-col gap-3">
                         <div>
                           <h3 class="text-sm font-semibold text-base-content/80">Saved notes</h3>
                           <p class="text-xs text-base-content/60">Select an entry to continue editing.</p>
@@ -1291,8 +1294,9 @@
                         <div class="desktop-panel-body workspace-pane__body flex-1 overflow-y-auto pr-1">
                           <ul id="notesList" class="space-y-1 text-sm text-base-content"></ul>
                         </div>
-                      </div>
-                    </aside>
+                        </div>
+                      </aside>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/styles/index.css
+++ b/styles/index.css
@@ -29,6 +29,7 @@ html {
   --planner-card-border: color-mix(in srgb, var(--desktop-border-subtle, #d7def1) 70%, transparent);
   --planner-card-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
   --planner-card-highlight: rgba(79, 70, 229, 0.18);
+  --desktop-header-height: 4.5rem;
 }
 
 body {
@@ -346,9 +347,38 @@ html[data-theme="professional"] {
   max-width: 1320px;
   margin: 0 auto;
   padding: 1.25rem 2.25rem 2.5rem;
+}
+
+ .desktop-shell .desktop-layout {
   display: grid;
-  grid-template-rows: auto 1fr;
-  gap: 1rem;
+  gap: clamp(1rem, 3vw, 1.75rem);
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-areas:
+    "header"
+    "sidebar"
+    "main";
+}
+
+@media (min-width: 1024px) {
+  .desktop-shell .desktop-layout {
+    grid-template-columns: var(--desktop-rail-width) minmax(0, 1fr);
+    grid-template-rows: auto 1fr;
+    grid-template-areas:
+      "header header"
+      "sidebar main";
+  }
+}
+
+ .desktop-shell .desktop-header {
+  grid-area: header;
+}
+
+ .desktop-shell .desktop-sidebar {
+  grid-area: sidebar;
+}
+
+ .desktop-shell .desktop-workspace {
+  grid-area: main;
 }
 
  .desktop-shell .desktop-hero,
@@ -372,12 +402,61 @@ html[data-theme="professional"] {
 }
 
  .desktop-shell .desktop-main-inner {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: var(--desktop-shell-gutter);
-  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: var(--dashboard-section-spacing);
+  align-items: stretch;
   padding: 0 var(--desktop-shell-gutter) 2.5rem;
   width: 100%;
+  min-height: 0;
+}
+
+ .desktop-shell .dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(1rem, 2vw, 1.5rem);
+  align-items: stretch;
+}
+
+ .desktop-shell .dashboard-grid > * {
+  min-width: 0;
+}
+
+ .desktop-shell :is(.desktop-task-card, .insight-card, .dashboard-card, .workspace-pane, .desktop-panel) {
+  box-sizing: border-box;
+}
+
+ .desktop-shell :is(.desktop-task-card, .insight-card) {
+  width: 100%;
+  padding: clamp(0.9rem, 1.8vw, 1.35rem);
+  border-radius: var(--desktop-radius-card, 18px);
+}
+
+ .desktop-shell .workspace-columns {
+  display: grid;
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+@media (min-width: 1024px) {
+  .desktop-shell .workspace-columns {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+}
+
+ .desktop-shell .workspace-column {
+  display: flex;
+  flex-direction: column;
+  gap: var(--dashboard-section-spacing);
+  min-width: 0;
+}
+
+@media (min-width: 1024px) {
+  .desktop-shell .workspace-column {
+    max-height: calc(100vh - var(--desktop-header-height) - 2rem);
+    overflow-y: auto;
+    padding-right: 0.25rem;
+    scrollbar-gutter: stable both-edges;
+  }
 }
 
  .desktop-shell .desktop-workspace-region {
@@ -459,12 +538,6 @@ html[data-theme="professional"] {
   }
 }
 
-@media (min-width: 1024px) {
-   .desktop-shell .desktop-main-inner {
-    grid-template-columns: var(--desktop-rail-width) minmax(0, 1fr);
-  }
-}
-
  .desktop-shell .desktop-rail {
   align-self: flex-start;
 }
@@ -502,10 +575,6 @@ html[data-theme="professional"] {
 }
 
 @media (max-width: 1023px) {
-   .desktop-shell .desktop-main-inner {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
    .desktop-shell .desktop-rail-sticky {
     position: static;
     padding: 0;
@@ -521,16 +590,7 @@ html[data-theme="professional"] {
 }
 
  .desktop-shell .desktop-dashboard-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 2.2fr) minmax(0, 1.4fr);
-  gap: 1rem;
   align-items: flex-start;
-}
-
-@media (max-width: 1024px) {
-   .desktop-shell .desktop-dashboard-grid {
-    grid-template-columns: minmax(0, 1fr);
-  }
 }
 
 
@@ -852,16 +912,7 @@ html[data-theme="professional"] {
 }
 
  .desktop-shell .desktop-reminders-layout {
-  display: flex;
-  flex-direction: column;
-}
-
-@media (min-width: 1024px) {
-   .desktop-shell .desktop-reminders-layout {
-    display: grid;
-    grid-template-columns: minmax(0, 22rem) minmax(0, 1fr);
-    align-items: stretch;
-  }
+  width: 100%;
 }
 
  .desktop-shell .desktop-reminders-column {
@@ -871,15 +922,9 @@ html[data-theme="professional"] {
  .desktop-shell .desktop-reminders-scroll {
   flex: 1;
   min-height: 0;
-}
-
-@media (min-width: 1024px) {
-   .desktop-shell .desktop-reminders-scroll {
-    height: clamp(24rem, 60vh, 32rem);
-    overflow-y: auto;
-    padding-right: 0.25rem;
-    scrollbar-gutter: stable both-edges;
-  }
+  overflow-y: auto;
+  padding-right: 0.25rem;
+  scrollbar-gutter: stable both-edges;
 }
 
  .desktop-shell .desktop-reminders-list {


### PR DESCRIPTION
## Summary
- wrap the header, navigation rail, and main workspace in the new `.desktop-layout` grid and use `.dashboard-grid` so dashboard cards stay in their lanes at desktop sizes
- group reminders, planner, and notes panes inside `.workspace-columns` so each column keeps consistent spacing and becomes scrollable when the viewport is short
- apply responsive box-sizing and padding rules to dashboard/reminder cards to prevent width overflow across the new layout

## Testing
- `npm test` *(fails: existing Jest harness cannot import ES module entry points such as js/reminders.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c14ff662883249d1482fbd5f03092)