### PR TITLE
Fix mobile notes action spacing

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -197,7 +197,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
-    padding: 0.75rem 0.85rem 1rem;
+    padding: 0.75rem 0.85rem calc(1rem + env(safe-area-inset-bottom, 0.75rem));
     border-radius: 0.85rem;
   }
 
@@ -211,6 +211,7 @@
   .mobile-panel--notes #scratch-notes-card .note-actions {
     margin-top: auto;
     padding-top: 0.5rem;
+    padding-bottom: env(safe-area-inset-bottom, 0.75rem);
   }
 
   .mobile-shell #view-notebook .card {


### PR DESCRIPTION
## Summary
- add safe-area aware padding to the notebook card so the action buttons sit above the bottom navigation
- give the note action bar extra padding at the bottom to keep the New and Save buttons tappable

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c5a66d2dc8324abc477580d14b41a)