### PR TITLE
Simplify desktop hero layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -387,16 +387,14 @@
         <div class="space-y-6">
           <!-- Hero section: use equal columns on large screens to prevent narrow side panel -->
           <section class="desktop-hero grid gap-4 lg:grid-cols-2">
-            <div class="hero-content max-w-none w-full">
-              <div class="desktop-dashboard-grid dashboard-grid grid gap-4 lg:grid-cols-2">
-                <!-- Left/main column: ensure cards stack with consistent spacing -->
-                <div class="space-y-4">
+            <!-- Left/main column: ensure cards stack with consistent spacing -->
+            <div class="space-y-4">
                   <article class="h-full rounded-2xl bg-base-100 border border-base-200/60 shadow-sm p-4 space-y-4">
                     <div class="flex items-center justify-between gap-2 pb-2 border-b border-base-200/60">
                       <h2 class="text-sm font-semibold tracking-tight">Weather</h2>
                       <span id="weatherIcon" class="text-3xl" aria-hidden="true">⛅️</span>
-                    </div>
-                    <div class="space-y-4">
+            </div>
+            <div class="space-y-4">
                       <div class="space-y-2">
                         <p id="weatherStatus" class="text-xs text-base-content/60" role="status" aria-live="polite">
                           Checking the latest forecast…
@@ -766,8 +764,6 @@
                       </div>
                     </div>
                   </section>
-                </div>
-              </div>
             </div>
           </section>
         </div>


### PR DESCRIPTION
## Summary
- remove the extra hero-content and desktop-dashboard-grid wrappers in the dashboard hero
- ensure the two space-y-4 column wrappers live directly under the desktop-hero grid so cards stay in two equal columns on large screens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c50a0f5708324b14b6f9899a57b0f)