### PR TITLE
Improve add lesson form layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -922,14 +922,14 @@
               </button>
             </div>
             <form id="planner-lesson-form" class="mt-6" novalidate>
-              <div class="mx-auto w-full max-w-3xl rounded-2xl bg-base-100 border border-base-200 p-6 shadow-sm">
-                <div class="space-y-6">
+              <div class="mx-auto w-full max-w-3xl rounded-2xl bg-base-100/90 border border-base-200 p-6 shadow-xl">
+                <div class="space-y-8">
                   <!-- SECTION A — Lesson details -->
                   <section data-planner-lesson-section class="space-y-4">
-                    <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
-                      <div class="md:col-span-1">
-                        <label class="block text-sm font-medium text-base-content mb-1">Day</label>
-                        <select id="planner-lesson-day" class="select select-bordered mt-1 w-full" required>
+                    <div class="grid grid-cols-1 gap-4 md:grid-cols-3 md:gap-6">
+                      <div class="md:col-span-1 space-y-1">
+                        <label class="block text-sm font-medium text-base-content">Day</label>
+                        <select id="planner-lesson-day" class="select select-bordered w-full" required>
                           <option value="Monday">Monday</option>
                           <option value="Tuesday">Tuesday</option>
                           <option value="Wednesday">Wednesday</option>
@@ -939,28 +939,28 @@
                           <option value="Sunday">Sunday</option>
                         </select>
                       </div>
-                      <div class="md:col-span-2">
-                        <label class="block text-sm font-medium text-base-content mb-1">Period or time</label>
+                      <div class="md:col-span-2 space-y-1">
+                        <label class="block text-sm font-medium text-base-content">Period or time</label>
                         <input
                           id="planner-lesson-period"
                           type="text"
-                          class="input input-bordered mt-1 w-full"
+                          class="input input-bordered w-full"
                           placeholder="e.g. Lesson 3 – 11:15–12:05"
                         />
                       </div>
                     </div>
 
-                    <div>
-                      <label class="block text-sm font-medium text-base-content mb-1">Title</label>
-                      <input id="planner-lesson-title" type="text" class="input input-bordered mt-1 w-full" required />
+                    <div class="space-y-1">
+                      <label class="block text-sm font-medium text-base-content">Title</label>
+                      <input id="planner-lesson-title" type="text" class="input input-bordered w-full" required />
                     </div>
                   </section>
 
                   <!-- SECTION B — Lesson structure -->
-                  <section data-planner-summary-section class="space-y-2">
-                    <div>
+                  <section data-planner-summary-section class="space-y-3">
+                    <div class="space-y-1">
                       <label class="block text-sm font-medium text-base-content">Summary</label>
-                      <p class="text-xs text-base-content/60 mt-1">What is the focus for this lesson? Use the templates below to structure your plan.</p>
+                      <p class="text-xs text-base-content/60">What is the focus for this lesson? Use the templates below to structure your plan.</p>
                     </div>
 
                     <div class="flex flex-wrap gap-2">
@@ -970,10 +970,10 @@
                       <button type="button" class="btn btn-xs btn-ghost" data-summary-template="cac">CAC</button>
                     </div>
 
-                    <div>
+                    <div class="space-y-1">
                       <textarea
                         id="planner-lesson-summary"
-                        class="textarea textarea-bordered mt-2 w-full"
+                        class="textarea textarea-bordered w-full"
                         rows="4"
                         placeholder="What is the focus for this lesson? E.g. ‘Introduce attacking space in small-sided games.’"
                       ></textarea>
@@ -982,20 +982,20 @@
 
                   <!-- SECTION C — Class & status -->
                   <section class="space-y-4">
-                    <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-                      <div>
-                        <label class="block text-sm font-medium text-base-content mb-1">Subject or class (optional)</label>
+                    <div class="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-6">
+                      <div class="space-y-1">
+                        <label class="block text-sm font-medium text-base-content">Subject or class (optional)</label>
                         <input
                           id="planner-lesson-subject"
                           type="text"
-                          class="input input-bordered mt-1 w-full"
+                          class="input input-bordered w-full"
                           placeholder="e.g. Year 9 HPE – 9WR"
                         />
-                        <p class="text-xs text-base-content/60 mt-1">Use subjects to filter the planner by class. e.g. ‘Year 9 HPE – 9WR’.</p>
+                        <p class="text-xs text-base-content/60">Use subjects to filter the planner by class. e.g. ‘Year 9 HPE – 9WR’.</p>
                       </div>
-                      <div>
-                        <label class="block text-sm font-medium text-base-content mb-1">Status</label>
-                        <select id="planner-lesson-status" class="select select-bordered mt-1 w-full">
+                      <div class="space-y-1">
+                        <label class="block text-sm font-medium text-base-content">Status</label>
+                        <select id="planner-lesson-status" class="select select-bordered w-full">
                           <option value="not_started">Not started</option>
                           <option value="in_progress">In progress</option>
                           <option value="ready">Ready</option>


### PR DESCRIPTION
## Summary
- restructure the planner lesson modal into a centered card with clearer section spacing
- align day/period, title, summary, and class/status fields into readable rows with helper text
- keep action buttons grouped to the right for consistent form actions

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922a00c3e5483248d7a1f76727a1475)