### PR TITLE
Wire up planner copy/clear controls

### DIFF
--- a/js/modules/planner.js
+++ b/js/modules/planner.js
@@ -815,6 +815,24 @@ export const duplicateWeekPlan = async (sourceWeekId, targetWeekId) => {
   return persisted;
 };
 
+export const clearWeekPlan = async (weekId) => {
+  if (!weekId) {
+    return null;
+  }
+  const plan = await loadWeekPlan(weekId);
+  if (!plan) {
+    return null;
+  }
+  const nextPlan = {
+    ...plan,
+    lessons: [],
+    updatedAt: new Date().toISOString()
+  };
+  const persisted = await persistPlan(nextPlan);
+  dispatchPlannerUpdated(persisted);
+  return persisted;
+};
+
 const cloneTemplateLesson = (lesson) => {
   if (!lesson || typeof lesson !== 'object') {
     return null;


### PR DESCRIPTION
## Summary
- add a `clearWeekPlan` helper so a week's lessons can be reset in storage
- connect the planner toolbar buttons to copy the previous week or clear the current one and surface status updates

## Testing
- npm test -- --runTestsByPath sample.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d9be126e08324a818598b91d1772c)