### PR TITLE
Improve reminder card layout

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -458,6 +458,11 @@
     list-style: none;
     margin: 0;
     padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1rem;
+    width: 100%;
+    grid-auto-rows: auto;
   }
 
     /* Each reminder item uses the Calming Tones card styling */
@@ -467,7 +472,7 @@
       align-items: start;
       gap: var(--reminder-card-gap);
       padding: var(--reminder-card-padding-y) var(--reminder-card-padding-x);
-      margin: 0 0 var(--reminder-card-gap) 0;
+      margin: 0;
       border: 1px solid var(--card-border);
       font-size: var(--reminder-card-font-size);
       line-height: 1.4;
@@ -475,6 +480,10 @@
       border-radius: 12px;
       box-shadow: 0 1px 3px var(--shadow-color);
       transition: all 0.2s ease;
+      width: 100%;
+      max-width: 100%;
+      box-sizing: border-box;
+      position: static;
     }
 
     #reminderList > *:hover {

--- a/mobile.html
+++ b/mobile.html
@@ -493,6 +493,11 @@
     list-style: none;
     margin: 0;
     padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1rem;
+    width: 100%;
+    grid-auto-rows: auto;
   }
 
     /* Each reminder item uses the Calming Tones card styling */
@@ -502,7 +507,7 @@
       align-items: start;
       gap: var(--reminder-card-gap);
       padding: var(--reminder-card-padding-y) var(--reminder-card-padding-x);
-      margin: 0 0 var(--reminder-card-gap) 0;
+      margin: 0;
       border: 1px solid var(--card-border);
       font-size: var(--reminder-card-font-size);
       line-height: 1.4;
@@ -510,6 +515,10 @@
       border-radius: 12px;
       box-shadow: 0 1px 3px var(--shadow-color);
       transition: all 0.2s ease;
+      width: 100%;
+      max-width: 100%;
+      box-sizing: border-box;
+      position: static;
     }
 
     #reminderList > *:hover {


### PR DESCRIPTION
## Summary
- convert the mobile reminder list container to a responsive CSS grid so cards flow naturally across the available width
- normalize reminder card styling so each card keeps consistent padding, full-width sizing, and stays in the normal flow without absolute positioning

## Testing
- `npm test -- --runInBand` *(fails: existing Jest suites cannot import ESM modules such as js/reminders.js, leading to "Cannot use import statement outside a module" errors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c1a223140832490663f8c0f4f5a7d)