### PR TITLE
Improve desktop dashboard layout responsiveness

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -411,11 +411,41 @@ html[data-theme="professional"] {
   min-height: 0;
 }
 
+@media (min-width: 1024px) {
+  .desktop-shell .desktop-main-inner {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    gap: clamp(2rem, 3vw, 3rem);
+    align-items: start;
+  }
+
+  .desktop-shell .desktop-main-inner > * {
+    min-width: 0;
+  }
+}
+
  .desktop-shell .dashboard-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: clamp(1rem, 2vw, 1.5rem);
   align-items: stretch;
+}
+
+@media (min-width: 1024px) {
+  .desktop-shell .dashboard-grid {
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    column-gap: clamp(1.75rem, 2.5vw, 2.75rem);
+    row-gap: clamp(1.5rem, 2vw, 2.25rem);
+  }
+
+  .desktop-shell .dashboard-grid > .dashboard-card {
+    grid-column: span 6;
+  }
+
+  .desktop-shell .dashboard-grid > .dashboard-card.dashboard-card--hero,
+  .desktop-shell .dashboard-grid > .dashboard-card.dashboard-card--wide {
+    grid-column: span 12;
+  }
 }
 
  .desktop-shell .dashboard-grid > * {


### PR DESCRIPTION
## Summary
- add a desktop-only grid to the main workspace container so sections can split into multiple columns with consistent spacing
- extend the dashboard card grid with desktop media queries so cards reliably form multi-column layouts while letting hero cards span the full width

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c1b84ec7c8324ba2bee999050b8f0)