### PR TITLE
Add planner shortcut to dashboard

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -527,10 +527,17 @@
                         ></textarea>
                       </div>
 
-                      <div class="flex justify-end gap-2 pt-1">
-                        <button class="btn btn-outline btn-sm" type="button">
-                          Copy to planner
-                        </button>
+                      <div class="space-y-1 pt-1">
+                        <div class="flex justify-end gap-2">
+                          <button class="btn btn-outline btn-sm" type="button" data-copy-next-lesson>
+                            Copy to planner
+                          </button>
+                        </div>
+                        <p
+                          class="text-xs text-base-content/60"
+                          data-next-lesson-feedback
+                          aria-live="polite"
+                        ></p>
                       </div>
                     </div>
                     </article>

--- a/index.html
+++ b/index.html
@@ -531,10 +531,17 @@
                         ></textarea>
                       </div>
 
-                      <div class="flex justify-end gap-2 pt-1">
-                        <button class="btn btn-outline btn-sm" type="button">
-                          Copy to planner
-                        </button>
+                      <div class="space-y-1 pt-1">
+                        <div class="flex justify-end gap-2">
+                          <button class="btn btn-outline btn-sm" type="button" data-copy-next-lesson>
+                            Copy to planner
+                          </button>
+                        </div>
+                        <p
+                          class="text-xs text-base-content/60"
+                          data-next-lesson-feedback
+                          aria-live="polite"
+                        ></p>
                       </div>
                     </div>
                     </article>


### PR DESCRIPTION
## Summary
- add identifiers and inline feedback for the dashboard “Copy to planner” control
- persist the next lesson fields to localStorage and reuse the planner module to create lessons from the dashboard

## Testing
- `npm test -- --runTestsByPath sample.test.js`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c30e0b6508324a3803d34750df2cc)