### PR TITLE
Add folder selector for moving saved notes

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -754,6 +754,75 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+    cursor: pointer;
+  }
+
+  .notebook-folder-selector {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: flex-end;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.2);
+    z-index: 999;
+  }
+
+  .notebook-folder-selector--open {
+    display: flex;
+  }
+
+  .notebook-folder-selector-sheet {
+    width: min(640px, 100%);
+    border-radius: 16px 16px 0 0;
+    padding: 12px 16px 16px;
+    background: rgba(255, 255, 255, 0.96);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+    box-shadow: 0 -14px 34px rgba(0, 0, 0, 0.14);
+  }
+
+  .notebook-folder-selector-header {
+    margin-bottom: 8px;
+  }
+
+  .notebook-folder-selector-title {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--primary-dark);
+  }
+
+  .notebook-folder-selector-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    max-height: 40vh;
+    overflow-y: auto;
+    padding-top: 4px;
+  }
+
+  .notebook-folder-selector-item {
+    border-radius: 999px;
+    border: 1px solid rgba(47, 27, 63, 0.1);
+    padding: 7px 11px;
+    font-size: 0.8rem;
+    background: rgba(255, 255, 255, 0.94);
+    color: var(--primary-dark);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    cursor: pointer;
+    transition: background-color 0.12s ease, box-shadow 0.12s ease, border-color 0.12s ease;
+  }
+
+  .notebook-folder-selector-item:hover {
+    background: rgba(81, 38, 99, 0.06);
+    box-shadow: 0 4px 12px rgba(81, 38, 99, 0.12);
+  }
+
+  .notebook-folder-selector-item-current {
+    border-color: var(--accent-color, #512663);
+    background: rgba(81, 38, 99, 0.08);
   }
 
   .mobile-shell #notesListMobile .note-item-mobile {
@@ -5473,6 +5542,14 @@
                   </div>
                 </div>
               </dialog>
+              <div id="notebook-folder-selector" class="notebook-folder-selector" aria-hidden="true">
+                <div class="notebook-folder-selector-sheet">
+                  <header class="notebook-folder-selector-header">
+                    <h3 class="notebook-folder-selector-title">Move note to...</h3>
+                  </header>
+                  <div class="notebook-folder-selector-list" id="notebook-folder-selector-list"></div>
+                </div>
+              </div>
               <!-- Rename Folder Modal -->
               <dialog id="renameFolderModal" class="memory-glass-card" aria-hidden="true">
                 <div class="p-4">

--- a/mobile.js
+++ b/mobile.js
@@ -357,6 +357,8 @@ const initMobileNotes = () => {
   const savedNotesSheet = document.getElementById('savedNotesSheet');
   const openSavedNotesButton = document.getElementById('openSavedNotesSheet');
   const closeSavedNotesButton = document.querySelector('[data-action="close-saved-notes"]');
+  const folderSelectorEl = document.getElementById('notebook-folder-selector');
+  const folderSelectorListEl = document.getElementById('notebook-folder-selector-list');
   const ACTIVE_NOTE_SHADOW_CLASS = 'shadow-[0_0_0_3px_var(--accent-color)]';
 
   const createScratchNotesEditor = () => {
@@ -591,6 +593,7 @@ const initMobileNotes = () => {
   let allNotes = [];
   let currentFolderId = 'all';
   let currentEditingNoteFolderId = 'unsorted';
+  let currentFolderMoveNoteId = null;
   let filterQuery = '';
   let skipAutoSelectOnce = false;
   let savedNotesSheetHideTimeout = null;
@@ -1102,6 +1105,7 @@ const initMobileNotes = () => {
       const folderId = note.folderId && typeof note.folderId === 'string' ? note.folderId : 'unsorted';
       const folderPill = document.createElement('span');
       folderPill.className = 'notebook-note-folder-pill';
+      folderPill.dataset.noteId = note.id;
       const folderName = getFolderNameById(folderId) || 'No folder';
       folderPill.textContent = folderName;
 
@@ -1507,6 +1511,73 @@ const initMobileNotes = () => {
     closeOverflowMenu();
   };
 
+  const closeFolderSelector = () => {
+    if (folderSelectorEl) {
+      folderSelectorEl.classList.remove('notebook-folder-selector--open');
+      folderSelectorEl.setAttribute('aria-hidden', 'true');
+    }
+    if (folderSelectorListEl) {
+      folderSelectorListEl.innerHTML = '';
+    }
+    currentFolderMoveNoteId = null;
+  };
+
+  const openFolderSelectorForNote = (noteId) => {
+    if (!noteId || !folderSelectorEl || !folderSelectorListEl) {
+      return;
+    }
+
+    currentFolderMoveNoteId = noteId;
+    folderSelectorListEl.innerHTML = '';
+
+    let folders = [];
+    try {
+      folders = Array.isArray(getFolders()) ? getFolders() : [];
+    } catch {
+      folders = [];
+    }
+
+    if (!folders.some((f) => f && f.id === 'unsorted')) {
+      folders.unshift({ id: 'unsorted', name: 'Unsorted' });
+    }
+
+    const activeNote = allNotes.find((n) => n.id === noteId) || null;
+    const activeFolderId =
+      activeNote && typeof activeNote.folderId === 'string' && activeNote.folderId
+        ? activeNote.folderId
+        : 'unsorted';
+
+    folders.forEach((folder) => {
+      if (!folder || typeof folder.id === 'undefined') return;
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'notebook-folder-selector-item';
+      button.dataset.folderId = folder.id;
+      button.textContent = folder.name || String(folder.id);
+      if (String(folder.id) === String(activeFolderId)) {
+        button.classList.add('notebook-folder-selector-item-current');
+      }
+      button.addEventListener('click', () => {
+        const targetNoteId = currentFolderMoveNoteId || noteId;
+        handleMoveNoteToFolder(targetNoteId, folder.id || 'unsorted');
+        closeFolderSelector();
+      });
+      folderSelectorListEl.appendChild(button);
+    });
+
+    folderSelectorEl.classList.add('notebook-folder-selector--open');
+    folderSelectorEl.setAttribute('aria-hidden', 'false');
+  };
+
+  if (folderSelectorEl) {
+    folderSelectorEl.addEventListener('click', (ev) => {
+      if (ev.target === folderSelectorEl) {
+        ev.preventDefault();
+        closeFolderSelector();
+      }
+    });
+  }
+
   const openNoteOverflowMenu = (note, anchorEl) => {
     if (!note || !anchorEl) return;
     closeOverflowMenu();
@@ -1863,6 +1934,18 @@ const initMobileNotes = () => {
     listElement.addEventListener('click', (event) => {
       const target = event.target;
       if (!(target instanceof HTMLElement)) {
+        return;
+      }
+
+      const folderPill = target.closest('.notebook-note-folder-pill');
+      if (folderPill && listElement.contains(folderPill)) {
+        event.preventDefault();
+        event.stopPropagation();
+        const hostButton = folderPill.closest('button[data-role="open-note"]');
+        const noteId = folderPill.dataset.noteId || hostButton?.getAttribute('data-note-id');
+        if (noteId) {
+          openFolderSelectorForNote(noteId);
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary
- add a minimal folder selector sheet for moving notes directly from the saved notes list
- make folder pills interactive so users can pick a destination folder using existing folder data and storage helpers
- style the selector to match the current premium glass theme and ensure notes refresh after moving

## Testing
- npm test -- --runInBand *(fails: mobile.* tests cannot load ES module imports in vm harness; other warnings from Firebase configuration)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69243f33c11483248f927d04ac4a14b7)