### PR TITLE
Move notification shortcut into overflow menu

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5167,18 +5167,6 @@
           </svg>
         </button>
 
-        <button
-          id="notifHeaderBtn"
-          type="button"
-          class="header-action-btn icon-btn quick-add-action"
-          aria-label="Notifications"
-        >
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/>
-            <path d="m13.73 21a2 2 0 0 1-3.46 0"/>
-          </svg>
-        </button>
-
         <!-- Overflow menu -->
         <div class="relative header-overflow-wrapper">
           <button
@@ -5203,6 +5191,19 @@
             role="menu"
             aria-labelledby="headerMenuBtn"
           >
+            <button
+              id="notifHeaderBtn"
+              type="button"
+              class="overflow-item w-full"
+              role="menuitem"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/>
+                <path d="m13.73 21a2 2 0 0 1-3.46 0"/>
+              </svg>
+              Notifications
+            </button>
+
             <button
               type="button"
               class="overflow-item w-full"


### PR DESCRIPTION
## Summary
- move the mobile notification shortcut into the header overflow dropdown
- keep the notification toggle accessible from the menu item

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f4dee2a248324a8f5a136db33fbbe)