### PR TITLE
Add sign-in controls to mobile overflow menu

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -4416,6 +4416,26 @@
             </button>
 
             <button
+              id="googleSignInBtn"
+              type="button"
+              class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-3"
+              role="menuitem"
+            >
+              <span aria-hidden="true">🔐</span>
+              Sign in
+            </button>
+
+            <button
+              id="googleSignOutBtn"
+              type="button"
+              class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-3 hidden"
+              role="menuitem"
+            >
+              <span aria-hidden="true">🔓</span>
+              Sign out
+            </button>
+
+            <button
               id="openSettings"
               type="button"
               class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-3"


### PR DESCRIPTION
## Summary
- add sign-in and sign-out controls to the mobile overflow menu
- ensure auth buttons use existing selectors for sign-in flow wiring

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69217a7b0db88324aae9555b64db106b)