### PR TITLE
Enhance notebook view styling for premium writing experience

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -267,15 +267,15 @@
 
   /* Distraction-free writing environment background */
   .mobile-panel--notes {
-    background: var(--mobile-quick-surface);
+    background: var(--background-gradient);
   }
 
   .mobile-panel--notes .mobile-view-inner {
-    background: var(--mobile-quick-surface);
+    background: var(--background-gradient);
   }
 
   .mobile-panel--notes #scratch-notes-card {
-    background: var(--mobile-quick-surface);
+    background: var(--background-gradient);
   }
 
   [data-view="notebook"] .textarea {
@@ -310,10 +310,22 @@
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 0.6rem;
-    padding: 0.6rem 0.75rem calc(0.75rem + env(safe-area-inset-bottom, 0.75rem));
+    gap: 0;
+    max-width: 640px;
+    margin: 12px auto 0;
+    padding: 0.75rem 1rem calc(1.25rem + env(safe-area-inset-bottom, 0.75rem));
     position: relative;
-    border-radius: 0.85rem;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.78);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    box-shadow:
+      0 10px 30px rgba(0, 0, 0, 0.08),
+      0 0 0 1px rgba(255, 255, 255, 0.7);
+  }
+
+  #view-notebook #scratch-notes-card > * + * {
+    margin-top: 0.35rem;
   }
 
   .mobile-panel--notes #scratch-notes-card .notes-editor {
@@ -1327,6 +1339,28 @@
       background: color-mix(in srgb, var(--success-color) 90%, transparent);
       box-shadow: 0 0 0 4px color-mix(in srgb, var(--success-color) 18%, transparent);
     }
+
+    #view-notebook .mobile-view-inner {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 0.75rem 0.75rem 1rem;
+    }
+
+    #view-notebook .notebook-actions-row {
+      margin-bottom: 6px;
+      padding: 0.4rem 0.5rem;
+      border-radius: 12px;
+    }
+
+    #view-notebook #noteTitleMobile,
+    #view-notebook .seamless-title-input {
+      color: var(--text-strong, #34163f);
+      font-weight: 600;
+    }
+
+    #view-notebook #noteTitleMobile::placeholder {
+      color: var(--text-muted, #9a8bb0);
+    }
     .note-title-field {
       border: 1.5px solid var(--border-subtle);
       border-radius: 1rem;
@@ -1624,34 +1658,42 @@
 
     .distraction-free-editor-container {
       margin-top: 0;
-      background-color: var(--surface-elevated);
-      border: 1px solid var(--border-subtle);
+      background: rgba(249, 249, 252, 0.66);
+      border: 1px solid rgba(230, 225, 240, 0.75);
       color: var(--text-body);
-      border-radius: 12px;
+      border-radius: 14px;
       padding: 0.35rem;
+      transition: box-shadow 0.18s ease, border-color 0.18s ease;
+    }
+
+    .distraction-free-editor-container:focus-within {
+      box-shadow:
+        0 0 0 1px rgba(81, 38, 99, 0.12),
+        0 0 0 4px rgba(81, 38, 99, 0.06);
     }
 
     .minimal-editor {
-      border: 1px solid var(--border-subtle);
-      box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.04);
+      border: 1px solid rgba(220, 214, 233, 0.9);
+      box-shadow: none;
       transition: all 0.2s ease;
       line-height: 1.45;
       min-height: calc(100vh - 220px);
       max-height: calc(100vh - 120px);
       overflow-y: auto;
-      background-color: #f9f9f9;
-      color: var(--text-body);
+      background: rgba(249, 249, 252, 0.96);
+      color: var(--text-body, #4a3c57);
       border-radius: 12px;
       font-family: var(--font-primary);
       font-size: var(--font-size-body);
       font-weight: 400;
+      padding: 10px 12px;
     }
 
     .minimal-editor:focus,
     .minimal-editor[contenteditable="true"]:focus {
-      border-color: #512663;
-      box-shadow: 0 0 0 3px rgba(81, 38, 99, 0.18), inset 0 1px 2px rgba(0, 0, 0, 0.05);
-      outline: 2px solid rgba(81, 38, 99, 0.25);
+      border-color: rgba(81, 38, 99, 0.22);
+      box-shadow: none;
+      outline: none;
     }
 
     .minimal-editor textarea {
@@ -1674,20 +1716,25 @@
 
     .minimal-editor:empty::before {
       content: attr(data-placeholder);
-      color: var(--text-muted);
+      color: var(--text-muted, #9a8bb0);
       font-style: italic;
     }
 
+    #view-notebook .editor-hint,
+    #view-notebook .note-subtitle {
+      color: var(--text-muted, #9a8bb0);
+    }
+
     .formatting-toolbar-strip {
-      margin: 0.05rem 0 0.2rem;
-      backdrop-filter: blur(6px);
+      display: flex;
+      gap: 6px;
+      padding: 4px 6px;
+      margin-bottom: 6px;
+      border-radius: 999px;
+      background: rgba(247, 247, 250, 0.96);
+      border: 1px solid rgba(230, 225, 240, 0.9);
+      box-shadow: none;
       min-height: auto;
-      background-color: #f9f9f9;
-      border: 1px solid #e6dff0;
-      border-radius: 10px;
-      padding: 0.25rem 0.35rem;
-      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
-      gap: 0.35rem;
     }
 
     .formatting-btn {
@@ -1696,13 +1743,20 @@
       justify-content: center;
       width: 32px;
       height: 32px;
-      border-radius: 8px;
-      border: 1px solid #e6dff0;
-      background: #f9f9f9;
-      color: #512663; /* Deep Violet Primary Accent */
+      border-radius: 50%;
+      border: none;
+      background: transparent;
+      color: var(--accent-color, #512663);
       cursor: pointer;
-      transition: all 0.2s ease;
-      margin: 1px;
+      transition: background-color 0.18s ease, color 0.18s ease;
+      margin: 0;
+    }
+
+    .formatting-btn:hover,
+    .formatting-btn:focus-visible {
+      background: rgba(81, 38, 99, 0.08);
+      color: var(--accent-color, #512663);
+      outline: none;
     }
 
     .formatting-btn svg {


### PR DESCRIPTION
## Summary
- center the notebook view on the lilac gradient background with an elevated, blurred card
- tighten spacing between title, toolbar, and editor while aligning typography to deep violet tokens
- soften editor container styling and toolbar buttons to match the new reminders/footer aesthetic

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922ab3919608324bad329b295ae438e)