### PR TITLE
Reduce mobile footer height

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -3704,19 +3704,19 @@
 
   <div id="mobile-nav-shell" class="fixed inset-x-0 bottom-3 z-50 flex justify-center pointer-events-none">
     <nav
-      class="btm-nav bg-base-100 border border-base-300 rounded-full shadow-lg px-3 py-1 flex items-center justify-around gap-2 max-w-md w-3/4 mx-auto pointer-events-auto"
+      class="btm-nav bg-base-100 border border-base-300 rounded-full shadow-lg px-2 py-0.5 flex items-center justify-around gap-2 max-w-md w-3/4 mx-auto pointer-events-auto"
       aria-label="Primary navigation"
     >
       <button
         type="button"
         aria-current="page"
-        class="active flex flex-col items-center justify-center gap-0.5 px-2 py-1 rounded-full text-[11px] font-medium text-base-content/70 transition"
+        class="active flex flex-col items-center justify-center gap-0.5 px-1 py-0.5 rounded-full text-[11px] font-medium text-base-content/70 transition"
       >
         <span class="leading-tight">Reminders</span>
       </button>
       <button
         type="button"
-        class="flex flex-col items-center justify-center gap-0.5 px-2 py-1 rounded-full text-[11px] font-medium text-base-content/70 transition"
+        class="flex flex-col items-center justify-center gap-0.5 px-1 py-0.5 rounded-full text-[11px] font-medium text-base-content/70 transition"
       >
         <span class="leading-tight">Notebook</span>
       </button>


### PR DESCRIPTION
## Summary
- shrink the mobile footer navigation by cutting its padding in half so it occupies less vertical space

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c3dee5ec88324b578a84790e1776b)