### PR TITLE
Restore footer navigation bar

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1906,8 +1906,8 @@
   #mobile-nav-shell .floating-footer {
     pointer-events: auto;
     display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    align-items: end;
+    grid-template-columns: repeat(4, 1fr);
+    align-items: center;
     gap: 0.85rem;
     width: min(640px, 100%);
     padding: 0 1rem;
@@ -4927,11 +4927,31 @@
 
       <button
         type="button"
-        class="floating-fab"
+        class="floating-card"
         data-nav-target="new"
         aria-label="Add reminder"
       >
-        +
+        <span class="icon" aria-hidden="true">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M12 5v14M5 12h14" />
+          </svg>
+        </span>
+        <span>New Reminder</span>
+      </button>
+
+      <button
+        type="button"
+        class="floating-card"
+        data-nav-target="add-note"
+        aria-label="Add note"
+      >
+        <span class="icon" aria-hidden="true">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M4 17.5V20h2.5L17 9.5 14.5 7 4 17.5z" />
+            <path d="M13.5 8.5l2 2" />
+          </svg>
+        </span>
+        <span>Add Note</span>
       </button>
 
       <button
@@ -4956,12 +4976,43 @@
       const navFooter = document.querySelector('#mobile-nav-shell .floating-footer');
       if (!navFooter) return;
 
+      const focusNotebookInputs = () => {
+        const focusField = () => {
+          const titleInput = document.getElementById('noteTitleMobile');
+          if (titleInput) {
+            titleInput.focus();
+            return;
+          }
+
+          const noteEditor = document.getElementById('scratchNotesEditor');
+          if (noteEditor) {
+            noteEditor.focus();
+          }
+        };
+
+        if (typeof queueMicrotask === 'function') {
+          queueMicrotask(focusField);
+        } else {
+          setTimeout(focusField, 0);
+        }
+      };
+
       navFooter.addEventListener('click', (event) => {
         const button = event.target instanceof Element ? event.target.closest('[data-nav-target]') : null;
         if (!button) return;
 
         const view = button.getAttribute('data-nav-target');
         if (!view) return;
+
+        if (view === 'add-note') {
+          window.dispatchEvent(
+            new CustomEvent('app:navigate', {
+              detail: { view: 'notebook' }
+            })
+          );
+          focusNotebookInputs();
+          return;
+        }
 
         window.dispatchEvent(
           new CustomEvent('app:navigate', {


### PR DESCRIPTION
## Summary
- replace the floating footer FAB with a four-button navigation bar matching the design
- add an add-note action that navigates to the notebook and focuses note inputs
- adjust footer layout to evenly space the navigation buttons

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922227dd0588324b918eecbe4b47472)