### PR TITLE
Fix mobile header menu wiring

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -7895,8 +7895,8 @@
       if (!slimHeader) return;
 
       const addBtn = slimHeader.querySelector('#addReminderBtn');
-      const overflowBtn = slimHeader.querySelector('#overflowMenuBtn');
-      const overflowMenu = slimHeader.querySelector('#overflowMenu');
+      const overflowBtn = slimHeader.querySelector('#headerMenuBtn');
+      const overflowMenu = slimHeader.querySelector('#headerMenu');
 
       if (addBtn) {
         addBtn.addEventListener('click', function(event) {


### PR DESCRIPTION
## Summary
- wire the slim header overflow toggle to the correct button and menu IDs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923866d2f9483248a07b43ab95338fd)