### PR TITLE
Remove dashboard header brand elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,19 +332,7 @@
   <a class="skip-link" href="#mainContent">Skip to main content</a>
   <div class="dashboard-root desktop-layout">
     <header class="desktop-header desktop-header-bar" aria-label="Primary">
-      <div class="desktop-header-left">
-        <div class="desktop-header-brand">
-          <a href="#dashboard" class="desktop-header-brand-link btn btn-ghost gap-2 text-left normal-case text-base-content">
-            <span class="desktop-header-logo inline-flex size-9 items-center justify-center rounded-full bg-primary/15 text-primary">
-              MC
-            </span>
-            <span class="flex flex-col leading-tight">
-              <span class="desktop-header-title text-base font-semibold text-base-content">Memory Cue</span>
-              <span class="desktop-header-subtitle text-xs text-base-content/70">Reminders · Planner · Notes</span>
-            </span>
-          </a>
-        </div>
-      </div>
+      <div class="desktop-header-left"></div>
       <nav class="desktop-header-nav-tabs" aria-label="Primary sections">
         <a href="#dashboard" class="btn btn-sm btn-ghost" data-nav="dashboard">Dashboard</a>
         <a href="#reminders" class="btn btn-sm btn-ghost" data-nav="reminders">Reminders</a>


### PR DESCRIPTION
## Summary
- remove the dashboard header brand block so the MC / Memory Cue text no longer renders

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c2cf885708324a5e2617a986a2d6c)