### PR TITLE
Simplify dashboard weather card

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -386,15 +386,16 @@
             <div class="hero-content max-w-none w-full">
               <div class="desktop-dashboard-grid">
                 <div class="space-y-6">
-                <article class="dashboard-card dashboard-card--compact dashboard-card--weather h-full">
-                    <div class="dashboard-card-content">
-                      <div class="weather-card-body">
-                        <div class="flex items-center justify-between gap-3 weather-card-header">
+                <div class="dashboard-weather-quick-card">
+                  <article class="dashboard-card dashboard-card--compact dashboard-card--weather dashboard-weather-card h-full">
+                      <div class="dashboard-card-content space-y-4">
+                        <div class="flex items-start justify-between gap-3 weather-card-header">
                           <div class="space-y-1">
                             <p class="dashboard-card-eyebrow">Weather</p>
                             <p id="weatherStatus" class="text-xs text-base-content/60" role="status" aria-live="polite">
                               Checking the latest forecast…
                             </p>
+                            <p id="weatherLocation" class="text-xs font-medium text-base-content/70">Locating…</p>
                           </div>
                           <span id="weatherIcon" class="text-3xl" aria-hidden="true">⛅️</span>
                         </div>
@@ -406,26 +407,8 @@
                           We use your approximate location to calculate these details.
                         </p>
                       </div>
-                      <dl class="grid gap-3 sm:grid-cols-2 weather-card-stats">
-                        <div>
-                          <dt class="text-[11px] font-semibold tracking-wide uppercase text-base-content/60">Location</dt>
-                          <dd id="weatherLocation" class="text-xs text-base-content/80">Locating…</dd>
-                        </div>
-                        <div>
-                          <dt class="text-[11px] font-semibold tracking-wide uppercase text-base-content/60">Wind</dt>
-                          <dd id="weatherWind" class="text-xs text-base-content/80">-- km/h</dd>
-                        </div>
-                        <div>
-                          <dt class="text-[11px] font-semibold tracking-wide uppercase text-base-content/60">Humidity</dt>
-                          <dd id="weatherHumidity" class="text-xs text-base-content/80">--%</dd>
-                        </div>
-                        <div>
-                          <dt class="text-[11px] font-semibold tracking-wide uppercase text-base-content/60">Feels like</dt>
-                          <dd id="weatherFeelsLike" class="text-xs text-base-content/80">--°C</dd>
-                        </div>
-                      </dl>
-                    </div>
-                  </article>
+                    </article>
+                </div>
 
                 <article class="dashboard-card dashboard-card--compact h-full">
                     <div class="dashboard-card-content">

--- a/index.html
+++ b/index.html
@@ -389,44 +389,26 @@
           <section class="desktop-hero desktop-dashboard-grid dashboard-grid">
             <!-- Left/main column: ensure cards stack with consistent spacing -->
             <div class="space-y-4 desktop-hero-column">
-                  <article class="dashboard-hero-card h-full rounded-2xl bg-base-100 border border-base-200/60 shadow-sm p-4 space-y-4">
-                    <div class="flex items-center justify-between gap-2 pb-2 border-b border-base-200/60">
-                      <h2 class="text-sm font-semibold tracking-tight">Weather</h2>
-                      <span id="weatherIcon" class="text-3xl" aria-hidden="true">⛅️</span>
-            </div>
-            <div class="space-y-4">
-                      <div class="space-y-2">
-                        <p id="weatherStatus" class="text-xs text-base-content/60" role="status" aria-live="polite">
-                          Checking the latest forecast…
-                        </p>
-                        <div class="flex flex-wrap items-end gap-3">
-                          <p id="weatherTemperature" class="text-4xl font-semibold text-base-content">--°C</p>
-                          <p id="weatherDescription" class="text-sm text-base-content/80">Awaiting update</p>
+                  <div class="dashboard-weather-quick-card">
+                    <article class="dashboard-hero-card dashboard-weather-card h-full rounded-2xl bg-base-100 border border-base-200/60 shadow-sm p-4 space-y-4">
+                      <div class="flex items-start justify-between gap-3">
+                        <div class="space-y-1">
+                          <p id="weatherStatus" class="text-xs text-base-content/60" role="status" aria-live="polite">
+                            Checking the latest forecast…
+                          </p>
+                          <p id="weatherLocation" class="text-sm font-medium text-base-content/80">Locating…</p>
                         </div>
