### PR TITLE
Simplify mobile reminders header and scratch notes

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -3279,21 +3279,18 @@
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: reminders view -->
     <section data-view="reminders" id="view-reminders" class="view-panel">
-      <div class="mobile-view-inner mx-auto w-full max-w-md px-4 pt-4 pb-4 space-y-3">
+      <div class="mobile-view-inner mx-auto w-full max-w-md px-4 pt-4 pb-4 space-y-2">
         <header class="mobile-header flex flex-col gap-1">
-          <div class="reminders-header-card bg-base-100 border border-base-300 rounded-2xl shadow-sm w-full px-4 py-3 space-y-3">
-            <div class="space-y-1">
-              <p
-                id="mobileRemindersHeaderSubtitle"
-                class="mt-1 text-xs text-base-content/70"
-              >
-                All reminders • Today
-              </p>
-            </div>
+          <div class="flex items-center justify-between">
+            <h1 class="text-lg font-semibold">Reminders</h1>
+            <!-- existing icons for drawer/menu remain unchanged -->
           </div>
+          <p id="mobileRemindersHeaderSubtitle" class="text-xs text-base-content/70">
+            <!-- placeholder, JS will update with date & temperature -->
+          </p>
         </header>
 
-        <div class="reminders-tabs-wrapper pt-1">
+        <div class="reminders-tabs-wrapper">
           <div class="tabs tabs-boxed w-full text-sm">
             <button
               type="button"
@@ -3316,7 +3313,7 @@
 
         <div id="quickAddBar" class="reminders-quick-add mc-quick-add-bar w-full rounded-xl bg-base-100 shadow-sm px-3 py-2 flex items-center gap-2" aria-label="Quick add reminder">
           <div class="mc-quick-add-inner space-y-1.5 w-full">
-            <div class="mc-quick-add-row flex flex-col items-center gap-2 w-full mt-1">
+            <div class="mc-quick-add-row flex flex-col items-center gap-2 w-full">
               <div class="mc-quick-input-group w-full">
                 <input
                   id="quickAddInput"
@@ -3359,7 +3356,6 @@
               <p id="reminderReorderHint" class="sr-only">
                 Press, hold, and drag a reminder card to reorder your list. Screen reader users can double-tap and hold, then drag to move a reminder.
               </p>
-              <p class="text-xs text-base-content/50 mb-2 pb-2 border-b border-base-200/30 sm:px-4">Total reminders: <span id="totalCount">0</span></p>
               <ul id="reminderList" class="grid grid-cols-2 gap-1 w-full overflow-x-hidden reminder-list" aria-describedby="reminderReorderHint"></ul>
             </div>
           </section>
@@ -3382,15 +3378,10 @@
         </header>
         <div
           id="scratch-notes-card"
-          class="scratch-notes-card bg-base-100 border border-base-300 rounded-xl shadow-sm p-3 space-y-2"
+          class="scratch-notes-card bg-base-100 border border-base-300 rounded-xl shadow-sm p-3 space-y-3"
         >
-          <div class="flex items-start justify-between gap-3">
-            <div>
-              <span class="text-xs uppercase tracking-wide text-base-content/50">Scratch notes</span>
-              <p class="text-xs text-base-content/60" data-note-summary>
-                Quick jot pad that syncs with your desktop notebook.
-              </p>
-            </div>
+          <div class="flex items-center justify-between gap-3">
+            <h2 class="text-base font-semibold text-base-content">Scratch notes</h2>
             <button
               type="button"
               class="btn btn-ghost btn-sm"
@@ -3400,7 +3391,7 @@
             </button>
           </div>
 
-          <div class="space-y-4">
+          <div class="space-y-3">
             <div class="space-y-1">
               <label
                 for="noteTitleMobile"
@@ -3414,22 +3405,6 @@
                 class="input input-bordered input-sm w-full text-sm text-base-content"
                 placeholder="e.g. Kids basketball schedule – this weekend"
               />
-            </div>
-
-            <div
-              class="flex flex-wrap items-center gap-3 rounded-2xl border border-base-200/70 bg-base-100/80 px-0 md:px-3 py-2 text-xs text-base-content/70"
-              data-note-toolbar
-            >
-              <span class="font-semibold text-base-content text-sm">Text size</span>
-              <select
-                class="select select-bordered select-xs w-full max-w-[160px]"
-                data-mobile-notes-text-size
-                aria-label="Select scratch notes text size"
-              >
-                <option value="small">Small</option>
-                <option value="default" selected>Default</option>
-                <option value="large">Large</option>
-              </select>
             </div>
 
             <div class="space-y-1">
@@ -3448,14 +3423,14 @@
                 >
                   <textarea
                     id="noteBodyMobile"
-                    class="textarea textarea-bordered w-full min-h-[8rem] text-sm text-base-content"
+                    class="textarea textarea-bordered w-full h-48 text-sm text-base-content"
                     placeholder="Start typing your scratch note…"
                   ></textarea>
                 </div>
               </div>
             </div>
 
-            <div id="scratch-notes-actions" class="flex justify-end gap-2 pt-1">
+            <div id="scratch-notes-actions" class="flex justify-end gap-2">
               <button
                 id="noteNewMobile"
                 type="button"


### PR DESCRIPTION
## Summary
- slimmed the mobile reminders header and removed redundant wrappers, sync text, and the total reminders row so the tab bar and quick add sit tighter
- kept the tab buttons and quick add controls but reduced extra spacing for a cleaner top of the reminders view
- simplified the scratch notes card by dropping helper text and the text-size dropdown, enlarging the textarea, and keeping the Save/New actions directly below it

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c1c42370483248b5740c275e51513)