### PR TITLE
Add mobile new note button next to save

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5157,6 +5157,17 @@
         </button>
 
         <button
+          id="noteNewMobile"
+          type="button"
+          class="header-action-btn icon-btn quick-add-action"
+          aria-label="New note"
+        >
+          <svg class="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg">
+            <path d="M11 11V5a1 1 0 0 1 2 0v6h6a1 1 0 1 1 0 2h-6v6a1 1 0 1 1-2 0v-6H5a1 1 0 1 1 0-2h6z" fill="currentColor" />
+          </svg>
+        </button>
+
+        <button
           id="noteSaveMobile"
           type="button"
           class="header-action-btn icon-btn quick-add-action"


### PR DESCRIPTION
## Summary
- add a New note button to the mobile notebook header alongside Save
- wire the button to the existing new-note flow via its ID

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ed38dc2948324adc3dfae76f8fffe)