### PR TITLE
Add floating footer buttons to mobile layout

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1815,6 +1815,82 @@
     border-top: 1px solid rgba(169, 190, 255, 0.25);
   }
 
+  /* Floating footer buttons */
+  #mobile-nav-shell .floating-footer {
+    pointer-events: auto;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: end;
+    gap: 0.85rem;
+    width: min(640px, 100%);
+    padding: 0 1rem;
+    margin-bottom: calc(env(safe-area-inset-bottom, 0.75rem));
+  }
+
+  #mobile-nav-shell .floating-card {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    padding: 0.7rem 0.95rem;
+    border-radius: 1rem;
+    background: #F7F7FA;
+    color: #424242;
+    box-shadow: 0 10px 28px rgba(81, 38, 99, 0.12), 0 4px 12px rgba(0, 0, 0, 0.08);
+    font-weight: 700;
+    font-size: 0.95rem;
+    border: 1px solid rgba(81, 38, 99, 0.06);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  #mobile-nav-shell .floating-card:hover,
+  #mobile-nav-shell .floating-card:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 32px rgba(81, 38, 99, 0.14), 0 6px 16px rgba(0, 0, 0, 0.1);
+    outline: none;
+  }
+
+  #mobile-nav-shell .floating-card span.icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.15rem;
+  }
+
+  #mobile-nav-shell .floating-fab {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 4.25rem;
+    height: 4.25rem;
+    border-radius: 999px;
+    background: #512663;
+    color: #FFFFFF;
+    box-shadow: 0 16px 38px rgba(81, 38, 99, 0.32), 0 6px 18px rgba(0, 0, 0, 0.14);
+    font-size: 1.6rem;
+    font-weight: 800;
+    border: none;
+    transition: transform 0.18s ease, box-shadow 0.18s ease;
+  }
+
+  #mobile-nav-shell .floating-fab:hover,
+  #mobile-nav-shell .floating-fab:focus-visible {
+    transform: translateY(-3px);
+    box-shadow: 0 18px 42px rgba(81, 38, 99, 0.38), 0 10px 20px rgba(0, 0, 0, 0.16);
+    outline: 3px solid rgba(81, 38, 99, 0.32);
+    outline-offset: 3px;
+  }
+
+  #mobile-nav-shell .floating-fab::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+    pointer-events: none;
+  }
+
   /* Enhanced mobile body */
   body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
@@ -1833,7 +1909,7 @@
     /* Mobile main container */
     main {
       padding-top: 0;
-      padding-bottom: calc(32px + var(--mobile-safe-area-bottom));
+      padding-bottom: calc(6.5rem + var(--mobile-safe-area-bottom));
       min-height: calc(100vh - var(--mobile-header-height));
       scroll-padding-top: calc(var(--mobile-header-height) + 16px);
     }
@@ -4309,8 +4385,22 @@
     </main>
   </div>
 
-  <div id="mobile-nav-shell" class="fixed inset-x-0 bottom-3 z-50 flex justify-center pointer-events-none">
-    <!-- old bottom nav removed: replaced by modern .bottom-nav (bottom-tab buttons) -->
+  <div id="mobile-nav-shell" class="fixed inset-x-0 bottom-3 z-50 flex justify-center pointer-events-none px-2">
+    <div class="floating-footer">
+      <button type="button" class="floating-card" aria-label="Open reminders">
+        <span class="icon" aria-hidden="true">🗒️</span>
+        <span>Reminders</span>
+      </button>
+
+      <button type="button" class="floating-fab" aria-label="Create new note">
+        <span aria-hidden="true">➕</span>
+      </button>
+
+      <button type="button" class="floating-card" aria-label="Open notebook">
+        <span class="icon" aria-hidden="true">📓</span>
+        <span>Notebook</span>
+      </button>
+    </div>
   </div>
   <!-- build-marker: mobile.html / runs mobile.js / EXPECTED LIVE -->
   <!-- When deployed, this should appear in View Source with today’s date. -->


### PR DESCRIPTION
## Summary
- add floating reminders and notebook cards with a deep violet central FAB in the mobile footer
- apply light, floating styles and shadows to align with the pale lilac and deep violet palette
- increase mobile main padding to give breathing room beneath the new floating controls
- add a deep-violet focus outline to the central FAB for clearer keyboard focus

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920e3670ed8832494fa0eab9103f0c2)