### PR TITLE
Restyle header and navigation surfaces

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -11,17 +11,17 @@
   <link rel="stylesheet" href="./styles/index.css" />
   <style>
     :root {
-      --card-bg: #232d61; /* soft indigo card surface */
-      --cauliflower-blue: #5080bf;
-      --card-border: #5e6fd8;
-      --text-primary: #f2f5ff; /* Light text for dark gradient */
-      --text-secondary: #d8defa; /* Muted lavender text */
-      --accent-color: #a9beff; /* Soft periwinkle accent */
+      --card-bg: #ffffff; /* off-white card surface */
+      --cauliflower-blue: #F7F7FA;
+      --card-border: #e6dff0;
+      --text-primary: #2f1b3f; /* Deep violet text */
+      --text-secondary: #5b4a68; /* Muted violet */
+      --accent-color: #512663; /* Deep violet accent */
       --success-color: #8ed6c1;
-      --background-color: #131a3d; /* deep indigo fallback */
-      --background-gradient: linear-gradient(135deg, #3a2c8e 0%, #273a8c 45%, #111b44 100%);
-      --hover-bg: rgba(255, 255, 255, 0.08);
-      --shadow-color: rgba(8, 12, 34, 0.28);
+      --background-color: #F7F7FA; /* soft pale backdrop */
+      --background-gradient: linear-gradient(135deg, #f7f7fa 0%, #ede9f5 45%, #e5dcf0 100%);
+      --hover-bg: rgba(81, 38, 99, 0.06);
+      --shadow-color: rgba(81, 38, 99, 0.12);
       --true-blue: #0073cf;
       --delete-color: #EF6A6A;
 
@@ -52,16 +52,16 @@
       --reminder-card-font-size: 0.85rem;
 
       /* Mobile chrome with comprehensive warm grey background */
-      --mobile-header-bg: var(--cauliflower-blue); /* Cauliflower blue header */
-      --mobile-header-border: rgba(80, 128, 191, 0.82);
-      --mobile-header-shadow: 0 18px 32px rgba(80, 128, 191, 0.35);
-      --mobile-header-text: #e8edff;
-      --mobile-header-button-bg: rgba(255, 255, 255, 0.14); /* soft translucent buttons */
-      --mobile-header-button-color: #e8edff;
-      --mobile-header-button-border: rgba(80, 128, 191, 0.82);
-      --mobile-quick-surface: #1f3252; /* complementary indigo surface */
-      --mobile-footer-bg: var(--cauliflower-blue);
-      --mobile-quick-shadow: 0 20px 34px rgba(34, 52, 86, 0.45);
+      --mobile-header-bg: #F7F7FA; /* Soft Pale Lilac header */
+      --mobile-header-border: rgba(81, 38, 99, 0.12);
+      --mobile-header-shadow: 0 14px 30px rgba(81, 38, 99, 0.12);
+      --mobile-header-text: #512663;
+      --mobile-header-button-bg: #F9F9F9; /* off-white buttons */
+      --mobile-header-button-color: #512663;
+      --mobile-header-button-border: rgba(81, 38, 99, 0.14);
+      --mobile-quick-surface: #F9F9F9; /* complementary off-white surface */
+      --mobile-footer-bg: #F7F7FA;
+      --mobile-quick-shadow: 0 20px 34px rgba(81, 38, 99, 0.12);
     }
 
     /* Force Soft Pale Lilac/Blue backgrounds with high specificity */
@@ -79,15 +79,15 @@
 
     html[data-theme="dark"],
     html.dark {
-      --mobile-header-bg: var(--cauliflower-blue); /* match new cauliflower blue header */
-      --mobile-header-border: rgba(80, 128, 191, 0.9);
-      --mobile-header-shadow: 0 16px 32px rgba(80, 128, 191, 0.4);
-      --mobile-header-text: #e8edff;
-      --mobile-header-button-bg: color-mix(in srgb, rgba(80, 128, 191, 0.6) 100%, transparent);
-      --mobile-header-button-color: #e8edff;
-      --mobile-header-button-border: rgba(80, 128, 191, 0.9);
-      --mobile-quick-surface: color-mix(in srgb, rgba(20, 32, 52, 0.94) 94%, transparent);
-      --mobile-quick-shadow: 0 18px 30px rgba(34, 52, 86, 0.6);
+      --mobile-header-bg: #F7F7FA; /* match Soft Pale Lilac header */
+      --mobile-header-border: rgba(81, 38, 99, 0.12);
+      --mobile-header-shadow: 0 14px 30px rgba(81, 38, 99, 0.12);
+      --mobile-header-text: #512663;
+      --mobile-header-button-bg: #F9F9F9;
+      --mobile-header-button-color: #512663;
+      --mobile-header-button-border: rgba(81, 38, 99, 0.14);
+      --mobile-quick-surface: #F9F9F9;
+      --mobile-quick-shadow: 0 18px 30px rgba(81, 38, 99, 0.12);
       --card-border-strong: color-mix(in srgb, var(--card-border) 50%, var(--text-primary) 50%);
     }
 
@@ -1810,20 +1810,20 @@
       --mobile-safe-area-bottom: env(safe-area-inset-bottom, 0px);
     }
 
-  /* Comprehensive Cauliflower Blue background application */
+  /* Comprehensive Soft Pale Lilac background application */
   body {
     background: var(--cauliflower-blue) !important;
-    color: var(--text-primary);
+    color: #2f1b3f;
   }
 
-  /* Footer navigation with Cauliflower Blue background */
+  /* Footer navigation softened to match header */
   #mobile-nav-shell {
-    background: var(--cauliflower-blue) !important;
+    background: transparent;
   }
 
   #mobile-nav-shell .btm-nav {
