### PR TITLE
Apply gradient theme to mobile notebook and saved notes

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -4201,7 +4201,7 @@
         <div class="mobile-view-inner mx-auto w-full px-0 pt-2 pb-2 space-y-0" style="background: var(--mobile-quick-surface); color: var(--text-primary);">
         <!-- notebook view header removed to keep UI minimal -->
         <!-- Enhanced Notebook Card -->
-        <div id="scratch-notes-card" class="scratch-notes-card rounded-2xl shadow-sm p-1 space-y-0 pb-1" style="background: var(--mobile-quick-surface) !important; color: var(--text-primary);">
+        <div id="scratch-notes-card" class="scratch-notes-card memory-glass-card p-4 space-y-4 pb-2" style="color: var(--text-primary);">
           <!-- Header Row -->
           <div class="flex items-center justify-between gap-2 pb-0 border-b border-base-200/70">
             <div class="flex flex-col">

--- a/styles/index.css
+++ b/styles/index.css
@@ -37,6 +37,45 @@ html {
   --z-skip-link: 1000;
 }
 
+/* Memory Cue – Gradient theme palette */
+:root {
+  --mc-grad-from: #4f46e5;  /* indigo */
+  --mc-grad-mid:  #a855f7;  /* purple */
+  --mc-grad-to:   #ec4899;  /* pink */
+}
+
+/* Optional: full-page gradient background helper */
+.memory-page-gradient {
+  background: radial-gradient(circle at top, #60a5fa 0, #4338ca 35%, #111827 100%);
+}
+
+/* Glassy gradient card style used for notebook and saved notes */
+.memory-glass-card {
+  background: linear-gradient(
+    135deg,
+    rgba(79, 70, 229, 0.96),
+    rgba(168, 85, 247, 0.94),
+    rgba(236, 72, 153, 0.92)
+  );
+  box-shadow:
+    0 18px 45px rgba(15, 23, 42, 0.55),
+    0 0 0 1px rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  border-radius: 1.25rem;
+  color: #f9fafb; /* near-white text */
+}
+
+/* Notebook card – apply gradient + soften inner spacing */
+.scratch-notes-card {
+  background: none; /* clear old solid bg if present */
+}
+
+/* Ensure any scratch-notes-card using Tailwind bg/border still looks glassy */
+.scratch-notes-card.memory-glass-card {
+  border: none;
+}
+
 body {
   font-family: var(--font-body);
   font-weight: var(--font-body-weight);
@@ -214,6 +253,13 @@ html[data-theme="professional"] {
 /* Saved notes list item helpers */
 .saved-note-item {
   text-decoration: none;
+  background: linear-gradient(
+    135deg,
+    rgba(96, 165, 250, 0.96),
+    rgba(168, 85, 247, 0.94)
+  );
+  border: none;
+  color: #f9fafb;
 }
 
 .saved-note-preview {
@@ -221,6 +267,7 @@ html[data-theme="professional"] {
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  color: rgba(249, 250, 251, 0.9);
 }
 
 /* Notebook header subtitle helper */


### PR DESCRIPTION
## Summary
- add gradient palette and glass card helper styles for mobile notebook and saved notes
- refresh saved note preview colors to stay legible on new backgrounds
- update notebook card markup to use the new glass gradient styling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692048a76a688324886cd728d4e01fb4)