### PR TITLE
Implement notebook folder persistence and filtering

### DIFF
--- a/js/modules/notes-storage.js
+++ b/js/modules/notes-storage.js
@@ -254,7 +254,13 @@ export const getFolders = () => {
   } catch (e) {
     // fall through to return default
   }
-  return defaultFolders();
+  const defaults = defaultFolders();
+  try {
+    localStorage.setItem(FOLDERS_STORAGE_KEY, JSON.stringify(defaults));
+  } catch {
+    // ignore write errors when seeding defaults
+  }
+  return defaults;
 };
 
 // Helper to look up a folder name by id

--- a/mobile.js
+++ b/mobile.js
@@ -970,19 +970,20 @@ const initMobileNotes = () => {
     } catch {
       folders = [];
     }
-    // Build a minimal, visible folder list: All, Unsorted, then any user folders
-    const DEFAULT_FOLDERS = [
-      { id: 'all', name: 'All' },
-      { id: 'unsorted', name: 'Unsorted' },
+    const normalized = Array.isArray(folders) ? folders.filter(Boolean) : [];
+    const unsortedFolder =
+      normalized.find((f) => f && f.id === 'unsorted') || { id: 'unsorted', name: 'Unsorted' };
+    const extraFolders = normalized
+      .filter((f) => f && f.id !== 'unsorted')
+      .sort((a, b) => String(a.name || '').localeCompare(String(b.name || ''), undefined, { sensitivity: 'base' }));
+
+    const chipModel = [
+      { id: 'all', name: 'All', isVirtual: true },
+      { ...unsortedFolder, isVirtual: false },
+      ...extraFolders.map((f) => ({ ...f, isVirtual: false })),
     ];
 
-    const userFolders = Array.isArray(folders)
-      ? folders.filter((f) => f && f.id !== 'unsorted' && f.id !== 'all')
-      : [];
-
-    const ordered = [...DEFAULT_FOLDERS, ...userFolders];
-
-    ordered.forEach((folder) => {
+    chipModel.forEach((folder) => {
       const chip = document.createElement('button');
       chip.type = 'button';
       // keep legacy `folder-chip` for existing code paths, add new premium class
@@ -1585,7 +1586,7 @@ const initMobileNotes = () => {
   }
 
   const renderFilteredNotes = () => {
-    renderNotesList(getFilteredNotes());
+    renderNotesList(getVisibleNotes());
   };
 
   if (filterInput) {


### PR DESCRIPTION
## Summary
- seed a default Unsorted folder in local storage when none exists
- render notebook folder chips from stored folders, sorted and including the All/Unsorted defaults
- apply folder-aware filtering when rendering notes in the mobile notebook view

## Testing
- npm test -- --runInBand *(fails: mobile.* tests raise "Cannot use import statement outside a module" when executing mobile.js via vm)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923e0a2d7108324a3bc16b9b0bfa3e0)