### PR TITLE
Refine reminder sheet layout

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -4084,74 +4084,282 @@
   <script src="./assets/register-service-worker-J3ZRTHIR.js" defer></script>
   <script type="module" src="./assets/mobile-NGXAV7ZY.js?v=2025-10-29-1"></script>
   <script type="module" src="./assets/mobile-theme-toggle-CKY7BNGT.js"></script>
-  <!-- BEGIN GPT CHANGE: bottom sheet for Create Reminder -->
+  <style id="reminder-editor-premium">
+    #create-sheet {
+      background: radial-gradient(circle at 50% 10%, rgba(104, 65, 144, 0.14), transparent 38%),
+        linear-gradient(180deg, #f2e8ff 0%, #eae0ff 45%, #f7f3ff 100%);
+    }
+
+    #create-sheet .sheet-panel {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: transparent;
+      border: none;
+      box-shadow: none;
+      padding: calc(20px + env(safe-area-inset-top)) 14px calc(20px + env(safe-area-inset-bottom));
+    }
+
+    #create-sheet .reminder-editor-shell {
+      margin: 0 auto;
+      width: min(640px, 100%);
+      border-radius: 20px;
+      padding: 16px 16px 20px;
+      background: rgba(255, 255, 255, 0.96);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      box-shadow:
+        0 -12px 30px rgba(0, 0, 0, 0.08),
+        0 -4px 12px rgba(0, 0, 0, 0.06);
+      transform: translateY(0);
+      transition: transform 0.18s ease-out, opacity 0.18s ease-out;
+      max-height: min(90vh, 720px);
+      overflow: auto;
+    }
+
+    #create-sheet .reminder-editor-shell.reminder-enter {
+      opacity: 0;
+      transform: translateY(16px);
+    }
+
+    #create-sheet .reminder-editor-shell.reminder-enter.reminder-enter-active {
+      opacity: 1;
+      transform: translateY(0);
+      transition: opacity 0.18s ease-out, transform 0.18s ease-out;
+    }
+
+    .reminder-editor-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 10px;
+    }
+
+    .reminder-header-back {
+      border: none;
+      border-radius: 999px;
+      background: rgba(81, 38, 99, 0.06);
+      color: var(--primary-dark);
+      width: 32px;
+      height: 32px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+    }
+
+    .reminder-header-title-group {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .reminder-header-eyebrow {
+      display: block;
+      font-size: 0.65rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: rgba(47, 27, 63, 0.6);
+    }
+
+    .reminder-header-title {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--primary-dark);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+
+    .reminder-header-save {
+      border-radius: 999px;
+      border: none;
+      padding: 6px 14px;
+      font-size: 0.8rem;
+      font-weight: 500;
+      color: #fff;
+      background: var(--accent-color, #512663);
+      box-shadow: 0 6px 16px rgba(81, 38, 99, 0.25);
+      cursor: pointer;
+    }
+
+    .reminder-editor-form {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .reminder-field {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .reminder-field-label {
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: rgba(47, 27, 63, 0.6);
+    }
+
+    .reminder-field-input,
+    .reminder-field-select,
+    .reminder-field-textarea {
+      border-radius: 12px;
+      border: 1px solid var(--border-subtle, rgba(0, 0, 0, 0.06));
+      padding: 8px 10px;
+      font-size: 0.85rem;
+      background: rgba(255, 255, 255, 0.94);
+      color: var(--primary-dark);
+      outline: none;
+      transition: border-color 0.14s ease, box-shadow 0.14s ease, background-color 0.14s ease;
+    }
+
+    .reminder-field-input:focus,
+    .reminder-field-select:focus,
+    .reminder-field-textarea:focus {
+      border-color: rgba(81, 38, 99, 0.35);
+      box-shadow: 0 0 0 1px rgba(81, 38, 99, 0.25);
+      background: #ffffff;
+    }
+
+    .reminder-field--row {
+      display: grid;
+      grid-template-columns: 1.1fr 0.9fr;
+      gap: 10px;
+    }
+
+    @media (max-width: 360px) {
+      .reminder-field--row {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    .reminder-chip-row {
+      display: flex;
+      flex-wrap: nowrap;
+      gap: 6px;
+    }
+
+    .reminder-chip,
+    .priority-pill-row .priority-pill {
+      border-radius: 999px;
+      border: 1px solid rgba(47, 27, 63, 0.12);
+      background: rgba(255, 255, 255, 0.9);
+      padding: 4px 10px;
+      font-size: 0.75rem;
+      cursor: pointer;
+      color: var(--primary-dark);
+      transition: background-color 0.14s ease, border-color 0.14s ease, color 0.14s ease, box-shadow 0.14s ease;
+    }
+
+    .reminder-chip--active,
+    .priority-pill-row .priority-input:checked + .priority-pill,
+    .priority-pill-row .priority-pill:has(+ .priority-input:checked),
+    .priority-pill-row input.priority-input:checked + label.priority-pill {
+      background: var(--accent-color, #512663);
+      border-color: var(--accent-color, #512663);
+      color: #fff;
+      box-shadow: 0 4px 12px rgba(81, 38, 99, 0.28);
+    }
+
+    .reminder-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+      padding-top: 4px;
+    }
+
+    #dateFeedback {
+      min-height: 1em;
+    }
+
+  </style>
+    <!-- BEGIN GPT CHANGE: bottom sheet for Create Reminder -->
   <div id="create-sheet" role="dialog" aria-modal="true" aria-labelledby="createSheetTitle" class="sheet hidden" tabindex="-1" data-add-task-dialog>
     <div class="sheet-backdrop backdrop fixed inset-0 z-30 bg-black/40" data-close></div>
     <div
-      class="sheet-panel fixed inset-x-0 bottom-0 z-40 bg-base-100 rounded-t-3xl shadow-xl border-t border-base-300 px-4 pt-3 pb-4 space-y-3"
+      class="sheet-panel reminder-sheet-panel fixed inset-x-0 bottom-0 z-40"
       data-dialog-content
     >
-      <div class="flex items-center justify-between gap-2 mb-1">
-        <h2 id="createSheetTitle" class="text-base font-semibold text-base-content">Create Reminder</h2>
-        <button type="button" id="closeCreateSheet" aria-label="Close" class="btn btn-ghost btn-sm btn-circle flex-shrink-0">✕</button>
-      </div>
-      <form id="createReminderForm" class="space-y-4">
-        <div class="space-y-4">
-          <div class="space-y-1">
-            <label class="text-xs font-semibold tracking-wide text-base-content/70 uppercase" for="reminderText">Reminder</label>
+      <div class="reminder-editor-shell mobile-new-reminder-card" data-reminder-editor>
+        <header class="reminder-editor-header">
+          <button type="button" id="closeCreateSheet" aria-label="Close" class="reminder-header-back">←</button>
+          <div class="reminder-header-title-group">
+            <span class="reminder-header-eyebrow">Reminder</span>
+            <h2 class="reminder-header-title" id="createSheetTitle">New reminder</h2>
+          </div>
+          <button
+            type="submit"
+            form="createReminderForm"
+            id="saveReminder"
+            class="reminder-header-save"
+          >
+            Save
+          </button>
+        </header>
+        <form id="createReminderForm" class="reminder-editor-form">
+          <div class="reminder-field">
+            <label for="reminderText" class="reminder-field-label">Title</label>
             <input
               id="reminderText"
               type="text"
-              placeholder=""
-              class="input input-bordered input-sm w-full text-sm text-base-content"
+              placeholder="What do you need to remember?"
+              class="reminder-field-input input input-bordered input-sm w-full text-sm text-base-content"
               autocomplete="off"
             />
           </div>
 
-          <div class="space-y-1">
-            <label class="text-xs font-semibold tracking-wide text-base-content/70 uppercase" for="reminderDetails">Notes</label>
+          <div class="reminder-field">
+            <label for="reminderDetails" class="reminder-field-label">Notes</label>
             <textarea
               id="reminderDetails"
-              class="textarea textarea-bordered w-full min-h-[6rem] text-sm text-base-content"
+              class="reminder-field-textarea textarea textarea-bordered w-full min-h-[6rem] text-sm text-base-content"
               rows="3"
               placeholder="Optional context for the reminder"
             ></textarea>
           </div>
 
-          <div class="grid grid-cols-2 gap-3">
-            <div class="space-y-1">
-              <label class="text-xs font-semibold tracking-wide text-base-content/70 uppercase" for="reminderDate">Date</label>
-              <input id="reminderDate" type="date" class="input input-bordered input-sm w-full text-sm text-base-content" />
+          <div class="reminder-field reminder-field--row">
+            <div class="reminder-field">
+              <label class="reminder-field-label" for="reminderDate">Date</label>
+              <input id="reminderDate" type="date" class="reminder-field-input input input-bordered input-sm w-full text-sm text-base-content" />
             </div>
-            <div class="space-y-1">
-              <label class="text-xs font-semibold tracking-wide text-base-content/70 uppercase" for="reminderTime">Time</label>
-              <input id="reminderTime" type="time" class="input input-bordered input-sm w-full text-sm text-base-content" />
+            <div class="reminder-field">
+              <label class="reminder-field-label" for="reminderTime">Time</label>
+              <input id="reminderTime" type="time" class="reminder-field-input input input-bordered input-sm w-full text-sm text-base-content" />
             </div>
           </div>
 
           <div id="dateFeedback" class="text-xs text-info"></div>
 
-          <div class="grid grid-cols-2 gap-3">
-            <div class="space-y-1">
-              <label class="text-xs font-semibold tracking-wide text-base-content/70 uppercase" for="priority">Priority</label>
+          <div class="reminder-field reminder-field--row">
+            <div class="reminder-field">
+              <label class="reminder-field-label" for="priority">Priority</label>
               <select id="priority" class="select select-bordered select-sm w-full text-sm text-base-content hidden" aria-hidden="true" tabindex="-1">
                 <option value="High">High</option>
                 <option value="Medium" selected>Medium</option>
                 <option value="Low">Low</option>
               </select>
-              <!-- BEGIN GPT CHANGE: priority chips -->
-              <fieldset id="priorityChips" aria-label="Priority" class="chip-row">
-                <label><input type="radio" name="priority" value="High"> High</label>
-                <label><input type="radio" name="priority" value="Medium" checked> Medium</label>
-                <label><input type="radio" name="priority" value="Low"> Low</label>
+              <fieldset id="priorityChips" aria-label="Priority" class="priority-pill-row reminder-chip-row" role="radiogroup">
+                <input class="priority-input" type="radio" id="priority-high" name="priority" value="High" aria-label="High priority">
+                <label class="priority-pill reminder-chip" for="priority-high">High</label>
+
+                <input class="priority-input" type="radio" id="priority-medium" name="priority" value="Medium" checked aria-label="Medium priority">
+                <label class="priority-pill reminder-chip" for="priority-medium">Medium</label>
+
+                <input class="priority-input" type="radio" id="priority-low" name="priority" value="Low" aria-label="Low priority">
+                <label class="priority-pill reminder-chip" for="priority-low">Low</label>
               </fieldset>
-              <!-- END GPT CHANGE: priority chips -->
             </div>
-            <div class="space-y-1">
-              <label class="text-xs font-semibold tracking-wide text-base-content/70 uppercase" for="category">Category</label>
+            <div class="reminder-field">
+              <label class="reminder-field-label" for="category">Category</label>
               <input
                 id="category"
-                class="input input-bordered input-sm w-full text-sm text-base-content"
+                class="reminder-field-input input input-bordered input-sm w-full text-sm text-base-content"
                 list="categorySuggestions"
                 placeholder="General"
                 value="General"
@@ -4171,57 +4379,27 @@
             </div>
           </div>
 
-          <div class="space-y-1">
-            <span class="text-xs font-semibold tracking-wide text-base-content/70 uppercase">Notifications</span>
-            <button id="notifBtn" class="btn btn-outline btn-sm w-full justify-center" type="button">Enable notifications</button>
-          </div>
-
-          <div class="space-y-2">
-            <span class="text-xs font-semibold tracking-wide text-base-content/70 uppercase">Voice tools</span>
-            <div class="flex items-center gap-2">
-              <button
-                id="voiceBtn"
-                type="button"
-                class="btn btn-circle btn-ghost"
-                aria-label="Start voice input"
-                aria-pressed="false"
-                title="Fill reminder using your voice"
-              >
-                <span aria-hidden="true">🎙️</span>
-                <span class="sr-only">Start voice input</span>
-              </button>
-              <button
-                id="sheetVoiceBtn"
-                class="btn btn-outline btn-sm flex-1"
-                type="button"
-                aria-pressed="false"
-                aria-label="Dictate reminder"
-              >
-                🎤 Voice input
-              </button>
+          <div class="reminder-field">
+            <span class="reminder-field-label">Notifications</span>
+            <div class="notif-switch-row">
+              <label class="ios-switch" for="notifBtn">
+                <input type="checkbox" id="notifBtn" class="notif-toggle" role="switch" aria-checked="false" />
+                <span class="switch-track"><span class="switch-thumb" aria-hidden="true"></span></span>
+                <span class="sr-only">Enable notifications</span>
+              </label>
             </div>
-            <p
-              id="sheetVoiceStatus"
-              class="text-xs text-base-content/60"
-              role="status"
-              aria-live="polite"
-              hidden
-            >
-              Tap the microphone to start speaking.
-            </p>
           </div>
-        </div>
 
-        <div class="flex justify-end gap-2 pt-2">
-          <button id="cancelEditBtn" class="btn btn-outline btn-sm hidden" type="button">Cancel</button>
-          <button id="saveReminder" class="btn btn-primary btn-sm" type="button">Save Reminder</button>
-        </div>
-        <p id="statusMessage" class="text-sm text-base-content/70" role="status" aria-live="polite"></p>
-      </form>
+          <div class="reminder-actions">
+            <button id="cancelEditBtn" class="btn btn-premium-secondary btn-sm hidden" type="button">Cancel</button>
+          </div>
+
+          <p id="statusMessage" class="text-sm text-base-content/70" role="status" aria-live="polite"></p>
+        </form>
+      </div>
     </div>
   </div>
   <!-- END GPT CHANGE: bottom sheet for Create Reminder -->
-
   <!-- BEGIN GPT CHANGE: settings modal -->
   <div id="settingsModal" role="dialog" aria-modal="true" aria-labelledby="settingsTitle" class="hidden">
     <div class="modal-panel">

--- a/mobile.html
+++ b/mobile.html
@@ -5734,79 +5734,281 @@
   <script src="./js/register-service-worker.js" defer></script>
   <script type="module" src="./mobile.js?v=2025-10-29-1"></script>
   <script type="module" src="./js/mobile-theme-toggle.js"></script>
+  <style id="reminder-editor-premium">
+    #create-sheet {
+      background: radial-gradient(circle at 50% 10%, rgba(104, 65, 144, 0.14), transparent 38%),
+        linear-gradient(180deg, #f2e8ff 0%, #eae0ff 45%, #f7f3ff 100%);
+    }
+
+    #create-sheet .sheet-panel {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: transparent;
+      border: none;
+      box-shadow: none;
+      padding: calc(20px + env(safe-area-inset-top)) 14px calc(20px + env(safe-area-inset-bottom));
+    }
+
+    #create-sheet .reminder-editor-shell {
+      margin: 0 auto;
+      width: min(640px, 100%);
+      border-radius: 20px;
+      padding: 16px 16px 20px;
+      background: rgba(255, 255, 255, 0.96);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      box-shadow:
+        0 -12px 30px rgba(0, 0, 0, 0.08),
+        0 -4px 12px rgba(0, 0, 0, 0.06);
+      transform: translateY(0);
+      transition: transform 0.18s ease-out, opacity 0.18s ease-out;
+      max-height: min(90vh, 720px);
+      overflow: auto;
+    }
+
+    #create-sheet .reminder-editor-shell.reminder-enter {
+      opacity: 0;
+      transform: translateY(16px);
+    }
+
+    #create-sheet .reminder-editor-shell.reminder-enter.reminder-enter-active {
+      opacity: 1;
+      transform: translateY(0);
+      transition: opacity 0.18s ease-out, transform 0.18s ease-out;
+    }
+
+    .reminder-editor-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 10px;
+    }
+
+    .reminder-header-back {
+      border: none;
+      border-radius: 999px;
+      background: rgba(81, 38, 99, 0.06);
+      color: var(--primary-dark);
+      width: 32px;
+      height: 32px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+    }
+
+    .reminder-header-title-group {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .reminder-header-eyebrow {
+      display: block;
+      font-size: 0.65rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: rgba(47, 27, 63, 0.6);
+    }
+
+    .reminder-header-title {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--primary-dark);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+
+    .reminder-header-save {
+      border-radius: 999px;
+      border: none;
+      padding: 6px 14px;
+      font-size: 0.8rem;
+      font-weight: 500;
+      color: #fff;
+      background: var(--accent-color, #512663);
+      box-shadow: 0 6px 16px rgba(81, 38, 99, 0.25);
+      cursor: pointer;
+    }
+
+    .reminder-editor-form {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .reminder-field {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .reminder-field-label {
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: rgba(47, 27, 63, 0.6);
+    }
+
+    .reminder-field-input,
+    .reminder-field-select,
+    .reminder-field-textarea {
+      border-radius: 12px;
+      border: 1px solid var(--border-subtle, rgba(0, 0, 0, 0.06));
+      padding: 8px 10px;
+      font-size: 0.85rem;
+      background: rgba(255, 255, 255, 0.94);
+      color: var(--primary-dark);
+      outline: none;
+      transition: border-color 0.14s ease, box-shadow 0.14s ease, background-color 0.14s ease;
+    }
+
+    .reminder-field-input:focus,
+    .reminder-field-select:focus,
+    .reminder-field-textarea:focus {
+      border-color: rgba(81, 38, 99, 0.35);
+      box-shadow: 0 0 0 1px rgba(81, 38, 99, 0.25);
+      background: #ffffff;
+    }
+
+    .reminder-field--row {
+      display: grid;
+      grid-template-columns: 1.1fr 0.9fr;
+      gap: 10px;
+    }
+
+    @media (max-width: 360px) {
+      .reminder-field--row {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    .reminder-chip-row {
+      display: flex;
+      flex-wrap: nowrap;
+      gap: 6px;
+    }
+
+    .reminder-chip,
+    .priority-pill-row .priority-pill {
+      border-radius: 999px;
+      border: 1px solid rgba(47, 27, 63, 0.12);
+      background: rgba(255, 255, 255, 0.9);
+      padding: 4px 10px;
+      font-size: 0.75rem;
+      cursor: pointer;
+      color: var(--primary-dark);
+      transition: background-color 0.14s ease, border-color 0.14s ease, color 0.14s ease, box-shadow 0.14s ease;
+    }
+
+    .reminder-chip--active,
+    .priority-pill-row .priority-input:checked + .priority-pill,
+    .priority-pill-row .priority-pill:has(+ .priority-input:checked),
+    .priority-pill-row input.priority-input:checked + label.priority-pill {
+      background: var(--accent-color, #512663);
+      border-color: var(--accent-color, #512663);
+      color: #fff;
+      box-shadow: 0 4px 12px rgba(81, 38, 99, 0.28);
+    }
+
+    .reminder-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+      padding-top: 4px;
+    }
+
+    #dateFeedback {
+      min-height: 1em;
+    }
+  </style>
   <!-- BEGIN GPT CHANGE: bottom sheet for Create Reminder -->
   <div id="create-sheet" role="dialog" aria-modal="true" aria-labelledby="createSheetTitle" class="sheet hidden" tabindex="-1" data-add-task-dialog>
     <div class="sheet-backdrop backdrop fixed inset-0 z-30 bg-black/40" data-close></div>
     <div
-      class="sheet-panel fixed inset-x-0 bottom-0 z-40 bg-base-100 rounded-t-3xl shadow-xl border-t border-base-300 px-4 pt-3 pb-4 space-y-3"
+      class="sheet-panel reminder-sheet-panel fixed inset-x-0 bottom-0 z-40"
       data-dialog-content
     >
-      <div class="flex items-center gap-2 mb-1">
-        <h2 id="createSheetTitle" class="text-base font-semibold text-base-content">Create Reminder</h2>
-      </div>
-      <div class="mobile-new-reminder-card">
-      <button type="button" id="closeCreateSheet" aria-label="Close" class="close-sheet-btn btn btn-ghost btn-sm btn-circle">✕</button>
-      <form id="createReminderForm" class="space-y-3">
-        <div class="space-y-4">
-          <div class="space-y-1">
+      <div class="reminder-editor-shell mobile-new-reminder-card" data-reminder-editor>
+        <header class="reminder-editor-header">
+          <button type="button" id="closeCreateSheet" aria-label="Close" class="reminder-header-back">←</button>
+          <div class="reminder-header-title-group">
+            <span class="reminder-header-eyebrow">Reminder</span>
+            <h2 class="reminder-header-title" id="createSheetTitle">New reminder</h2>
+          </div>
+          <button
+            type="submit"
+            form="createReminderForm"
+            id="saveReminder"
+            class="reminder-header-save"
+          >
+            Save
+          </button>
+        </header>
+        <form id="createReminderForm" class="reminder-editor-form">
+          <div class="reminder-field">
+            <label for="reminderText" class="reminder-field-label">Title</label>
             <input
               id="reminderText"
               type="text"
-              placeholder=""
-              class="input input-bordered input-sm w-full text-sm text-base-content"
+              placeholder="What do you need to remember?"
+              class="reminder-field-input input input-bordered input-sm w-full text-sm text-base-content"
               autocomplete="off"
             />
           </div>
 
-          <div class="space-y-1">
+          <div class="reminder-field">
+            <label for="reminderDetails" class="reminder-field-label">Notes</label>
             <textarea
               id="reminderDetails"
-              class="textarea textarea-bordered w-full min-h-[6rem] text-sm text-base-content"
+              class="reminder-field-textarea textarea textarea-bordered w-full min-h-[6rem] text-sm text-base-content"
               rows="3"
               placeholder="Optional context for the reminder"
             ></textarea>
           </div>
 
-          
-          <div class="grid grid-cols-2 gap-3">
-            <div class="space-y-1">
-              <label class="text-xs font-semibold tracking-wide text-base-content/70 uppercase" for="reminderDate">Date</label>
-              <input id="reminderDate" type="date" class="input input-bordered input-sm w-full text-sm text-base-content" />
+          <div class="reminder-field reminder-field--row">
+            <div class="reminder-field">
+              <label class="reminder-field-label" for="reminderDate">Date</label>
+              <input id="reminderDate" type="date" class="reminder-field-input input input-bordered input-sm w-full text-sm text-base-content" />
             </div>
-            <div class="space-y-1">
-              <label class="text-xs font-semibold tracking-wide text-base-content/70 uppercase" for="reminderTime">Time</label>
-              <input id="reminderTime" type="time" class="input input-bordered input-sm w-full text-sm text-base-content" />
+            <div class="reminder-field">
+              <label class="reminder-field-label" for="reminderTime">Time</label>
+              <input id="reminderTime" type="time" class="reminder-field-input input input-bordered input-sm w-full text-sm text-base-content" />
             </div>
           </div>
 
           <div id="dateFeedback" class="text-xs text-info"></div>
 
-          <div class="grid grid-cols-2 gap-3">
-            <div class="space-y-1">
-              <label class="text-xs font-semibold tracking-wide text-base-content/70 uppercase" for="priority">Priority</label>
+          <div class="reminder-field reminder-field--row">
+            <div class="reminder-field">
+              <label class="reminder-field-label" for="priority">Priority</label>
               <select id="priority" class="select select-bordered select-sm w-full text-sm text-base-content hidden" aria-hidden="true" tabindex="-1">
                 <option value="High">High</option>
                 <option value="Medium" selected>Medium</option>
                 <option value="Low">Low</option>
               </select>
-              <!-- BEGIN GPT CHANGE: priority pill selectors -->
-              <fieldset id="priorityChips" aria-label="Priority" class="priority-pill-row" role="radiogroup">
+              <fieldset id="priorityChips" aria-label="Priority" class="priority-pill-row reminder-chip-row" role="radiogroup">
                 <input class="priority-input" type="radio" id="priority-high" name="priority" value="High" aria-label="High priority">
-                <label class="priority-pill" for="priority-high">High</label>
+                <label class="priority-pill reminder-chip" for="priority-high">High</label>
 
                 <input class="priority-input" type="radio" id="priority-medium" name="priority" value="Medium" checked aria-label="Medium priority">
-                <label class="priority-pill" for="priority-medium">Medium</label>
+                <label class="priority-pill reminder-chip" for="priority-medium">Medium</label>
 
                 <input class="priority-input" type="radio" id="priority-low" name="priority" value="Low" aria-label="Low priority">
-                <label class="priority-pill" for="priority-low">Low</label>
+                <label class="priority-pill reminder-chip" for="priority-low">Low</label>
               </fieldset>
-              <!-- END GPT CHANGE: priority pill selectors -->
             </div>
-            <div class="space-y-1">
-              <label class="text-xs font-semibold tracking-wide text-base-content/70 uppercase" for="category">Category</label>
+            <div class="reminder-field">
+              <label class="reminder-field-label" for="category">Category</label>
               <input
                 id="category"
-                class="input input-bordered input-sm w-full text-sm text-base-content"
+                class="reminder-field-input input input-bordered input-sm w-full text-sm text-base-content"
                 list="categorySuggestions"
                 placeholder="General"
                 value="General"
@@ -5826,8 +6028,8 @@
             </div>
           </div>
 
-          <div class="space-y-1">
-            <div class="section-label">Notifications</div>
+          <div class="reminder-field">
+            <span class="reminder-field-label">Notifications</span>
             <div class="notif-switch-row">
               <label class="ios-switch" for="notifBtn">
                 <input type="checkbox" id="notifBtn" class="notif-toggle" role="switch" aria-checked="false" />
@@ -5837,16 +6039,13 @@
             </div>
           </div>
 
-          
-        </div>
+          <div class="reminder-actions">
+            <button id="cancelEditBtn" class="btn btn-premium-secondary btn-sm hidden" type="button">Cancel</button>
+          </div>
 
-        <div class="flex justify-end gap-2 pt-2">
-          <button id="cancelEditBtn" class="btn btn-premium-secondary btn-sm hidden" type="button">Cancel</button>
-          <button id="saveReminder" class="btn btn-premium-primary btn-sm" type="button">Save Reminder</button>
-        </div>
-        <p id="statusMessage" class="text-sm text-base-content/70" role="status" aria-live="polite"></p>
-      </form>
-    </div>
+          <p id="statusMessage" class="text-sm text-base-content/70" role="status" aria-live="polite"></p>
+        </form>
+      </div>
     </div>
   </div>
   <!-- END GPT CHANGE: bottom sheet for Create Reminder -->

--- a/mobile.js
+++ b/mobile.js
@@ -42,6 +42,9 @@ initViewportHeight();
     const saveBtn = document.getElementById('saveReminder');
     const prioritySelect = document.getElementById('priority');
     const chips = document.getElementById('priorityChips');
+    const editorShell = sheet.querySelector('.reminder-editor-shell');
+    const notifSwitchRow = sheet.querySelector('.notif-switch-row');
+    const notifToggle = sheet.querySelector('#notifBtn');
     const priorityRadios = chips
       ? Array.from(chips.querySelectorAll('input[name="priority"]'))
       : [];
@@ -66,6 +69,10 @@ initViewportHeight();
     };
 
     ensureHidden();
+
+    [notifSwitchRow, notifToggle].forEach((el) => {
+      el?.addEventListener('click', (event) => event.stopPropagation());
+    });
 
     let lastTrigger = null;
 
@@ -121,6 +128,16 @@ initViewportHeight();
       }
     };
 
+    const playEnterAnimation = () => {
+      if (!(editorShell instanceof HTMLElement)) return;
+      editorShell.classList.remove('reminder-enter', 'reminder-enter-active');
+      void editorShell.offsetWidth;
+      editorShell.classList.add('reminder-enter');
+      requestAnimationFrame(() => {
+        editorShell.classList.add('reminder-enter-active');
+      });
+    };
+
     const openSheet = (trigger) => {
       lastTrigger = trigger instanceof HTMLElement ? trigger : null;
       sheet.classList.remove('hidden');
@@ -135,12 +152,16 @@ initViewportHeight();
 
       syncRadiosFromSelect();
       focusFirstField();
+      playEnterAnimation();
 
       dispatchSheetEvent('reminder:sheet-opened', { trigger: lastTrigger });
     };
 
     const closeSheet = (reason = 'dismissed') => {
       const wasOpen = !sheet.classList.contains('hidden');
+      if (editorShell) {
+        editorShell.classList.remove('reminder-enter', 'reminder-enter-active');
+      }
       ensureHidden();
 
       if (lastTrigger) {


### PR DESCRIPTION
## Summary
- center the reminder editor card in the viewport with updated padding and sizing
- remove the voice input controls from the new reminder form in both source and built pages
- prevent notification toggle clicks from bubbling and closing the reminder sheet

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924058f555c8324abecab0eaedfe704)