### PR TITLE
Add planner detail panel markup and styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1045,7 +1045,48 @@
                         </label>
                       </div>
                     </div>
-                    <div class="planner-detail-panel space-y-6">
+                    <div id="planner-detail-panel" class="planner-detail-panel space-y-6">
+                      <div
+                        class="planner-detail-card planner-detail-card--empty"
+                        data-planner-detail-empty
+                      >
+                        <p class="text-sm font-semibold uppercase tracking-[0.3em] text-base-content/50">Lesson details</p>
+                        <p class="mt-3 text-base text-base-content/70">
+                          Select a lesson card from your weekly plan to view the schedule, summary, and lesson details here.
+                        </p>
+                      </div>
+                      <div
+                        class="planner-detail-card planner-detail-card--content hidden"
+                        data-planner-detail-content
+                        aria-live="polite"
+                      >
+                        <div class="flex flex-wrap items-start justify-between gap-6">
+                          <div class="space-y-2">
+                            <p id="planner-detail-day" class="text-xs font-semibold uppercase tracking-[0.35em] text-base-content/60"></p>
+                            <h4 id="planner-detail-title" class="text-2xl font-semibold text-base-content"></h4>
+                            <p id="planner-detail-summary" class="text-sm text-base-content/80"></p>
+                          </div>
+                          <div class="min-w-[160px] flex flex-col items-end gap-1 text-right">
+                            <span class="text-[0.65rem] uppercase tracking-[0.3em] text-base-content/50">Subject</span>
+                            <div id="planner-detail-subject"></div>
+                          </div>
+                        </div>
+                        <div class="mt-6 space-y-3">
+                          <p class="text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-base-content/50">Lesson details</p>
+                          <div id="planner-detail-details" class="space-y-3"></div>
+                        </div>
+                        <div id="planner-detail-actions" class="planner-detail-actions flex flex-wrap items-center gap-2">
+                          <button type="button" class="btn btn-outline btn-sm" data-planner-detail-action="duplicate">
+                            Duplicate lesson
+                          </button>
+                          <button type="button" class="btn btn-ghost btn-sm" data-planner-detail-action="reminder">
+                            Create reminder
+                          </button>
+                          <button type="button" class="btn btn-primary btn-sm" data-planner-detail-action="resources">
+                            Add resources
+                          </button>
+                        </div>
+                      </div>
                       <div class="planner-week-grid" data-planner-grid></div>
                     </div>
                   </div>

--- a/styles/index.css
+++ b/styles/index.css
@@ -2843,6 +2843,47 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   font-weight: 600;
 }
 
+[data-route="planner"] .planner-detail-card {
+  border-radius: 1.5rem;
+  border: 1px solid color-mix(
+    in srgb,
+    var(--planner-panel-border, var(--desktop-border-subtle, var(--color-base-300, #d7def1))) 80%,
+    transparent
+  );
+  background: color-mix(in srgb, var(--planner-panel-bg, #ffffff) 85%, transparent);
+  padding: clamp(1.25rem, 2vw, 1.75rem);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+[data-route="planner"] .planner-detail-card--empty {
+  border-style: dashed;
+  text-align: center;
+  color: var(
+    --desktop-text-muted,
+    color-mix(in srgb, var(--color-base-content, #0f172a) 60%, transparent)
+  );
+  background: color-mix(in srgb, var(--planner-panel-bg, #ffffff) 55%, transparent);
+}
+
+[data-route="planner"] .planner-detail-card--content {
+  box-shadow: 0 20px 40px color-mix(
+      in srgb,
+      var(--planner-card-shadow, rgba(15, 23, 42, 0.08)) 60%,
+      transparent
+    ),
+    inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+[data-route="planner"] .planner-detail-actions {
+  border-top: 1px solid color-mix(
+    in srgb,
+    var(--planner-panel-border, var(--desktop-border-subtle, var(--color-base-300, #d7def1))) 65%,
+    transparent
+  );
+  padding-top: 1rem;
+  margin-top: 1.25rem;
+}
+
 .mobile-panel--notes {
   --mobile-notes-text-scale: 1;
   --mobile-notes-detail-base: 0.75rem;


### PR DESCRIPTION
## Summary
- add the planner detail panel markup required by app.js, including empty and populated states, lesson metadata, and action buttons wired to planner detail events
- introduce planner-specific styling for the new detail card variants so the content matches the existing desktop panel aesthetics

## Testing
- npm test *(fails: existing Jest suites cannot execute ESM modules such as js/reminders.js and mobile.js, raising "Cannot use import statement outside a module" before reaching the assertions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d94f69c6483249cf6aef1ca5bad66)