### PR TITLE
Fix slim header overflow menu toggle

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5145,32 +5145,10 @@
     (function() {
       const menuBtn = document.getElementById('headerMenuBtn');
       const menu = document.getElementById('headerMenu');
-      
-      if (menuBtn && menu) {
-        menuBtn.addEventListener('click', function(e) {
-          e.stopPropagation();
-          const isOpen = menuBtn.getAttribute('aria-expanded') === 'true';
-          
-          if (isOpen) {
-            menu.classList.add('hidden');
-            menuBtn.setAttribute('aria-expanded', 'false');
-          } else {
-            menu.classList.remove('hidden');
-            menuBtn.setAttribute('aria-expanded', 'true');
-          }
-        });
 
-        // Close menu when clicking outside
-        document.addEventListener('click', function() {
-          menu.classList.add('hidden');
-          menuBtn.setAttribute('aria-expanded', 'false');
-        });
-
-        // Prevent menu close when clicking inside menu
-        menu.addEventListener('click', function(e) {
-          e.stopPropagation();
-        });
-      }
+      // The slim header script below binds the current overflow menu behavior.
+      // Skip the legacy handler to avoid double toggles closing the menu.
+      if (menuBtn && menu) return;
     })();
   </script>
 


### PR DESCRIPTION
## Summary
- disable legacy header menu handler to avoid double toggling the overflow menu
- allow the slim header script to control the overflow menu so it opens correctly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692428e27778832493971e15f86d3d7d)