### PR TITLE
Allow dashboard to use full width

### DIFF
--- a/index.html
+++ b/index.html
@@ -296,9 +296,7 @@
 
     /* Dashboard overall spacing */
     section[data-route="dashboard"] {
-      max-width: 56rem;
-      margin-left: auto;
-      margin-right: auto;
+      width: 100%;
     }
 
     /* Dashboard: emphasise Today's focus card */

--- a/styles/index.css
+++ b/styles/index.css
@@ -108,8 +108,8 @@ html[data-theme="professional"] {
   justify-content: space-between;
   gap: 1rem;
   padding: 0.45rem 1.25rem;
+  width: 100%;
   margin: 0 auto 0.75rem;
-  max-width: 1180px;
   background: color-mix(in srgb, var(--desktop-header-bg, var(--color-base-200, #e6edff)) 92%, transparent);
   backdrop-filter: blur(14px);
   border-radius: 999px;


### PR DESCRIPTION
## Summary
- remove the 56rem constraint from the dashboard section so its cards can expand with the viewport
- let the desktop header bar stretch across the full width by removing its max-width cap

## Testing
- `npm test` *(fails: existing Jest suites cannot load ES module style imports in several reminder/mobile tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c44bbd56483249e294af8902a1a99)