### PR TITLE
Fix reminder sheet layer visibility

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -66,6 +66,14 @@ initViewportHeight();
       sheet.setAttribute('aria-hidden', 'true');
       sheet.removeAttribute('open');
       sheet.classList.remove('open');
+
+      [backdrop, sheetContent].forEach((layer) => {
+        if (layer instanceof HTMLElement) {
+          layer.classList.add('hidden');
+          layer.setAttribute('hidden', '');
+          layer.setAttribute('aria-hidden', 'true');
+        }
+      });
     };
 
     ensureHidden();
@@ -140,6 +148,16 @@ initViewportHeight();
 
     const openSheet = (trigger) => {
       lastTrigger = trigger instanceof HTMLElement ? trigger : null;
+      if (backdrop instanceof HTMLElement) {
+        backdrop.classList.remove('hidden');
+        backdrop.removeAttribute('hidden');
+        backdrop.setAttribute('aria-hidden', 'false');
+      }
+      if (sheetContent instanceof HTMLElement) {
+        sheetContent.classList.remove('hidden');
+        sheetContent.removeAttribute('hidden');
+        sheetContent.setAttribute('aria-hidden', 'false');
+      }
       sheet.classList.remove('hidden');
       sheet.removeAttribute('hidden');
       sheet.setAttribute('aria-hidden', 'false');


### PR DESCRIPTION
## Summary
- ensure the reminder sheet backdrop and panel layers are hidden when the sheet closes so state resets cleanly
- unhide the sheet backdrop and content when opening to restore full UI for create/edit flows

## Testing
- npm test -- --runInBand *(fails: mobile.new-folder.test.js, mobile.auth.test.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f67e53d2c83249b47bcaf28685a2a)