### PR TITLE
Add sticky notebook header pill

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -4066,108 +4066,128 @@
   <!-- Mobile header matching screenshot -->
   <header
     id="reminders-slim-header"
-    class="mobile-header flex items-center gap-3 px-3 py-3 shadow-sm"
-    style="position: fixed !important; top: 0 !important; left: 0 !important; right: 0 !important; z-index: 9999 !important; background: #F7F7FA; backdrop-filter: blur(10px); width: 100% !important;"
+    class="mobile-header px-4 py-3 pt-safe-top"
+    style="position: fixed !important; top: env(safe-area-inset-top, 0) !important; left: 0 !important; right: 0 !important; z-index: 9999 !important; background: #F7F7FA; backdrop-filter: blur(10px); width: 100% !important;"
     role="banner"
   >
-    <!-- Left: Logo -->
-    <div class="flex-shrink-0">
-      <div class="w-8 h-8 bg-red-500 rounded-lg flex items-center justify-center">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="white">
-          <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
-        </svg>
-      </div>
-    </div>
-
-    <!-- Center: Quick reminder input -->
-    <div class="flex-1">
-      <div class="relative">
-        <input
-          id="quickAddInput"
-          type="text"
-          placeholder="Quick reminder..."
-          class="w-full px-4 py-2 text-sm rounded-xl border border-gray-200 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-          style="background: #F9F9F9; color: #424242;"
-        />
-      </div>
-    </div>
-
-    <!-- Right: Notification bell and menu -->
-    <div class="flex-shrink-0 flex items-center gap-2">
-      <button
-        type="button"
-        class="p-2 rounded-lg hover:bg-gray-100 transition-colors"
-        aria-label="Notifications"
-      >
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#424242" stroke-width="2">
-          <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/>
-          <path d="m13.73 21a2 2 0 0 1-3.46 0"/>
-        </svg>
-      </button>
-
-      <!-- Overflow menu -->
-      <div class="relative">
-        <button
-          id="headerMenuBtn"
-          type="button"
-          class="p-2 rounded-lg hover:bg-gray-100 transition-colors"
-          aria-label="More options"
-          aria-expanded="false"
-          aria-haspopup="true"
-        >
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#424242" stroke-width="2">
-            <circle cx="12" cy="12" r="1"/>
-            <circle cx="12" cy="5" r="1"/>
-            <circle cx="12" cy="19" r="1"/>
-          </svg>
-        </button>
-
-        <!-- Dropdown menu -->
-        <div
-          id="headerMenu"
-          class="absolute right-0 top-full mt-2 w-48 bg-gray-50 rounded-lg shadow-lg border border-gray-200 py-1 z-50 hidden"
-          role="menu"
-          aria-labelledby="headerMenuBtn"
-        >
-          <button
-            type="button"
-            class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-3"
-            role="menuitem"
-            onclick="window.location.href='/'"
-          >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
-              <polyline points="9,22 9,12 15,12 15,22"/>
+    <div class="w-full">
+      <div class="flex items-center gap-3 rounded-full border border-gray-200 bg-white px-3 py-2 shadow-sm">
+        <!-- Left: Quick reminder icon + input -->
+        <div class="flex items-center gap-2 flex-1 min-w-0">
+          <div class="w-9 h-9 bg-red-500 rounded-full flex items-center justify-center shadow-sm">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="white" aria-hidden="true">
+              <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
             </svg>
-            Home
+          </div>
+          <input
+            id="quickAddInput"
+            type="text"
+            placeholder="Quick reminder..."
+            class="w-full px-3 py-2 text-sm rounded-full border border-gray-200 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent bg-[#F7F7FA] text-gray-800"
+          />
+        </div>
+
+        <!-- Right: Notebook save + overflow controls -->
+        <div class="flex items-center gap-1 flex-shrink-0">
+          <button
+            id="openSavedNotesSheet"
+            type="button"
+            class="p-2 rounded-full hover:bg-gray-100 transition-colors"
+            aria-label="Open Notebook"
+            title="Open Notebook"
+          >
+            <svg class="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+              <path d="M6 2h9a2 2 0 012 2v16a1 1 0 01-1.5.86L12 19l-3.5 1.86A1 1 0 017 20V4a2 2 0 012-2z" fill="currentColor" />
+            </svg>
           </button>
