### PR TITLE
Wire header notification icon button

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -4368,6 +4368,7 @@
         </button>
 
         <button
+          id="notifHeaderBtn"
           type="button"
           class="header-action-btn icon-btn"
           aria-label="Notifications"

--- a/mobile.js
+++ b/mobile.js
@@ -300,6 +300,23 @@ if (document.readyState === 'loading') {
   bootstrapReminders();
 }
 
+const wireHeaderIconShortcuts = () => {
+  const notifShortcutButton = document.getElementById('notifHeaderBtn');
+  const notificationCta = document.getElementById('notifBtn');
+
+  if (notifShortcutButton && notificationCta) {
+    notifShortcutButton.addEventListener('click', () => {
+      notificationCta.click();
+    });
+  }
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', wireHeaderIconShortcuts, { once: true });
+} else {
+  wireHeaderIconShortcuts();
+}
+
 const initMobileNotes = () => {
   if (typeof document === 'undefined') {
     return;


### PR DESCRIPTION
## Summary
- add an id to the mobile header notification icon
- wire the header notification shortcut to trigger the existing enable notifications control

## Testing
- npm test -- --runInBand *(fails: npm not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69217b1c88d4832484e725b777c55bb4)