### PR TITLE
Shrink weather dashboard card

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -428,9 +428,9 @@
             <div class="hero-content max-w-none w-full">
               <div class="desktop-dashboard-grid">
                 <div class="space-y-6">
-                  <article class="dashboard-card dashboard-card--hero h-full">
+                  <article class="dashboard-card dashboard-card--compact dashboard-card--weather h-full">
                     <div class="dashboard-card-content">
-                      <div class="flex items-start justify-between gap-3">
+                      <div class="flex items-center justify-between gap-3 weather-card-header">
                         <div class="space-y-1">
                           <p class="dashboard-card-eyebrow">Weather</p>
                           <p id="weatherStatus" class="text-xs text-base-content/60" role="status" aria-live="polite">
@@ -439,11 +439,11 @@
                         </div>
                         <span id="weatherIcon" class="text-3xl" aria-hidden="true">⛅️</span>
                       </div>
-                      <div class="flex flex-wrap items-end gap-4">
+                      <div class="flex flex-wrap items-end gap-3 weather-card-main">
                         <p id="weatherTemperature" class="dashboard-card-metric">--°C</p>
                         <p id="weatherDescription" class="dashboard-card-text">Awaiting update</p>
                       </div>
-                      <dl class="grid gap-3 sm:grid-cols-2">
+                      <dl class="grid gap-3 sm:grid-cols-2 weather-card-stats">
                         <div>
                           <dt class="text-[11px] font-semibold tracking-wide uppercase text-base-content/60">Location</dt>
                           <dd id="weatherLocation" class="text-xs text-base-content/80">Locating…</dd>
@@ -461,20 +461,9 @@
                           <dd id="weatherFeelsLike" class="text-xs text-base-content/80">--°C</dd>
                         </div>
                       </dl>
-                      <p id="weatherFootnote" class="text-xs text-base-content/60">We use your approximate location to calculate these details.</p>
-                      <div class="weather-radar" aria-label="Live radar" role="group">
-                        <p class="weather-radar__message text-xs text-base-content/60">
-                          Live radar opens in a new tab due to browser security settings.
-                        </p>
-                        <a
-                          class="btn btn-primary btn-sm mt-2"
-                          href="https://www.windy.com/-Weather-radar-radar"
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          Open Windy radar
-                        </a>
-                      </div>
+                      <p id="weatherFootnote" class="text-xs text-base-content/60 weather-card-footnote">
+                        We use your approximate location to calculate these details.
+                      </p>
                     </div>
                   </article>
 

--- a/docs/styles/index.css
+++ b/docs/styles/index.css
@@ -1767,11 +1767,6 @@ section[data-route="dashboard"] .dashboard-card--hero .dashboard-card-eyebrow {
   letter-spacing: 0.24em;
 }
 
-section[data-route="dashboard"] .dashboard-card--hero #weatherIcon,
-section[data-route="dashboard"] .dashboard-card--hero #weatherTemperature {
-  font-size: 2.25rem;
-}
-
 section[data-route="dashboard"] .weather-status-row {
   display: flex;
   align-items: center;
@@ -1785,51 +1780,71 @@ section[data-route="dashboard"] .weather-status-row #weatherStatus {
   min-width: 220px;
 }
 
-section[data-route="dashboard"] .dashboard-card--hero #weatherStatus {
-  font-size: 0.65625rem;
-}
-
-section[data-route="dashboard"] .dashboard-card--hero #weatherDescription {
-  font-size: 0.75rem;
-}
-
-section[data-route="dashboard"] .dashboard-card--hero dl {
+section[data-route="dashboard"] .dashboard-card--weather .dashboard-card-content {
+  padding: clamp(1rem, 1.5vw, 1.25rem);
+  display: flex;
+  flex-direction: column;
   gap: 0.75rem;
 }
 
-section[data-route="dashboard"] .dashboard-card--hero dt {
-  font-size: 0.5625rem;
+section[data-route="dashboard"] .dashboard-card--weather .dashboard-card-eyebrow {
+  font-size: 0.5rem;
   letter-spacing: 0.24em;
 }
 
-section[data-route="dashboard"] .dashboard-card--hero #weatherLocation,
-section[data-route="dashboard"] .dashboard-card--hero #weatherWind,
-section[data-route="dashboard"] .dashboard-card--hero #weatherHumidity,
-section[data-route="dashboard"] .dashboard-card--hero #weatherFeelsLike {
+section[data-route="dashboard"] .dashboard-card--weather .weather-card-header {
+  align-items: center;
+}
+
+section[data-route="dashboard"] .dashboard-card--weather #weatherIcon,
+section[data-route="dashboard"] .dashboard-card--weather #weatherTemperature {
+  font-size: 1.5rem;
+}
+
+section[data-route="dashboard"] .dashboard-card--weather #weatherDescription {
   font-size: 0.75rem;
 }
 