-          
+
           <button
-            id="openSettings"
+            id="noteSaveMobile"
             type="button"
-            class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-3"
-            role="menuitem"
+            class="p-2 rounded-full hover:bg-gray-100 transition-colors"
+            aria-label="Save note"
           >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
-              <circle cx="12" cy="12" r="3"/>
+            <svg class="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg">
+              <path d="M20.285 6.708a1 1 0 0 0-1.414-1.416L9 15.164l-3.871-3.87a1 1 0 1 0-1.414 1.415l4.578 4.579a1 1 0 0 0 1.414 0l10.478-10.479z" fill="currentColor" />
             </svg>
-            Settings
           </button>
 
           <button
             type="button"
-            class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-3"
-            role="menuitem"
-            onclick="window.open('https://github.com/dmaher42/memory-cue', '_blank')"
+            class="p-2 rounded-full hover:bg-gray-100 transition-colors"
+            aria-label="Notifications"
           >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <circle cx="12" cy="12" r="10"/>
-              <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
-              <path d="M12 17h.01"/>
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#424242" stroke-width="2">
+              <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/>
+              <path d="m13.73 21a2 2 0 0 1-3.46 0"/>
             </svg>
-            About
           </button>
+
+          <!-- Overflow menu -->
+          <div class="relative">
+            <button
+              id="headerMenuBtn"
+              type="button"
+              class="p-2 rounded-full hover:bg-gray-100 transition-colors"
+              aria-label="More options"
+              aria-expanded="false"
+              aria-haspopup="true"
+            >
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#424242" stroke-width="2">
+                <circle cx="12" cy="12" r="1"/>
+                <circle cx="12" cy="5" r="1"/>
+                <circle cx="12" cy="19" r="1"/>
+              </svg>
+            </button>
+
+            <!-- Dropdown menu -->
+            <div
+              id="headerMenu"
+              class="absolute right-0 top-full mt-2 w-48 bg-gray-50 rounded-lg shadow-lg border border-gray-200 py-1 z-50 hidden"
+              role="menu"
+              aria-labelledby="headerMenuBtn"
+            >
+              <button
+                type="button"
+                class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-3"
+                role="menuitem"
+                onclick="window.location.href='/'"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+                  <polyline points="9,22 9,12 15,12 15,22"/>
+                </svg>
+                Home
+              </button>
+
+              <button
+                id="openSettings"
+                type="button"
+                class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-3"
+                role="menuitem"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
+                  <circle cx="12" cy="12" r="3"/>
+                </svg>
+                Settings
+              </button>
+
+              <button
+                type="button"
+                class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-3"
+                role="menuitem"
+                onclick="window.open('https://github.com/dmaher42/memory-cue', '_blank')"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <circle cx="12" cy="12" r="10"/>
+                  <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
+                  <path d="M12 17h.01"/>
+                </svg>
+                About
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -4208,7 +4228,11 @@
   </script>
 
   <!-- quickAddBar is now integrated in the header -->
-  <div id="mobile-shell" class="mobile-shell mx-auto w-full px-4 pb-16" style="background: #FBFBFB; padding-top: 70px;">
+  <div
+    id="mobile-shell"
+    class="mobile-shell mx-auto w-full px-4 pb-16"
+    style="background: #FBFBFB; padding-top: calc(env(safe-area-inset-top, 0) + 90px);"
+  >
     <main id="main" class="mx-auto pt-4 pb-4 w-full max-w-none sm:max-w-lg" tabindex="-1" data-active-view="reminders" style="background: #274b50;">
     <!-- BEGIN GPT CHANGE: create form moved to bottom sheet -->
     <!-- END GPT CHANGE -->


### PR DESCRIPTION
## Summary
- wrap the mobile notebook header in a sticky pill container with the quick reminder field on the left and action controls on the right
- add notebook save/open controls beside the overflow menu while keeping existing IDs intact
- offset the main shell padding to start content below the fixed header

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692112dbadf48324bb0d96a3ac97f150)