### PR TITLE
Add microphone control to quick add bar

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -3537,6 +3537,16 @@
               />
               <div class="mc-quick-actions flex items-center gap-2">
                 <button
+                  id="quickAddVoice"
+                  type="button"
+                  class="mc-quick-voice"
+                  aria-pressed="false"
+                  title="Voice quick add"
+                >
+                  <span aria-hidden="true">🎤</span>
+                  <span class="sr-only">Voice quick add</span>
+                </button>
+                <button
                   id="quickAddSubmit"
                   type="button"
                   class="mc-quick-submit btn btn-primary btn-sm"


### PR DESCRIPTION
## Summary
- add a dedicated microphone control inside the quick add bar on the mobile page
- include accessible labeling for the voice quick add button

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692261f53dc0832480afd049cc3941c2)