### PR TITLE
Ensure footer reminder CTA opens sheet before navigation

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -207,14 +207,36 @@ initViewportHeight();
       lastTrigger = null;
     };
 
+    const triggerCueOpen = (trigger) => {
+      const detail = { mode: 'create', trigger };
+      dispatchSheetEvent('cue:prepare', detail);
+      dispatchSheetEvent('cue:open', detail);
+    };
+
+    const bindOpener = (trigger, options = undefined) => {
+      if (!(trigger instanceof HTMLElement)) return;
+      const listenerOptions = options || false;
+      trigger.addEventListener(
+        'click',
+        (event) => {
+          event.preventDefault();
+          triggerCueOpen(trigger);
+        },
+        listenerOptions,
+      );
+    };
+
+    const primaryCta = document.getElementById('mobile-footer-new-reminder');
+
     openers.forEach((trigger) => {
-      trigger.addEventListener('click', (event) => {
-        event.preventDefault();
-        const detail = { mode: 'create', trigger };
-        dispatchSheetEvent('cue:prepare', detail);
-        dispatchSheetEvent('cue:open', detail);
-      });
+      const isFooterCta = trigger === primaryCta;
+      const options = isFooterCta ? { capture: true } : undefined;
+      bindOpener(trigger, options);
     });
+
+    if (primaryCta && !openers.includes(primaryCta)) {
+      bindOpener(primaryCta, { capture: true });
+    }
 
     closeBtn.addEventListener('click', (event) => {
       event.preventDefault();


### PR DESCRIPTION
## Summary
- refactor reminder sheet open binding to reuse a common cue dispatch helper
- bind the footer “Add reminder” button with a capture listener so it dispatches cue events before other handlers
- keep sheet opening logic in one place to ensure backdrop, panel, and dialog become visible together

## Testing
- npm test -- --runInBand *(fails: mobile.new-folder wiring, mobile.auth supabase init issues)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f849481688324b80871ad84c7d40f)