### PR TITLE
Create compact mobile saved notes rows

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5551,6 +5551,29 @@
                   aria-label="Saved scratch notes"
                 >
                   <!-- Note items are rendered here by JS -->
+                  <template id="notesListMobileItemTemplate">
+                    <article
+                      class="premium-note-card note-item-mobile notebook-note-card"
+                      data-role="open-note"
+                      tabindex="0"
+                    >
+                      <div class="note-card-main">
+                        <div class="note-card-header">
+                          <h4 class="note-card-title line-clamp-2">Untitled</h4>
+                          <button type="button" class="note-card-action" aria-label="Note actions">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                              <circle cx="5" cy="12" r="1.5" />
+                              <circle cx="12" cy="12" r="1.5" />
+                              <circle cx="19" cy="12" r="1.5" />
+                            </svg>
+                          </button>
+                        </div>
+                        <div class="note-card-meta-row">
+                          <span class="note-card-folder">Folder</span>
+                        </div>
+                      </div>
+                    </article>
+                  </template>
                 </div>
               </div>
               <!-- New Folder Modal -->

--- a/mobile.js
+++ b/mobile.js
@@ -1067,20 +1067,17 @@ const initMobileNotes = () => {
       listItem.setAttribute('role', 'button');
       listItem.tabIndex = 0;
 
-      const noteRow = document.createElement('div');
-      noteRow.className = 'notebook-note-row';
+      const cardMain = document.createElement('div');
+      cardMain.className = 'note-card-main';
+
+      const headerRow = document.createElement('div');
+      headerRow.className = 'note-card-header';
 
       const noteTitle = note.title || 'Untitled';
       const titleEl = document.createElement('h4');
       titleEl.className = 'note-card-title line-clamp-2';
       titleEl.textContent = noteTitle;
       titleEl.setAttribute('title', noteTitle);
-
-      const folderId = note.folderId && typeof note.folderId === 'string' ? note.folderId : 'unsorted';
-      const folderPill = document.createElement('span');
-      folderPill.className = 'note-card-folder';
-      const folderName = getFolderNameById(folderId) || 'Unsorted';
-      folderPill.textContent = folderName;
 
       const actionBtn = document.createElement('button');
       actionBtn.type = 'button';
@@ -1098,11 +1095,23 @@ const initMobileNotes = () => {
         </svg>
       `;
 
-      noteRow.appendChild(titleEl);
-      noteRow.appendChild(folderPill);
-      noteRow.appendChild(actionBtn);
+      headerRow.appendChild(titleEl);
+      headerRow.appendChild(actionBtn);
 
-      listItem.appendChild(noteRow);
+      const metaRow = document.createElement('div');
+      metaRow.className = 'note-card-meta-row';
+
+      const folderId = note.folderId && typeof note.folderId === 'string' ? note.folderId : 'unsorted';
+      const folderPill = document.createElement('span');
+      folderPill.className = 'note-card-folder';
+      const folderName = getFolderNameById(folderId) || 'Unsorted';
+      folderPill.textContent = folderName;
+
+      metaRow.appendChild(folderPill);
+
+      cardMain.appendChild(headerRow);
+      cardMain.appendChild(metaRow);
+      listItem.appendChild(cardMain);
       listElement.appendChild(listItem);
     });
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -568,16 +568,16 @@ html[data-theme="dracula"] .notebook-folder-scroll-wrap::after {
   .mobile-shell #notesListMobile .premium-note-card {
     width: 100%;
     margin: 0;
-    padding: 12px 14px;
+    padding: 10px 12px;
     background: transparent;
     border: none;
     border-bottom: 1px solid rgba(230, 224, 242, 0.5);
     box-shadow: none;
     border-radius: 0;
     display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
+    align-items: stretch;
+    justify-content: flex-start;
+    gap: 10px;
     transition: background-color 0.18s ease, box-shadow 0.16s ease;
   }
 
@@ -597,6 +597,25 @@ html[data-theme="dracula"] .notebook-folder-scroll-wrap::after {
     color: var(--text-strong, #34163f);
   }
 
+  .mobile-shell #notesListMobile .note-card-main {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    width: 100%;
+  }
+
+  .mobile-shell #notesListMobile .note-card-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .mobile-shell #notesListMobile .note-card-meta-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
   .mobile-shell #notesListMobile .note-card-preview,
   .mobile-shell #notesListMobile .note-card-meta,
   .mobile-shell #notesListMobile .notebook-note-timestamp {
@@ -605,8 +624,8 @@ html[data-theme="dracula"] .notebook-folder-scroll-wrap::after {
 
   .mobile-shell #notesListMobile .note-card-folder {
     flex-shrink: 0;
-    padding: 3px 10px;
-    font-size: 0.75rem;
+    padding: 2px 8px;
+    font-size: 0.72rem;
     background: rgba(81, 38, 99, 0.08);
     color: var(--primary-dark, #3E1D4C);
     border-radius: 999px;
@@ -720,9 +739,9 @@ html[data-theme="dracula"] .notebook-folder-scroll-wrap::after {
 
   #notesListMobile .premium-note-card {
     display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 11px 14px;
+    align-items: stretch;
+    gap: 10px;
+    padding: 10px 12px;
     margin: 0;
     background: transparent;
     border: none;
@@ -748,10 +767,29 @@ html[data-theme="dracula"] .notebook-folder-scroll-wrap::after {
     color: var(--text-strong, #34163f);
   }
 
+  #notesListMobile .note-card-main {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    width: 100%;
+  }
+
+  #notesListMobile .note-card-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  #notesListMobile .note-card-meta-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
   #notesListMobile .note-card-folder {
     flex-shrink: 0;
-    padding: 3px 10px;
-    font-size: 0.75rem;
+    padding: 2px 8px;
+    font-size: 0.72rem;
     background: rgba(81, 38, 99, 0.08);
     color: var(--primary-dark, #3E1D4C);
     border-radius: 999px;


### PR DESCRIPTION
## Summary
- add a compact saved-note row template in the mobile sheet that keeps the action menu
- render saved notes with a title header and folder badge while omitting body previews
- adjust mobile note list spacing and alignment for the compact layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f451ac1b48324a326e72d3307c5c6)