### PR TITLE
Add hero card borders and shadows

### DIFF
--- a/docs/styles/index.css
+++ b/docs/styles/index.css
@@ -640,12 +640,29 @@ html[data-theme="professional"] {
   margin: 0 auto;
 }
 
- .desktop-shell .desktop-hero h1 {
-  font-size: clamp(1.8rem, 3vw, 2.3rem);
+.desktop-shell .desktop-hero h1 {
+ font-size: clamp(1.8rem, 3vw, 2.3rem);
 }
 
- .desktop-shell #dailySnapshotList,
- .desktop-shell #todaysFocusList,
+.desktop-shell .desktop-hero-column {
+  min-width: 0;
+}
+
+.desktop-shell .dashboard-hero-card {
+  border-radius: var(--desktop-radius-card, 18px);
+  border: 1px solid var(--desktop-border-subtle, var(--color-base-300, #d7def1));
+  background: var(--desktop-surface, var(--color-base-100, #ffffff));
+  box-shadow: var(--desktop-shadow-card, 0 12px 30px rgba(15, 23, 42, 0.12));
+}
+
+@media (min-width: 1024px) {
+  .desktop-shell .desktop-hero-column {
+    grid-column: span 6;
+  }
+}
+
+.desktop-shell #dailySnapshotList,
+.desktop-shell #todaysFocusList,
  .desktop-shell #weekAtAGlanceList,
  .desktop-shell #pinnedNotesList {
   list-style: none;

--- a/index.html
+++ b/index.html
@@ -386,10 +386,10 @@
       <section data-route="dashboard" class="space-y-6 lg:space-y-12">
         <div class="space-y-6">
           <!-- Hero section: use equal columns on large screens to prevent narrow side panel -->
-          <section class="desktop-hero grid gap-4 lg:grid-cols-2">
+          <section class="desktop-hero desktop-dashboard-grid dashboard-grid">
             <!-- Left/main column: ensure cards stack with consistent spacing -->
-            <div class="space-y-4">
-                  <article class="h-full rounded-2xl bg-base-100 border border-base-200/60 shadow-sm p-4 space-y-4">
+            <div class="space-y-4 desktop-hero-column">
+                  <article class="dashboard-hero-card h-full rounded-2xl bg-base-100 border border-base-200/60 shadow-sm p-4 space-y-4">
                     <div class="flex items-center justify-between gap-2 pb-2 border-b border-base-200/60">
                       <h2 class="text-sm font-semibold tracking-tight">Weather</h2>
                       <span id="weatherIcon" class="text-3xl" aria-hidden="true">⛅️</span>
@@ -428,7 +428,7 @@
                     </div>
                   </article>
 
-                  <article class="rounded-2xl bg-base-100 border border-base-200/60 shadow-sm p-4 space-y-4 h-full">
+                  <article class="dashboard-hero-card rounded-2xl bg-base-100 border border-base-200/60 shadow-sm p-4 space-y-4 h-full">
                     <div class="flex items-center justify-between gap-2 pb-2 border-b border-base-200/60">
                       <h2 class="text-sm font-semibold tracking-tight">Today’s reminders</h2>
                       <span class="text-lg" aria-hidden="true">⏰</span>
@@ -463,7 +463,7 @@
                     </div>
                   </article>
 
-                  <article class="rounded-2xl bg-base-100 border border-base-200/60 shadow-sm p-4 space-y-4 h-full">
+                  <article class="dashboard-hero-card rounded-2xl bg-base-100 border border-base-200/60 shadow-sm p-4 space-y-4 h-full">
                     <div class="flex items-center justify-between gap-2 pb-2 border-b border-base-200/60">
                       <h2 class="text-sm font-semibold tracking-tight">Next lesson</h2>
                       <span class="text-lg" aria-hidden="true">🗓️</span>
@@ -510,8 +510,8 @@
                 </div>
 
                 <!-- Right/side column: same spacing as main column -->
-                <div class="space-y-4">
-                  <article class="rounded-2xl bg-base-100 border border-base-200/60 shadow-sm p-4 space-y-4 h-full">
+                <div class="space-y-4 desktop-hero-column">
+                  <article class="dashboard-hero-card rounded-2xl bg-base-100 border border-base-200/60 shadow-sm p-4 space-y-4 h-full">
                     <div class="flex items-center justify-between gap-2 pb-2 border-b border-base-200/60">
                       <h2 class="text-sm font-semibold tracking-tight">Top educational news</h2>
                     </div>
@@ -542,7 +542,7 @@
                   </article>
 
                   <section
-                    class="rounded-2xl bg-base-100 border border-base-200/60 shadow-sm p-4 space-y-4"
+                    class="dashboard-hero-card rounded-2xl bg-base-100 border border-base-200/60 shadow-sm p-4 space-y-4"
                     aria-labelledby="kpi-heading"
                     data-dashboard-tab-group="kpi"
                   >
@@ -659,7 +659,7 @@
                   </section>
 
                   <section
-                    class="rounded-2xl bg-base-100 border border-base-200/60 shadow-sm p-4 space-y-4"
+                    class="dashboard-hero-card rounded-2xl bg-base-100 border border-base-200/60 shadow-sm p-4 space-y-4"
                     data-dashboard-tab-group="daily-focus"
                     aria-labelledby="daily-overview-heading"
                   >

--- a/styles/index.css
+++ b/styles/index.css
@@ -659,6 +659,23 @@ html[data-theme="professional"] {
 
  .desktop-shell .desktop-hero h1 {
   font-size: clamp(1.8rem, 3vw, 2.3rem);
+ }
+
+ .desktop-shell .desktop-hero-column {
+  min-width: 0;
+ }
+
+ .desktop-shell .dashboard-hero-card {
+  border-radius: var(--desktop-radius-card, 18px);
+  border: 1px solid var(--desktop-border-subtle, var(--color-base-300, #d7def1));
+  background: var(--desktop-surface, var(--color-base-100, #ffffff));
+  box-shadow: var(--desktop-shadow-card, 0 12px 30px rgba(15, 23, 42, 0.12));
+ }
+
+@media (min-width: 1024px) {
+   .desktop-shell .desktop-hero-column {
+    grid-column: span 6;
+  }
 }
 
  .desktop-shell #dailySnapshotList,


### PR DESCRIPTION
## Summary
- introduce a reusable `dashboard-hero-card` helper in both CSS bundles so dashboard hero surfaces get a clear border, background, and shadow
- apply the helper to each hero article/section so weather, reminders, metrics, and daily overview cards are visually separated on desktop

## Testing
- `npm test` *(fails: existing Jest suites attempt to import ESM modules like `js/reminders.js`, which triggers "Cannot use import statement outside a module" errors across the reminders/mobile test suites)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c53ed9214832488f7f7486a330397)