### PR TITLE
Use dashboard grid layout for hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -386,7 +386,7 @@
       <section data-route="dashboard" class="space-y-6 lg:space-y-12">
         <div class="space-y-6">
           <!-- Hero section: use equal columns on large screens to prevent narrow side panel -->
-          <section class="desktop-hero grid gap-4 lg:grid-cols-2">
+          <section class="desktop-hero desktop-dashboard-grid dashboard-grid">
             <!-- Left/main column: ensure cards stack with consistent spacing -->
             <div class="space-y-4">
                   <article class="h-full rounded-2xl bg-base-100 border border-base-200/60 shadow-sm p-4 space-y-4">


### PR DESCRIPTION
## Summary
- switch the dashboard hero container over to the custom `desktop-dashboard-grid`/`dashboard-grid` classes
- keep the existing column wrappers as direct grid children so the cards line up correctly without the old utility gap

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c53ed9214832488f7f7486a330397)