### PR TITLE
Revamp footer layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1371,37 +1371,50 @@
   <!-- BEGIN GPT CHANGE: live region -->
   <div id="live-status" class="sr-only" aria-live="polite" role="status"></div>
   <!-- END GPT CHANGE -->
-  <footer class="border-t border-base-300 bg-base-200 py-[18px] sm:py-6">
-    <div class="mx-auto flex max-w-7xl flex-col gap-4 px-4 text-sm text-base-content/80 sm:px-6 lg:px-8">
-      <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div class="max-w-lg space-y-2">
-          <p class="text-base font-semibold text-base-content">Memory Cue</p>
-          <p>Designed to help teachers stay organised, communicate clearly, and celebrate daily wins.</p>
+  <footer class="site-footer">
+    <div class="site-footer__inner">
+      <div class="site-footer__content">
+        <div class="site-footer__brand">
+          <a class="site-footer__brand-mark" href="./index.html">
+            <span class="site-footer__logo" aria-hidden="true">MC</span>
+            <div>
+              <p class="site-footer__brand-name">Memory Cue</p>
+              <p class="site-footer__brand-tagline">Clarity for busy classrooms</p>
+            </div>
+          </a>
+          <p class="site-footer__description">
+            Designed to help teachers stay organised, communicate clearly, and celebrate daily wins.
+          </p>
+          <a class="site-footer__cta" href="mailto:hello@memorycue.app">Get updates</a>
         </div>
-        <div class="grid gap-4 text-sm sm:grid-cols-3">
-          <div class="space-y-2">
-            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Product</p>
-            <a href="#dashboard" class="block hover:text-base-content">Dashboard</a>
-            <a href="#planner" class="block hover:text-base-content">Planner</a>
-            <a href="#resources" class="block hover:text-base-content">Resources</a>
+        <div class="site-footer__links">
+          <div class="site-footer__column">
+            <p class="site-footer__heading">Product</p>
+            <a href="./index.html">Web dashboard</a>
+            <a href="./mobile.html">Mobile companion</a>
+            <a href="./docs/index.html">Product tour</a>
           </div>
-          <div class="space-y-2">
-            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Support</p>
-            <a href="#notes" class="block hover:text-base-content">Guides</a>
-            <a href="#templates" class="block hover:text-base-content">Templates</a>
-            <a href="#" class="block hover:text-base-content">Contact</a>
+          <div class="site-footer__column">
+            <p class="site-footer__heading">Resources</p>
+            <a href="./docs/mobile.html">Mobile guide</a>
+            <a href="./docs/index.html#planner">Planner handbook</a>
+            <a href="https://github.com/dmaher42/memory-cue">Open source repo</a>
           </div>
-          <div class="space-y-2">
-            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Company</p>
-            <a href="#" class="block hover:text-base-content">Privacy</a>
-            <a href="#" class="block hover:text-base-content">Terms</a>
-            <a href="#" class="block hover:text-base-content">Support</a>
+          <div class="site-footer__column">
+            <p class="site-footer__heading">Company</p>
+            <a href="./docs/index.html#about">About Memory Cue</a>
+            <a href="https://memorycue.app/">Press kit</a>
+            <a href="mailto:hello@memorycue.app">Contact</a>
           </div>
         </div>
       </div>
-      <div class="flex flex-col gap-2 border-t border-base-300/60 pt-[9px] text-xs text-base-content/60 sm:flex-row sm:items-center sm:justify-between">
+      <div class="site-footer__bottom">
         <p>© <span id="year"></span> Memory Cue. All rights reserved.</p>
-        <p>Crafted with care for classrooms everywhere.</p>
+        <div class="site-footer__social">
+          <a href="mailto:hello@memorycue.app">hello@memorycue.app</a>
+          <a href="https://github.com/dmaher42/memory-cue" target="_blank" rel="noreferrer">GitHub</a>
+          <a href="https://memorycue.app/" target="_blank" rel="noreferrer">Website</a>
+        </div>
       </div>
     </div>
   </footer>

--- a/styles/index.css
+++ b/styles/index.css
@@ -2718,3 +2718,171 @@ section[data-route="dashboard"] .dashboard-shortcuts {
 .mobile-panel--notes .note-body-field textarea::placeholder {
   font-size: inherit;
 }
+
+.site-footer {
+  margin-top: clamp(3rem, 6vw, 5rem);
+  background: radial-gradient(circle at top, rgba(15, 23, 42, 0.3), transparent 60%),
+    linear-gradient(135deg, #0f172a, #1d3557 55%, #2a4858);
+  color: rgba(248, 250, 252, 0.9);
+}
+
+.site-footer a {
+  color: inherit;
+}
+
+.site-footer__inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: clamp(2.5rem, 6vw, 4rem) clamp(1.5rem, 4vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 4vw, 3.5rem);
+}
+
+.site-footer__content {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 5vw, 3rem);
+}
+
+.site-footer__brand {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  box-shadow: 0 30px 70px rgba(2, 6, 23, 0.45);
+}
+
+.site-footer__brand-mark {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.85rem;
+  text-decoration: none;
+  margin-bottom: 0.75rem;
+}
+
+.site-footer__logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.9rem;
+  background: linear-gradient(135deg, #22d3ee, #6366f1);
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.site-footer__brand-name {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.site-footer__brand-tagline {
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.8;
+}
+
+.site-footer__description {
+  margin-bottom: 1.25rem;
+  color: rgba(248, 250, 252, 0.75);
+}
+
+.site-footer__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.6rem 1.25rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #34d399, #10b981);
+  color: #041b14;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 12px 25px rgba(16, 185, 129, 0.35);
+}
+
+.site-footer__cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 30px rgba(16, 185, 129, 0.45);
+}
+
+.site-footer__links {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.site-footer__column {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.site-footer__heading {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  color: rgba(248, 250, 252, 0.55);
+  margin-bottom: 0.4rem;
+}
+
+.site-footer__column a {
+  text-decoration: none;
+  color: rgba(248, 250, 252, 0.85);
+  transition: color 0.2s ease;
+}
+
+.site-footer__column a:hover {
+  color: #ffffff;
+}
+
+.site-footer__bottom {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  font-size: 0.85rem;
+  color: rgba(248, 250, 252, 0.65);
+}
+
+.site-footer__social {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.2rem;
+}
+
+.site-footer__social a {
+  text-decoration: none;
+  font-weight: 600;
+  color: rgba(248, 250, 252, 0.85);
+}
+
+.site-footer__social a:hover {
+  color: #ffffff;
+}
+
+@media (min-width: 768px) {
+  .site-footer__content {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+
+  .site-footer__brand {
+    max-width: 360px;
+  }
+
+  .site-footer__links {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .site-footer__bottom {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the simple footer stack with a structured layout that includes a Memory Cue brand blurb, CTA, and multi-column navigation
- add explicit routes for footer links plus contact, GitHub, and website references, and introduce a bottom bar for copyright and quick links
- move footer styling into `styles/index.css` and build a responsive, high-contrast presentation with better spacing

## Testing
- Not Run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c3a0ecf0c8324a069540effd01cfe)