### PR TITLE
Standardize notebook body formatting handling

### DIFF
--- a/js/modules/notes-sync.js
+++ b/js/modules/notes-sync.js
@@ -114,6 +114,8 @@ export const initNotesSync = (options = {}) => {
       [userColumn]: currentUserId,
       title: note.title,
       body: typeof note.bodyHtml === 'string' && note.bodyHtml.length ? note.bodyHtml : note.body,
+      body_html: typeof note.bodyHtml === 'string' ? note.bodyHtml : null,
+      body_text: typeof note.bodyText === 'string' ? note.bodyText : null,
       folder_id: typeof note.folderId === 'string' && note.folderId ? note.folderId : null,
       [updatedAtColumn]: typeof note.updatedAt === 'string' && note.updatedAt
         ? note.updatedAt
@@ -153,7 +155,7 @@ export const initNotesSync = (options = {}) => {
     try {
       const { data, error } = await client
         .from(tableName)
-        .select(`id,title,body,folder_id,${updatedAtColumn}`)
+        .select(`id,title,body,body_html,body_text,folder_id,${updatedAtColumn}`)
         .eq(userColumn, currentUserId);
       if (error) {
         throw error;


### PR DESCRIPTION
## Summary
- add helper functions to read/write notebook editor HTML reliably and derive plain-text previews
- normalize note creation/loading so bodyHtml/bodyText are always populated and mirrored to legacy body fields
- include body_html/body_text in Supabase sync payloads and selection to preserve rich text remotely

## Testing
- npm test -- --runInBand (fails: existing mobile auth/new-folder tests in suite)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f6576d2b483248d11bafb74eca92a)