### PR TITLE
Add rename and delete actions to notebook folder chips

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -1012,7 +1012,7 @@ const initMobileNotes = () => {
       if (folder.id !== 'all' && folder.id !== 'unsorted') {
         const overflowBtn = document.createElement('button');
         overflowBtn.type = 'button';
-        overflowBtn.className = 'chip-overflow';
+        overflowBtn.className = 'notebook-folder-chip-overflow';
         overflowBtn.setAttribute('aria-label', 'Folder options');
         overflowBtn.innerHTML = '⋯';
         overflowBtn.addEventListener('click', (ev) => {
@@ -1301,6 +1301,7 @@ const initMobileNotes = () => {
   };
 
   const openFolderOverflowMenu = (folderId, anchorEl) => {
+    if (!folderId || folderId === 'all' || folderId === 'unsorted') return;
     closeOverflowMenu();
     const menu = document.createElement('div');
     menu.className = 'memory-glass-card p-2 rounded shadow-lg';
@@ -1427,7 +1428,7 @@ const initMobileNotes = () => {
   };
 
   const openRenameDialog = (folderId) => {
-    if (!renameFolderModalEl) return;
+    if (!renameFolderModalEl || folderId === 'all' || folderId === 'unsorted') return;
     pendingRenameFolderId = folderId;
     const folders = Array.isArray(getFolders()) ? getFolders() : [];
     const found = folders.find((f) => f && String(f.id) === String(folderId));
@@ -1490,7 +1491,7 @@ const initMobileNotes = () => {
   let pendingDeleteFolderId = null;
 
   const openDeleteConfirm = (folderId) => {
-    if (!deleteFolderModalEl) return;
+    if (!deleteFolderModalEl || folderId === 'all' || folderId === 'unsorted') return;
     pendingDeleteFolderId = folderId;
     if (!deleteFolderController) {
       deleteFolderController = new ModalController({

--- a/styles/index.css
+++ b/styles/index.css
@@ -368,17 +368,15 @@ html[data-theme="professional"] {
 
 /* Overflow icon inside folder chip */
 .folder-chip { position: relative; }
-.folder-chip .chip-overflow {
-  margin-left: 8px;
-  font-size: 0.9rem;
-  opacity: 0.75;
+.folder-chip .notebook-folder-chip-overflow {
   border: none;
   background: transparent;
+  padding: 0 0 0 4px;
+  font-size: 0.9rem;
+  line-height: 1;
+  color: inherit;
   cursor: pointer;
-  padding: 2px 6px;
-  border-radius: 8px;
 }
-.folder-chip .chip-overflow:hover { opacity: 1; background: rgba(0,0,0,0.04); }
 
 .notebook-action-btn {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- style folder chip overflow buttons for notebook view and ensure they only appear on custom folders
- guard overflow, rename, and delete flows from running on All/Unsorted folders
- keep rename/delete dialogs wired with updated menu trigger

## Testing
- npm test -- --runInBand (fails: existing mobile jest harness cannot load ES module imports, plus Firebase config warnings)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923e9c1bb20832483554ea88c928c65)