### PR TITLE
Update header palette to match new premium theme

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -746,18 +746,27 @@
       justify-content: space-between;
       padding: 0.5rem 1rem;
       padding-top: calc(env(safe-area-inset-top, 0) + 0.5rem);
-      background: var(--mobile-header-bg);
-      border-bottom: 1px solid var(--mobile-header-border);
+      background-color: var(--surface-main);
+      border-bottom: 1px solid var(--border-subtle);
       backdrop-filter: blur(12px);
       -webkit-backdrop-filter: blur(12px);
-      box-shadow: var(--mobile-header-shadow);
+      box-shadow: 0 2px 6px rgba(81, 38, 99, 0.08);
+    }
+
+    #slimMobileHeader svg {
+      color: var(--accent-color);
     }
 
     #slimMobileHeader h1 {
       font-size: 1rem;
       font-weight: 600;
       margin: 0;
-      color: var(--mobile-header-text);
+      color: var(--text-main);
+    }
+
+    #slimMobileHeader .header-title {
+      color: var(--text-main);
+      font-weight: 600;
     }
 
     #slimMobileHeader .header-actions {

--- a/mobile.html
+++ b/mobile.html
@@ -1027,11 +1027,15 @@
       justify-content: center;
       padding: 0.5rem 1rem;
       padding-top: env(safe-area-inset-top, 0);
-      background: var(--mobile-header-bg);
-      border-bottom: 1px solid var(--mobile-header-border);
+      background-color: var(--surface-main);
+      border-bottom: 1px solid var(--border-subtle);
       backdrop-filter: blur(12px);
       -webkit-backdrop-filter: blur(12px);
-      box-shadow: var(--mobile-header-shadow);
+      box-shadow: 0 2px 6px rgba(81, 38, 99, 0.08);
+    }
+
+    #slimMobileHeader svg {
+      color: var(--accent-color);
     }
 
     /* Pill container in the header for quick‑add and icons */
@@ -1110,7 +1114,12 @@
       font-size: 1rem;
       font-weight: 600;
       margin: 0;
-      color: var(--mobile-header-text);
+      color: var(--text-main);
+    }
+
+    #slimMobileHeader .header-title {
+      color: var(--text-main);
+      font-weight: 600;
     }
 
     #slimMobileHeader .header-actions {


### PR DESCRIPTION
## Summary
- update the slim mobile header background, border, and shadow to use the new surface palette
- apply accent color to header icons and text color to header titles in mobile view and documentation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922616ab8d88324b1ee92e5dae1c241)