### PR TITLE
Remove blue background from mobile reminders

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -3313,7 +3313,7 @@
     }
 
     .reminders-content-shell {
-      background-color: var(--true-blue);
+      background-color: transparent;
       border-radius: 1.25rem;
       padding: 1rem;
       width: 100%;


### PR DESCRIPTION
## Summary
- make the reminders list container transparent so the blue background no longer shows on mobile

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cfd70a6148324bb1bf9872f1fdb4f)