### PR TITLE
Update mobile theme to cauliflower blue

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -18,7 +18,7 @@ body.mobile-theme footer {
 body.mobile-theme .app-header,
 body.mobile-theme header,
 body.mobile-theme .top-bar {
-  background-color: #0073CF;
+  background-color: #5080BF;
   color: #FFFFFF;
   padding: 1rem 1.25rem;
   display: flex;
@@ -55,20 +55,20 @@ body.mobile-theme .top-bar .icon-button {
 body.mobile-theme .app-header button:focus-visible,
 body.mobile-theme .top-bar button:focus-visible,
 body.mobile-theme header button:focus-visible {
-  outline: 2px solid #2563EB;
+  outline: 2px solid #5080BF;
   outline-offset: 2px;
 }
 
 body.mobile-theme .app-header button:hover,
 body.mobile-theme .top-bar button:hover,
 body.mobile-theme header button:hover {
-  color: #2563EB;
-  background-color: rgba(37, 99, 235, 0.1);
+  color: #3f6aa0;
+  background-color: rgba(80, 128, 191, 0.12);
 }
 
 body.mobile-theme .app-header button.is-active,
 body.mobile-theme .top-bar button.is-active {
-  color: #2563EB;
+  color: #3f6aa0;
 }
 
 /* Card Styles */
@@ -113,7 +113,7 @@ body.mobile-theme .text-secondary {
 body.mobile-theme .btn-primary,
 body.mobile-theme button.btn-primary,
 body.mobile-theme .button-primary {
-  background-color: #2563EB;
+  background-color: #5080BF;
   color: #FFFFFF;
   border: none;
   border-radius: 0.65rem;
@@ -131,13 +131,13 @@ body.mobile-theme .button-primary {
 body.mobile-theme .btn-primary:hover,
 body.mobile-theme button.btn-primary:hover,
 body.mobile-theme .button-primary:hover {
-  background-color: #1D4ED8;
+  background-color: #3f6aa0;
 }
 
 body.mobile-theme .btn-primary:focus-visible,
 body.mobile-theme button.btn-primary:focus-visible,
 body.mobile-theme .button-primary:focus-visible {
-  outline: 3px solid rgba(37, 99, 235, 0.4);
+  outline: 3px solid rgba(80, 128, 191, 0.4);
   outline-offset: 2px;
 }
 
@@ -199,8 +199,8 @@ body.mobile-theme input:focus,
 body.mobile-theme select:focus,
 body.mobile-theme textarea:focus,
 body.mobile-theme .form-control:focus {
-  border-color: #2563EB;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  border-color: #5080BF;
+  box-shadow: 0 0 0 3px rgba(80, 128, 191, 0.18);
   outline: none;
 }
 
@@ -227,14 +227,14 @@ body.mobile-theme a,
 body.mobile-theme .link,
 body.mobile-theme .icon,
 body.mobile-theme .text-accent {
-  color: #2563EB;
+  color: #5080BF;
   text-decoration: none;
 }
 
 body.mobile-theme a:hover,
 body.mobile-theme .link:hover,
 body.mobile-theme .hover\:text-accent-dark:hover {
-  color: #1D4ED8;
+  color: #3f6aa0;
 }
 
 /* Utilities */
@@ -260,7 +260,7 @@ body.mobile-theme .card-grid {
 
 /* Accessibility Helpers */
 body.mobile-theme :focus-visible {
-  outline: 2px solid #2563EB;
+  outline: 2px solid #5080BF;
   outline-offset: 2px;
 }
 

--- a/docs/css/theme-mobile.css
+++ b/docs/css/theme-mobile.css
@@ -18,7 +18,7 @@ body.mobile-theme footer {
 body.mobile-theme .app-header,
 body.mobile-theme header,
 body.mobile-theme .top-bar {
-  background-color: #0073CF;
+  background-color: #5080BF;
   color: #FFFFFF;
   padding: 1rem 1.25rem;
   display: flex;
@@ -55,20 +55,20 @@ body.mobile-theme .top-bar .icon-button {
 body.mobile-theme .app-header button:focus-visible,
 body.mobile-theme .top-bar button:focus-visible,
 body.mobile-theme header button:focus-visible {
-  outline: 2px solid #2563EB;
+  outline: 2px solid #5080BF;
   outline-offset: 2px;
 }
 
 body.mobile-theme .app-header button:hover,
 body.mobile-theme .top-bar button:hover,
 body.mobile-theme header button:hover {
-  color: #2563EB;
-  background-color: rgba(37, 99, 235, 0.1);
+  color: #3f6aa0;
+  background-color: rgba(80, 128, 191, 0.12);
 }
 
 body.mobile-theme .app-header button.is-active,
 body.mobile-theme .top-bar button.is-active {
-  color: #2563EB;
+  color: #3f6aa0;
 }
 
 /* Card Styles */
@@ -113,7 +113,7 @@ body.mobile-theme .text-secondary {
 body.mobile-theme .btn-primary,
 body.mobile-theme button.btn-primary,
 body.mobile-theme .button-primary {
-  background-color: #2563EB;
+  background-color: #5080BF;
   color: #FFFFFF;
   border: none;
   border-radius: 0.65rem;
@@ -131,13 +131,13 @@ body.mobile-theme .button-primary {
 body.mobile-theme .btn-primary:hover,
 body.mobile-theme button.btn-primary:hover,
 body.mobile-theme .button-primary:hover {
-  background-color: #1D4ED8;
+  background-color: #3f6aa0;
 }
 
 body.mobile-theme .btn-primary:focus-visible,
 body.mobile-theme button.btn-primary:focus-visible,
 body.mobile-theme .button-primary:focus-visible {
-  outline: 3px solid rgba(37, 99, 235, 0.4);
+  outline: 3px solid rgba(80, 128, 191, 0.4);
   outline-offset: 2px;
 }
 
@@ -199,8 +199,8 @@ body.mobile-theme input:focus,
 body.mobile-theme select:focus,
 body.mobile-theme textarea:focus,
 body.mobile-theme .form-control:focus {
-  border-color: #2563EB;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  border-color: #5080BF;
+  box-shadow: 0 0 0 3px rgba(80, 128, 191, 0.18);
   outline: none;
 }
 
@@ -227,14 +227,14 @@ body.mobile-theme a,
 body.mobile-theme .link,
 body.mobile-theme .icon,
 body.mobile-theme .text-accent {
-  color: #2563EB;
+  color: #5080BF;
   text-decoration: none;
 }
 
 body.mobile-theme a:hover,
 body.mobile-theme .link:hover,
 body.mobile-theme .hover\:text-accent-dark:hover {
-  color: #1D4ED8;
+  color: #3f6aa0;
 }
 
 /* Utilities */
@@ -260,7 +260,7 @@ body.mobile-theme .card-grid {
 
 /* Accessibility Helpers */
 body.mobile-theme :focus-visible {
-  outline: 2px solid #2563EB;
+  outline: 2px solid #5080BF;
   outline-offset: 2px;
 }
 

--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -48,28 +48,28 @@
       --reminder-card-font-size: 0.85rem;
 
       /* Mobile chrome for refreshed indigo shell */
-      --mobile-header-bg: #1e3a8a; /* Solid blue header to match desktop */
-      --mobile-header-border: rgba(30, 58, 138, 0.8);
-      --mobile-header-shadow: 0 18px 32px rgba(30, 58, 138, 0.35);
+      --mobile-header-bg: #5080bf; /* Cauliflower blue header */
+      --mobile-header-border: rgba(80, 128, 191, 0.82);
+      --mobile-header-shadow: 0 18px 32px rgba(80, 128, 191, 0.35);
       --mobile-header-text: #e8edff;
-      --mobile-header-button-bg: color-mix(in srgb, var(--card-bg) 94%, rgba(30, 58, 138, 0.16));
+      --mobile-header-button-bg: color-mix(in srgb, var(--card-bg) 94%, rgba(80, 128, 191, 0.16));
       --mobile-header-button-color: #e8edff;
-      --mobile-header-button-border: rgba(30, 58, 138, 0.8);
-      --mobile-quick-surface: #1e3a8a; /* updated quick surface token to match header */
-      --mobile-quick-shadow: 0 20px 34px rgba(30, 58, 138, 0.28);
+      --mobile-header-button-border: rgba(80, 128, 191, 0.82);
+      --mobile-quick-surface: #1f3252; /* updated quick surface token to match header */
+      --mobile-quick-shadow: 0 20px 34px rgba(34, 52, 86, 0.45);
     }
 
     html[data-theme="dark"],
     html.dark {
-      --mobile-header-bg: #1e3a8a; /* match solid desktop header */
-      --mobile-header-border: rgba(30, 58, 138, 0.85);
-      --mobile-header-shadow: 0 16px 32px rgba(30, 58, 138, 0.4);
+      --mobile-header-bg: #5080bf; /* match new cauliflower blue header */
+      --mobile-header-border: rgba(80, 128, 191, 0.9);
+      --mobile-header-shadow: 0 16px 32px rgba(80, 128, 191, 0.4);
       --mobile-header-text: #e8edff;
-      --mobile-header-button-bg: color-mix(in srgb, rgba(30, 58, 138, 0.6) 100%, transparent);
+      --mobile-header-button-bg: color-mix(in srgb, rgba(80, 128, 191, 0.6) 100%, transparent);
       --mobile-header-button-color: #e8edff;
-      --mobile-header-button-border: rgba(30, 58, 138, 0.85);
-      --mobile-quick-surface: color-mix(in srgb, rgba(15, 23, 42, 0.92) 94%, transparent);
-      --mobile-quick-shadow: 0 18px 30px rgba(15, 23, 42, 0.6);
+      --mobile-header-button-border: rgba(80, 128, 191, 0.9);
+      --mobile-quick-surface: color-mix(in srgb, rgba(20, 32, 52, 0.94) 94%, transparent);
+      --mobile-quick-shadow: 0 18px 30px rgba(34, 52, 86, 0.6);
     }
 
     .pt-safe-top {

--- a/mobile.html
+++ b/mobile.html
@@ -51,16 +51,16 @@
       --reminder-card-font-size: 0.85rem;
 
       /* Mobile chrome with comprehensive warm grey background */
-      --mobile-header-bg: #1e3a8a; /* Solid blue header to match desktop */
-      --mobile-header-border: rgba(30, 58, 138, 0.8);
-      --mobile-header-shadow: 0 18px 32px rgba(30, 58, 138, 0.35);
+      --mobile-header-bg: #5080bf; /* Cauliflower blue header */
+      --mobile-header-border: rgba(80, 128, 191, 0.82);
+      --mobile-header-shadow: 0 18px 32px rgba(80, 128, 191, 0.35);
       --mobile-header-text: #e8edff;
       --mobile-header-button-bg: rgba(255, 255, 255, 0.14); /* soft translucent buttons */
       --mobile-header-button-color: #e8edff;
-      --mobile-header-button-border: rgba(30, 58, 138, 0.8);
-      --mobile-quick-surface: #1f285a; /* complementary indigo surface */
-      --mobile-footer-bg: var(--background-gradient);
-      --mobile-quick-shadow: 0 20px 34px rgba(34, 27, 96, 0.45);
+      --mobile-header-button-border: rgba(80, 128, 191, 0.82);
+      --mobile-quick-surface: #1f3252; /* complementary indigo surface */
+      --mobile-footer-bg: linear-gradient(135deg, #6a9ad6 0%, #5080bf 50%, #365c8a 100%);
+      --mobile-quick-shadow: 0 20px 34px rgba(34, 52, 86, 0.45);
     }
 
     /* Force Soft Pale Lilac/Blue backgrounds with high specificity */
@@ -78,15 +78,15 @@
 
     html[data-theme="dark"],
     html.dark {
-      --mobile-header-bg: #1e3a8a; /* match solid desktop header */
-      --mobile-header-border: rgba(30, 58, 138, 0.85);
-      --mobile-header-shadow: 0 16px 32px rgba(30, 58, 138, 0.4);
+      --mobile-header-bg: #5080bf; /* match new cauliflower blue header */
+      --mobile-header-border: rgba(80, 128, 191, 0.9);
+      --mobile-header-shadow: 0 16px 32px rgba(80, 128, 191, 0.4);
       --mobile-header-text: #e8edff;
-      --mobile-header-button-bg: color-mix(in srgb, rgba(30, 58, 138, 0.6) 100%, transparent);
+      --mobile-header-button-bg: color-mix(in srgb, rgba(80, 128, 191, 0.6) 100%, transparent);
       --mobile-header-button-color: #e8edff;
-      --mobile-header-button-border: rgba(30, 58, 138, 0.85);
-      --mobile-quick-surface: color-mix(in srgb, rgba(15, 23, 42, 0.92) 94%, transparent);
-      --mobile-quick-shadow: 0 18px 30px rgba(15, 23, 42, 0.6);
+      --mobile-header-button-border: rgba(80, 128, 191, 0.9);
+      --mobile-quick-surface: color-mix(in srgb, rgba(20, 32, 52, 0.94) 94%, transparent);
+      --mobile-quick-shadow: 0 18px 30px rgba(34, 52, 86, 0.6);
       --card-border-strong: color-mix(in srgb, var(--card-border) 50%, var(--text-primary) 50%);
     }
 


### PR DESCRIPTION
## Summary
- update mobile CSS palette to use cauliflower blue hues for headers, buttons, and links
- refresh mobile HTML theme tokens for light and dark modes with the new color blend
- sync built docs assets with the updated mobile theme colors

## Testing
- npm test -- --runInBand


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69217d9c44048324acef2a77d76560a7)