### PR TITLE
Ensure mobile new reminder sheet opens

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5776,6 +5776,36 @@
           });
       };
 
+      const openReminderSheetDirectly = (trigger) => {
+        const sheet = document.getElementById('create-sheet');
+        if (!(sheet instanceof HTMLElement)) return false;
+
+        sheet.classList.remove('hidden');
+        sheet.removeAttribute('hidden');
+        sheet.setAttribute('aria-hidden', 'false');
+        sheet.setAttribute('open', '');
+        sheet.classList.add('open');
+
+        const backdrop = sheet.querySelector('.sheet-backdrop');
+        backdrop?.classList.remove('hidden');
+
+        const panel = sheet.querySelector('.sheet-panel');
+        panel?.classList.remove('hidden');
+
+        if (trigger instanceof HTMLElement) {
+          trigger.setAttribute('aria-expanded', 'true');
+        }
+
+        const focusTarget = sheet.querySelector(
+          'input, textarea, select, button, [contenteditable="true"]'
+        );
+        if (focusTarget instanceof HTMLElement) {
+          setTimeout(() => focusTarget.focus(), 0);
+        }
+
+        return true;
+      };
+
       navFooter.addEventListener('click', (event) => {
         const button = event.target instanceof Element ? event.target.closest('[data-nav-target]') : null;
         if (!button) return;
@@ -5813,7 +5843,24 @@
               detail: { view }
             })
           );
-          triggerAddReminder();
+
+          const sheet = document.getElementById('create-sheet');
+          if (sheet) {
+            document.dispatchEvent(
+              new CustomEvent('cue:prepare', { detail: { mode: 'create', trigger: button } })
+            );
+            document.dispatchEvent(
+              new CustomEvent('cue:open', { detail: { mode: 'create', trigger: button } })
+            );
+
+            const isOpen = !sheet.classList.contains('hidden');
+            if (!isOpen) {
+              openReminderSheetDirectly(button);
+            }
+          } else {
+            triggerAddReminder();
+          }
+
           return;
         }
 

--- a/mobile.js
+++ b/mobile.js
@@ -66,6 +66,16 @@ initViewportHeight();
       sheet.setAttribute('aria-hidden', 'true');
       sheet.removeAttribute('open');
       sheet.classList.remove('open');
+      if (backdrop instanceof HTMLElement) {
+        backdrop.classList.add('hidden');
+        backdrop.setAttribute('hidden', '');
+        backdrop.setAttribute('aria-hidden', 'true');
+      }
+      if (sheetContent instanceof HTMLElement) {
+        sheetContent.classList.add('hidden');
+        sheetContent.setAttribute('hidden', '');
+        sheetContent.setAttribute('aria-hidden', 'true');
+      }
     };
 
     ensureHidden();
@@ -140,6 +150,16 @@ initViewportHeight();
 
     const openSheet = (trigger) => {
       lastTrigger = trigger instanceof HTMLElement ? trigger : null;
+      if (backdrop instanceof HTMLElement) {
+        backdrop.classList.remove('hidden');
+        backdrop.removeAttribute('hidden');
+        backdrop.setAttribute('aria-hidden', 'false');
+      }
+      if (sheetContent instanceof HTMLElement) {
+        sheetContent.classList.remove('hidden');
+        sheetContent.removeAttribute('hidden');
+        sheetContent.setAttribute('aria-hidden', 'false');
+      }
       sheet.classList.remove('hidden');
       sheet.removeAttribute('hidden');
       sheet.setAttribute('aria-hidden', 'false');


### PR DESCRIPTION
## Summary
- add direct sheet opener to the mobile footer handler so the New Reminder action always reveals the create sheet
- dispatch cue events and fall back to explicitly unhiding and focusing the reminder editor if needed

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f4b8597e0832483f7c9bb5c15923b)