### PR TITLE
Remove aqua background from mobile view

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -4742,7 +4742,13 @@
     class="mobile-shell mx-auto w-full px-4 pb-16"
     style="background: #FBFBFB; padding-top: env(safe-area-inset-top, 0);"
   >
-    <main id="main" class="mx-auto pt-4 pb-4 w-full max-w-none sm:max-w-lg" tabindex="-1" data-active-view="reminders" style="background: #274b50;">
+    <main
+      id="main"
+      class="mx-auto pt-4 pb-4 w-full max-w-none sm:max-w-lg"
+      tabindex="-1"
+      data-active-view="reminders"
+      style="background: #FBFBFB;"
+    >
     <!-- BEGIN GPT CHANGE: create form moved to bottom sheet -->
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: reminders view -->


### PR DESCRIPTION
## Summary
- replace the teal background on the mobile main area with the standard light surface color

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69224ab3a7dc8324b75bdba756afb0bf)