### PR TITLE
config: move Supabase keys to .env and use import.meta.env with Vite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ yarn-error.log*
 coverage/
 build.log
 *.log
+.env

--- a/js/supabase-client.js
+++ b/js/supabase-client.js
@@ -27,8 +27,14 @@ export function getSupabaseClient() {
 
   attemptedInitialisation = true;
 
-  const supabaseUrl = normalise(ENV?.SUPABASE_URL);
-  const supabaseAnonKey = normalise(ENV?.SUPABASE_ANON_KEY);
+  const supabaseUrl = normalise(
+    (typeof import.meta !== 'undefined' ? import.meta.env?.VITE_SUPABASE_URL : undefined) ||
+      ENV?.SUPABASE_URL,
+  );
+  const supabaseAnonKey = normalise(
+    (typeof import.meta !== 'undefined' ? import.meta.env?.VITE_SUPABASE_ANON_KEY : undefined) ||
+      ENV?.SUPABASE_ANON_KEY,
+  );
 
   if (!supabaseUrl || !supabaseAnonKey) {
     console.error('[supabase] Missing SUPABASE_URL or SUPABASE_ANON_KEY.');


### PR DESCRIPTION
## Summary
- load Supabase configuration from Vite-style environment variables and preserve the existing fallback
- ignore the new .env file to keep credentials out of version control

## Testing
- npm run dev
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ecde32f408324b258cd000c87cc41)