### PR TITLE
Simplify planner view layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1058,86 +1058,15 @@
         </div>
       </section>
       <section data-route="planner" class="space-y-6" style="display: none;" data-planner-support-state="expanded">
-        <div class="space-y-4">
-          <div class="desktop-panel-header space-y-1">
-            <div class="flex flex-wrap items-start justify-between gap-4">
-              <div>
-                <p class="desktop-panel-title text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Weekly planner</p>
-                <h3 class="desktop-panel-title text-2xl font-semibold tracking-wide text-base-content" data-primary-heading>Planner</h3>
-              </div>
-              <div class="flex flex-wrap items-center gap-2">
-                <button type="button" class="btn btn-ghost btn-xs" data-planner-today>Today</button>
-                <div class="flex items-center rounded-full border border-base-300/80 bg-base-100/80 text-sm text-base-content">
-                  <button type="button" class="btn btn-ghost btn-xs" data-planner-prev aria-label="Previous week">◀</button>
-                  <span id="plannerWeekRange" class="px-3" aria-live="polite"></span>
-                  <button type="button" class="btn btn-ghost btn-xs" data-planner-next aria-label="Next week">▶</button>
-                </div>
-              </div>
+        <div class="section-pane desktop-panel desktop-panel--planner card border border-base-300/80 bg-base-100 text-base-content shadow-sm" data-planner-card-panel>
+          <div class="desktop-panel-body section-pane__body px-4 py-6">
+            <div class="planner-cards-scroll">
+              <div
+                id="plannerCards"
+                class="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 [&_[data-planner-lesson]]:rounded-2xl [&_[data-planner-lesson]]:bg-base-100 [&_[data-planner-lesson]]:px-4 [&_[data-planner-lesson]]:py-4 [&_[data-planner-lesson]]:text-base-content [&_[data-planner-lesson]]:shadow-lg [&_[data-planner-lesson]]:space-y-2 [&_[data-planner-lesson]]:flex [&_[data-planner-lesson]]:flex-col [&_[data-planner-lesson]]:justify-between [&_[data-planner-lesson]_.badge]:text-[11px] [&_[data-planner-lesson]_.badge]:text-base-content/80 [&_[data-planner-lesson]_.label-text]:text-[11px] [&_[data-planner-lesson]_.label-text]:tracking-[0.2em] [&_[data-planner-lesson]_.label-text]:text-base-content/60 [&_[data-planner-lesson] textarea]:text-sm [&_[data-planner-lesson] textarea]:text-base-content [&_[data-planner-lesson] textarea]:placeholder:text-base-content/60 [&_[data-planner-lesson]>div:last-child]:mt-3 [&_[data-planner-lesson]>div:last-child]:flex [&_[data-planner-lesson]>div:last-child]:gap-2 [&_[data-planner-lesson]>div:last-child]:justify-start"
+              ></div>
             </div>
           </div>
