### PR TITLE
Make quick add bar replace legacy reminders header

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -3205,88 +3205,68 @@
       top: 0;
       z-index: 50;
       width: 100%;
-      background: #98c1d9;
-      color: #fff;
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      gap: 0.75rem;
+      padding: 0.6rem 1rem;
+      background: var(--mobile-quick-surface);
+      color: var(--text-primary);
       backdrop-filter: blur(18px);
       -webkit-backdrop-filter: blur(18px);
-      border-bottom: 1px solid #7aaac2;
-      box-shadow: 0 6px 20px rgba(152, 193, 217, 0.25);
-      padding: 0.5rem 1rem;
-      display: flex;
-      flex-direction: column;
-      align-items: stretch;
-      gap: 0.75rem;
-      min-height: 3rem;
+      border-bottom: 1px solid color-mix(in srgb, var(--card-border) 70%, transparent);
+      box-shadow: var(--mobile-header-shadow);
     }
 
-    #reminders-slim-header .header-top {
-      display: flex;
+    #reminders-slim-header .header-leading,
+    #reminders-slim-header .header-actions {
+      display: inline-flex;
       align-items: center;
-      justify-content: space-between;
-      gap: 0.75rem;
-      width: 100%;
-    }
-
-    #reminders-slim-header .header-title {
-      font-size: 1.125rem;
-      font-weight: 600;
-      color: inherit;
-      margin: 0;
-      flex-shrink: 1;
-      min-width: 0;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+      gap: 0.4rem;
+      flex-wrap: nowrap;
     }
 
     #reminders-slim-header .header-leading {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      flex: 1;
-      min-width: 0;
+      justify-content: flex-start;
     }
 
     #reminders-slim-header .header-actions {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      flex-shrink: 0;
+      justify-content: flex-end;
     }
 
     #reminders-slim-header .header-quick-add {
       width: 100%;
+      min-width: 0;
     }
 
     #reminders-slim-header .header-btn {
-      min-height: 44px;
-      min-width: 44px;
-      padding: 0.5rem 0.75rem;
-      border-radius: 0.5rem;
-      border: 1px solid rgba(255, 255, 255, 0.45);
-      background: rgba(255, 255, 255, 0.15);
-      color: #fff;
-      font-size: 0.875rem;
+      min-height: 40px;
+      min-width: 40px;
+      padding: 0.35rem;
+      border-radius: 999px;
+      border: 1px solid var(--mobile-header-button-border);
+      background: var(--mobile-header-button-bg);
+      color: var(--mobile-header-button-color);
+      font-size: 0.85rem;
       font-weight: 600;
       cursor: pointer;
       transition: all 0.2s ease;
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      gap: 0.375rem;
+      gap: 0.25rem;
     }
 
     #reminders-slim-header .header-btn:hover,
     #reminders-slim-header .header-btn:focus-visible {
-      background: rgba(255, 255, 255, 0.25);
-      color: #fff;
+      background: color-mix(in srgb, var(--mobile-header-button-bg) 55%, var(--accent-color) 45%);
+      color: var(--mobile-header-button-color);
       transform: translateY(-1px);
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+      box-shadow: 0 4px 12px rgba(15, 23, 42, 0.12);
       outline: none;
     }
 
     #reminders-slim-header .header-btn:focus-visible {
-      outline: 3px solid rgba(255, 255, 255, 0.45);
+      outline: 3px solid color-mix(in srgb, var(--accent-color) 35%, transparent);
       outline-offset: 2px;
     }
 
@@ -3295,18 +3275,14 @@
     }
 
     #reminders-slim-header .header-btn-icon {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 2.5rem;
-      height: 2.5rem;
       padding: 0;
-      border-radius: 50%;
+      width: 2.25rem;
+      height: 2.25rem;
     }
 
     #reminders-slim-header .header-overflow-wrapper {
       position: relative;
-      display: flex;
+      display: inline-flex;
       align-items: center;
       justify-content: center;
     }
@@ -3328,15 +3304,7 @@
       #reminders-slim-header {
         padding: 0.4rem 0.75rem;
         gap: 0.5rem;
-      }
-
-      #reminders-slim-header .header-title {
-        font-size: 1rem;
-      }
-
-      #reminders-slim-header .header-top {
-        flex-direction: column;
-        align-items: stretch;
+        grid-template-columns: minmax(0, 1fr);
       }
 
       #reminders-slim-header .header-actions {
