### PR TITLE
Adjust desktop main layout columns

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -413,12 +413,18 @@ html[data-theme="professional"] {
   padding: 0 var(--desktop-shell-gutter) 2.5rem;
   width: 100%;
   min-height: 0;
-}
+  --desktop-main-columns: minmax(0, 1fr);
+ }
+
+ .desktop-shell .desktop-main-inner[data-layout="dual"],
+ .desktop-shell .desktop-main-inner[data-desktop-columns="dual"] {
+  --desktop-main-columns: minmax(0, 2fr) minmax(0, 1fr);
+ }
 
 @media (min-width: 1024px) {
   .desktop-shell .desktop-main-inner {
     display: grid;
-    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    grid-template-columns: var(--desktop-main-columns);
     gap: clamp(2rem, 3vw, 3rem);
     align-items: start;
   }


### PR DESCRIPTION
## Summary
- update the desktop workspace container so it defaults to a single column and only reserves a second column when explicitly requested
- keep an opt-in data attribute hook to restore the two-column layout when supporting panels are added later

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c1fad82888324b1114d4ac0b69da9)