-section[data-route="dashboard"] .dashboard-card--hero #weatherFootnote {
+section[data-route="dashboard"] .dashboard-card--weather #weatherStatus {
   font-size: 0.5625rem;
+  max-width: 260px;
 }
 
-section[data-route="dashboard"] .dashboard-card--hero .weather-radar {
-  margin-top: 1rem;
-  border-radius: 1rem;
-  padding: 1rem;
-  box-shadow: 0 10px 25px hsl(var(--bc) / 0.08);
-  border: 1px solid hsl(var(--b2) / 0.3);
-  background: hsl(var(--b2) / 0.25);
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
+section[data-route="dashboard"] .dashboard-card--weather .weather-card-main {
   align-items: center;
-  justify-content: space-between;
 }
 
-section[data-route="dashboard"] .dashboard-card--hero .weather-radar .weather-radar__message {
-  margin: 0;
-  flex: 1 1 220px;
+@media (min-width: 640px) {
+  section[data-route="dashboard"] .dashboard-card--weather .weather-card-main {
+    flex-wrap: nowrap;
+  }
+}
+
+section[data-route="dashboard"] .dashboard-card--weather dl {
+  gap: 0.5rem;
+}
+
+section[data-route="dashboard"] .dashboard-card--weather .weather-card-stats {
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+}
+
+section[data-route="dashboard"] .dashboard-card--weather dt {
+  font-size: 0.5rem;
+  letter-spacing: 0.18em;
+}
+
+section[data-route="dashboard"] .dashboard-card--weather #weatherLocation,
+section[data-route="dashboard"] .dashboard-card--weather #weatherWind,
+section[data-route="dashboard"] .dashboard-card--weather #weatherHumidity,
+section[data-route="dashboard"] .dashboard-card--weather #weatherFeelsLike {
+  font-size: 0.6875rem;
+}
+
+section[data-route="dashboard"] .dashboard-card--weather #weatherFootnote,
+section[data-route="dashboard"] .dashboard-card--weather .weather-card-footnote {
+  font-size: 0.5rem;
+  margin-top: 0.25rem;
+  color: hsl(var(--bc) / 0.6);
 }
 
 section[data-route="dashboard"] .dashboard-card-text {

--- a/index.html
+++ b/index.html
@@ -440,9 +440,9 @@
           <section class="desktop-hero">
             <div class="hero-content max-w-none w-full">
               <div class="desktop-dashboard-grid dashboard-grid">
-                <article class="dashboard-card dashboard-card--hero h-full">
+                <article class="dashboard-card dashboard-card--compact dashboard-card--weather h-full">
                     <div class="dashboard-card-content">
-                      <div class="flex items-start justify-between gap-3">
+                      <div class="flex items-center justify-between gap-3 weather-card-header">
                         <div class="space-y-1">
                           <p class="dashboard-card-eyebrow">Weather</p>
                           <p id="weatherStatus" class="text-xs text-base-content/60" role="status" aria-live="polite">
@@ -451,11 +451,11 @@
                         </div>
                         <span id="weatherIcon" class="text-3xl" aria-hidden="true">⛅️</span>
                       </div>
-                      <div class="flex flex-wrap items-end gap-4">
+                      <div class="flex flex-wrap items-end gap-3 weather-card-main">
                         <p id="weatherTemperature" class="dashboard-card-metric">--°C</p>
                         <p id="weatherDescription" class="dashboard-card-text">Awaiting update</p>
                       </div>
-                      <dl class="grid gap-3 sm:grid-cols-2">
+                      <dl class="grid gap-3 sm:grid-cols-2 weather-card-stats">
                         <div>
                           <dt class="text-[11px] font-semibold tracking-wide uppercase text-base-content/60">Location</dt>
                           <dd id="weatherLocation" class="text-xs text-base-content/80">Locating…</dd>
@@ -473,20 +473,9 @@
                           <dd id="weatherFeelsLike" class="text-xs text-base-content/80">--°C</dd>
                         </div>
                       </dl>
-                      <p id="weatherFootnote" class="text-xs text-base-content/60">We use your approximate location to calculate these details.</p>
-                      <div class="weather-radar" aria-label="Live radar" role="group">
-                        <p class="weather-radar__message text-xs text-base-content/60">
-                          Live radar opens in a new tab due to browser security settings.
-                        </p>
-                        <a
-                          class="btn btn-primary btn-sm mt-2"
-                          href="https://www.windy.com/-Weather-radar-radar"
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          Open Windy radar
-                        </a>
-                      </div>
+                      <p id="weatherFootnote" class="text-xs text-base-content/60 weather-card-footnote">
+                        We use your approximate location to calculate these details.
+                      </p>
                     </div>
                   </article>
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -1848,11 +1848,6 @@ section[data-route="dashboard"] .dashboard-card--hero .dashboard-card-eyebrow {
   letter-spacing: 0.24em;
 }
 
-section[data-route="dashboard"] .dashboard-card--hero #weatherIcon,
-section[data-route="dashboard"] .dashboard-card--hero #weatherTemperature {
-  font-size: 2.25rem;
-}
-
 section[data-route="dashboard"] .weather-status-row {
   display: flex;
   align-items: center;
@@ -1866,51 +1861,71 @@ section[data-route="dashboard"] .weather-status-row #weatherStatus {
   min-width: 220px;
 }
 
-section[data-route="dashboard"] .dashboard-card--hero #weatherStatus {
-  font-size: 0.65625rem;
-}
-
-section[data-route="dashboard"] .dashboard-card--hero #weatherDescription {
-  font-size: 0.75rem;
-}
-
-section[data-route="dashboard"] .dashboard-card--hero dl {
+section[data-route="dashboard"] .dashboard-card--weather .dashboard-card-content {
+  padding: clamp(1rem, 1.5vw, 1.25rem);
+  display: flex;
+  flex-direction: column;
   gap: 0.75rem;
 }
 
-section[data-route="dashboard"] .dashboard-card--hero dt {
-  font-size: 0.5625rem;
+section[data-route="dashboard"] .dashboard-card--weather .dashboard-card-eyebrow {
+  font-size: 0.5rem;
   letter-spacing: 0.24em;
 }
 
-section[data-route="dashboard"] .dashboard-card--hero #weatherLocation,
-section[data-route="dashboard"] .dashboard-card--hero #weatherWind,
-section[data-route="dashboard"] .dashboard-card--hero #weatherHumidity,
-section[data-route="dashboard"] .dashboard-card--hero #weatherFeelsLike {
+section[data-route="dashboard"] .dashboard-card--weather .weather-card-header {
+  align-items: center;
+}
+
+section[data-route="dashboard"] .dashboard-card--weather #weatherIcon,
+section[data-route="dashboard"] .dashboard-card--weather #weatherTemperature {
+  font-size: 1.5rem;
+}
+
+section[data-route="dashboard"] .dashboard-card--weather #weatherDescription {
   font-size: 0.75rem;
 }
 
