### PR TITLE
Improve text contrast and typography for premium mobile writing UI

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -16,6 +16,12 @@
       --card-border: color-mix(in srgb, #e6dff0 70%, #d6d0c4 30%);
       --text-primary: #2f1b3f; /* Deep violet text */
       --text-secondary: #5b4a68; /* Muted violet */
+      --text-main: #1F1A24;               /* deep neutral */
+      --text-secondary: #4A4153;          /* softer label text */
+      --text-placeholder: #9B8FA8;        /* subtle, elegant placeholder */
+      --font-primary: 'Inter', system-ui, sans-serif;
+      --font-size-title: 1.1rem;
+      --font-size-body: 0.95rem;
       --accent-color: #512663; /* Deep violet accent */
       --success-color: #8ed6c1;
       --background-color: #F7F7FA; /* soft pale backdrop */
@@ -1101,6 +1107,21 @@
       color: #dc2626;
     }
 
+    .fab-card,
+    .nav-card,
+    .pill-button {
+      font-family: var(--font-primary);
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+      font-weight: 500;
+    }
+
+    .pill-voice-btn {
+      font-family: var(--font-primary);
+      font-size: 0.85rem;
+      font-weight: 500;
+    }
+
     #slimMobileHeader h1 {
       font-size: 1rem;
       font-weight: 600;
@@ -1279,11 +1300,18 @@
       background-color: color-mix(in srgb, var(--card-bg) 98%, rgba(148, 163, 184, 0.05));
     }
 
+    .note-title-field input:focus {
+      outline: 2px solid rgba(81, 38, 99, 0.25);
+    }
+
+    .note-title-field input,
     .seamless-title-input {
-      font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
-      font-size: 1.05rem;
-      font-weight: 700;
+      font-family: var(--font-primary);
+      font-size: var(--font-size-title);
+      font-weight: 600;
       line-height: 1.4;
+      color: var(--text-main);
+      letter-spacing: -0.2px;
     }
 
     .notes-editor {
@@ -1508,14 +1536,16 @@
     .seamless-title-input {
       background-color: #f9f9f9;
       border-radius: 10px;
-      color: #1a1a1a;
+      color: var(--text-main);
       border: 1px solid #e6dff0;
       box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.03);
       padding: 0.65rem 0.75rem;
     }
 
+    .header-pill input::placeholder,
+    .note-title-field input::placeholder,
     .seamless-title-input::placeholder {
-      color: #7b6b8a;
+      color: var(--text-placeholder);
     }
 
     .seamless-title-input:focus {
@@ -1523,6 +1553,7 @@
       border-radius: 10px;
       box-shadow: 0 0 0 3px rgba(81, 38, 99, 0.18);
       border-color: #512663;
+      outline: 2px solid rgba(81, 38, 99, 0.25);
     }
     
     .distraction-free-editor-container {
@@ -1537,24 +1568,40 @@
       border: 1px solid #e6dff0;
       box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.04);
       transition: all 0.2s ease;
-      line-height: 1.7;
+      line-height: 1.45;
       min-height: calc(100vh - 220px);
       max-height: calc(100vh - 120px);
       overflow-y: auto;
       background-color: #f9f9f9;
-      color: #1a1a1a;
+      color: var(--text-main);
       border-radius: 12px;
+      font-family: var(--font-primary);
+      font-size: var(--font-size-body);
+      font-weight: 400;
     }
 
-    .minimal-editor:focus {
+    .minimal-editor:focus,
+    .minimal-editor[contenteditable="true"]:focus {
       border-color: #512663;
       box-shadow: 0 0 0 3px rgba(81, 38, 99, 0.18), inset 0 1px 2px rgba(0, 0, 0, 0.05);
-      outline: none;
+      outline: 2px solid rgba(81, 38, 99, 0.25);
+    }
+
+    .minimal-editor textarea {
+      font-family: var(--font-primary);
+      font-size: var(--font-size-body);
+      font-weight: 400;
+      color: var(--text-main);
+      line-height: 1.45;
+    }
+
+    .minimal-editor textarea:focus {
+      outline: 2px solid rgba(81, 38, 99, 0.25);
     }
 
     .minimal-editor:empty::before {
       content: attr(data-placeholder);
-      color: #7b6b8a;
+      color: var(--text-placeholder);
       font-style: italic;
     }
 
@@ -1987,9 +2034,11 @@
     height: 3.25rem;
     border-radius: 999px;
     background: var(--card-bg);
-    color: var(--text-primary);
+    color: var(--text-secondary);
     box-shadow: var(--shadow-sm);
-    font-size: 1rem;
+    font-size: 0.85rem;
+    font-family: var(--font-primary);
+    font-weight: 500;
     border: 1px solid var(--card-border);
     transition: transform 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
   }
@@ -2006,6 +2055,7 @@
     align-items: center;
     justify-content: center;
     font-size: 1.15rem;
+    color: var(--accent-color);
   }
 
   #mobile-nav-shell .floating-fab {
@@ -3796,8 +3846,14 @@
       border: none;
       background: transparent;
       padding: 0.25rem 0.5rem;
-      color: var(--text-primary);
-      font-size: 0.95rem;
+      color: var(--text-main);
+      font-size: var(--font-size-body);
+      font-family: var(--font-primary);
+      font-weight: 400;
+    }
+
+    .header-pill input.quick-reminder:focus {
+      outline: 2px solid rgba(81, 38, 99, 0.25);
     }
 
     .header-pill button {


### PR DESCRIPTION
## Summary
- add typography tokens for premium text color and sizing across the mobile writing UI
- apply the new font, sizing, and placeholder styling to note titles, editor body, and quick-add inputs
- refresh floating card and pill/button typography and focus outlines for clearer contrast

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69226040e5ac8324925e56009af6ba69)