### PR TITLE
Improve mobile notes panel contrast

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -30,6 +30,7 @@
       --info-color: var(--accent-color);
       --bg-color: var(--background-color);
       --border-color: var(--card-border);
+      --card-border-strong: color-mix(in srgb, var(--card-border) 65%, var(--text-primary) 35%);
       --priority-high-border: #F4A259; /* Bio Orange */
       --priority-high-bg: color-mix(in srgb, var(--priority-high-border) 18%, #FFFFFF);
       --priority-medium-border: #6C8AE4; /* Quantum Blue */
@@ -70,6 +71,7 @@
       --mobile-header-button-border: rgba(148, 163, 184, 0.45);
       --mobile-quick-surface: color-mix(in srgb, rgba(15, 23, 42, 0.92) 94%, transparent);
       --mobile-quick-shadow: 0 18px 30px rgba(15, 23, 42, 0.6);
+      --card-border-strong: color-mix(in srgb, var(--card-border) 50%, var(--text-primary) 50%);
     }
 
     .pt-safe-top {
@@ -303,7 +305,7 @@
   .note-body-field {
     position: relative;
     border-radius: 1.25rem;
-    border: 1px solid color-mix(in srgb, var(--card-border) 85%, transparent);
+    border: 1.5px solid var(--card-border-strong);
     background: color-mix(in srgb, var(--card-bg) 94%, rgba(148, 163, 184, 0.12));
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
     overflow: hidden;
@@ -311,8 +313,13 @@
   }
 
   .note-body-field:focus-within {
-    border-color: color-mix(in srgb, var(--accent-color) 70%, var(--card-border));
+    border-color: color-mix(in srgb, var(--accent-color) 60%, var(--card-border-strong));
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-color) 20%, transparent);
+  }
+
+  .mobile-panel--notes #scratch-notes-card {
+    border: 1.5px solid var(--card-border-strong);
+    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
   }
 
   .note-body-field::before {
@@ -373,7 +380,7 @@
   }
 
   .mobile-shell #notesListMobile .saved-note-row {
-    border: 1px solid color-mix(in srgb, var(--card-border) 85%, transparent);
+    border: 1.5px solid var(--card-border-strong);
     background-color: color-mix(in srgb, var(--card-bg) 90%, rgba(148, 163, 184, 0.08));
     padding: 0.35rem 0.65rem;
     border-radius: 999px;
@@ -382,7 +389,7 @@
 
   .mobile-shell #notesListMobile .saved-note-row:hover {
     background-color: color-mix(in srgb, var(--card-bg) 92%, rgba(148, 163, 184, 0.18));
-    border-color: color-mix(in srgb, var(--accent-color) 35%, var(--card-border));
+    border-color: color-mix(in srgb, var(--accent-color) 40%, var(--card-border-strong));
   }
 
   .mobile-shell #notesListMobile .saved-note-row:active {
@@ -416,6 +423,8 @@
     transition:
       transform 0.35s cubic-bezier(0.25, 0.8, 0.25, 1),
       opacity 0.25s ease;
+    border: 1.5px solid var(--card-border-strong);
+    box-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
   }
 
   .mobile-shell #savedNotesSheet[data-open="true"] .saved-notes-panel {


### PR DESCRIPTION
## Summary
- introduce a reusable strong border token for the mobile notebook palette
- apply thicker, higher-contrast borders to the scratch card, saved notes sheet, and saved-note rows so the panels are easier to distinguish

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c4a97fa7883248e94972f342c6be7)