-section[data-route="dashboard"] .dashboard-card--hero #weatherFootnote {
+section[data-route="dashboard"] .dashboard-card--weather #weatherStatus {
   font-size: 0.5625rem;
+  max-width: 260px;
 }
 
-section[data-route="dashboard"] .dashboard-card--hero .weather-radar {
-  margin-top: 1rem;
-  border-radius: 1rem;
-  padding: 1rem;
-  box-shadow: 0 10px 25px hsl(var(--bc) / 0.08);
-  border: 1px solid hsl(var(--b2) / 0.3);
-  background: hsl(var(--b2) / 0.25);
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
+section[data-route="dashboard"] .dashboard-card--weather .weather-card-main {
   align-items: center;
-  justify-content: space-between;
 }
 
-section[data-route="dashboard"] .dashboard-card--hero .weather-radar .weather-radar__message {
-  margin: 0;
-  flex: 1 1 220px;
+@media (min-width: 640px) {
+  section[data-route="dashboard"] .dashboard-card--weather .weather-card-main {
+    flex-wrap: nowrap;
+  }
+}
+
+section[data-route="dashboard"] .dashboard-card--weather dl {
+  gap: 0.5rem;
+}
+
+section[data-route="dashboard"] .dashboard-card--weather .weather-card-stats {
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+}
+
+section[data-route="dashboard"] .dashboard-card--weather dt {
+  font-size: 0.5rem;
+  letter-spacing: 0.18em;
+}
+
+section[data-route="dashboard"] .dashboard-card--weather #weatherLocation,
+section[data-route="dashboard"] .dashboard-card--weather #weatherWind,
+section[data-route="dashboard"] .dashboard-card--weather #weatherHumidity,
+section[data-route="dashboard"] .dashboard-card--weather #weatherFeelsLike {
+  font-size: 0.6875rem;
+}
+
+section[data-route="dashboard"] .dashboard-card--weather #weatherFootnote,
+section[data-route="dashboard"] .dashboard-card--weather .weather-card-footnote {
+  font-size: 0.5rem;
+  margin-top: 0.25rem;
+  color: hsl(var(--bc) / 0.6);
 }
 
 section[data-route="dashboard"] .dashboard-card-text {


### PR DESCRIPTION
## Summary
- convert the weather hero card into a compact widget so it takes up far less space on the dashboard
- add weather-specific styles that tighten spacing, typography, and stat layout while removing the bulky radar block
- mirror the markup and style updates in the docs build so both entry points stay in sync

## Testing
- `npm test` *(fails: existing Jest suites cannot import ESM modules such as js/reminders.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c281db7908324b9c8373b393862f6)