### PR TITLE
Remove instructional dashboard copy

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1011,7 +1011,6 @@
                         <button type="button" class="btn btn-ghost btn-xs" disabled title="Filtering not available yet">Today</button>
                       </div>
                     </div>
-                    <p class="desktop-panel-subtitle text-sm text-base-content/70">Keep track of tasks, family updates, and prep work in one organised list.</p>
                     <span id="sync-status" class="hidden text-xs text-base-content/70" role="status" aria-live="polite"></span>
                   </div>
                   <div class="desktop-reminders-layout workspace-columns">
@@ -1030,7 +1029,6 @@
                         <div class="desktop-panel-header flex flex-wrap items-start justify-between gap-3">
                           <div class="space-y-1">
                             <p class="desktop-panel-title text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Quick add</p>
-                            <p class="desktop-panel-subtitle text-sm text-base-content/80">Capture a reminder without leaving the workspace.</p>
                           </div>
                           <button type="button" class="btn btn-ghost btn-xs" data-open-reminder-modal>
                             Open add reminder modal
@@ -1115,7 +1113,6 @@
                 >
                   <div class="desktop-panel-header space-y-1">
                     <h3 class="desktop-panel-title text-2xl font-semibold tracking-wide text-base-content" data-primary-heading>Weekly planner</h3>
-                    <p class="desktop-panel-subtitle text-sm text-base-content/70">Draft the key lessons, checkpoints, and resources your classes need this week.</p>
                   </div>
                   <div class="workspace-columns">
                     <div class="workspace-column column-primary">
@@ -1181,7 +1178,6 @@
                 >
                   <div class="desktop-panel-header space-y-1">
                     <h3 class="desktop-panel-title text-2xl font-semibold tracking-wide text-base-content" data-primary-heading>Notes</h3>
-                    <p class="desktop-panel-subtitle text-sm text-base-content/70">Capture observations, behaviour wins, and quick reflections to revisit later.</p>
                   </div>
                   <div class="workspace-columns">
                     <div class="workspace-column column-primary">

--- a/index.html
+++ b/index.html
@@ -936,7 +936,6 @@
                 <button type="button" class="btn btn-ghost btn-xs" disabled title="Filtering not available yet">Today</button>
               </div>
             </div>
-            <p class="desktop-panel-subtitle text-sm text-base-content/70">Keep track of tasks, family updates, and prep work in one organised list.</p>
             <span id="sync-status" class="hidden text-xs text-base-content/70" role="status" aria-live="polite"></span>
           </div>
           <div class="desktop-reminders-layout section-columns">
@@ -955,7 +954,6 @@
                   <div class="desktop-panel-header flex flex-wrap items-start justify-between gap-3">
                     <div class="space-y-1">
                       <p class="desktop-panel-title text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Quick add</p>
-                      <p class="desktop-panel-subtitle text-sm text-base-content/80">Capture a reminder without leaving this page.</p>
                     </div>
                     <button type="button" class="btn btn-ghost btn-xs" data-open-reminder-modal>
                       Open add reminder modal
@@ -1048,9 +1046,6 @@
                 </div>
               </div>
             </div>
-            <p class="desktop-panel-subtitle text-sm text-base-content/70">
-              Plan your lessons, rotate templates, and capture quick adjustments to keep the week on track.
-            </p>
           </div>
           <div class="section-columns">
             <div class="section-column column-primary">
@@ -1127,7 +1122,6 @@
         <div class="space-y-4">
           <div class="desktop-panel-header space-y-1">
             <h3 class="desktop-panel-title text-2xl font-semibold tracking-wide text-base-content" data-primary-heading>Notes</h3>
-            <p class="desktop-panel-subtitle text-sm text-base-content/70">Capture observations, behaviour wins, and quick reflections to revisit later.</p>
           </div>
           <div class="section-columns notes-layout" data-notes-layout data-notes-shelf-state="expanded">
             <div class="section-column column-primary">


### PR DESCRIPTION
## Summary
- remove the reminder, planner, and notes instructional subtitles from the dashboard markup
- mirror the same content removal in the generated docs build so the public site matches

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c4e94a02883248bc3b01363dd9258)