### PR TITLE
Set mobile quick add bar to cauliflower blue

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -2745,8 +2745,9 @@
     .mc-quick-add-bar {
       /* No longer sticky – just part of the normal flow under the header */
       position: static;
-      background: transparent;
-      border-bottom: none;
+      background: var(--mobile-header-bg);
+      border-bottom: 1px solid var(--mobile-header-border);
+      box-shadow: var(--mobile-header-shadow);
       backdrop-filter: none;
       margin: 0.25rem 0 0.25rem;
       width: 100%;

--- a/mobile.html
+++ b/mobile.html
@@ -3250,8 +3250,9 @@
     .mc-quick-add-bar {
       /* No longer sticky – just part of the normal flow under the header */
       position: static;
-      background: transparent;
-      border-bottom: none;
+      background: var(--mobile-header-bg);
+      border-bottom: 1px solid var(--mobile-header-border);
+      box-shadow: var(--mobile-header-shadow);
       backdrop-filter: none;
       margin: 0.25rem 0 0.25rem;
       width: 100%;


### PR DESCRIPTION
## Summary
- color the mobile quick-add bar with the cauliflower blue header palette, adding matching border and shadow
- mirror the styling change in the generated docs mobile page

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692183e0a84083248c8731582fc4e191)