### PR TITLE
Add soft blurred backdrop behind bottom action buttons

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2058,6 +2058,7 @@
   }
 
   #mobile-nav-shell .floating-footer {
+    position: relative;
     pointer-events: auto;
     display: flex;
     justify-content: center;
@@ -2072,11 +2073,28 @@
     box-shadow: none;
   }
 
+  #mobile-nav-shell .floating-footer::before {
+    content: "";
+    position: absolute;
+    inset: 0.25rem 0.75rem;
+    border-radius: 999px;
+
+    background: rgba(255, 255, 255, 0.78);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+
+    border: 1px solid var(--border-subtle);
+    z-index: 0;
+  }
+
   #mobile-nav-shell .floating-footer .floating-card {
     flex-shrink: 0;
   }
 
   #mobile-nav-shell .floating-card {
+    position: relative;
+    z-index: 1;
     display: inline-flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
## Summary
- add a blurred translucent backdrop behind the floating mobile footer buttons
- ensure the floating footer is positioned relative so the backdrop sits behind the buttons
- raise footer button stacking context so buttons stay above the new backdrop

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69226a7cea508324a432a80b9595a2d1)