### PR TITLE
Enhance notebook list with elevated card styling

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -368,33 +368,63 @@
     padding: 0;
   }
 
+  .notebook-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 8px 0 16px;
+  }
+
   .mobile-shell #notesListMobile .note-item-mobile {
     margin: 0;
   }
 
-  .mobile-shell #notesListMobile .saved-note-row {
-    border: 1px solid color-mix(in srgb, var(--card-border) 85%, transparent);
-    background-color: color-mix(in srgb, var(--card-bg) 90%, rgba(148, 163, 184, 0.08));
-    padding: 0.35rem 0.65rem;
-    border-radius: 999px;
-    transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  .note-list-item {
+    background: rgba(255, 255, 255, 0.72);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border-radius: 14px;
+    padding: 10px 12px;
+    box-shadow:
+      0 2px 6px rgba(0, 0, 0, 0.05),
+      0 0 0 1px rgba(255, 255, 255, 0.7);
+    border: 1px solid rgba(230, 224, 242, 0.9);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    transition:
+      transform 0.16s ease,
+      box-shadow 0.2s ease,
+      background-color 0.18s ease;
   }
 
-  .mobile-shell #notesListMobile .saved-note-row:hover {
-    background-color: color-mix(in srgb, var(--card-bg) 92%, rgba(148, 163, 184, 0.18));
-    border-color: color-mix(in srgb, var(--accent-color) 35%, var(--card-border));
+  .note-list-item:hover {
+    transform: translateY(-1px);
+    box-shadow:
+      0 6px 16px rgba(0, 0, 0, 0.08),
+      0 2px 4px rgba(0, 0, 0, 0.04);
   }
 
-  .mobile-shell #notesListMobile .saved-note-row:active {
-    transform: translateY(1px);
+  .note-list-title {
+    font-size: 0.98rem;
+    font-weight: 600;
+    color: var(--text-strong);
+    margin-bottom: 1px;
   }
 
-  .mobile-shell #notesListMobile .saved-note-row .open-note-btn {
-    padding: 0;
+  .note-list-preview {
+    font-size: 0.86rem;
+    color: var(--text-body);
+    line-height: 1.3;
+    max-height: 2.6em;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
-  .mobile-shell #notesListMobile .delete-note-btn {
-    border-radius: 999px;
+  .note-list-meta {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    margin-top: 2px;
   }
 
   .mobile-shell #savedNotesSheet {
@@ -3864,7 +3894,7 @@
             <div class="mt-1 max-h-56 overflow-y-auto flex-1 w-full">
               <ul
                 id="notesListMobile"
-                class="space-y-2 text-sm"
+                class="notebook-list text-sm"
                 aria-label="Saved scratch notes"
               ></ul>
             </div>

--- a/mobile.html
+++ b/mobile.html
@@ -668,33 +668,63 @@
     padding: 0;
   }
 
+  .notebook-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 8px 0 16px;
+  }
+
   .mobile-shell #notesListMobile .note-item-mobile {
     margin: 0;
   }
 
-  .mobile-shell #notesListMobile .saved-note-row {
-    border: 1.5px solid var(--card-border-strong);
-    background-color: color-mix(in srgb, var(--card-bg) 90%, rgba(148, 163, 184, 0.08));
-    padding: 0.35rem 0.65rem;
-    border-radius: 999px;
-    transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  .note-list-item {
+    background: rgba(255, 255, 255, 0.72);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border-radius: 14px;
+    padding: 10px 12px;
+    box-shadow:
+      0 2px 6px rgba(0, 0, 0, 0.05),
+      0 0 0 1px rgba(255, 255, 255, 0.7);
+    border: 1px solid rgba(230, 224, 242, 0.9);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    transition:
+      transform 0.16s ease,
+      box-shadow 0.2s ease,
+      background-color 0.18s ease;
   }
 
-  .mobile-shell #notesListMobile .saved-note-row:hover {
-    background-color: color-mix(in srgb, var(--card-bg) 92%, rgba(148, 163, 184, 0.18));
-    border-color: color-mix(in srgb, var(--accent-color) 40%, var(--card-border-strong));
+  .note-list-item:hover {
+    transform: translateY(-1px);
+    box-shadow:
+      0 6px 16px rgba(0, 0, 0, 0.08),
+      0 2px 4px rgba(0, 0, 0, 0.04);
   }
 
-  .mobile-shell #notesListMobile .saved-note-row:active {
-    transform: translateY(1px);
+  .note-list-title {
+    font-size: 0.98rem;
+    font-weight: 600;
+    color: var(--text-strong);
+    margin-bottom: 1px;
   }
 
-  .mobile-shell #notesListMobile .saved-note-row .open-note-btn {
-    padding: 0;
+  .note-list-preview {
+    font-size: 0.86rem;
+    color: var(--text-body);
+    line-height: 1.3;
+    max-height: 2.6em;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
-  .mobile-shell #notesListMobile .delete-note-btn {
-    border-radius: 999px;
+  .note-list-meta {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    margin-top: 2px;
   }
 
   .mobile-shell #savedNotesSheet {
@@ -5327,7 +5357,7 @@
               <div class="px-2 pb-3 overflow-y-auto">
                 <div
                   id="notesListMobile"
-                  class="space-y-2 text-sm"
+                  class="notebook-list text-sm"
                   aria-label="Saved scratch notes"
                 >
                   <!-- Note items are rendered here by JS -->

--- a/mobile.js
+++ b/mobile.js
@@ -743,20 +743,20 @@ const initMobileNotes = () => {
       itemButton.dataset.noteId = note.id;
       itemButton.dataset.role = 'open-note';
       itemButton.className =
-        'saved-note-item w-full text-left rounded-xl bg-base-100 border border-base-300 px-3 py-2 flex flex-col gap-1 active:scale-[0.99] transition-transform';
+        'saved-note-item note-list-item w-full text-left active:scale-[0.99] focus:outline-none';
 
       // Top row: title and optional meta (timestamp)
       const topRow = document.createElement('div');
       topRow.className = 'flex items-center justify-between gap-2';
 
       const titleEl = document.createElement('span');
-      titleEl.className = 'saved-note-title text-sm font-semibold truncate';
+      titleEl.className = 'saved-note-title note-list-title truncate';
       const noteTitle = note.title || 'Untitled';
       titleEl.textContent = noteTitle;
       titleEl.setAttribute('title', noteTitle);
 
       const metaEl = document.createElement('span');
-      metaEl.className = 'saved-note-meta text-[11px] text-base-content/60';
+      metaEl.className = 'saved-note-meta note-list-meta';
       const ts = note.updatedAt || note.modifiedAt || note.createdAt || '';
       metaEl.textContent = ts ? formatNoteTimestamp(ts) : '';
 
@@ -765,7 +765,7 @@ const initMobileNotes = () => {
 
       // Body preview (strip HTML and clamp to two lines)
       const previewEl = document.createElement('p');
-      previewEl.className = 'saved-note-preview text-xs text-base-content/70 line-clamp-2';
+      previewEl.className = 'saved-note-preview note-list-preview line-clamp-2';
       const rawBody = note.body || '';
       const plainBody = String(rawBody).replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
       previewEl.textContent = plainBody || 'No content yet.';


### PR DESCRIPTION
## Summary
- refresh the notebook list container with card-focused layout spacing and translucent surfaces
- align notebook list typography to shared strong/body/muted tokens for titles, snippets, and metadata
- update notebook list rendering classes so saved notes adopt the new card presentation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922bd1a05908324af23876ccfc04470)