### PR TITLE
Adjust mobile formatting toolbar styling

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1446,29 +1446,35 @@
     }
 
     .formatting-toolbar-strip {
-      margin: 0.15rem 0 0.35rem;
+      margin: 0.05rem 0 0.2rem;
       backdrop-filter: blur(6px);
       min-height: auto;
       background-color: #f9f9f9;
       border: 1px solid #e6dff0;
       border-radius: 10px;
-      padding: 0.35rem 0.5rem;
+      padding: 0.25rem 0.35rem;
       box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
+      gap: 0.35rem;
     }
 
     .formatting-btn {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 30px;
-      height: 30px;
+      width: 32px;
+      height: 32px;
       border-radius: 8px;
-      border: none;
-      background: transparent;
+      border: 1px solid #e6dff0;
+      background: #f9f9f9;
       color: #512663; /* Deep Violet Primary Accent */
       cursor: pointer;
       transition: all 0.2s ease;
       margin: 1px;
+    }
+
+    .formatting-btn svg {
+      width: 16px;
+      height: 16px;
     }
 
     .formatting-btn:hover {


### PR DESCRIPTION
## Summary
- tighten spacing so the mobile formatting toolbar sits directly beneath the note title with minimal vertical gap
- apply off-white backgrounds, borders, and consistent sizing for the deep-violet formatting icons

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692191df42a08324a8b75ee25350c60a)