### PR TITLE
Refactor header UI: sticky header, pill style, Deep Violet/Soft Lilac theme

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -101,8 +101,39 @@
   color: var(--mc-text-soft);
 }
 
+
 .mobile-header {
-  z-index: 90;
+  background: #F7F7FA;
+  position: sticky;
+  top: 0;
+  width: 100%;
+  z-index: 1000;
+  padding: 8px 16px;
+}
+
+.header-pill {
+  background: #F7F7FA;
+  border-radius: 24px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+}
+
+.header-pill .quick-reminder {
+  background: #F9F9F9;
+  border: none;
+  flex: 1;
+  margin-right: 12px;
+  padding: 8px;
+  border-radius: 12px;
+  color: #333;
+}
+
+.header-pill .header-icons svg,
+.header-pill .header-icons button {
+  color: #512663;
 }
 
 .mobile-footer {

--- a/mobile.html
+++ b/mobile.html
@@ -4109,123 +4109,112 @@
     class="mobile-header px-3 py-2 pt-safe-top"
     role="banner"
   >
-    <div class="header-shell w-full">
-      <div class="reminders-quick-add header-pill flex items-center gap-3">
-        <!-- Left: Quick reminder icon + input -->
-        <div class="flex items-center gap-2 flex-1 min-w-0">
-          <div class="quick-icon">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-            </svg>
-          </div>
-          <input
-            id="quickAddInput"
-            type="text"
-            placeholder="Quick reminder..."
-            class="w-full text-sm"
-          />
-        </div>
+    <div class="header-pill w-full">
+      <input
+        id="quickAddInput"
+        type="text"
+        placeholder="Quick reminder…"
+        class="quick-reminder w-full text-sm"
+      />
 
-        <!-- Right: Notebook save + overflow controls -->
-        <div class="header-actions flex items-center gap-2 flex-shrink-0">
+      <div class="header-icons header-actions flex items-center gap-2 flex-shrink-0">
+        <button
+          id="openSavedNotesSheet"
+          type="button"
+          class="header-action-btn icon-btn"
+          aria-label="Open Notebook"
+          title="Open Notebook"
+        >
+          <svg class="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+            <path d="M6 2h9a2 2 0 012 2v16a1 1 0 01-1.5.86L12 19l-3.5 1.86A1 1 0 017 20V4a2 2 0 012-2z" fill="currentColor" />
+          </svg>
+        </button>
+
+        <button
+          id="noteSaveMobile"
+          type="button"
+          class="header-action-btn icon-btn"
+          aria-label="Save note"
+        >
+          <svg class="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg">
+            <path d="M20.285 6.708a1 1 0 0 0-1.414-1.416L9 15.164l-3.871-3.87a1 1 0 1 0-1.414 1.415l4.578 4.579a1 1 0 0 0 1.414 0l10.478-10.479z" fill="currentColor" />
+          </svg>
+        </button>
+
+        <button
+          type="button"
+          class="header-action-btn icon-btn"
+          aria-label="Notifications"
+        >
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/>
+            <path d="m13.73 21a2 2 0 0 1-3.46 0"/>
+          </svg>
+        </button>
+
+        <!-- Overflow menu -->
+        <div class="relative">
           <button
-            id="openSavedNotesSheet"
+            id="headerMenuBtn"
             type="button"
             class="header-action-btn icon-btn"
-            aria-label="Open Notebook"
-            title="Open Notebook"
-          >
-            <svg class="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
-              <path d="M6 2h9a2 2 0 012 2v16a1 1 0 01-1.5.86L12 19l-3.5 1.86A1 1 0 017 20V4a2 2 0 012-2z" fill="currentColor" />
-            </svg>
-          </button>
-
-          <button
-            id="noteSaveMobile"
-            type="button"
-            class="header-action-btn icon-btn"
-            aria-label="Save note"
-          >
-            <svg class="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg">
-              <path d="M20.285 6.708a1 1 0 0 0-1.414-1.416L9 15.164l-3.871-3.87a1 1 0 1 0-1.414 1.415l4.578 4.579a1 1 0 0 0 1.414 0l10.478-10.479z" fill="currentColor" />
-            </svg>
-          </button>
-
-          <button
-            type="button"
-            class="header-action-btn icon-btn"
-            aria-label="Notifications"
+            aria-label="More options"
+            aria-expanded="false"
+            aria-haspopup="true"
           >
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/>
-              <path d="m13.73 21a2 2 0 0 1-3.46 0"/>
+              <circle cx="12" cy="12" r="1"/>
+              <circle cx="12" cy="5" r="1"/>
+              <circle cx="12" cy="19" r="1"/>
             </svg>
           </button>
 
-          <!-- Overflow menu -->
-          <div class="relative">
+          <!-- Dropdown menu -->
+          <div
+            id="headerMenu"
+            class="absolute right-0 top-full mt-2 w-48 bg-gray-50 rounded-lg shadow-lg border border-gray-200 py-1 z-50 hidden"
+            role="menu"
+            aria-labelledby="headerMenuBtn"
+          >
             <button
-              id="headerMenuBtn"
               type="button"
-              class="header-action-btn icon-btn"
-              aria-label="More options"
-              aria-expanded="false"
-              aria-haspopup="true"
+              class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-3"
+              role="menuitem"
+              onclick="window.location.href='/'"
             >
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <circle cx="12" cy="12" r="1"/>
-                <circle cx="12" cy="5" r="1"/>
-                <circle cx="12" cy="19" r="1"/>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+                <polyline points="9,22 9,12 15,12 15,22"/>
               </svg>
+              Home
             </button>
 
-            <!-- Dropdown menu -->
-            <div
-              id="headerMenu"
-              class="absolute right-0 top-full mt-2 w-48 bg-gray-50 rounded-lg shadow-lg border border-gray-200 py-1 z-50 hidden"
-              role="menu"
-              aria-labelledby="headerMenuBtn"
+            <button
+              id="openSettings"
+              type="button"
+              class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-3"
+              role="menuitem"
             >
-              <button
-                type="button"
-                class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-3"
-                role="menuitem"
-                onclick="window.location.href='/'"
-              >
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
-                  <polyline points="9,22 9,12 15,12 15,22"/>
-                </svg>
-                Home
-              </button>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
+                <circle cx="12" cy="12" r="3"/>
+              </svg>
+              Settings
+            </button>
 
-              <button
-                id="openSettings"
-                type="button"
-                class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-3"
-                role="menuitem"
-              >
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
-                  <circle cx="12" cy="12" r="3"/>
-                </svg>
-                Settings
-              </button>
-
-              <button
-                type="button"
-                class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-3"
-                role="menuitem"
-                onclick="window.open('https://github.com/dmaher42/memory-cue', '_blank')"
-              >
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <circle cx="12" cy="12" r="10"/>
-                  <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
-                  <path d="M12 17h.01"/>
-                </svg>
-                About
-              </button>
-            </div>
+            <button
+              type="button"
+              class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-3"
+              role="menuitem"
+              onclick="window.open('https://github.com/dmaher42/memory-cue', '_blank')"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <circle cx="12" cy="12" r="10"/>
+                <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
+                <path d="M12 17h.01"/>
+              </svg>
+              About
+            </button>
           </div>
         </div>
       </div>

--- a/styles/index.css
+++ b/styles/index.css
@@ -3381,3 +3381,23 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   color: #f9fafb;
   font-weight: 600;
 }
+
+/* Override header styles for light theme */
+.mobile-header,
+.header-pill {
+  background: #F7F7FA !important;
+}
+
+.header-pill .quick-reminder {
+  background: #F9F9F9 !important;
+}
+
+.header-pill .header-icons svg,
+.header-pill .header-icons button {
+  color: #512663 !important;
+}
+
+/* Ensure content beneath header starts after sticky header */
+body {
+  margin-top: 72px;
+}


### PR DESCRIPTION
Converted notebook header to a fixed/sticky header so content scrolls underneath.

Updated header background to Soft Pale Lilac (#F7F7FA).

Wrapped header content into a rounded pill container with shadow.

Restyled quick reminder input to Soft Off-White (#F9F9F9) and icons to Deep Violet (#512663).

Preserved all existing JS hooks and functionality.

Reviewed mobile and desktop layouts to ensure header behaves correctly at all sizes.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69211a6560588324b8fa35645c9f3f59)