### PR TITLE
Center bottom button row and tighten spacing for cleaner layout

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2059,18 +2059,21 @@
 
   #mobile-nav-shell .floating-footer {
     pointer-events: auto;
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    display: flex;
+    justify-content: center;
     align-items: center;
-    justify-items: center;
-    gap: 0.85rem;
+    gap: 24px;
     width: min(640px, 100%);
-    padding: 0.65rem 1rem;
+    padding: 6px 1rem 12px;
     margin-bottom: calc(env(safe-area-inset-bottom, 0.5rem));
     background: transparent;
     backdrop-filter: none;
     border-radius: 1rem;
     box-shadow: none;
+  }
+
+  #mobile-nav-shell .floating-footer .floating-card {
+    flex-shrink: 0;
   }
 
   #mobile-nav-shell .floating-card {


### PR DESCRIPTION
## Summary
- center the mobile floating footer button row with flex alignment and 24px gap
- prevent floating footer buttons from shrinking within the row and adjust padding for balanced spacing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692267be5a548324ae0e37e89d1cbaf4)