### PR TITLE
Add mobile bottom sheet for moving notes to folders

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -762,8 +762,9 @@
     display: none;
     align-items: flex-end;
     justify-content: center;
-    background: rgba(0, 0, 0, 0.2);
+    background: rgba(81, 38, 99, 0.08);
     z-index: 999;
+    transition: background 0.2s ease;
   }
 
   .notebook-folder-selector--open {
@@ -772,56 +773,136 @@
 
   .notebook-folder-selector-sheet {
     width: min(640px, 100%);
-    border-radius: 16px 16px 0 0;
+    border-radius: 18px 18px 0 0;
     padding: 12px 16px 16px;
-    background: rgba(255, 255, 255, 0.96);
-    backdrop-filter: blur(18px);
-    -webkit-backdrop-filter: blur(18px);
-    box-shadow: 0 -14px 34px rgba(0, 0, 0, 0.14);
+    background: #fff;
+    box-shadow: 0 -18px 38px rgba(0, 0, 0, 0.14);
+    transform: translateY(18px);
+    opacity: 0;
+    transition: transform 0.22s ease, opacity 0.22s ease;
+  }
+
+  .notebook-folder-selector--open .notebook-folder-selector-sheet {
+    transform: translateY(0);
+    opacity: 1;
+  }
+
+  .notebook-folder-selector-grip {
+    width: 46px;
+    height: 5px;
+    border-radius: 999px;
+    background: rgba(81, 38, 99, 0.16);
+    margin: 0 auto 8px;
   }
 
   .notebook-folder-selector-header {
-    margin-bottom: 8px;
+    margin-bottom: 10px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
   }
 
   .notebook-folder-selector-title {
     margin: 0;
-    font-size: 0.9rem;
-    font-weight: 600;
+    font-size: 0.95rem;
+    font-weight: 700;
     color: var(--primary-dark);
   }
 
   .notebook-folder-selector-list {
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 8px;
     max-height: 40vh;
     overflow-y: auto;
     padding-top: 4px;
+    margin-bottom: 12px;
   }
 
   .notebook-folder-selector-item {
-    border-radius: 999px;
-    border: 1px solid rgba(47, 27, 63, 0.1);
-    padding: 7px 11px;
-    font-size: 0.8rem;
-    background: rgba(255, 255, 255, 0.94);
+    border-radius: 14px;
+    border: 1px solid rgba(47, 27, 63, 0.12);
+    padding: 9px 12px;
+    font-size: 0.9rem;
+    background: rgba(255, 255, 255, 0.96);
     color: var(--primary-dark);
     display: flex;
-    justify-content: space-between;
     align-items: center;
+    justify-content: space-between;
     cursor: pointer;
     transition: background-color 0.12s ease, box-shadow 0.12s ease, border-color 0.12s ease;
+    text-align: left;
   }
 
-  .notebook-folder-selector-item:hover {
+  .notebook-folder-selector-item:hover,
+  .notebook-folder-selector-item:focus-visible {
     background: rgba(81, 38, 99, 0.06);
     box-shadow: 0 4px 12px rgba(81, 38, 99, 0.12);
+    outline: none;
   }
 
   .notebook-folder-selector-item-current {
     border-color: var(--accent-color, #512663);
     background: rgba(81, 38, 99, 0.08);
+  }
+
+  .notebook-folder-selector-item-label {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .notebook-folder-selector-icon {
+    width: 18px;
+    height: 18px;
+    color: var(--primary-dark);
+    opacity: 0.75;
+    flex-shrink: 0;
+  }
+
+  .notebook-folder-selector-name {
+    flex: 1;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .notebook-folder-selector-create,
+  .notebook-folder-selector-cancel {
+    width: 100%;
+    border: none;
+    border-radius: 12px;
+    padding: 10px 12px;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: background-color 0.12s ease, box-shadow 0.12s ease;
+  }
+
+  .notebook-folder-selector-create {
+    background: rgba(81, 38, 99, 0.08);
+    color: var(--primary-dark);
+    margin-bottom: 8px;
+  }
+
+  .notebook-folder-selector-create:hover,
+  .notebook-folder-selector-create:focus-visible {
+    background: rgba(81, 38, 99, 0.12);
+    outline: none;
+    box-shadow: 0 6px 16px rgba(81, 38, 99, 0.16);
+  }
+
+  .notebook-folder-selector-cancel {
+    background: #f8f5fb;
+    color: var(--primary-dark);
+  }
+
+  .notebook-folder-selector-cancel:hover,
+  .notebook-folder-selector-cancel:focus-visible {
+    background: rgba(81, 38, 99, 0.1);
+    outline: none;
   }
 
   .mobile-shell #notesListMobile .note-item-mobile {
@@ -5542,12 +5623,39 @@
                   </div>
                 </div>
               </dialog>
-              <div id="notebook-folder-selector" class="notebook-folder-selector" aria-hidden="true">
-                <div class="notebook-folder-selector-sheet">
+              <div
+                id="notebook-folder-selector"
+                class="notebook-folder-selector"
+                aria-hidden="true"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="notebook-folder-selector-title"
+              >
+                <div class="notebook-folder-selector-sheet" role="document">
+                  <div class="notebook-folder-selector-grip" aria-hidden="true"></div>
                   <header class="notebook-folder-selector-header">
-                    <h3 class="notebook-folder-selector-title">Move note to...</h3>
+                    <h3 id="notebook-folder-selector-title" class="notebook-folder-selector-title">Move to folder</h3>
                   </header>
-                  <div class="notebook-folder-selector-list" id="notebook-folder-selector-list"></div>
+                  <div
+                    class="notebook-folder-selector-list"
+                    id="notebook-folder-selector-list"
+                    role="listbox"
+                    aria-label="Available folders"
+                  ></div>
+                  <button
+                    id="notebook-folder-selector-create"
+                    class="notebook-folder-selector-create"
+                    type="button"
+                  >
+                    + Create new folder
+                  </button>
+                  <button
+                    id="notebook-folder-selector-cancel"
+                    class="notebook-folder-selector-cancel"
+                    type="button"
+                  >
+                    Cancel
+                  </button>
                 </div>
               </div>
               <!-- Rename Folder Modal -->


### PR DESCRIPTION
## Summary
- add a new slide-up folder picker sheet with updated styling for mobile notes
- wire the note folder controls and overflow menu to the bottom sheet with focus trapping and improved selection handling
- reuse existing folder creation logic from the sheet to immediately assign newly created folders

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69244842943c8324884c5f1597c284cb)