### PR TITLE
Log cue open visibility issues on mobile sheet

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -184,6 +184,26 @@ initViewportHeight();
       focusFirstField();
       playEnterAnimation();
 
+      const hiddenLayers = [
+        { name: 'sheet', el: sheet },
+        { name: 'backdrop', el: backdrop },
+        { name: 'content', el: sheetContent },
+      ]
+        .filter(({ el }) => el instanceof HTMLElement)
+        .filter(({ el }) =>
+          el.classList.contains('hidden') ||
+          el.hasAttribute('hidden') ||
+          el.getAttribute('aria-hidden') === 'true'
+        );
+
+      if (hiddenLayers.length) {
+        console.warn(
+          `cue:open visibility issue: ${hiddenLayers
+            .map(({ name }) => name)
+            .join(', ')}`
+        );
+      }
+
       dispatchSheetEvent('reminder:sheet-opened', { trigger: lastTrigger });
     };
 


### PR DESCRIPTION
## Summary
- add minimal logging for cue open when sheet, backdrop, or content remain hidden

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f93051c7c83249c1a35bafea843a5)