### PR TITLE
Stabilize mobile reminder tests

### DIFF
--- a/js/__tests__/mobile.open-sheet.test.js
+++ b/js/__tests__/mobile.open-sheet.test.js
@@ -22,6 +22,14 @@ function loadMobileModule() {
     "import { initSupabaseAuth } from './js/supabase-auth.js';",
     'const { initSupabaseAuth } = window.__mobileMocks;'
   );
+  source = source.replace(
+    "import {\n  loadAllNotes,\n  saveAllNotes,\n  createNote,\n  NOTES_STORAGE_KEY,\n} from './js/modules/notes-storage.js';",
+    'const { loadAllNotes, saveAllNotes, createNote, NOTES_STORAGE_KEY } = window.__mobileMocks;',
+  );
+  source = source.replace(
+    "import { initNotesSync } from './js/modules/notes-sync.js';",
+    'const { initNotesSync } = window.__mobileMocks;',
+  );
   const context = vm.createContext({
     window,
     document,
@@ -75,6 +83,11 @@ describe('mobile sheet opener events', () => {
       initViewportHeight: jest.fn(),
       initReminders: jest.fn().mockResolvedValue({}),
       initSupabaseAuth: jest.fn(),
+      loadAllNotes: () => [],
+      saveAllNotes: () => {},
+      createNote: () => ({}),
+      NOTES_STORAGE_KEY: 'memoryCue:notes',
+      initNotesSync: () => ({ handleSessionChange() {}, setSupabaseClient() {} }),
     };
 
     loadMobileModule();

--- a/js/__tests__/mobile.sheet.test.js
+++ b/js/__tests__/mobile.sheet.test.js
@@ -21,6 +21,14 @@ function runMobileModule(window) {
     "import { initSupabaseAuth } from './js/supabase-auth.js';",
     'const initSupabaseAuth = window.__initSupabaseAuth;',
   );
+  source = source.replace(
+    "import {\n  loadAllNotes,\n  saveAllNotes,\n  createNote,\n  NOTES_STORAGE_KEY,\n} from './js/modules/notes-storage.js';",
+    'const { loadAllNotes, saveAllNotes, createNote, NOTES_STORAGE_KEY } = window.__notesModule;',
+  );
+  source = source.replace(
+    "import { initNotesSync } from './js/modules/notes-sync.js';",
+    'const initNotesSync = window.__initNotesSync;',
+  );
 
   const context = vm.createContext({});
   context.window = window;
@@ -36,6 +44,16 @@ function runMobileModule(window) {
   context.navigator = window.navigator;
   context.globalThis = context;
   context.self = window;
+
+  context.window.__notesModule =
+    context.window.__notesModule || {
+      loadAllNotes: () => [],
+      saveAllNotes: () => {},
+      createNote: (note) => note || {},
+      NOTES_STORAGE_KEY: 'memoryCue:notes',
+    };
+  context.window.__initNotesSync =
+    context.window.__initNotesSync || (() => ({ handleSessionChange() {}, setSupabaseClient() {} }));
 
   vm.runInContext(source, context, { filename: filePath });
 }

--- a/js/__tests__/reminders.dom-sync.test.js
+++ b/js/__tests__/reminders.dom-sync.test.js
@@ -10,6 +10,10 @@ const vm = require('vm');
 function loadRemindersModule() {
   const filePath = path.resolve(__dirname, '../reminders.js');
   let source = fs.readFileSync(filePath, 'utf8');
+  source = source.replace(
+    "import { setAuthContext, startSignInFlow, startSignOutFlow } from './supabase-auth.js';\n",
+    'const setAuthContext = () => {}; const startSignInFlow = () => {}; const startSignOutFlow = () => {};\n',
+  );
   source = source.replace(/export\s+async\s+function\s+initReminders/, 'async function initReminders');
   source += '\nmodule.exports = { initReminders };\n';
   const module = { exports: {} };
@@ -24,6 +28,7 @@ function loadRemindersModule() {
     document,
     localStorage,
     navigator,
+    HTMLElement: window.HTMLElement,
     Notification,
     CustomEvent: window.CustomEvent,
     fetch: global.fetch,

--- a/js/__tests__/reminders.notes.test.js
+++ b/js/__tests__/reminders.notes.test.js
@@ -11,6 +11,10 @@ const firebaseConfigModule = require('../firebase-config.js');
 function loadRemindersModule() {
   const filePath = path.resolve(__dirname, '../reminders.js');
   let source = fs.readFileSync(filePath, 'utf8');
+  source = source.replace(
+    "import { setAuthContext, startSignInFlow, startSignOutFlow } from './supabase-auth.js';\n",
+    'const setAuthContext = () => {}; const startSignInFlow = () => {}; const startSignOutFlow = () => {};\n',
+  );
   source = source.replace(/export\s+async\s+function\s+initReminders/, 'async function initReminders');
   source += '\nmodule.exports = { initReminders };\n';
   const module = { exports: {} };
@@ -25,6 +29,7 @@ function loadRemindersModule() {
     document,
     localStorage,
     navigator,
+    HTMLElement: window.HTMLElement,
     Notification,
     fetch: global.fetch,
     Blob: global.Blob,

--- a/js/__tests__/reminders.notifications.test.js
+++ b/js/__tests__/reminders.notifications.test.js
@@ -10,6 +10,10 @@ const vm = require('vm');
 function loadRemindersModule() {
   const filePath = path.resolve(__dirname, '../reminders.js');
   let source = fs.readFileSync(filePath, 'utf8');
+  source = source.replace(
+    "import { setAuthContext, startSignInFlow, startSignOutFlow } from './supabase-auth.js';\n",
+    'const setAuthContext = () => {}; const startSignInFlow = () => {}; const startSignOutFlow = () => {};\n',
+  );
   source = source.replace(/export\s+async\s+function\s+initReminders/, 'async function initReminders');
   source += '\nmodule.exports = { initReminders };\n';
   const module = { exports: {} };
@@ -24,6 +28,7 @@ function loadRemindersModule() {
     document,
     localStorage,
     navigator,
+    HTMLElement: window.HTMLElement,
     Notification,
     fetch: global.fetch,
     Blob: global.Blob,

--- a/js/__tests__/reminders.offline.test.js
+++ b/js/__tests__/reminders.offline.test.js
@@ -10,6 +10,10 @@ const vm = require('vm');
 function loadRemindersModule() {
   const filePath = path.resolve(__dirname, '../reminders.js');
   let source = fs.readFileSync(filePath, 'utf8');
+  source = source.replace(
+    "import { setAuthContext, startSignInFlow, startSignOutFlow } from './supabase-auth.js';\n",
+    'const setAuthContext = () => {}; const startSignInFlow = () => {}; const startSignOutFlow = () => {};\n',
+  );
   source = source.replace(/export\s+async\s+function\s+initReminders/, 'async function initReminders');
   source += '\nmodule.exports = { initReminders };\n';
   const module = { exports: {} };
@@ -24,6 +28,7 @@ function loadRemindersModule() {
     document,
     localStorage,
     navigator,
+    HTMLElement: window.HTMLElement,
     Notification,
     CustomEvent: window.CustomEvent,
     fetch: global.fetch,

--- a/js/__tests__/reminders.quick-add.test.js
+++ b/js/__tests__/reminders.quick-add.test.js
@@ -8,6 +8,10 @@ const vm = require('vm');
 function loadRemindersModule() {
   const filePath = path.resolve(__dirname, '../reminders.js');
   let source = fs.readFileSync(filePath, 'utf8');
+  source = source.replace(
+    "import { setAuthContext, startSignInFlow, startSignOutFlow } from './supabase-auth.js';\n",
+    'const setAuthContext = () => {}; const startSignInFlow = () => {}; const startSignOutFlow = () => {};\n',
+  );
   source = source.replace(/export\s+async\s+function\s+initReminders/, 'async function initReminders');
   source += '\nmodule.exports = { initReminders };\n';
   const module = { exports: {} };
@@ -22,6 +26,7 @@ function loadRemindersModule() {
     document,
     localStorage,
     navigator,
+    HTMLElement: window.HTMLElement,
     Date,
     fetch: global.fetch,
     Blob: global.Blob,

--- a/js/__tests__/reminders.save-click.test.js
+++ b/js/__tests__/reminders.save-click.test.js
@@ -10,6 +10,10 @@ const vm = require('vm');
 function loadRemindersModule() {
   const filePath = path.resolve(__dirname, '../reminders.js');
   let source = fs.readFileSync(filePath, 'utf8');
+  source = source.replace(
+    "import { setAuthContext, startSignInFlow, startSignOutFlow } from './supabase-auth.js';\n",
+    'const setAuthContext = () => {}; const startSignInFlow = () => {}; const startSignOutFlow = () => {};\n',
+  );
   source = source.replace(/export\s+async\s+function\s+initReminders/, 'async function initReminders');
   source += '\nmodule.exports = { initReminders };\n';
   const module = { exports: {} };
@@ -24,6 +28,7 @@ function loadRemindersModule() {
     document,
     localStorage,
     navigator,
+    HTMLElement: window.HTMLElement,
     Notification,
     CustomEvent: window.CustomEvent,
     fetch: global.fetch,

--- a/js/__tests__/reminders.undo-delete.test.js
+++ b/js/__tests__/reminders.undo-delete.test.js
@@ -8,6 +8,10 @@ const vm = require('vm');
 function loadRemindersModule() {
   const filePath = path.resolve(__dirname, '../reminders.js');
   let source = fs.readFileSync(filePath, 'utf8');
+  source = source.replace(
+    "import { setAuthContext, startSignInFlow, startSignOutFlow } from './supabase-auth.js';\n",
+    'const setAuthContext = () => {}; const startSignInFlow = () => {}; const startSignOutFlow = () => {};\n',
+  );
   source = source.replace(/export\s+async\s+function\s+initReminders/, 'async function initReminders');
   source += '\nmodule.exports = { initReminders };\n';
   const module = { exports: {} };
@@ -22,6 +26,7 @@ function loadRemindersModule() {
     document,
     localStorage,
     navigator,
+    HTMLElement: window.HTMLElement,
     CustomEvent: window.CustomEvent,
     fetch: global.fetch,
     Blob: global.Blob,

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -3242,7 +3242,7 @@ export async function initReminders(sel = {}) {
   }
 
   const PIN_TOGGLE_HANDLER_PROP = '__mcPinToggleHandler';
-  let pinToggleSyncScheduled = false;
+  var pinToggleSyncScheduled = false;
 
   function updatePinToggleVisualState(toggle, pinned) {
     if (!(toggle instanceof HTMLElement)) {
@@ -3762,6 +3762,7 @@ export async function initReminders(sel = {}) {
       deleteBtn.className = 'btn btn-ghost btn-circle btn-xs text-error task-toolbar-btn';
       deleteBtn.innerHTML = '<span aria-hidden="true">🗑️</span>';
       deleteBtn.setAttribute('aria-label', `Delete reminder: ${reminder.title}`);
+      deleteBtn.setAttribute('data-action', 'delete');
       deleteBtn.setAttribute('data-reminder-control', 'delete');
       deleteBtn.setAttribute('data-no-swipe', 'true');
       deleteBtn.addEventListener('click', (event) => {

--- a/reminders.categories.test.js
+++ b/reminders.categories.test.js
@@ -10,6 +10,10 @@ let initReminders;
 function loadRemindersModule() {
   const filePath = path.resolve(__dirname, './js/reminders.js');
   let source = fs.readFileSync(filePath, 'utf8');
+  source = source.replace(
+    "import { setAuthContext, startSignInFlow, startSignOutFlow } from './supabase-auth.js';\n",
+    'const setAuthContext = () => {}; const startSignInFlow = () => {}; const startSignOutFlow = () => {};\n',
+  );
   source = source.replace(/export\s+async\s+function\s+initReminders/, 'async function initReminders');
   source += '\nmodule.exports = { initReminders };\n';
   const NotificationRef = typeof global.Notification === 'undefined' ? undefined : global.Notification;
@@ -28,6 +32,7 @@ function loadRemindersModule() {
     document,
     localStorage,
     navigator,
+    HTMLElement: window.HTMLElement,
     Notification: NotificationRef,
     fetch: global.fetch,
     Blob: BlobRef,


### PR DESCRIPTION
## Summary
- stub ES module imports in mobile and reminder test harnesses so vm-based execution works with new dependencies
- add HTMLElement stubs and expose delete action controls for reminder items used by tests
- prevent pin toggle scheduling errors by loosening variable scoping around reminder rendering

## Testing
- npm test --silent

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69204f73b2a08324829ce467cb3231eb)