### PR TITLE
Soften reminder category colours to pastel tones aligned with the premium violet/lilac theme

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -9,6 +9,10 @@
   --mc-border-soft: rgba(255, 255, 255, 0.12);
   --mc-text-main: #f9fafb;
   --mc-text-soft: rgba(249, 250, 251, 0.86);
+  --cat-yellow: #f2d38b;
+  --cat-red:    #f29cab;
+  --cat-green:  #9ed8b7;
+  --cat-violet: #c6b4f2;
 }
 
 /* Full-page gradient background, applied to main shells / body */

--- a/mobile.html
+++ b/mobile.html
@@ -63,6 +63,10 @@
       --priority-high-color: #ef4444; /* Tailwind red-500 */
       --priority-medium-color: #eab308; /* Tailwind yellow-500 */
       --priority-low-color: #22c55e; /* Tailwind green-500 */
+      --cat-yellow: #f2d38b;
+      --cat-red:    #f29cab;
+      --cat-green:  #9ed8b7;
+      --cat-violet: #c6b4f2;
       --shadow-sm: 0 1px 3px var(--shadow-color);
       --shadow-md: 0 4px 12px var(--shadow-color);
       --transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);


### PR DESCRIPTION
## Summary
- add pastel category color tokens to shared mobile and main stylesheets

## Testing
- not run (CSS-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922a8a1b0ec832486b2ecbbd1e9546e)