### PR TITLE
Fix action shortcuts card width

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -796,7 +796,7 @@
             </div>
           </section>
 
-          <div class="flex flex-col gap-6">
+          <div class="dashboard-card-stack flex flex-col gap-6">
             <section id="pinnedNotesCard" class="dashboard-card card dashboard-card--compact h-full">
               <div class="card-body dashboard-card-body gap-3">
                 <div class="flex flex-wrap items-center justify-between gap-3">

--- a/docs/styles/index.css
+++ b/docs/styles/index.css
@@ -323,7 +323,7 @@ html[data-theme="professional"] {
   --desktop-shell-gutter: clamp(1rem, 4vw, 2rem);
 }
 
- .desktop-shell .desktop-main-inner {
+.desktop-shell .desktop-main-inner {
   display: flex;
   flex-direction: column;
   gap: var(--dashboard-section-spacing);
@@ -331,6 +331,20 @@ html[data-theme="professional"] {
   padding: 0 var(--desktop-shell-gutter) 2.5rem;
   width: 100%;
   min-height: 0;
+}
+
+.desktop-shell .dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(1rem, 2vw, 1.5rem);
+  align-items: stretch;
+}
+
+.desktop-shell .dashboard-card-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: 100%;
 }
 
  .desktop-shell .desktop-workspace-region {
@@ -422,6 +436,25 @@ html[data-theme="professional"] {
 
    .desktop-shell .desktop-main-inner > * {
     min-width: 0;
+  }
+
+  .desktop-shell .dashboard-grid {
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    column-gap: clamp(1.75rem, 2.5vw, 2.75rem);
+    row-gap: clamp(1.5rem, 2vw, 2.25rem);
+  }
+
+  .desktop-shell .dashboard-grid > .dashboard-card {
+    grid-column: span 6;
+  }
+
+  .desktop-shell .dashboard-grid > .dashboard-card.dashboard-card--hero,
+  .desktop-shell .dashboard-grid > .dashboard-card.dashboard-card--wide {
+    grid-column: span 12;
+  }
+
+  .desktop-shell .dashboard-grid > .dashboard-card-stack {
+    grid-column: span 6;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -296,9 +296,7 @@
 
     /* Dashboard overall spacing */
     section[data-route="dashboard"] {
-      max-width: 56rem;
-      margin-left: auto;
-      margin-right: auto;
+      width: 100%;
     }
 
     /* Dashboard: emphasise Today's focus card */
@@ -800,7 +798,7 @@
             </div>
           </section>
 
-          <div class="flex flex-col gap-6">
+          <div class="dashboard-card-stack flex flex-col gap-6">
             <section id="pinnedNotesCard" class="dashboard-card card dashboard-card--compact h-full">
               <div class="card-body dashboard-card-body gap-3">
                 <div class="flex flex-wrap items-center justify-between gap-3">

--- a/styles/index.css
+++ b/styles/index.css
@@ -108,8 +108,8 @@ html[data-theme="professional"] {
   justify-content: space-between;
   gap: 1rem;
   padding: 0.45rem 1.25rem;
+  width: 100%;
   margin: 0 auto 0.75rem;
-  max-width: 1180px;
   background: color-mix(in srgb, var(--desktop-header-bg, var(--color-base-200, #e6edff)) 92%, transparent);
   backdrop-filter: blur(14px);
   border-radius: 999px;
@@ -355,6 +355,13 @@ html[data-theme="professional"] {
   align-items: stretch;
 }
 
+.desktop-shell .dashboard-card-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: 100%;
+}
+
 @media (min-width: 1024px) {
   .desktop-shell .dashboard-grid {
     grid-template-columns: repeat(12, minmax(0, 1fr));
@@ -369,6 +376,10 @@ html[data-theme="professional"] {
   .desktop-shell .dashboard-grid > .dashboard-card.dashboard-card--hero,
   .desktop-shell .dashboard-grid > .dashboard-card.dashboard-card--wide {
     grid-column: span 12;
+  }
+
+  .desktop-shell .dashboard-grid > .dashboard-card-stack {
+    grid-column: span 6;
   }
 }
 


### PR DESCRIPTION
## Summary
- tag the pinned notes + action shortcuts stack so it spans the same desktop grid width as the surrounding dashboard cards
- add shared styles for `.dashboard-card-stack` so stacked cards keep full-width layouts in both the app and docs builds

## Testing
- `npm test` *(fails: existing reminder and mobile Jest suites still cannot load ES module style imports in CommonJS Jest)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c44bbd56483249e294af8902a1a99)