### PR TITLE
Differentiate bottom action buttons into primary-create and secondary-view

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2064,17 +2064,17 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 3.25rem;
-    height: 3.25rem;
-    border-radius: 999px;
-    background: var(--card-bg);
-    color: var(--text-secondary);
-    box-shadow: var(--shadow-sm);
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    background-color: var(--surface-elevated);
+    border: 1px solid var(--border-subtle);
+    box-shadow: 0 4px 12px rgba(81, 38, 99, 0.08);
     font-size: 0.85rem;
     font-family: var(--font-primary);
     font-weight: 500;
-    border: 1px solid var(--card-border);
-    transition: transform 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+    transition: transform 0.12s ease, box-shadow 0.12s ease, background-color 0.12s ease, border-color 0.12s ease;
+    color: var(--accent-color);
   }
 
   #mobile-nav-shell .floating-card:hover,
@@ -2084,19 +2084,52 @@
     outline: none;
   }
 
+  #mobile-nav-shell .floating-card:active {
+    transform: scale(0.94);
+    box-shadow: 0 2px 8px rgba(81, 38, 99, 0.12);
+  }
+
   #mobile-nav-shell .floating-card span.icon {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     font-size: 1.15rem;
-    color: var(--accent-color);
+    color: inherit;
   }
 
   .header-pill svg,
   .nav-card svg,
   .fab-card svg,
   .floating-card svg {
+    width: 20px;
+    height: 20px;
+  }
+
+  /* Secondary view buttons: clock + notebook */
+  .floating-card.btn-reminders,
+  .floating-card.btn-notebook {
+    background-color: var(--surface-elevated);
+    border-color: var(--border-subtle);
     color: var(--accent-color);
+  }
+
+  .floating-card.btn-reminders svg,
+  .floating-card.btn-notebook svg {
+    color: var(--accent-color);
+  }
+
+  /* Primary create buttons: plus + pencil */
+  .floating-card.btn-new-reminder,
+  .floating-card.btn-new-note {
+    background-color: var(--accent-color);
+    border-color: transparent;
+    box-shadow: 0 6px 16px rgba(81, 38, 99, 0.22);
+    color: #ffffff;
+  }
+
+  .floating-card.btn-new-reminder svg,
+  .floating-card.btn-new-note svg {
+    color: #ffffff;
   }
 
   #mobile-nav-shell .floating-fab {
@@ -5087,7 +5120,7 @@
     <div class="floating-footer">
       <button
         type="button"
-        class="floating-card"
+        class="floating-card btn-reminders"
         data-nav-target="reminders"
         aria-label="Go to Reminders"
       >
@@ -5101,7 +5134,7 @@
 
       <button
         type="button"
-        class="floating-card"
+        class="floating-card btn-new-reminder"
         data-nav-target="new"
         aria-label="Add reminder"
       >
@@ -5114,7 +5147,7 @@
 
       <button
         type="button"
-        class="floating-card"
+        class="floating-card btn-new-note"
         data-nav-target="add-note"
         aria-label="Add note"
       >
@@ -5128,7 +5161,7 @@
 
       <button
         type="button"
-        class="floating-card"
+        class="floating-card btn-notebook"
         data-nav-target="notebook"
         aria-label="Go to Notes"
       >


### PR DESCRIPTION
## Summary
- restyle mobile bottom action buttons with shared circular base styles
- add semantic modifier classes to distinguish reminders/notebook view buttons from create actions
- apply primary and secondary color treatments with active press feedback

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69226357b84483249fabfc8e1bd9e89f)