### PR TITLE
Preserve Notebook formatting and add Markdown-style list shortcuts

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5301,13 +5301,20 @@
                 <circle cx="4" cy="17" r="1.25" fill="currentColor" />
               </svg>
             </button>
+
+            <button type="button" class="formatting-btn" data-format="ol" aria-label="Numbered list">
+              <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M9 6h11v2H9V6zm0 5h11v2H9v-2zm0 5h11v2H9v-2z" fill="currentColor" />
+                <path d="M4 6.5V8h2V4H4v1.5h1v1H4zm1.5 4H4a.5.5 0 0 0-.5.5v.75H4V12h1v2H3.5v1H6v-3.5a1 1 0 0 0-1-1Zm.5 5H4v1h1v1H4v1h2v-3Z" fill="currentColor" />
+              </svg>
+            </button>
           </div>
 
           <!-- Minimal main editor with soft styling -->
           <div class="distraction-free-editor-container">
             <div
               id="scratchNotesEditor"
-              class="minimal-editor px-1 py-1 text-base leading-relaxed focus:outline-none rounded-lg"
+              class="note-editor-area minimal-editor px-1 py-1 text-base leading-relaxed focus:outline-none rounded-lg"
               contenteditable="true"
               data-placeholder="Start typing your note…"
             ></div>


### PR DESCRIPTION
## Summary
- ensure the mobile notebook editor stores and restores HTML content instead of stripping formatting
- wire up toolbar controls, including a new numbered-list button, to apply formatting in the editor
- add simple Markdown-style list shortcuts for bullets and numbered lists in the notebook editor

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922bf1c219c8324afc4cfdbb958f042)