-    background: var(--cauliflower-blue) !important;
-    border-top: 1px solid rgba(169, 190, 255, 0.25);
+    background: transparent;
+    border-top: 1px solid rgba(81, 38, 99, 0.12);
   }
 
   /* Floating footer buttons */
@@ -1846,7 +1846,7 @@
     padding: 0.7rem 0.95rem;
     border-radius: 1rem;
     background: #F7F7FA;
-    color: #424242;
+    color: #512663;
     box-shadow: 0 10px 28px rgba(81, 38, 99, 0.12), 0 4px 12px rgba(0, 0, 0, 0.08);
     font-weight: 700;
     font-size: 0.95rem;
@@ -4736,9 +4736,69 @@
 
   <div id="mobile-nav-shell" class="fixed inset-x-0 bottom-3 z-50 flex justify-center pointer-events-none px-2">
     <div class="floating-footer">
-      <!-- Footer action buttons removed per request -->
+      <button
+        type="button"
+        class="floating-card"
+        data-nav-target="reminders"
+        aria-label="Go to Reminders"
+      >
+        <span class="icon" aria-hidden="true">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <rect x="4" y="5" width="16" height="14" rx="3" ry="3" />
+            <path d="M9 3v4" />
+            <path d="M15 3v4" />
+            <path d="M7 11h10" />
+          </svg>
+        </span>
+        <span>Reminders</span>
+      </button>
+
+      <button
+        type="button"
+        class="floating-fab"
+        data-nav-target="new"
+        aria-label="Add reminder"
+      >
+        +
+      </button>
+
+      <button
+        type="button"
+        class="floating-card"
+        data-nav-target="notebook"
+        aria-label="Go to Notes"
+      >
+        <span class="icon" aria-hidden="true">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M4 4h13a3 3 0 013 3v13H7a3 3 0 01-3-3V4z" />
+            <path d="M9 4v16" />
+            <path d="M4 9h16" />
+          </svg>
+        </span>
+        <span>Notes</span>
+      </button>
     </div>
   </div>
