### PR TITLE
Allow desktop hero content to span full width

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -640,8 +640,8 @@ html[data-theme="professional"] {
   box-shadow: var(--desktop-shadow-subtle, 0 4px 14px rgba(15, 23, 42, 0.08));
 }
 
- .desktop-shell .desktop-hero .hero-content {
-  max-width: 65ch;
+.desktop-shell .desktop-hero .hero-content {
+  max-width: none;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
## Summary
- remove the fixed 65ch cap on the desktop hero content so the dashboard grid can fill the same width as the rest of the layout

## Testing
- Not run (CSS-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c2ff451ec832496880ef6a49f7e88)