### PR TITLE
Remove header new note button

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5157,17 +5157,6 @@
         </button>
 
         <button
-          id="noteNewMobile"
-          type="button"
-          class="header-action-btn icon-btn quick-add-action"
-          aria-label="New note"
-        >
-          <svg class="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg">
-            <path d="M11 11V5a1 1 0 0 1 2 0v6h6a1 1 0 1 1 0 2h-6v6a1 1 0 1 1-2 0v-6H5a1 1 0 1 1 0-2h6z" fill="currentColor" />
-          </svg>
-        </button>
-
-        <button
           id="noteSaveMobile"
           type="button"
           class="header-action-btn icon-btn quick-add-action"

--- a/mobile.js
+++ b/mobile.js
@@ -350,7 +350,6 @@ const initMobileNotes = () => {
   const titleInput = document.getElementById('noteTitleMobile');
   const scratchNotesEditorElement = document.getElementById('notebook-editor-body');
   const saveButton = document.getElementById('noteSaveMobile');
-  const newButton = document.getElementById('noteNewMobile');
   const listElement = document.getElementById('notesListMobile');
   const countElement = document.getElementById('notesCountMobile');
   const filterInput = document.getElementById('notebook-search-input');
@@ -2431,13 +2430,6 @@ const initMobileNotes = () => {
       try { titleInput.focus(); } catch {}
     }
   };
-
-  if (newButton) {
-    newButton.addEventListener('click', (e) => {
-      e.preventDefault();
-      prepareNewNote();
-    });
-  }
 
   // Also wire the footer 'New note' floating button to the same behavior
   const footerNewNoteBtn = document.getElementById('mobile-footer-new-note');


### PR DESCRIPTION
## Summary
- remove the notebook header "New note" button
- keep footer new note controls unchanged while still wiring note creation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f4d186d04832487d5240a92db8d20)