@@ -3344,15 +3312,20 @@
         justify-content: space-between;
       }
 
+      #reminders-slim-header .header-leading,
+      #reminders-slim-header .header-quick-add {
+        width: 100%;
+      }
+
+      #reminders-slim-header .header-quick-add {
+        grid-column: 1 / -1;
+      }
+
       #reminders-slim-header .header-btn {
         min-width: 40px;
         min-height: 40px;
         padding: 0.4rem 0.6rem;
         font-size: 0.8rem;
-      }
-
-      #reminders-slim-header .header-btn-text {
-        display: none;
       }
     }
   </style>
@@ -3421,9 +3394,10 @@
       const drawerSyncDot = document.getElementById('mcStatus');
       const quickAddPanel = document.getElementById('quickAddBar');
       const quickAddInputField = document.getElementById('quickAddInput');
-      const quickAddCloseBtn = document.getElementById('quickAddClose');
       const quickAddSelector = '[data-open-quick-add]';
       let activeQuickAddTrigger = null;
+      const isPersistentQuickAdd =
+        quickAddPanel instanceof HTMLElement && quickAddPanel.dataset.persistent === 'true';
 
       const toggleClass = (el, className, force) => {
         if (!el) return;
@@ -3498,11 +3472,24 @@
         window.scrollTo({ top: 0, behavior: 'smooth' });
       });
 
