### PR TITLE
Fix mobile new reminder footer button

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5813,7 +5813,19 @@
               detail: { view }
             })
           );
-          triggerAddReminder();
+
+          const sheet = document.getElementById('create-sheet');
+          if (sheet) {
+            document.dispatchEvent(
+              new CustomEvent('cue:prepare', { detail: { mode: 'create', trigger: button } })
+            );
+            document.dispatchEvent(
+              new CustomEvent('cue:open', { detail: { mode: 'create', trigger: button } })
+            );
+          } else {
+            triggerAddReminder();
+          }
+
           return;
         }
 


### PR DESCRIPTION
## Summary
- route the mobile footer "New Reminder" button to open the reminder creation sheet via existing cue events
- fall back to the previous quick add focus if the sheet is unavailable

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f4b8597e0832483f7c9bb5c15923b)