### PR TITLE
Add logging guards for cue open sheet

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -148,6 +148,18 @@ initViewportHeight();
 
     const openSheet = (trigger) => {
       lastTrigger = trigger instanceof HTMLElement ? trigger : null;
+      if (!(sheet instanceof HTMLElement)) {
+        console.warn('cue:open skipped: sheet element missing');
+        return;
+      }
+
+      const missingElements = [];
+      if (!(backdrop instanceof HTMLElement)) missingElements.push('backdrop');
+      if (!(sheetContent instanceof HTMLElement)) missingElements.push('content');
+      if (missingElements.length) {
+        console.warn(`cue:open incomplete: missing ${missingElements.join(', ')}`);
+      }
+
       if (backdrop instanceof HTMLElement) {
         backdrop.classList.remove('hidden');
         backdrop.removeAttribute('hidden');


### PR DESCRIPTION
## Summary
- add guardrails around cue:open sheet activation when expected elements are missing
- log minimal warnings to surface failures without changing user behavior

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f8e3058a08324be8a327b2e3e0ca4)