### PR TITLE
Condense mobile notebook layout

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -3547,8 +3547,8 @@
     </section>
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: notebook view -->
-    <section data-view="notebook" id="view-notebook" class="view-panel hidden mobile-panel--notes">
-      <div class="mobile-view-inner mx-auto w-full max-w-md px-4 pt-4 pb-4 space-y-3">
+    <section data-view="notebook" id="view-notebook" class="view-panel hidden mobile-panel--notes mobile-panel--notes-size-small">
+      <div class="mobile-view-inner mx-auto w-full max-w-md px-3 pt-3 pb-3 space-y-2">
         <header class="mobile-header flex flex-col gap-1">
           <div id="notebook-view-header" class="space-y-1">
             <div class="flex items-baseline justify-between gap-2">
@@ -3558,13 +3558,13 @@
         </header>
         <div
           id="scratch-notes-card"
-          class="scratch-notes-card bg-base-100 border border-base-300 rounded-xl shadow-sm p-3 space-y-3"
+          class="scratch-notes-card bg-base-100 border border-base-300 rounded-lg shadow-sm p-3 space-y-3"
         >
           <div class="flex items-center justify-between gap-3">
             <h2 class="text-sm font-semibold text-base-content">Scratch notes</h2>
             <button
               type="button"
-              class="btn btn-ghost btn-sm"
+              class="btn btn-ghost btn-xs"
               data-action="open-saved-notes"
             >
               Saved notes
@@ -3603,7 +3603,7 @@
                 >
                   <textarea
                     id="noteBodyMobile"
-                    class="textarea textarea-bordered w-full h-48 text-sm text-base-content"
+                    class="textarea textarea-bordered w-full text-sm text-base-content"
                     placeholder="Start typing your scratch note…"
                   ></textarea>
                 </div>

--- a/docs/styles/index.css
+++ b/docs/styles/index.css
@@ -2684,6 +2684,35 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   --mobile-notes-text-scale: 1;
   --mobile-notes-detail-base: 0.75rem;
   --mobile-notes-textarea-base: 1rem;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+}
+
+.mobile-panel--notes .mobile-view-inner {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding-bottom: clamp(0.5rem, 2vh, 1.5rem);
+}
+
+.mobile-panel--notes header.mobile-header {
+  flex-shrink: 0;
+}
+
+.mobile-panel--notes #scratch-notes-card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.75rem 0.85rem 1rem;
+  border-radius: 0.85rem;
+}
+
+.mobile-panel--notes #scratch-notes-card #scratch-notes-actions {
+  margin-top: auto;
+  padding-top: 0.5rem;
 }
 
 .mobile-panel--notes-size-small {
@@ -2708,6 +2737,9 @@ section[data-route="dashboard"] .dashboard-shortcuts {
 .mobile-panel--notes .note-body-field textarea {
   font-size: calc(var(--mobile-notes-textarea-base, 1rem) * var(--mobile-notes-text-scale, 1));
   line-height: calc(1.45 * var(--mobile-notes-text-scale, 1));
+  min-height: clamp(9rem, 32vh, 18rem);
+  max-height: clamp(12rem, 40vh, 22rem);
+  overflow-y: auto;
 }
 
 .mobile-panel--notes .note-body-field textarea::placeholder {

--- a/mobile.html
+++ b/mobile.html
@@ -184,6 +184,8 @@
     flex: 1;
     display: flex;
     flex-direction: column;
+    gap: 0.75rem;
+    padding-bottom: clamp(0.5rem, 2vh, 1.5rem);
   }
 
   .mobile-panel--notes header.mobile-header {
@@ -194,16 +196,21 @@
     flex: 1;
     display: flex;
     flex-direction: column;
+    gap: 0.75rem;
+    padding: 0.75rem 0.85rem 1rem;
+    border-radius: 0.85rem;
   }
 
   .mobile-panel--notes #scratch-notes-card .notes-editor {
     flex: 1;
-    min-height: clamp(14rem, 55vh, 36rem);
+    min-height: clamp(9rem, 32vh, 18rem);
+    max-height: clamp(12rem, 40vh, 22rem);
+    overflow-y: auto;
   }
 
   .mobile-panel--notes #scratch-notes-card .note-actions {
     margin-top: auto;
-    padding-top: 1rem;
+    padding-top: 0.5rem;
   }
 
   .mobile-shell #view-notebook .card {
@@ -3812,8 +3819,8 @@
     </section>
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: notebook view -->
-    <section data-view="notebook" id="view-notebook" class="view-panel hidden mobile-panel--notes">
-      <div class="mobile-view-inner mx-auto w-full max-w-md px-4 pt-4 pb-4 space-y-3">
+    <section data-view="notebook" id="view-notebook" class="view-panel hidden mobile-panel--notes mobile-panel--notes-size-small">
+      <div class="mobile-view-inner mx-auto w-full max-w-md px-3 pt-3 pb-3 space-y-2">
         <header class="mobile-header flex flex-col gap-1">
           <div id="notebook-view-header" class="space-y-1">
             <div class="flex items-baseline justify-between gap-2">
@@ -3824,7 +3831,7 @@
         <!-- Enhanced Notebook Card -->
         <div
           id="scratch-notes-card"
-          class="scratch-notes-card rounded-xl bg-base-100 shadow-sm p-4 space-y-4"
+          class="scratch-notes-card rounded-lg bg-base-100 shadow-sm p-3 space-y-3"
         >
           <!-- Header Row -->
           <div class="flex items-center justify-between">
@@ -3832,7 +3839,7 @@
             <button
               id="openSavedNotesSheet"
               type="button"
-              class="btn btn-sm btn-ghost text-sm font-medium"
+              class="btn btn-xs btn-ghost text-sm font-medium"
             >
               Saved notes
             </button>


### PR DESCRIPTION
## Summary
- shrink the notebook mobile panel by reducing padding, rounding, and button sizing so the full UI fits onscreen
- clamp the scratch note editor heights and enable internal scrolling to avoid page-level scrolling, mirroring the change in both the runtime HTML and the published docs assets
- add layout helpers to the shared docs stylesheet so the textarea respects the condensed sizing and flex layout

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c4dc9d9308324b96a9715a704dbec)