### PR TITLE
mobile: don't switch to new folder on create (keep All Notes visible)

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -2149,7 +2149,8 @@ const initMobileNotes = () => {
     try {
       newFolderModalController.requestClose('created');
     } catch { /* ignore */ }
-    currentFolderId = folderId;
+    // Do NOT switch to the new folder automatically — keep the current view
+    // currentFolderId = folderId;
     clearSearchFilter();
     try {
       buildFolderChips();


### PR DESCRIPTION
When creating a new folder on mobile the UI used to stay on the current view (e.g. ‘All Notes’). A recent change automatically switched into the newly created folder, which is often empty and caused all saved notes to disappear from the list.\n\nThis PR reverts that behavior by preventing the runtime from switching to the new folder after creation. Only the single line that assigned  is commented out; other behavior (closing the modal, clearing the search, rebuilding folder chips, rendering notes, and firing post-create hooks) is unchanged.\n\nManual checks to run after merge: create a new folder on mobile and confirm existing notes remain visible, folder chips appear, and saving/syncing/reminders still work.\n