### PR TITLE
Remove duplicate desktop nav buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -376,24 +376,8 @@
         </div>
       </div>
     </header>
-    <aside class="desktop-rail desktop-sidebar" aria-label="Workspace navigation">
+    <aside class="desktop-rail desktop-sidebar" aria-label="Workspace controls">
       <div class="desktop-rail-sticky">
-        <nav class="desktop-rail-nav" aria-label="Primary">
-          <ul class="menu menu-vertical gap-1 nav-pill-glass text-sm">
-            <li>
-              <a href="#dashboard" data-nav="dashboard" id="nav-dashboard" class="btn btn-sm btn-ghost">Dashboard</a>
-            </li>
-            <li>
-              <a href="#reminders" data-nav="reminders" id="nav-reminders" class="btn btn-sm btn-ghost">Reminders</a>
-            </li>
-            <li>
-              <a href="#planner" data-nav="planner" id="nav-planner" class="btn btn-sm btn-ghost">Planner</a>
-            </li>
-            <li>
-              <a href="#notes" data-nav="notes" id="nav-notes" class="btn btn-sm btn-ghost">Notes</a>
-            </li>
-          </ul>
-        </nav>
         <div class="desktop-rail-controls">
           <button
             id="theme-toggle"
@@ -885,24 +869,9 @@
                   <h2 class="dashboard-card-title">Action shortcuts</h2>
                   <span class="text-xs font-medium text-base-content/70">Jump back in</span>
                 </div>
-                <div class="grid gap-2 sm:grid-cols-2">
-                  <a href="#reminders" class="btn btn-ghost btn-sm justify-start gap-2 text-sm text-base-content/80" data-nav="reminders">
-                    <span aria-hidden="true">🔔</span>
-                    Open reminders
-                  </a>
-                  <a href="#planner" class="btn btn-ghost btn-sm justify-start gap-2 text-sm text-base-content/80" data-nav="planner">
-                    <span aria-hidden="true">🗓️</span>
-                    Weekly planner
-                  </a>
-                  <a href="#notes" class="btn btn-ghost btn-sm justify-start gap-2 text-sm text-base-content/80" data-nav="notes">
-                    <span aria-hidden="true">📝</span>
-                    Daily notes
-                  </a>
-                  <a href="#resources" class="btn btn-ghost btn-sm justify-start gap-2 text-sm text-base-content/80" data-nav="resources">
-                    <span aria-hidden="true">📚</span>
-                    Resource library
-                  </a>
-                </div>
+                <p class="text-sm text-base-content/70">
+                  Use the top navigation bar to jump between Reminders, Planner, and Notes.
+                </p>
                 <div class="rounded-2xl border border-dashed border-base-300 bg-base-100/70 p-4">
                   <p class="text-sm font-semibold text-base-content/90">Need inspiration?</p>
                   <p class="text-sm text-base-content/70 mt-1">


### PR DESCRIPTION
## Summary
- remove the redundant Reminders, Planner, and Notes links from the desktop sidebar so the top navigation is the single source
- replace the dashboard shortcut buttons that duplicated those links with a short note directing users to the top navigation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c244ac66c8324994b364d427c13c3)