+                        <span id="weatherIcon" class="text-3xl" aria-hidden="true">⛅️</span>
+                      </div>
+                      <div class="flex flex-wrap items-end gap-3">
+                        <p id="weatherTemperature" class="text-4xl font-semibold text-base-content">--°C</p>
+                        <p id="weatherDescription" class="text-sm text-base-content/80">Awaiting update</p>
                       </div>
                       <p id="weatherFootnote" class="hidden text-xs text-base-content/60 weather-card-footnote">
                         We use your approximate location to calculate these details.
                       </p>
-                      <dl class="grid gap-3 sm:grid-cols-2 text-xs text-base-content/80">
-                        <div class="space-y-1">
-                          <dt class="text-[11px] font-semibold tracking-wide uppercase text-base-content/60">Location</dt>
-                          <dd id="weatherLocation">Locating…</dd>
-                        </div>
-                        <div class="space-y-1">
-                          <dt class="text-[11px] font-semibold tracking-wide uppercase text-base-content/60">Wind</dt>
-                          <dd id="weatherWind">-- km/h</dd>
-                        </div>
-                        <div class="space-y-1">
-                          <dt class="text-[11px] font-semibold tracking-wide uppercase text-base-content/60">Humidity</dt>
-                          <dd id="weatherHumidity">--%</dd>
-                        </div>
-                        <div class="space-y-1">
-                          <dt class="text-[11px] font-semibold tracking-wide uppercase text-base-content/60">Feels like</dt>
-                          <dd id="weatherFeelsLike">--°C</dd>
-                        </div>
-                      </dl>
-                    </div>
-                  </article>
+                    </article>
+                  </div>
 
                   <article class="dashboard-hero-card rounded-2xl bg-base-100 border border-base-200/60 shadow-sm p-4 space-y-4 h-full">
                     <div class="flex items-center justify-between gap-2 pb-2 border-b border-base-200/60">

--- a/js/dashboard-insights.js
+++ b/js/dashboard-insights.js
@@ -38,9 +38,6 @@ const weatherElements = {
   temperature: document.getElementById('weatherTemperature'),
   description: document.getElementById('weatherDescription'),
   location: document.getElementById('weatherLocation'),
-  wind: document.getElementById('weatherWind'),
-  humidity: document.getElementById('weatherHumidity'),
-  feelsLike: document.getElementById('weatherFeelsLike'),
   footnote: document.getElementById('weatherFootnote'),
   icon: document.getElementById('weatherIcon')
 };
@@ -290,9 +287,6 @@ async function updateWeatherSummary(coords) {
     safeText(weatherElements.temperature, `${Math.round(current.temperature_2m ?? 0)}°C`);
     safeText(weatherElements.description, description.label);
     safeText(weatherElements.location, prettyLocation || coords.label || 'Your area');
-    safeText(weatherElements.wind, `${Math.round(current.wind_speed_10m ?? 0)} km/h`);
-    safeText(weatherElements.humidity, `${Math.round(current.relative_humidity_2m ?? 0)}%`);
-    safeText(weatherElements.feelsLike, `${Math.round(current.apparent_temperature ?? current.temperature_2m ?? 0)}°C`);
     safeText(weatherElements.status, `Updated at ${formatTimeLabel(current.time)}.`);
     safeText(weatherElements.footnote, 'Powered by Open-Meteo');
 
@@ -306,7 +300,15 @@ async function updateWeatherSummary(coords) {
 }
 
 function requestWeather() {
-  if (!weatherElements.status) {
+  const hasWeatherCard =
+    weatherElements.status ||
+    weatherElements.temperature ||
+    weatherElements.description ||
+    weatherElements.location ||
+    weatherElements.footnote ||
+    weatherElements.icon;
+
+  if (!hasWeatherCard) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- restyle the dashboard weather module in both HTML entry points to use the compact quick-card markup with only the icon, temperature, condition, location, and status text
- remove the obsolete stats rows so only the required badge nodes remain for weather updates
- update the weather script to match the new markup, only targeting the nodes that still exist

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ce9d8bba883248548cb02000bf178)