### PR TITLE
Add notebook list transition animations

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -325,6 +325,24 @@ html[data-theme="professional"] {
   color: var(--accent-color);
 }
 
+/* Notebook list transitions */
+.notebook-list-transition-out {
+  opacity: 0;
+  transform: translateY(-6px);
+  transition: opacity 0.16s ease, transform 0.16s ease;
+}
+
+.notebook-list-transition-in {
+  opacity: 0;
+  transform: translateY(6px);
+}
+
+.notebook-list-transition-in-active {
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 0.16s ease, transform 0.16s ease;
+}
+
 /* New folder modal tweaks */
 #newFolderModal {
   border: none;


### PR DESCRIPTION
## Summary
- add reusable transition classes for notebook list fade and slide states
- wrap notebook list rendering with timed transitions to animate folder, search, and move updates

## Testing
- npm test *(fails in existing mobile jest suites because `mobile.js` uses ESM imports in a CJS context)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923ef9ff944832492f32d31cd640d0d)