### PR TITLE
Improve mobile saved notes list layout

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -846,16 +846,24 @@ const initMobileNotes = () => {
     return currentTitle !== originalTitle || currentBody !== originalBody;
   };
 
+  const getNoteTimestamp = (note) => {
+    if (!note) return 0;
+    const candidates = [note.updatedAt, note.modifiedAt, note.createdAt];
+    for (const value of candidates) {
+      const parsed = Date.parse(value || '');
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    return 0;
+  };
+
   const getSortedNotes = () => {
     const notes = loadAllNotes();
     if (!Array.isArray(notes)) {
       return [];
     }
-    return [...notes].sort((a, b) => {
-      const aTime = Date.parse(a?.updatedAt || '');
-      const bTime = Date.parse(b?.updatedAt || '');
-      return (Number.isNaN(bTime) ? 0 : bTime) - (Number.isNaN(aTime) ? 0 : aTime);
-    });
+    return [...notes].sort((a, b) => getNoteTimestamp(b) - getNoteTimestamp(a));
   };
 
   const readStoredSnapshot = () => {

--- a/styles/index.css
+++ b/styles/index.css
@@ -401,6 +401,41 @@ html[data-theme="professional"] {
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
 }
 
+@media (max-width: 768px) {
+  .mobile-shell #notesListMobile {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 0 4px 14px;
+  }
+
+  .mobile-shell #notesListMobile .premium-note-card {
+    width: 100%;
+    margin: 0;
+    padding: 12px 14px;
+    background: color-mix(in srgb, var(--surface-elevated, #f9f9fb) 92%, #ece7f3 8%);
+    border: 1px solid color-mix(in srgb, var(--border-subtle, #e3d9f4) 70%, #d6cfee 30%);
+    box-shadow: 0 6px 16px rgba(81, 38, 99, 0.12);
+  }
+
+  .mobile-shell #notesListMobile .note-card-title {
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--accent-color, #512663);
+    font-weight: 600;
+  }
+
+  .mobile-shell #notesListMobile .note-card-preview,
+  .mobile-shell #notesListMobile .note-card-meta,
+  .mobile-shell #notesListMobile .note-card-folder,
+  .mobile-shell #notesListMobile .notebook-note-timestamp {
+    display: none;
+  }
+}
+
 .premium-note-card {
   position: relative;
   background: rgba(255, 255, 255, 0.94);


### PR DESCRIPTION
## Summary
- ensure saved notes are sorted by latest update or creation time for consistent ordering
- simplify the mobile saved notes list into a single-column, title-focused layout with premium styling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924445b765883248beab36b5693b48c)