-      const isQuickAddVisible = () => quickAddPanel?.dataset.visible === 'true';
+      const isQuickAddVisible = () =>
+        isPersistentQuickAdd || quickAddPanel?.dataset.visible === 'true';
 
       const showQuickAddPanel = (trigger) => {
         if (!(quickAddPanel instanceof HTMLElement)) {
           return false;
+        }
+        if (isPersistentQuickAdd) {
+          if (quickAddInputField instanceof HTMLElement) {
+            window.requestAnimationFrame(() => {
+              try {
+                quickAddInputField.focus({ preventScroll: true });
+              } catch {
+                quickAddInputField.focus();
+              }
+            });
+          }
+          return true;
         }
         activeQuickAddTrigger = trigger instanceof HTMLElement ? trigger : null;
         quickAddPanel.hidden = false;
@@ -3522,7 +3509,7 @@
       };
 
       const hideQuickAddPanel = () => {
-        if (!(quickAddPanel instanceof HTMLElement)) {
+        if (!(quickAddPanel instanceof HTMLElement) || isPersistentQuickAdd) {
           return false;
         }
         if (quickAddPanel.dataset.visible !== 'true') {
@@ -3562,6 +3549,10 @@
           if (typeof event.stopImmediatePropagation === 'function') {
             event.stopImmediatePropagation();
           }
+          if (isPersistentQuickAdd) {
+            showQuickAddPanel(trigger);
+            return;
+          }
           if (isQuickAddVisible()) {
             hideQuickAddPanel();
           } else {
@@ -3570,11 +3561,6 @@
         },
         true,
       );
-
-      quickAddCloseBtn?.addEventListener('click', (event) => {
-        event.preventDefault();
-        hideQuickAddPanel();
-      });
 
       document.addEventListener('reminder:quick-add:complete', hideQuickAddPanel);
 
@@ -3654,161 +3640,72 @@
 
   <!-- NEW: Slim sticky header for reminders -->
   <div id="reminders-slim-header" role="banner">
-    <div class="header-top">
-      <div class="header-leading">
-        <button
-          id="btn-open-drawer"
-          type="button"
-          class="header-btn header-btn-icon"
-          aria-label="Open navigation menu"
-          aria-expanded="false"
-        >
-          <span class="text-xl leading-none" aria-hidden="true">🏠</span>
-          <span class="sr-only">Open navigation menu</span>
-        </button>
-        <h1 class="header-title">Reminders</h1>
-      </div>
-      <div class="header-actions">
-        <button
-          id="addReminderBtn"
-          type="button"
-          class="header-btn mc-add-btn btn btn-primary btn-sm gap-1 whitespace-nowrap"
-          data-open-add-task
-          data-open-quick-add
-          aria-controls="quickAddBar"
-          aria-expanded="false"
-        >
-          <span class="mc-add-btn-icon" aria-hidden="true">＋</span>
-          <span class="mc-add-btn-label">Add reminder</span>
-        </button>
-        <div class="header-overflow-wrapper">
-          <button
-            id="overflowMenuBtn"
-            type="button"
-            class="header-btn header-btn-icon"
-            aria-label="Open quick settings"
-            aria-haspopup="menu"
-            aria-controls="overflowMenu"
-            aria-expanded="false"
-          >
-            <span class="text-xl leading-none" aria-hidden="true">⚙️</span>
-          </button>
-
-          <div
-            id="overflowMenu"
-            class="hidden quick-actions-panel absolute right-0 mt-2"
-            role="menu"
-            aria-hidden="true"
-            aria-labelledby="overflowMenuHeading"
-          >
-            <h2 id="overflowMenuHeading" class="sr-only">Quick settings</h2>
-            <ul class="quick-actions" role="presentation">
-              <li role="none">
-                <button id="voiceAddBtn" type="button" class="quick-action-btn" title="Dictate reminder" role="menuitem">
-                  <span class="quick-action-icon" aria-hidden="true">🎤</span>
-                  <span class="sr-only">Dictate reminder</span>
-                </button>
-              </li>
-              <li role="none">
-                <button id="viewToggleMenu" type="button" class="quick-action-btn" title="Toggle layout" role="menuitem">
-                  <span class="quick-action-icon" aria-hidden="true">🗂</span>
-                  <span id="viewToggleLabel" class="sr-only">View layout: Compact</span>
-                </button>
-              </li>
-              <li role="none">
-                <button id="openSettings" type="button" class="quick-action-btn" data-open="settings" title="Open settings" role="menuitem">
-                  <span class="quick-action-icon" aria-hidden="true">⚙️</span>
-                  <span class="sr-only">Open settings</span>
-                </button>
-              </li>
-              <li role="none">
-                <button id="themeToggle" type="button" class="quick-action-btn" title="Toggle theme" role="menuitem">
-                  <span class="quick-action-icon" aria-hidden="true">🌗</span>
-                  <span class="sr-only">Toggle theme</span>
-                </button>
-              </li>
-              <li role="none">
-                <button id="googleSignInBtn" type="button" class="quick-action-btn" title="Sign in" role="menuitem">
-                  <span class="quick-action-icon" aria-hidden="true">🔐</span>
-                  <span class="sr-only">Sign in</span>
-                </button>
-              </li>
-              <li role="none">
-                <button id="googleSignOutBtn" type="button" class="quick-action-btn hidden" title="Sign out" role="menuitem">
-                  <span class="quick-action-icon" aria-hidden="true">🔓</span>
-                  <span class="sr-only">Sign out</span>
-                </button>
-              </li>
-            </ul>
-          </div>
-        </div>
-        <button
-          id="remindersHomeBtn"
-          type="button"
-          class="header-btn header-btn-icon"
-          aria-label="Go to home"
-          data-scroll-home
-        >
-          <span class="text-xl leading-none" aria-hidden="true">🏠</span>
-          <span class="sr-only">Go to home</span>
-        </button>
-      </div>
+    <div class="header-leading">
+      <button
+        id="btn-open-drawer"
+        type="button"
+        class="header-btn header-btn-icon"
+        aria-label="Open navigation menu"
+        aria-expanded="false"
+      >
+        <span class="text-xl leading-none" aria-hidden="true">☰</span>
+        <span class="sr-only">Open navigation menu</span>
+      </button>
+      <button
+        id="addReminderBtn"
+        type="button"
+        class="header-btn header-btn-icon"
+        data-open-add-task
+        aria-label="Open detailed reminder form"
+        aria-controls="createReminderModal"
+        aria-expanded="false"
+      >
+        <span class="text-lg leading-none" aria-hidden="true">＋</span>
+        <span class="sr-only">Open detailed reminder form</span>
+      </button>
     </div>
     <div class="header-quick-add">
       <div
         id="quickAddBar"
-        class="reminders-quick-add mc-quick-add-bar w-full rounded-xl bg-base-100 shadow-sm px-3 py-2 flex items-center gap-2"
+        class="reminders-quick-add mc-quick-add-bar w-full rounded-xl bg-base-100 shadow-sm px-3 py-2"
         aria-label="Quick add reminder"
-        hidden
-        data-visible="false"
-        aria-hidden="true"
+        data-visible="true"
+        data-persistent="true"
       >
-        <div class="w-full flex flex-col gap-2">
-          <div class="flex justify-end">
-            <button
-              id="quickAddClose"
-              type="button"
-              class="mc-quick-close btn btn-ghost btn-circle btn-sm"
-              aria-label="Close quick add"
-            >
-              <span aria-hidden="true">✕</span>
-            </button>
-          </div>
-          <div class="mc-quick-add-inner space-y-1.5 w-full">
-            <div class="mc-quick-add-row flex flex-col items-center gap-2 w-full">
-              <div class="mc-quick-input-group w-full">
-                <input
-                  id="quickAddInput"
-                  class="mc-quick-input input input-bordered input-sm w-full text-sm text-base-content"
-                  type="text"
-                  autocomplete="off"
-                  placeholder="Quick reminder…"
-                />
-                <div class="mc-quick-actions flex items-center gap-2">
-                  <button
-                    id="quickAddSubmit"
-                    type="button"
-                    class="mc-quick-submit btn btn-primary btn-sm"
-                    data-quick-add-submit
-                  >
-                    Add
-                  </button>
-                  <button
-                    id="quickAddReminderOptions"
-                    type="button"
-                    class="mc-quick-options btn btn-ghost btn-sm"
-                    aria-haspopup="menu"
-                    aria-expanded="false"
-                    data-quick-add-options
-                  >
-                    Options
-                  </button>
-                </div>
+        <div class="mc-quick-add-inner space-y-1.5 w-full">
+          <div class="mc-quick-add-row flex flex-col items-center gap-2 w-full">
+            <div class="mc-quick-input-group w-full">
+              <input
+                id="quickAddInput"
+                class="mc-quick-input input input-bordered input-sm w-full text-sm text-base-content"
+                type="text"
+                autocomplete="off"
+                placeholder="Quick reminder…"
+              />
+              <div class="mc-quick-actions flex items-center gap-2">
+                <button
+                  id="quickAddSubmit"
+                  type="button"
+                  class="mc-quick-submit btn btn-primary btn-sm"
+                  data-quick-add-submit
+                >
+                  Add
+                </button>
+                <button
+                  id="quickAddReminderOptions"
+                  type="button"
+                  class="mc-quick-options btn btn-ghost btn-sm"
+                  aria-haspopup="menu"
+                  aria-expanded="false"
+                  data-quick-add-options
+                >
+                  Options
+                </button>
               </div>
-              <div class="mc-quick-meta flex items-center gap-2 text-xs text-base-content/70 w-full">
-                <span id="quickAddDueLabel" class="mc-quick-meta-due" aria-live="polite"></span>
-                <span id="quickAddListLabel" class="mc-quick-meta-list" aria-live="polite"></span>
-              </div>
+            </div>
+            <div class="mc-quick-meta flex items-center gap-2 text-xs text-base-content/70 w-full">
+              <span id="quickAddDueLabel" class="mc-quick-meta-due" aria-live="polite"></span>
+              <span id="quickAddListLabel" class="mc-quick-meta-list" aria-live="polite"></span>
             </div>
             <div class="mc-quick-chips flex flex-wrap gap-2 text-sm">
               <button type="button" class="mc-quick-chip" data-chip-due-today>Today</button>
@@ -3819,8 +3716,80 @@
         </div>
       </div>
     </div>
-  </div>
+    <div class="header-actions">
+      <div class="header-overflow-wrapper">
+        <button
+          id="overflowMenuBtn"
+          type="button"
+          class="header-btn header-btn-icon"
+          aria-label="Open quick settings"
+          aria-haspopup="menu"
+          aria-controls="overflowMenu"
+          aria-expanded="false"
+        >
+          <span class="text-xl leading-none" aria-hidden="true">⚙️</span>
+        </button>
 
+        <div
+          id="overflowMenu"
+          class="hidden quick-actions-panel absolute right-0 mt-2"
+          role="menu"
+          aria-hidden="true"
+          aria-labelledby="overflowMenuHeading"
+        >
+          <h2 id="overflowMenuHeading" class="sr-only">Quick settings</h2>
+          <ul class="quick-actions" role="presentation">
+            <li role="none">
+              <button id="voiceAddBtn" type="button" class="quick-action-btn" title="Dictate reminder" role="menuitem">
+                <span class="quick-action-icon" aria-hidden="true">🎤</span>
+                <span class="sr-only">Dictate reminder</span>
+              </button>
+            </li>
+            <li role="none">
+              <button id="viewToggleMenu" type="button" class="quick-action-btn" title="Toggle layout" role="menuitem">
+                <span class="quick-action-icon" aria-hidden="true">🗂</span>
+                <span id="viewToggleLabel" class="sr-only">View layout: Compact</span>
+              </button>
+            </li>
+            <li role="none">
+              <button id="openSettings" type="button" class="quick-action-btn" data-open="settings" title="Open settings" role="menuitem">
+                <span class="quick-action-icon" aria-hidden="true">⚙️</span>
+                <span class="sr-only">Open settings</span>
+              </button>
+            </li>
+            <li role="none">
+              <button id="themeToggle" type="button" class="quick-action-btn" title="Toggle theme" role="menuitem">
+                <span class="quick-action-icon" aria-hidden="true">🌗</span>
+                <span class="sr-only">Toggle theme</span>
+              </button>
+            </li>
+            <li role="none">
+              <button id="googleSignInBtn" type="button" class="quick-action-btn" title="Sign in" role="menuitem">
+                <span class="quick-action-icon" aria-hidden="true">🔐</span>
+                <span class="sr-only">Sign in</span>
+              </button>
+            </li>
+            <li role="none">
+              <button id="googleSignOutBtn" type="button" class="quick-action-btn hidden" title="Sign out" role="menuitem">
+                <span class="quick-action-icon" aria-hidden="true">🔓</span>
+                <span class="sr-only">Sign out</span>
+              </button>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <button
+        id="remindersHomeBtn"
+        type="button"
+        class="header-btn header-btn-icon"
+        aria-label="Go to home"
+        data-scroll-home
+      >
+        <span class="text-xl leading-none" aria-hidden="true">🏠</span>
+        <span class="sr-only">Go to home</span>
+      </button>
+    </div>
+  </div>
   <div id="mobile-shell" class="mobile-shell max-w-md mx-auto w-full px-4 pb-16">
     <main id="main" class="mx-auto pt-4 pb-4 w-full max-w-none sm:max-w-lg" tabindex="-1" data-active-view="reminders">
     <!-- BEGIN GPT CHANGE: create form moved to bottom sheet -->
@@ -6303,13 +6272,10 @@
       const slimHeader = document.getElementById('reminders-slim-header');
       if (!slimHeader) return;
 
-      const headerActions = slimHeader.querySelector('.header-actions');
-      if (!headerActions) return;
-
-      const addBtn = headerActions.querySelector('#addReminderBtn');
-      const overflowBtn = headerActions.querySelector('#overflowMenuBtn');
-      const overflowMenu = headerActions.querySelector('#overflowMenu');
-      const homeBtn = headerActions.querySelector('[data-scroll-home]');
+      const addBtn = slimHeader.querySelector('#addReminderBtn');
+      const overflowBtn = slimHeader.querySelector('#overflowMenuBtn');
+      const overflowMenu = slimHeader.querySelector('#overflowMenu');
+      const homeBtn = slimHeader.querySelector('[data-scroll-home]');
 
       if (addBtn) {
         addBtn.addEventListener('click', function(event) {
@@ -6365,18 +6331,6 @@
         });
       }
 
-      const titleEl = slimHeader.querySelector('.header-title');
-      if (titleEl) {
-        const possibleTitles = [
-          document.querySelector('#view-reminders h1'),
-          document.querySelector('[data-section="reminders"] h1'),
-          document.querySelector('.mobile-header h1')
-        ].filter(Boolean);
-
-        if (possibleTitles.length > 0 && possibleTitles[0].textContent.trim()) {
-          titleEl.textContent = possibleTitles[0].textContent.trim();
-        }
-      }
     });
   </script>
 


### PR DESCRIPTION
## Summary
- restyle the reminders slim header to eliminate the legacy blue chrome and dedicate the space to the quick add surface
- keep navigation, settings, and home controls available via compact utility buttons while making the quick add bar persistently visible
- update the quick add script so the panel no longer hides when submissions complete, ensuring the quick capture bar always stays in view

## Testing
- `npm test -- --runTestsByPath js/__tests__/mobile.open-sheet.test.js` *(fails: SyntaxError: Cannot use import statement outside a module when loading mobile.js in the Jest harness)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691da06abddc8324bbda3b56ecc74ffe)