### PR TITLE
Show saved notes in floating panel

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -284,12 +284,20 @@
   }
 
   #savedNotesSheet .saved-notes-panel {
-    transform: translateY(100%);
-    transition: transform 0.35s cubic-bezier(0.25, 0.8, 0.25, 1);
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    width: min(92vw, 28rem);
+    transform: translate(-50%, calc(-50% + 24px)) scale(0.96);
+    opacity: 0;
+    transition:
+      transform 0.35s cubic-bezier(0.25, 0.8, 0.25, 1),
+      opacity 0.25s ease;
   }
 
   #savedNotesSheet[data-open="true"] .saved-notes-panel {
-    transform: translateY(0);
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
   }
 
   .note-body-field {
@@ -399,12 +407,20 @@
   }
 
   .mobile-shell #savedNotesSheet .saved-notes-panel {
-    transform: translateY(100%);
-    transition: transform 0.35s cubic-bezier(0.25, 0.8, 0.25, 1);
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    width: min(92vw, 28rem);
+    transform: translate(-50%, calc(-50% + 24px)) scale(0.96);
+    opacity: 0;
+    transition:
+      transform 0.35s cubic-bezier(0.25, 0.8, 0.25, 1),
+      opacity 0.25s ease;
   }
 
   .mobile-shell #savedNotesSheet[data-open="true"] .saved-notes-panel {
-    transform: translateY(0);
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
   }
 
   .quick-actions-panel {
@@ -3666,7 +3682,7 @@
         >
           <div
             id="saved-notes-panel"
-            class="saved-notes-panel mt-4 bg-base-100 border border-base-300 rounded-2xl shadow-sm px-4 py-3 space-y-2 fixed inset-x-0 bottom-0 z-40 max-w-md mx-auto rounded-t-3xl shadow-xl border-t border-base-300 pt-3 pb-4 transition-transform flex flex-col max-h-[80vh]"
+            class="saved-notes-panel fixed left-1/2 top-1/2 z-50 flex max-h-[80vh] max-w-md flex-col space-y-2 rounded-3xl border border-base-300 bg-base-100 px-4 py-3 shadow-xl transition-transform"
           >
             <div class="flex flex-col max-h-[70vh]">
               <div class="flex justify-center pt-2 pb-1">

--- a/mobile.js
+++ b/mobile.js
@@ -437,17 +437,10 @@ const initMobileNotes = () => {
       event.preventDefault();
       showSavedNotesSheet();
 
-      const notesSearchMobile = document.getElementById('notesSearchMobile');
       const notesListMobileEl = document.getElementById('notesListMobile');
 
       if (notesListMobileEl) {
         notesListMobileEl.scrollTop = 0;
-      }
-
-      if (notesSearchMobile) {
-        setTimeout(() => {
-          notesSearchMobile.focus();
-        }, 150);
       }
     });
     closeSavedNotesButton?.addEventListener('click', (event) => {


### PR DESCRIPTION
## Summary
- stop automatically focusing the Saved Notes search input when the sheet is opened so the on-screen keyboard no longer pops up immediately
- display the Saved Notes sheet as a floating overlay panel centered over the UI so it no longer covers content from the bottom of the screen

## Testing
- `npm test` *(fails: existing js/reminders and mobile module tests expect CommonJS modules and error with "Cannot use import statement outside a module")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c40da2dc483248aeda5fada5597d8)