### PR TITLE
Align mobile footer buttons evenly

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1920,6 +1920,7 @@
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
     align-items: center;
+    justify-items: center;
     gap: 0.85rem;
     width: min(640px, 100%);
     padding: 0.65rem 1rem;


### PR DESCRIPTION
## Summary
- center the mobile footer grid items to keep nav buttons evenly aligned and spaced

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69225701d8a083249d2e493207a6a7ef)