### PR TITLE
Add active state styling for mobile view buttons

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2131,6 +2131,20 @@
     color: var(--accent-color);
   }
 
+  .circle-btn.is-active,
+  .floating-card.btn-reminders.is-active,
+  .floating-card.btn-notebook.is-active {
+    background-color: rgba(81, 38, 99, 0.12);
+    border-color: var(--accent-color);
+    box-shadow: 0 4px 12px rgba(81, 38, 99, 0.12);
+  }
+
+  .circle-btn.is-active svg,
+  .floating-card.btn-reminders.is-active svg,
+  .floating-card.btn-notebook.is-active svg {
+    color: var(--accent-color);
+  }
+
   /* Primary create buttons: plus + pencil */
   .floating-card.btn-new-reminder,
   .floating-card.btn-new-note {


### PR DESCRIPTION
## Summary
- add subtle active-state styling for circular navigation buttons via the `.is-active` class
- highlight the Reminders and Notebook mobile view buttons without affecting creation buttons

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692266c055788324ae64837a9d16c8d0)