### PR TITLE
Expand dashboard hero width

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -381,7 +381,7 @@
       <div class="desktop-main-inner">
         <div class="desktop-workspace desktop-workspace-region space-y-8">
       <section data-route="dashboard" class="space-y-6 lg:space-y-12">
-        <div class="max-w-6xl mx-auto space-y-6">
+        <div class="space-y-6">
           <section class="desktop-hero">
             <div class="hero-content max-w-none w-full">
               <div class="desktop-dashboard-grid">

--- a/docs/styles/index.css
+++ b/docs/styles/index.css
@@ -267,10 +267,11 @@ html[data-theme="professional"] {
 
 
  .desktop-shell .dashboard-root {
-  max-width: 1320px;
+  width: 100%;
+  max-width: none;
   margin: 0 auto;
   padding: 1.25rem 2.25rem 2.5rem;
-}
+ }
 
  .desktop-shell .desktop-layout {
   display: grid;
@@ -308,10 +309,10 @@ html[data-theme="professional"] {
  .desktop-shell .desktop-panel,
  .desktop-shell .desktop-dashboard-grid {
   width: 100%;
-  max-width: 1320px;
+  max-width: none;
   margin-left: auto;
   margin-right: auto;
-}
+ }
 
  .desktop-shell .desktop-main {
   padding-top: 0;
@@ -535,7 +536,7 @@ html[data-theme="professional"] {
 
  .desktop-shell .desktop-hero {
   width: 100%;
-  max-width: 1320px;
+  max-width: none;
   margin: 0 auto;
   padding: clamp(1.4rem, 2vw, 2.5rem);
   box-sizing: border-box;

--- a/index.html
+++ b/index.html
@@ -386,7 +386,7 @@
       <div class="desktop-main-inner">
         <div class="desktop-main-region space-y-8">
       <section data-route="dashboard" class="space-y-6 lg:space-y-12">
-        <div class="max-w-6xl mx-auto space-y-6">
+        <div class="space-y-6">
           <section class="desktop-hero">
             <div class="hero-content max-w-none w-full">
               <div class="desktop-dashboard-grid dashboard-grid">

--- a/styles/index.css
+++ b/styles/index.css
@@ -267,10 +267,11 @@ html[data-theme="professional"] {
 
 
  .desktop-shell .dashboard-root {
-  max-width: 1320px;
+  width: 100%;
+  max-width: none;
   margin: 0 auto;
   padding: 1.25rem 2.25rem 2.5rem;
-}
+ }
 
  .desktop-shell .desktop-layout {
   display: grid;
@@ -303,10 +304,10 @@ html[data-theme="professional"] {
  .desktop-shell .desktop-panel,
  .desktop-shell .desktop-dashboard-grid {
   width: 100%;
-  max-width: 1320px;
+  max-width: none;
   margin-left: auto;
   margin-right: auto;
-}
+ }
 
  .desktop-shell .desktop-main {
   grid-area: main;
@@ -574,7 +575,7 @@ html[data-theme="professional"] {
 
  .desktop-shell .desktop-hero {
   width: 100%;
-  max-width: 1320px;
+  max-width: none;
   margin: 0 auto;
   padding: clamp(1.4rem, 2vw, 2.5rem);
   box-sizing: border-box;


### PR DESCRIPTION
## Summary
- remove the max-width wrapper around the dashboard hero cards so the weather and reminders area can span the whole viewport
- lift the CSS max-width constraints on the dashboard root, hero, and grid containers so the desktop layout can take advantage of the full screen width

## Testing
- `npm test -- --runTestsByPath sample.test.js reminders.categories.test.js theme-toggle.test.js service-worker.test.js` *(fails: reminders.categories.test.js expects CommonJS and throws "Cannot use import statement outside a module" when loading js/reminders.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c4106e82483249a09711e87f3d3a6)