### PR TITLE
Add symbols to mobile footer buttons

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -3886,12 +3886,14 @@
         aria-current="page"
         class="active flex flex-col items-center justify-center gap-0.5 px-2 py-1 rounded-full text-[11px] font-medium text-base-content/70 transition"
       >
+        <span class="text-base-content/70" aria-hidden="true">⏰</span>
         <span class="leading-tight">Reminders</span>
       </button>
       <button
         type="button"
         class="flex flex-col items-center justify-center gap-0.5 px-2 py-1 rounded-full text-[11px] font-medium text-base-content/70 transition"
       >
+        <span class="text-base-content/70" aria-hidden="true">📝</span>
         <span class="leading-tight">Notebook</span>
       </button>
     </nav>

--- a/mobile.html
+++ b/mobile.html
@@ -5217,12 +5217,7 @@
         data-nav-target="reminders"
         aria-label="Go to Reminders"
       >
-        <span class="icon" aria-hidden="true">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <circle cx="12" cy="12" r="8" />
-            <path d="M12 7v5l3 2" />
-          </svg>
-        </span>
+        <span class="icon" aria-hidden="true">⏰</span>
       </button>
 
       <button
@@ -5277,13 +5272,7 @@
         data-nav-target="notebook"
         aria-label="Go to Notes"
       >
-        <span class="icon" aria-hidden="true">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="M5 4h12a2 2 0 0 1 2 2v14H7a2 2 0 0 1-2-2V4z" />
-            <path d="M9 4v14" />
-            <path d="M5 9h12" />
-          </svg>
-        </span>
+        <span class="icon" aria-hidden="true">📝</span>
       </button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- replace reminders and notebook footer icons in the mobile shell with matching symbol glyphs for consistency

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69227772be90832494a3d326e0093055)