### PR TITLE
Ensure dashboard hero columns span grid

### DIFF
--- a/docs/styles/index.css
+++ b/docs/styles/index.css
@@ -640,12 +640,22 @@ html[data-theme="professional"] {
   margin: 0 auto;
 }
 
- .desktop-shell .desktop-hero h1 {
-  font-size: clamp(1.8rem, 3vw, 2.3rem);
+.desktop-shell .desktop-hero h1 {
+ font-size: clamp(1.8rem, 3vw, 2.3rem);
 }
 
- .desktop-shell #dailySnapshotList,
- .desktop-shell #todaysFocusList,
+.desktop-shell .desktop-hero-column {
+  min-width: 0;
+}
+
+@media (min-width: 1024px) {
+  .desktop-shell .desktop-hero-column {
+    grid-column: span 6;
+  }
+}
+
+.desktop-shell #dailySnapshotList,
+.desktop-shell #todaysFocusList,
  .desktop-shell #weekAtAGlanceList,
  .desktop-shell #pinnedNotesList {
   list-style: none;

--- a/index.html
+++ b/index.html
@@ -386,9 +386,9 @@
       <section data-route="dashboard" class="space-y-6 lg:space-y-12">
         <div class="space-y-6">
           <!-- Hero section: use equal columns on large screens to prevent narrow side panel -->
-          <section class="desktop-hero grid gap-4 lg:grid-cols-2">
+          <section class="desktop-hero desktop-dashboard-grid dashboard-grid">
             <!-- Left/main column: ensure cards stack with consistent spacing -->
-            <div class="space-y-4">
+            <div class="space-y-4 desktop-hero-column">
                   <article class="h-full rounded-2xl bg-base-100 border border-base-200/60 shadow-sm p-4 space-y-4">
                     <div class="flex items-center justify-between gap-2 pb-2 border-b border-base-200/60">
                       <h2 class="text-sm font-semibold tracking-tight">Weather</h2>
@@ -510,7 +510,7 @@
                 </div>
 
                 <!-- Right/side column: same spacing as main column -->
-                <div class="space-y-4">
+                <div class="space-y-4 desktop-hero-column">
                   <article class="rounded-2xl bg-base-100 border border-base-200/60 shadow-sm p-4 space-y-4 h-full">
                     <div class="flex items-center justify-between gap-2 pb-2 border-b border-base-200/60">
                       <h2 class="text-sm font-semibold tracking-tight">Top educational news</h2>

--- a/styles/index.css
+++ b/styles/index.css
@@ -659,6 +659,16 @@ html[data-theme="professional"] {
 
  .desktop-shell .desktop-hero h1 {
   font-size: clamp(1.8rem, 3vw, 2.3rem);
+ }
+
+ .desktop-shell .desktop-hero-column {
+  min-width: 0;
+ }
+
+@media (min-width: 1024px) {
+   .desktop-shell .desktop-hero-column {
+    grid-column: span 6;
+  }
 }
 
  .desktop-shell #dailySnapshotList,


### PR DESCRIPTION
## Summary
- add a `desktop-hero-column` helper so the hero column wrappers can span half of the dashboard grid on desktop
- apply the helper to the hero’s left and right column wrappers so the weather, reminders, and news cards occupy two columns instead of stacking
- mirror the new helper in the docs stylesheet for parity

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c53ed9214832488f7f7486a330397)