### PR TITLE
Stop auto focusing saved notes search

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -437,17 +437,10 @@ const initMobileNotes = () => {
       event.preventDefault();
       showSavedNotesSheet();
 
-      const notesSearchMobile = document.getElementById('notesSearchMobile');
       const notesListMobileEl = document.getElementById('notesListMobile');
 
       if (notesListMobileEl) {
         notesListMobileEl.scrollTop = 0;
-      }
-
-      if (notesSearchMobile) {
-        setTimeout(() => {
-          notesSearchMobile.focus();
-        }, 150);
       }
     });
     closeSavedNotesButton?.addEventListener('click', (event) => {


### PR DESCRIPTION
## Summary
- stop automatically focusing the Saved Notes search input when the sheet is opened so the on-screen keyboard no longer pops up immediately

## Testing
- `npm test` *(fails: existing js/reminders and mobile module tests expect CommonJS modules and error with "Cannot use import statement outside a module")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c40da2dc483248aeda5fada5597d8)