### PR TITLE
Add active highlighting and tap feedback to saved notes list

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -1060,7 +1060,9 @@ const initMobileNotes = () => {
 
     notes.forEach((note) => {
       const listItem = document.createElement('article');
+      const isActiveNote = String(note.id) === String(currentNoteId);
       listItem.className = 'premium-note-card note-item-mobile notebook-note-card';
+      listItem.classList.toggle('notebook-note-card--active', isActiveNote);
       listItem.dataset.noteId = note.id;
       listItem.dataset.role = 'open-note';
       listItem.setAttribute('role', 'button');

--- a/styles/index.css
+++ b/styles/index.css
@@ -578,12 +578,29 @@ html[data-theme="dracula"] .notebook-folder-scroll-wrap::after {
     align-items: stretch;
     justify-content: flex-start;
     gap: 10px;
-    transition: background-color 0.18s ease, box-shadow 0.16s ease;
+    transition: background-color 0.18s ease, box-shadow 0.16s ease, transform 0.14s ease;
   }
 
   .mobile-shell #notesListMobile .premium-note-card:hover {
     background: rgba(248, 245, 252, 0.65);
     box-shadow: 0 2px 8px rgba(81, 38, 99, 0.08);
+  }
+
+  .mobile-shell #notesListMobile .notebook-note-card--active {
+    background: color-mix(in srgb, var(--accent-color, #512663) 8%, var(--surface-elevated, #f9f9fb));
+    border-left: 4px solid color-mix(in srgb, var(--accent-color, #512663) 75%, transparent);
+    box-shadow: 0 4px 14px rgba(81, 38, 99, 0.12);
+  }
+
+  .mobile-shell #notesListMobile .notebook-note-card--active .note-card-title {
+    color: var(--text-main, #231B2E);
+    font-weight: 700;
+  }
+
+  .mobile-shell #notesListMobile .premium-note-card:active {
+    background: color-mix(in srgb, var(--accent-color, #512663) 6%, rgba(248, 245, 252, 0.9));
+    transform: scale(0.985);
+    box-shadow: 0 2px 10px rgba(81, 38, 99, 0.12);
   }
 
   .mobile-shell #notesListMobile .note-card-title {
@@ -748,12 +765,29 @@ html[data-theme="dracula"] .notebook-folder-scroll-wrap::after {
     border-bottom: 1px solid rgba(230, 224, 242, 0.5);
     box-shadow: none;
     border-radius: 0;
-    transition: background-color 0.18s ease, box-shadow 0.16s ease;
+    transition: background-color 0.18s ease, box-shadow 0.16s ease, transform 0.14s ease;
   }
 
   #notesListMobile .premium-note-card:hover {
     background: rgba(248, 245, 252, 0.65);
     box-shadow: 0 2px 8px rgba(81, 38, 99, 0.08);
+  }
+
+  #notesListMobile .notebook-note-card--active {
+    background: color-mix(in srgb, var(--accent-color, #512663) 8%, var(--surface-elevated, #f9f9fb));
+    border-left: 4px solid color-mix(in srgb, var(--accent-color, #512663) 75%, transparent);
+    box-shadow: 0 4px 14px rgba(81, 38, 99, 0.12);
+  }
+
+  #notesListMobile .notebook-note-card--active .note-card-title {
+    color: var(--text-main, #231B2E);
+    font-weight: 700;
+  }
+
+  #notesListMobile .premium-note-card:active {
+    background: color-mix(in srgb, var(--accent-color, #512663) 6%, rgba(248, 245, 252, 0.9));
+    transform: scale(0.985);
+    box-shadow: 0 2px 10px rgba(81, 38, 99, 0.12);
   }
 
   #notesListMobile .note-card-title {


### PR DESCRIPTION
## Summary
- mark the currently open note row as active when rendering the saved notes list
- add themed active-row styling that matches the notebook aesthetic
- provide responsive tap/press feedback for note rows on mobile and wider views

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f50e150e483249e7932a477a2e49b)