### PR TITLE
Update mobile backgrounds to soft pale lilac

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -203,15 +203,15 @@
 
   /* Distraction-free writing environment background */
   .mobile-panel--notes {
-    background: #FBFBFB;
+    background: #F7F7FA;
   }
 
   .mobile-panel--notes .mobile-view-inner {
-    background: #00796B; /* deep teal space around writing panel */
+    background: #F7F7FA;
   }
 
   .mobile-panel--notes #scratch-notes-card {
-    background: #00796B; /* deep teal space between title and writing panel */
+    background: #F7F7FA;
   }
 
   [data-view="notebook"] .textarea {
@@ -1792,11 +1792,11 @@
 
     /* Footer navigation with deep aqua background */
     #mobile-nav-shell {
-      background: #274b50;
+      background: #F7F7FA !important;
     }
 
     #mobile-nav-shell .btm-nav {
-      background: #274b50;
+      background: #F7F7FA !important;
       border-top: 1px solid rgba(0, 121, 107, 0.1);
     }
 


### PR DESCRIPTION
## Summary
- Force the mobile header, notes panel, and footer navigation backgrounds to the soft pale lilac/blue tint
- Apply overrides to replace the previous teal/white surfaces while keeping existing layout and styling intact

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920443966b0832482daed65a9159707)