### PR TITLE
Define stacking context tokens for overlays

### DIFF
--- a/docs/styles/a11y.css
+++ b/docs/styles/a11y.css
@@ -8,7 +8,7 @@
   border-radius: 0.5rem;
   transform: translateY(-200%);
   transition: transform 0.2s ease;
-  z-index: 1000;
+  z-index: var(--z-skip-link, 1000);
   text-decoration: none;
   font-weight: 600;
 }

--- a/docs/styles/index.css
+++ b/docs/styles/index.css
@@ -29,6 +29,11 @@ html {
   --planner-card-border: color-mix(in srgb, var(--desktop-border-subtle, #d7def1) 70%, transparent);
   --planner-card-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
   --planner-card-highlight: rgba(79, 70, 229, 0.18);
+  /* Stacking context tokens (overlays only) */
+  --z-dropdown: 40;
+  --z-quick-toolbar: 50;
+  --z-tooltip: 60;
+  --z-skip-link: 1000;
 }
 
 body {
@@ -97,7 +102,6 @@ html[data-theme="professional"] {
  .desktop-header-bar {
   position: static;
   top: auto;
-  z-index: 40;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -1049,7 +1053,7 @@ textarea {
   pointer-events: none;
   white-space: nowrap;
   transition: opacity 0.15s ease, transform 0.15s ease;
-  z-index: 60;
+  z-index: var(--z-tooltip);
 }
 
 .tooltip::after {
@@ -1073,7 +1077,7 @@ textarea {
   opacity: 0;
   transition: opacity 0.15s ease, transform 0.15s ease;
   pointer-events: none;
-  z-index: 59;
+  z-index: calc(var(--z-tooltip) - 1);
 }
 
 .tooltip:focus-visible::after,
@@ -1294,7 +1298,7 @@ textarea {
   transform: translateY(-0.25rem);
   pointer-events: none;
   transition: opacity 0.18s ease, transform 0.18s ease;
-  z-index: 55;
+  z-index: var(--z-dropdown);
 }
 
 .nav-mobile-menu {
@@ -1927,7 +1931,7 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   position: fixed;
   right: clamp(0.75rem, 2vw, 1.5rem);
   bottom: clamp(0.75rem, 2vw, 1.5rem);
-  z-index: 60;
+  z-index: var(--z-quick-toolbar);
   display: flex;
   flex-direction: column;
   align-items: flex-end;

--- a/index.html
+++ b/index.html
@@ -242,7 +242,6 @@
     .planner-toolbar {
       position: sticky;
       top: 0;
-      z-index: 10;
       background: color-mix(in srgb, var(--fallback-b1, #ffffff) 92%, transparent);
       border-bottom: 1px solid color-mix(in srgb, var(--fallback-b3, #e5e7eb) 80%, transparent);
       padding-bottom: 1.5rem;

--- a/styles/a11y.css
+++ b/styles/a11y.css
@@ -8,7 +8,7 @@
   border-radius: 0.5rem;
   transform: translateY(-200%);
   transition: transform 0.2s ease;
-  z-index: 1000;
+  z-index: var(--z-skip-link, 1000);
   text-decoration: none;
   font-weight: 600;
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -30,6 +30,11 @@ html {
   --planner-card-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
   --planner-card-highlight: rgba(79, 70, 229, 0.18);
   --desktop-header-height: 4.5rem;
+  /* Stacking context tokens (overlays only) */
+  --z-dropdown: 40;
+  --z-quick-toolbar: 50;
+  --z-tooltip: 60;
+  --z-skip-link: 1000;
 }
 
 body {
@@ -98,7 +103,6 @@ html[data-theme="professional"] {
  .desktop-header-bar {
   position: static;
   top: auto;
-  z-index: 40;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -1124,7 +1128,7 @@ textarea {
   pointer-events: none;
   white-space: nowrap;
   transition: opacity 0.15s ease, transform 0.15s ease;
-  z-index: 60;
+  z-index: var(--z-tooltip);
 }
 
 .tooltip::after {
@@ -1148,7 +1152,7 @@ textarea {
   opacity: 0;
   transition: opacity 0.15s ease, transform 0.15s ease;
   pointer-events: none;
-  z-index: 59;
+  z-index: calc(var(--z-tooltip) - 1);
 }
 
 .tooltip:focus-visible::after,
@@ -1369,7 +1373,7 @@ textarea {
   transform: translateY(-0.25rem);
   pointer-events: none;
   transition: opacity 0.18s ease, transform 0.18s ease;
-  z-index: 55;
+  z-index: var(--z-dropdown);
 }
 
 .nav-mobile-menu {
@@ -2002,7 +2006,7 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   position: fixed;
   right: clamp(0.75rem, 2vw, 1.5rem);
   bottom: clamp(0.75rem, 2vw, 1.5rem);
-  z-index: 60;
+  z-index: var(--z-quick-toolbar);
   display: flex;
   flex-direction: column;
   align-items: flex-end;


### PR DESCRIPTION
## Summary
- add shared stacking-context tokens to the main stylesheets and document which components rely on them
- remove non-essential z-index declarations and scope the remaining overlays (dropdowns, tooltips, quick-action toolbar, skip link) to the shared scale

## Testing
- Not Run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c1d8ddc548324b771f5244bb11fe8)