### PR TITLE
Fix auth feedback selectors

### DIFF
--- a/404.html
+++ b/404.html
@@ -195,7 +195,7 @@
             <button id="sign-out-btn" type="button" hidden class="btn btn-sm btn-error">Sign out</button>
           </div>
           <!-- BEGIN GPT CHANGE: auth feedback -->
-          <div id="auth-feedback" role="status" aria-live="polite" hidden></div>
+          <div id="auth-feedback-header" role="status" aria-live="polite" hidden></div>
           <!-- END GPT CHANGE -->
         </div>
       </div>

--- a/app.js
+++ b/app.js
@@ -751,7 +751,7 @@ const initialiseReminders = () => {
     saveBtnSel: '#saveReminder',
     cancelEditBtnSel: null,
     listSel: '#reminders-list',
-    statusSel: '#auth-feedback',
+    statusSel: '#auth-feedback-header',
     syncStatusSel: '#sync-status',
     voiceBtnSel: null,
     categoryOptionsSel: null,
@@ -818,7 +818,7 @@ const supabaseAuthController = initSupabaseAuth({
     userBadgeInitial: '#user-badge-initial',
     userName: '#googleUserName',
     syncStatus: ['#sync-status'],
-    feedback: '#auth-feedback',
+    feedback: ['#auth-feedback-header', '#auth-feedback-rail'],
   },
   disableButtonBinding: true,
   onSessionChange: (user) => {

--- a/docs/404.html
+++ b/docs/404.html
@@ -195,7 +195,7 @@
             <button id="sign-out-btn" type="button" hidden class="btn btn-sm btn-error">Sign out</button>
           </div>
           <!-- BEGIN GPT CHANGE: auth feedback -->
-          <div id="auth-feedback" role="status" aria-live="polite" hidden></div>
+          <div id="auth-feedback-header" role="status" aria-live="polite" hidden></div>
           <!-- END GPT CHANGE -->
         </div>
       </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -289,7 +289,8 @@
       }
     }
 
-    #auth-feedback:empty {
+    #auth-feedback-header:empty,
+    #auth-feedback-rail:empty {
       display: none;
     }
 
@@ -372,7 +373,7 @@
               Sign out
             </button>
           </div>
-          <div id="auth-feedback" class="text-xs text-base-content/70" role="status" aria-live="polite"></div>
+          <div id="auth-feedback-header" class="text-xs text-base-content/70" role="status" aria-live="polite"></div>
         </div>
       </div>
     </header>

--- a/docs/styles/index.css
+++ b/docs/styles/index.css
@@ -179,7 +179,7 @@ html[data-theme="professional"] {
   color: var(--desktop-text-muted, color-mix(in srgb, var(--color-base-content, #0f172a) 65%, transparent));
 }
 
- .desktop-header-right #auth-feedback {
+ .desktop-header-right #auth-feedback-header {
   width: 100%;
   text-align: right;
 }

--- a/index.html
+++ b/index.html
@@ -289,7 +289,8 @@
       }
     }
 
-    #auth-feedback:empty {
+    #auth-feedback-header:empty,
+    #auth-feedback-rail:empty {
       display: none;
     }
 
@@ -350,7 +351,7 @@
           >
             Add reminder
           </button>
-          <div id="auth-feedback" class="text-xs text-base-content/70" role="status" aria-live="polite"></div>
+          <div id="auth-feedback-header" class="text-xs text-base-content/70" role="status" aria-live="polite"></div>
         </div>
       </div>
     </header>
@@ -377,7 +378,7 @@
               Sign out
             </button>
           </div>
-          <div id="auth-feedback" class="text-xs text-base-content/70" role="status" aria-live="polite"></div>
+          <div id="auth-feedback-rail" class="text-xs text-base-content/70" role="status" aria-live="polite"></div>
         </div>
       </div>
     </aside>

--- a/js/supabase-auth.js
+++ b/js/supabase-auth.js
@@ -114,7 +114,7 @@ const DEFAULT_SELECTORS = {
   syncStatus: '#sync-status',
   syncStatusText: null,
   statusIndicator: null,
-  feedback: '#auth-feedback',
+  feedback: ['#auth-feedback-header', '#auth-feedback-rail'],
 };
 
 const DEFAULT_MESSAGES = {

--- a/mobile.js
+++ b/mobile.js
@@ -829,7 +829,7 @@ const supabaseAuthController = initSupabaseAuth({
     syncStatus: ['#sync-status'],
     syncStatusText: ['#mcStatusText'],
     statusIndicator: ['#mcStatus'],
-    feedback: '#auth-feedback',
+    feedback: ['#auth-feedback-header', '#auth-feedback-rail'],
   },
   disableButtonBinding: true,
   onSessionChange: (user) => {

--- a/styles/index.css
+++ b/styles/index.css
@@ -179,7 +179,7 @@ html[data-theme="professional"] {
   color: var(--desktop-text-muted, color-mix(in srgb, var(--color-base-content, #0f172a) 65%, transparent));
 }
 
- .desktop-header-right #auth-feedback {
+ .desktop-header-right #auth-feedback-header {
   width: 100%;
   text-align: right;
 }


### PR DESCRIPTION
## Summary
- rename the header/rail auth feedback containers and collapse both when empty
- point the desktop reminder status region and Supabase selectors at the new IDs (desktop + mobile)
- mirror the markup/CSS changes in the docs build so both areas stay in sync

## Testing
- `npm test -- --runInBand` *(fails: existing Jest suites expect CommonJS builds and currently throw "Cannot use import statement outside a module")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c38d2abdc8324a67a2014e3b984f9)