### PR TITLE
Restore footer icons on mobile navigation

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -3886,12 +3886,14 @@
         aria-current="page"
         class="active flex flex-col items-center justify-center gap-0.5 px-2 py-1 rounded-full text-[11px] font-medium text-base-content/70 transition"
       >
+        <span class="text-base-content/70" aria-hidden="true">⏰</span>
         <span class="leading-tight">Reminders</span>
       </button>
       <button
         type="button"
         class="flex flex-col items-center justify-center gap-0.5 px-2 py-1 rounded-full text-[11px] font-medium text-base-content/70 transition"
       >
+        <span class="text-base-content/70" aria-hidden="true">📝</span>
         <span class="leading-tight">Notebook</span>
       </button>
     </nav>


### PR DESCRIPTION
## Summary
- add icon glyphs back to the mobile footer navigation buttons so their visuals match the current design

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69227772be90832494a3d326e0093055)