+  <script>
+    (function() {
+      const navFooter = document.querySelector('#mobile-nav-shell .floating-footer');
+      if (!navFooter) return;
+
+      navFooter.addEventListener('click', (event) => {
+        const button = event.target instanceof Element ? event.target.closest('[data-nav-target]') : null;
+        if (!button) return;
+
+        const view = button.getAttribute('data-nav-target');
+        if (!view) return;
+
+        window.dispatchEvent(
+          new CustomEvent('app:navigate', {
+            detail: { view }
+          })
+        );
+      });
+    })();
+  </script>
   <!-- build-marker: mobile.html / runs mobile.js / EXPECTED LIVE -->
   <!-- When deployed, this should appear in View Source with today’s date. -->
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -140,9 +140,10 @@ html[data-theme="professional"] {
 /* PROFESSIONAL DESKTOP HEADER */
 
  .desktop-header-bar {
-  --desktop-header-solid: #1e3a8a;
-  position: static;
-  top: auto;
+  --desktop-header-solid: #F7F7FA;
+  --desktop-header-accent: #512663;
+  position: sticky;
+  top: calc(env(safe-area-inset-top, 0) + 0.5rem);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -153,8 +154,10 @@ html[data-theme="professional"] {
   background: var(--desktop-header-solid);
   backdrop-filter: blur(14px);
   border-radius: 999px;
-  border: 1px solid var(--desktop-header-solid);
-  box-shadow: 0 18px 38px rgba(30, 58, 138, 0.28);
+  border: 1px solid color-mix(in srgb, var(--desktop-header-accent) 8%, transparent);
+  box-shadow: 0 14px 30px rgba(81, 38, 99, 0.12);
+  color: var(--desktop-header-accent);
+  z-index: 40;
 }
 
  .desktop-header-left {
@@ -370,9 +373,9 @@ html[data-theme="professional"] {
   padding: 0.3rem;
   border-radius: 999px;
   background: var(--desktop-header-solid);
-  box-shadow: 0 16px 32px rgba(30, 58, 138, 0.28);
-  border: 1px solid var(--desktop-header-solid);
-}
+  box-shadow: 0 16px 32px rgba(81, 38, 99, 0.12);
+  border: 1px solid color-mix(in srgb, var(--desktop-header-accent, #512663) 10%, transparent);
+ }
 
  .desktop-header-nav-tabs .btn {
   border-radius: 999px;
@@ -380,27 +383,27 @@ html[data-theme="professional"] {
   font-weight: 600;
   padding: 0.3rem 0.85rem;
   border-width: 0;
-  background: transparent;
-  color: #e8edff;
+  background: color-mix(in srgb, #ffffff 65%, transparent);
+  color: var(--desktop-header-accent, #512663);
   box-shadow: none;
-}
+ }
 
  .desktop-header-nav-tabs .btn[aria-current="page"],
  .desktop-header-nav-tabs .btn.btn-active {
-  background: linear-gradient(135deg, #4f46e5, #22d3ee);
-  color: #ffffff;
-  box-shadow: 0 10px 22px rgba(79, 70, 229, 0.28);
-}
+  background: #ffffff;
+  color: var(--desktop-header-accent, #512663);
+  box-shadow: 0 10px 22px rgba(81, 38, 99, 0.18);
+ }
 
  .desktop-header-nav-tabs .btn:hover {
-  background: color-mix(in srgb, var(--desktop-nav-active, var(--color-primary, #4f46e5)) 18%, transparent);
-  color: var(--desktop-nav-text, var(--color-base-content, #0f172a));
-}
+  background: color-mix(in srgb, #ffffff 85%, transparent);
+  color: var(--desktop-header-accent, #512663);
+ }
 
 @media (min-width: 1024px) {
    .desktop-header-bar {
-    position: static;
-    top: auto;
+    position: sticky;
+    top: calc(env(safe-area-inset-top, 0) + 0.5rem);
     display: flex;
     align-items: center;
   }
@@ -3094,9 +3097,10 @@ section[data-route="dashboard"] .dashboard-shortcuts {
 
 .site-footer {
   margin-top: clamp(0.75rem, 2vw, 1.25rem);
-  background: radial-gradient(circle at top, rgba(15, 23, 42, 0.3), transparent 60%),
-    linear-gradient(135deg, #0f172a, #1d3557 55%, #2a4858);
-  color: rgba(248, 250, 252, 0.9);
+  background: #F7F7FA;
+  color: #2f1b3f;
+  border-top: 1px solid rgba(81, 38, 99, 0.08);
+  box-shadow: 0 -8px 18px rgba(81, 38, 99, 0.06);
 }
 
 .site-footer a {
@@ -3202,18 +3206,18 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   font-size: 0.85rem;
   text-transform: uppercase;
   letter-spacing: 0.3em;
-  color: rgba(248, 250, 252, 0.55);
+  color: color-mix(in srgb, #512663 35%, #2f1b3f 65%);
   margin-bottom: 0.2rem;
 }
 
 .site-footer__column a {
   text-decoration: none;
-  color: rgba(248, 250, 252, 0.85);
+  color: color-mix(in srgb, #512663 60%, #2f1b3f 40%);
   transition: color 0.2s ease;
 }
 
 .site-footer__column a:hover {
-  color: #ffffff;
+  color: #512663;
 }
 
 .site-footer__bottom {
@@ -3221,9 +3225,9 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   flex-direction: column;
   gap: 0.2rem;
   padding-top: 0.35rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  border-top: 1px solid rgba(81, 38, 99, 0.08);
   font-size: 0.85rem;
-  color: rgba(248, 250, 252, 0.65);
+  color: color-mix(in srgb, #512663 55%, #2f1b3f 45%);
 }
 
 .site-footer__bottom--compact {
@@ -3323,7 +3327,7 @@ section[data-route="dashboard"] .dashboard-shortcuts {
 .site-footer__quick-links a {
   text-decoration: none;
   font-weight: 600;
-  color: rgba(248, 250, 252, 0.85);
+  color: color-mix(in srgb, #512663 65%, #2f1b3f 35%);
 }
 
 .site-footer__social {
@@ -3335,11 +3339,11 @@ section[data-route="dashboard"] .dashboard-shortcuts {
 .site-footer__social a {
   text-decoration: none;
   font-weight: 600;
-  color: rgba(248, 250, 252, 0.85);
+  color: color-mix(in srgb, #512663 65%, #2f1b3f 35%);
 }
 
 .site-footer__social a:hover {
-  color: #ffffff;
+  color: #512663;
 }
 
 @media (min-width: 768px) {
@@ -3386,20 +3390,21 @@ section[data-route="dashboard"] .dashboard-shortcuts {
 /* Override header styles for light theme */
 .mobile-header,
 .header-pill {
-  background: #1e3a8a !important;
-  color: #e8edff;
-  border: 1px solid #1e3a8a;
+  background: #F7F7FA !important;
+  color: #512663;
+  border: 1px solid rgba(81, 38, 99, 0.08);
+  box-shadow: 0 10px 24px rgba(81, 38, 99, 0.12);
 }
 
 .header-pill .quick-reminder {
-  background: #1e3a8a !important;
-  color: #e8edff;
+  background: #F9F9F9 !important;
+  color: #2f1b3f;
   min-width: 0;
 }
 
 .header-pill .header-icons svg,
 .header-pill .header-icons button {
-  color: #e8edff !important;
+  color: #512663 !important;
 }
 
 .header-pill {


### PR DESCRIPTION
## Summary
- update desktop and mobile headers to use a soft pale lilac palette with deep violet accents
- refresh footer styling and quick-add pill colors to match the lighter theme
- add floating navigation cards and FAB for reminders and notes views on mobile

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69218d94ff548324838806b57d05c1eb)