### PR TITLE
Add mic button inside quick-add pill (Reminders)

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1053,6 +1053,26 @@
       transition: background-color 0.2s ease;
     }
 
+    .pill-voice-btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 2rem;
+      height: 2rem;
+      border: none;
+      background: transparent;
+      color: var(--accent-color);
+      border-radius: 0.5rem;
+      cursor: pointer;
+      padding: 0;
+      transition: background-color 0.15s ease;
+    }
+
+    .pill-voice-btn:hover,
+    .pill-voice-btn:focus {
+      background-color: rgba(81, 38, 99, 0.08);
+    }
+
     #slimMobileHeader h1 {
       font-size: 1rem;
       font-weight: 600;
@@ -4539,6 +4559,12 @@
         >
           <svg class="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
             <path d="M6 2h9a2 2 0 012 2v16a1 1 0 01-1.5.86L12 19l-3.5 1.86A1 1 0 017 20V4a2 2 0 012-2z" fill="currentColor" />
+          </svg>
+        </button>
+
+        <button class="pill-voice-btn" aria-label="Voice Input">
+          <svg xmlns="http://www.w3.org/2000/svg" height="20" width="20" viewBox="0 0 24 24">
+            <path fill="currentColor" d="M12 14q-1.25 0-2.125-.875T9 11V6q0-1.25.875-2.125T12 3q1.25 0 2.125.875T15 6v5q0 1.25-.875 2.125T12 14Zm-1 7v-3.1q-3.05-.35-5.025-2.5T4 10h2q0 2.3 1.6 3.9T12 15.5q2.3 0 3.9-1.6T17.5 10h2q0 2.8-1.975 4.95T12 17.9V21Z"/>
           </svg>
         </button>
 


### PR DESCRIPTION
## Summary
- add a microphone icon button to the quick-add pill in the mobile reminders header
- style the voice button to match existing pill controls

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69225727d574832480fea720467e1376)