### PR TITLE
Upgrade mobile reminder list items with soft translucent styling

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -45,6 +45,11 @@
       --true-blue: #0073cf;
       --delete-color: #EF6A6A;
 
+      --cat-yellow: #f2d38b;
+      --cat-red:    #f29cab;
+      --cat-green:  #9ed8b7;
+      --cat-violet: #c6b4f2;
+
       /* Legacy tokens mapped to Calming Tones palette */
       --primary-color: var(--accent-color);
       --primary-dark: #3E1D4C;
@@ -809,39 +814,45 @@
     grid-auto-rows: auto;
   }
 
-    /* Each reminder item uses the Calming Tones card styling */
+    /* Each reminder item uses the premium soft elevated card styling */
     #reminderList > * {
       display: grid;
       grid-template-columns: minmax(0, 1fr) auto;
       align-items: start;
       gap: var(--reminder-card-gap);
-      padding: var(--reminder-card-padding-y) var(--reminder-card-padding-x);
-      margin: 0;
-      border: 1px solid var(--card-border);
+      padding: 12px 14px;
+      margin: 6px 0;
+      border: 1px solid rgba(255, 255, 255, 0.5);
       font-size: var(--reminder-card-font-size);
       line-height: 1.4;
-      background: var(--card-bg);
+      background: rgba(255, 255, 255, 0.65);
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
       border-radius: 12px;
-      box-shadow: 0 1px 3px var(--shadow-color);
-      transition: all 0.2s ease;
+      box-shadow:
+        0 2px 4px rgba(0, 0, 0, 0.06),
+        0 1px 2px rgba(0, 0, 0, 0.04);
+      transition: box-shadow 0.18s ease, transform 0.18s ease;
       width: 100%;
       max-width: 100%;
       box-sizing: border-box;
       position: static;
+      border-left: 4px solid var(--cat-violet);
     }
 
     #reminderList > *:hover {
-      box-shadow: 0 4px 12px var(--shadow-color);
-      transform: translateY(-2px);
-      border-color: var(--accent-color);
+      transform: translateY(-1px);
+      box-shadow:
+        0 6px 16px rgba(0, 0, 0, 0.08),
+        0 2px 6px rgba(0, 0, 0, 0.04);
     }
 
     /* --- Priority Tints & Borders --- */
 
     /* Update the base card to include a default border */
     .reminder-card {
-      border-left: 3px solid var(--border-color);
-      transition: all 0.2s ease;
+      border-left: 4px solid var(--cat-violet);
+      transition: box-shadow 0.18s ease, transform 0.18s ease;
     }
 
     /* High priority: Bio Orange tint + border */
@@ -885,14 +896,19 @@
         grid-template-columns: minmax(0, 1fr) auto;
         align-items: start;
         gap: 0.5rem;
-        padding: 0.6rem 0.8rem;
+        padding: 12px 14px;
         margin-bottom: 0.5rem;
-        background: var(--card-bg);
-        border: 1px solid var(--card-border);
-        border-radius: 0.5rem;
-        box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+        background: rgba(255, 255, 255, 0.65);
+        backdrop-filter: blur(6px);
+        -webkit-backdrop-filter: blur(6px);
+        border: 1px solid rgba(255, 255, 255, 0.5);
+        border-radius: 12px;
+        box-shadow:
+          0 2px 4px rgba(0, 0, 0, 0.06),
+          0 1px 2px rgba(0, 0, 0, 0.04);
         font-size: var(--reminder-card-font-size);
         line-height: 1.4;
+        border-left: 4px solid var(--cat-violet);
       }
 
       #reminderList > .reminder-card.priority-high {
@@ -987,7 +1003,7 @@
     #reminderList > * [data-reminder-title] {
       margin: 0;
       color: var(--text-strong);
-      font-weight: 700;
+      font-weight: 600;
       font-size: 1rem;
       margin-bottom: 0.5rem;
       grid-column: 1;
@@ -2688,7 +2704,7 @@
     #reminderList [data-reminder] strong,
     #reminderList [data-reminder] [data-reminder-title] {
       margin: 0;
-      color: var(--text-primary);
+      color: var(--text-strong, #34163f);
       font-weight: 600;
       font-size: 1rem;
       margin-bottom: 0.5rem;
@@ -2705,7 +2721,7 @@
     .cue-meta,
     #reminderList [data-reminder] time,
     #reminderList [data-reminder] .reminder-meta {
-      color: var(--text-secondary);
+      color: var(--text-muted, #9a8bb0);
       font-size: 0.8rem;
       display: flex;
       justify-content: space-between;
@@ -2724,7 +2740,7 @@
     #reminderList [data-reminder] p,
     #reminderList [data-reminder] .description,
     #reminderList [data-reminder] .details {
-      color: var(--text-secondary);
+      color: var(--text-muted, #9a8bb0);
     }
 
     .cue-actions,
@@ -3110,7 +3126,7 @@
     .mobile-shell #reminderList > .reminder-card [data-reminder-title] {
       font-size: 1.02rem;
       font-weight: 600;
-      color: var(--desktop-text-main, var(--text-primary));
+      color: var(--text-strong, #34163f);
       line-height: 1.3;
       margin: 0;
       overflow: hidden;
@@ -3128,7 +3144,7 @@
     .mobile-shell #reminderList > .reminder-card .task-meta-text,
     .mobile-shell #reminderList > .reminder-card time {
       font-size: 0.78rem;
-      color: var(--desktop-text-muted, var(--text-secondary));
+      color: var(--text-muted, #9a8bb0);
       line-height: 1.35;
     }
 
@@ -3174,7 +3190,7 @@
       padding-top: 0.35rem;
       border-top: 1px solid color-mix(in srgb, var(--card-border) 35%, transparent);
       font-size: 0.8rem;
-      color: var(--text-secondary, var(--desktop-text-muted));
+      color: var(--text-muted, #9a8bb0);
     }
 
     .mobile-shell #reminderList > .reminder-card .priority-pill,


### PR DESCRIPTION
## Summary
- restyle mobile reminder list items as soft elevated translucent cards with blur, rounded corners, and gentle shadows
- refresh reminder typography to use the updated strong and muted text palette for titles and meta details
- introduce pastel category color tokens and apply the softened accent strip to reminder cards

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922a7a89af083248163757e24ae1b40)