### PR TITLE
Make note folder chips open move sheet

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5558,7 +5558,7 @@
                           </button>
                         </div>
                         <div class="note-card-meta-row">
-                          <span class="note-card-folder">Folder</span>
+                          <button type="button" class="note-card-folder" aria-label="Move note to folder">Folder</button>
                         </div>
                       </div>
                     </article>

--- a/mobile.js
+++ b/mobile.js
@@ -1101,10 +1101,21 @@ const initMobileNotes = () => {
       metaRow.className = 'note-card-meta-row';
 
       const folderId = note.folderId && typeof note.folderId === 'string' ? note.folderId : 'unsorted';
-      const folderPill = document.createElement('span');
+      const folderPill = document.createElement('button');
+      folderPill.type = 'button';
       folderPill.className = 'note-card-folder';
+      folderPill.setAttribute('aria-label', 'Move note to folder');
       const folderName = getFolderNameById(folderId) || 'Unsorted';
       folderPill.textContent = folderName;
+
+      folderPill.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        openFolderSelectorForNote(note.id, {
+          initialFolderId: folderId,
+          triggerEl: folderPill,
+        });
+      });
 
       metaRow.appendChild(folderPill);
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -902,10 +902,12 @@ html[data-theme="dracula"] .notebook-folder-scroll-wrap::after {
   align-items: center;
   gap: 6px;
   padding: 4px 10px;
+  border: none;
   border-radius: 999px;
   background: rgba(92, 76, 123, 0.08);
   color: #4f3b78;
   font-weight: 600;
+  cursor: pointer;
 }
 
 .note-card-folder::before {


### PR DESCRIPTION
## Summary
- turn note folder pills on saved note cards into buttons that open the move-to-folder sheet when tapped
- update the note card template to match the new button semantics and adjust styling for button chips

## Testing
- npm test -- --runInBand *(fails: existing mobile.new-folder and mobile.auth tests in baseline)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f4e1fa69c8324aad0fe22686b7e7a)