### PR TITLE
Adjust mobile header pill styling

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1000,14 +1000,52 @@
       z-index: 50;
       display: flex;
       align-items: center;
-      justify-content: space-between;
+      justify-content: center;
       padding: 0.5rem 1rem;
-      padding-top: calc(env(safe-area-inset-top, 0) + 0.5rem);
+      padding-top: env(safe-area-inset-top, 0); /* remove extra 0.5rem */
       background: var(--mobile-header-bg);
       border-bottom: 1px solid var(--mobile-header-border);
       backdrop-filter: blur(12px);
       -webkit-backdrop-filter: blur(12px);
       box-shadow: var(--mobile-header-shadow);
+    }
+
+    /* Pill container in the header for quick‑add and icons */
+    #slimMobileHeader .header-pill {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.35rem 0.75rem;
+      background: var(--mobile-header-button-bg);
+      border: 1px solid var(--mobile-header-button-border);
+      border-radius: 9999px;
+      box-shadow: 0 2px 6px rgba(81, 38, 99, 0.15);
+    }
+
+    /* Style the quick reminder input inside the pill */
+    #slimMobileHeader .header-pill input.quick-reminder {
+      flex: 1;
+      border: none;
+      background: transparent;
+      padding: 0.25rem 0.5rem;
+      color: var(--text-primary);
+      font-size: 0.9rem;
+    }
+
+    /* Style the header action buttons inside the pill */
+    #slimMobileHeader .header-pill button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 2rem;
+      height: 2rem;
+      border: none;
+      background: transparent;
+      color: var(--accent-color);
+      border-radius: 0.5rem;
+      cursor: pointer;
+      transition: background-color 0.2s ease;
     }
 
     #slimMobileHeader h1 {
@@ -1447,8 +1485,8 @@
       box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.04);
       transition: all 0.2s ease;
       line-height: 1.7;
-      min-height: calc(100vh - 280px);
-      max-height: calc(100vh - 180px);
+      min-height: calc(100vh - 220px);
+      max-height: calc(100vh - 120px);
       overflow-y: auto;
       background-color: #f9f9f9;
       color: #1a1a1a;


### PR DESCRIPTION
## Summary
- center the slim mobile header and add pill styling for quick add and action icons
- style quick reminder input and header buttons within the new pill container
- reduce the minimal editor height so the writing panel begins closer to the header

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69219ab0b80083248447896d77049088)