### PR TITLE
Add notebook search bar to mobile notebook view

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5344,19 +5344,18 @@
                 </button>
               </div>
 
-              <div class="px-4 pb-2">
-                <input
-                  id="notesSearchMobile"
-                  type="text"
-                  class="input input-sm w-full"
-                  placeholder="Search notes"
-                  autocomplete="off"
-                />
-              </div>
-
               <div class="px-2 pb-3 overflow-y-auto">
                 <div id="notebook-folder-bar" class="notebook-folder-bar px-3 py-2">
                   <!-- Folder chips will be populated dynamically by JS -->
+                </div>
+
+                <div class="px-3 pb-3">
+                  <input
+                    id="notebook-search-input"
+                    type="search"
+                    placeholder="Search notes…"
+                    class="notebook-search-bar"
+                  />
                 </div>
 
                 <div

--- a/mobile.js
+++ b/mobile.js
@@ -332,7 +332,7 @@ const initMobileNotes = () => {
   const newButton = document.getElementById('noteNewMobile');
   const listElement = document.getElementById('notesListMobile');
   const countElement = document.getElementById('notesCountMobile');
-  const filterInput = document.getElementById('notesSearchMobile');
+  const filterInput = document.getElementById('notebook-search-input');
   const savedNotesSheet = document.getElementById('savedNotesSheet');
   const openSavedNotesButton = document.getElementById('openSavedNotesSheet');
   const closeSavedNotesButton = document.querySelector('[data-action="close-saved-notes"]');
@@ -543,6 +543,13 @@ const initMobileNotes = () => {
   let filterQuery = '';
   let skipAutoSelectOnce = false;
   let savedNotesSheetHideTimeout = null;
+
+  const clearSearchFilter = () => {
+    filterQuery = '';
+    if (filterInput) {
+      filterInput.value = '';
+    }
+  };
 
   const isSavedNotesSheetOpen = () =>
     savedNotesSheet?.dataset.open === 'true';
@@ -1072,6 +1079,7 @@ const initMobileNotes = () => {
         currentFolderId = folder.id === 'all' ? 'all' : folder.id;
         // set active class and auto-scroll
         setActiveFolderChip(currentFolderId);
+        clearSearchFilter();
         // re-render notes using current filter
         renderFilteredNotes();
       });
@@ -1195,6 +1203,7 @@ const initMobileNotes = () => {
       newFolderModalController.requestClose('created');
     } catch { /* ignore */ }
     currentFolderId = folderId;
+    clearSearchFilter();
     try {
       buildFolderChips();
     } catch (e) {
@@ -1701,6 +1710,7 @@ const initMobileNotes = () => {
     // If current filter was the deleted folder, switch to unsorted
     if (String(currentFolderId) === String(pendingDeleteFolderId)) {
       currentFolderId = 'unsorted';
+      clearSearchFilter();
     }
     pendingDeleteFolderId = null;
     try { deleteFolderController.requestClose('deleted'); } catch {}

--- a/styles/index.css
+++ b/styles/index.css
@@ -325,6 +325,31 @@ html[data-theme="professional"] {
   color: var(--accent-color);
 }
 
+.notebook-search-bar {
+  width: 100%;
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(81, 38, 99, 0.12);
+  background: rgba(255, 255, 255, 0.72);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
+  font-size: 0.95rem;
+  color: var(--primary-dark, #1f112e);
+  outline: none;
+  transition: box-shadow 0.16s ease, border-color 0.16s ease, background-color 0.16s ease;
+}
+
+.notebook-search-bar::placeholder {
+  color: #4b2a63;
+  opacity: 0.72;
+}
+
+.notebook-search-bar:focus {
+  border-color: rgba(81, 38, 99, 0.3);
+  box-shadow: 0 6px 16px rgba(81, 38, 99, 0.18);
+  background: rgba(255, 255, 255, 0.88);
+}
+
 /* New folder modal tweaks */
 #newFolderModal {
   border: none;


### PR DESCRIPTION
## Summary
- add a pill-style search bar below the notebook folder chips in the mobile notebook view
- style the search input with a blurred background and violet placeholder text
- clear search filters when switching folders and hook filtering to the new field

## Testing
- npm test *(fails: mobile open/sheet tests report "Cannot use import statement outside a module" and existing Firebase config warnings)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923ee989e74832496b31e95edf765c8)