-          <div class="rounded-2xl border border-base-200/80 bg-base-200/50 p-4">
-            <div class="flex flex-wrap items-center justify-between gap-4">
-              <div class="space-y-1">
-                <p class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">This week</p>
-                <p class="text-3xl font-semibold text-base-content tabular-nums" id="plannerSummaryCount">0</p>
-                <p class="text-xs text-base-content/60">Lessons scheduled</p>
-              </div>
-              <div class="text-right">
-                <p class="text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">Week range</p>
-                <p class="text-sm font-semibold text-base-content" id="plannerSummaryRange">—</p>
-                <p class="text-xs text-base-content/60">Use Today to jump back to the current week.</p>
-              </div>
-            </div>
-          </div>
-          <div class="section-columns planner-columns">
-            <div class="section-column column-primary planner-column-primary">
-              <div class="section-pane desktop-panel desktop-panel--planner card border border-base-300/80 bg-base-100 text-base-content shadow-sm" data-planner-card-panel>
-                <div class="desktop-panel-body section-pane__body px-6 py-4">
-                  <div class="planner-layout space-y-6">
-                    <div class="planner-toolbar flex flex-wrap items-center justify-between gap-3">
-                      <div class="flex flex-wrap items-center gap-3 text-sm text-base-content/80">
-                        <button type="button" class="btn btn-outline btn-sm" id="planner-copy-week">Copy previous week</button>
-                        <button type="button" class="btn btn-ghost btn-sm" id="planner-clear-week">Clear week</button>
-                        <button type="button" class="btn btn-primary btn-sm" id="planner-new-lesson-btn">New lesson</button>
-                        <button type="button" class="btn btn-outline btn-sm" id="planner-duplicate-btn">Duplicate plan</button>
-                      </div>
-                      <div class="flex items-center gap-3">
-                        <label class="flex items-center gap-2 text-[0.65rem] tracking-[0.2em] text-base-content/70" aria-label="Choose planner text size">
-                          <span class="hidden sm:inline">Text size</span>
-                          <select class="select select-bordered select-xs w-auto" data-planner-text-size aria-label="Planner text size">
-                            <option value="small">Small</option>
-                            <option value="default">Default</option>
-                            <option value="large">Large</option>
-                          </select>
-                        </label>
-                      </div>
-                    </div>
-                    <div class="grid gap-3 text-sm text-base-content/70 md:grid-cols-3">
-                      <article class="rounded-2xl border border-base-200/80 bg-base-200/40 p-3">
-                        <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-base-content/60">Lessons planned</p>
-                        <p class="mt-1 text-2xl font-semibold text-base-content tabular-nums" id="plannerInsightsLessons">0</p>
-                        <p class="text-xs text-base-content/60">Total lessons scheduled in this view.</p>
-                      </article>
-                      <article class="rounded-2xl border border-base-200/80 bg-base-200/40 p-3">
-                        <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-base-content/60">Subjects covered</p>
-                        <p class="mt-1 text-2xl font-semibold text-base-content tabular-nums" id="plannerInsightsSubjects">0</p>
-                        <p class="text-xs text-base-content/60">Unique subjects tagged across the week.</p>
-                      </article>
-                      <article class="rounded-2xl border border-base-200/80 bg-base-200/40 p-3">
-                        <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-base-content/60">Notes added</p>
-                        <p class="mt-1 text-2xl font-semibold text-base-content tabular-nums" id="plannerInsightsNotes">0</p>
-                        <p class="text-xs text-base-content/60">Lessons that include saved notes.</p>
-                      </article>
-                    </div>
-                    <div class="planner-cards-scroll">
-                      <div class="[&_[data-planner-lesson]]:rounded-2xl [&_[data-planner-lesson]]:bg-base-100 [&_[data-planner-lesson]]:px-4 [&_[data-planner-lesson]]:py-4 [&_[data-planner-lesson]]:text-base-content [&_[data-planner-lesson]]:shadow-lg [&_[data-planner-lesson]]:space-y-2 [&_[data-planner-lesson]]:flex [&_[data-planner-lesson]]:flex-col [&_[data-planner-lesson]]:justify-between [&_[data-planner-lesson]_.badge]:text-[11px] [&_[data-planner-lesson]_.badge]:text-base-content/80 [&_[data-planner-lesson]_.label-text]:text-[11px] [&_[data-planner-lesson]_.label-text]:tracking-[0.2em] [&_[data-planner-lesson]_.label-text]:text-base-content/60 [&_[data-planner-lesson] textarea]:text-sm [&_[data-planner-lesson] textarea]:text-base-content [&_[data-planner-lesson] textarea]:placeholder:text-base-content/60 [&_[data-planner-lesson]>div:last-child]:mt-3 [&_[data-planner-lesson]>div:last-child]:flex [&_[data-planner-lesson]>div:last-child]:gap-2 [&_[data-planner-lesson]>div:last-child]:justify-start">
-                        <div id="plannerCards" class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"></div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
         </div>
       </section>
       <section data-route="notes" class="space-y-6" style="display: none;">


### PR DESCRIPTION
## Summary
- remove planner header, insights, and controls so only lesson cards remain
- expand planner lesson cards into a wider grid that fills the available screen space

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e285d94c883248ef3f08994550c3e)