### PR TITLE
Make notebook saved notes list compact

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -1062,11 +1062,26 @@ const initMobileNotes = () => {
 
     notes.forEach((note) => {
       const listItem = document.createElement('article');
-      listItem.className = 'premium-note-card note-item-mobile';
+      listItem.className = 'premium-note-card note-item-mobile notebook-note-card';
       listItem.dataset.noteId = note.id;
       listItem.dataset.role = 'open-note';
       listItem.setAttribute('role', 'button');
       listItem.tabIndex = 0;
+
+      const noteRow = document.createElement('div');
+      noteRow.className = 'notebook-note-row';
+
+      const noteTitle = note.title || 'Untitled';
+      const titleEl = document.createElement('h4');
+      titleEl.className = 'note-card-title line-clamp-2';
+      titleEl.textContent = noteTitle;
+      titleEl.setAttribute('title', noteTitle);
+
+      const folderId = note.folderId && typeof note.folderId === 'string' ? note.folderId : 'unsorted';
+      const folderPill = document.createElement('span');
+      folderPill.className = 'note-card-folder';
+      const folderName = getFolderNameById(folderId) || 'Unsorted';
+      folderPill.textContent = folderName;
 
       const actionBtn = document.createElement('button');
       actionBtn.type = 'button';
@@ -1082,41 +1097,11 @@ const initMobileNotes = () => {
         </svg>
       `;
 
-      const noteTitle = note.title || 'Untitled';
-      const titleEl = document.createElement('h4');
-      titleEl.className = 'note-card-title line-clamp-2';
-      titleEl.textContent = noteTitle;
-      titleEl.setAttribute('title', noteTitle);
+      noteRow.appendChild(titleEl);
+      noteRow.appendChild(folderPill);
+      noteRow.appendChild(actionBtn);
 
-      const previewEl = document.createElement('p');
-      previewEl.className = 'note-card-preview line-clamp-2';
-      const previewText = getNoteBodyText(note);
-      const truncated = previewText.length > 120
-        ? `${previewText.slice(0, 120).trimEnd()}…`
-        : previewText;
-      previewEl.textContent = truncated || 'No content yet.';
-
-      const metaRow = document.createElement('div');
-      metaRow.className = 'note-card-meta';
-
-      const metaEl = document.createElement('span');
-      metaEl.className = 'notebook-note-timestamp';
-      const ts = note.updatedAt || note.modifiedAt || note.createdAt || '';
-      metaEl.textContent = ts ? formatNoteTimestamp(ts) : '';
-
-      const folderId = note.folderId && typeof note.folderId === 'string' ? note.folderId : 'unsorted';
-      const folderPill = document.createElement('span');
-      folderPill.className = 'note-card-folder';
-      const folderName = getFolderNameById(folderId) || 'Unsorted';
-      folderPill.textContent = folderName;
-
-      metaRow.appendChild(metaEl);
-      metaRow.appendChild(folderPill);
-
-      listItem.appendChild(actionBtn);
-      listItem.appendChild(titleEl);
-      listItem.appendChild(previewEl);
-      listItem.appendChild(metaRow);
+      listItem.appendChild(noteRow);
       listElement.appendChild(listItem);
     });
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -428,11 +428,71 @@ html[data-theme="professional"] {
     font-weight: 600;
   }
 
-  .mobile-shell #notesListMobile .note-card-preview,
-  .mobile-shell #notesListMobile .note-card-meta,
-  .mobile-shell #notesListMobile .note-card-folder,
-  .mobile-shell #notesListMobile .notebook-note-timestamp {
-    display: none;
+.mobile-shell #notesListMobile .note-card-preview,
+.mobile-shell #notesListMobile .note-card-meta,
+.mobile-shell #notesListMobile .notebook-note-timestamp {
+  display: none;
+}
+}
+
+.notebook-note-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  #notesListMobile {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 0 2px 12px;
+  }
+
+  #notesListMobile .premium-note-card {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    margin: 0;
+    background: color-mix(in srgb, var(--surface-elevated, #f9f9fb) 92%, #ece7f3 8%);
+    border: 1px solid color-mix(in srgb, var(--border-subtle, #e3d9f4) 70%, #d6cfee 30%);
+    box-shadow: 0 6px 16px rgba(81, 38, 99, 0.12);
+    border-radius: 14px;
+  }
+
+  #notesListMobile .note-card-title {
+    flex: 1;
+    min-width: 0;
+    font-size: 0.95rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  #notesListMobile .note-card-folder {
+    flex-shrink: 0;
+    padding: 4px 10px;
+    font-size: 0.8rem;
+    background: rgba(81, 38, 99, 0.08);
+    color: rgba(47, 27, 63, 0.9);
+  }
+
+  #notesListMobile .note-card-action {
+    position: static;
+    opacity: 1;
+    transform: none;
+    box-shadow: none;
+    background: transparent;
+    padding: 6px;
+    margin-left: 4px;
+  }
+
+  #notesListMobile .note-card-action:hover,
+  #notesListMobile .note-card-action:focus-visible {
+    background: var(--hover-bg, rgba(81, 38, 99, 0.08));
+    border-radius: 12px;
   }
 }
 


### PR DESCRIPTION
## Summary
- render saved notebook notes as single-row pills with title, folder, and action menu
- remove preview and timestamp content from notebook note items
- add responsive styling to align rows with compact reminder-like layout on larger screens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924478673d48324a661f5944938a559)