### PR TITLE
Add premium Deep Violet focus ring to note editor using focus-within

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1367,7 +1367,14 @@
     }
     .notes-editor:focus-visible {
       border-color: color-mix(in srgb, var(--accent-color) 60%, var(--border-subtle));
-      box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-color) 22%, transparent);
+      box-shadow: none;
+    }
+
+    .notes-editor:focus-within {
+      box-shadow:
+        0 0 0 1px rgba(81, 38, 99, 0.12),
+        0 0 0 4px rgba(81, 38, 99, 0.06);
+      transition: box-shadow 0.18s ease;
     }
 
     .notes-editor textarea,


### PR DESCRIPTION
## Summary
- add focus-within styling to the mobile note editor container to create a premium Deep Violet focus ring
- soften the existing focus-visible shadow so the new focus elevation is the primary highlight

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922a6e4059c8324bd5694d93e7f4835)