### PR TITLE
Simplify footer layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1376,45 +1376,10 @@
   <div id="live-status" class="sr-only" aria-live="polite" role="status"></div>
   <!-- END GPT CHANGE -->
   <footer class="site-footer">
-    <div class="site-footer__inner">
-      <div class="site-footer__content">
-        <div class="site-footer__brand">
-          <a class="site-footer__brand-mark" href="./index.html">
-            <span class="site-footer__logo" aria-hidden="true">MC</span>
-            <div>
-              <p class="site-footer__brand-name">Memory Cue</p>
-              <p class="site-footer__brand-tagline">Clarity for busy classrooms</p>
-            </div>
-          </a>
-          <p class="site-footer__description">
-            Designed to help teachers stay organised, communicate clearly, and celebrate daily wins.
-          </p>
-          <a class="site-footer__cta" href="mailto:hello@memorycue.app">Get updates</a>
-        </div>
-        <div class="site-footer__links">
-          <div class="site-footer__column">
-            <p class="site-footer__heading">Product</p>
-            <a href="./index.html">Web dashboard</a>
-            <a href="./mobile.html">Mobile companion</a>
-            <a href="./docs/index.html">Product tour</a>
-          </div>
-          <div class="site-footer__column">
-            <p class="site-footer__heading">Resources</p>
-            <a href="./docs/mobile.html">Mobile guide</a>
-            <a href="./docs/index.html#planner">Planner handbook</a>
-            <a href="https://github.com/dmaher42/memory-cue">Open source repo</a>
-          </div>
-          <div class="site-footer__column">
-            <p class="site-footer__heading">Company</p>
-            <a href="./docs/index.html#about">About Memory Cue</a>
-            <a href="https://memorycue.app/">Press kit</a>
-            <a href="mailto:hello@memorycue.app">Contact</a>
-          </div>
-        </div>
-      </div>
-      <div class="site-footer__bottom">
-        <p>© <span id="year"></span> Memory Cue. All rights reserved.</p>
-        <div class="site-footer__social">
+    <div class="site-footer__inner site-footer__inner--compact">
+      <div class="site-footer__bottom site-footer__bottom--compact">
+        <p>© <span id="year"></span> Memory Cue</p>
+        <div class="site-footer__quick-links">
           <a href="mailto:hello@memorycue.app">hello@memorycue.app</a>
           <a href="https://github.com/dmaher42/memory-cue" target="_blank" rel="noreferrer">GitHub</a>
           <a href="https://memorycue.app/" target="_blank" rel="noreferrer">Website</a>

--- a/styles/index.css
+++ b/styles/index.css
@@ -2938,6 +2938,10 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   gap: clamp(0.5rem, 1.25vw, 1rem);
 }
 
+.site-footer__inner--compact {
+  padding: clamp(0.5rem, 1.5vw, 0.9rem) clamp(0.75rem, 2vw, 1.25rem);
+}
+
 .site-footer__content {
   display: flex;
   flex-direction: column;
@@ -3046,6 +3050,23 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   border-top: 1px solid rgba(255, 255, 255, 0.12);
   font-size: 0.85rem;
   color: rgba(248, 250, 252, 0.65);
+}
+
+.site-footer__bottom--compact {
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-footer__quick-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.75rem;
+}
+
+.site-footer__quick-links a {
+  text-decoration: none;
+  font-weight: 600;
+  color: rgba(248, 250, 252, 0.85);
 }
 
 .site-footer__social {


### PR DESCRIPTION
## Summary
- replace the busy footer content with a single compact row that only shows copyright and the key quick links
- add compact footer styles so the remaining content stays slim and aligned across breakpoints

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d9af881cc8324ba00cb2e41d2b1a6)