### PR TITLE
Standardize notebook note body handling

### DIFF
--- a/js/modules/notes-storage.js
+++ b/js/modules/notes-storage.js
@@ -67,6 +67,17 @@ const extractPlainText = (html = '') => {
   return html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
 };
 
+const deriveBodyText = (html = '', fallbackText = '') => {
+  const textFromHtml = extractPlainText(html);
+  if (textFromHtml) {
+    return textFromHtml;
+  }
+  if (typeof fallbackText === 'string') {
+    return fallbackText.trim();
+  }
+  return '';
+};
+
 const isValidDateString = (value) => {
   if (typeof value !== 'string') {
     return false;
@@ -84,7 +95,7 @@ export const createNote = (title, bodyHtml, overrides = {}) => {
   const normalizedBodyHtml = normalizeBodyValue(rawBodyHtml);
   const providedBodyText = typeof overrides.bodyText === 'string' ? overrides.bodyText : null;
   const normalizedBodyText =
-    providedBodyText !== null ? providedBodyText.trim() : extractPlainText(normalizedBodyHtml);
+    providedBodyText !== null ? providedBodyText.trim() : deriveBodyText(normalizedBodyHtml);
   return {
     id: overrides.id && typeof overrides.id === 'string' ? overrides.id : generateId(),
     title: trimmedTitle || 'Untitled note',
@@ -112,13 +123,12 @@ const normalizeNotes = (value) => {
             ? note.bodyHtml
             : typeof note.body === 'string'
               ? note.body
-              : '';
+              : typeof note.bodyText === 'string'
+                ? note.bodyText
+                : '';
         const fallbackText = typeof note.bodyText === 'string' ? note.bodyText : '';
         const body = normalizeBodyValue(rawBodyHtml || fallbackText);
-        const bodyText =
-          fallbackText && fallbackText.trim().length
-            ? fallbackText.trim()
-            : extractPlainText(body);
+        const bodyText = deriveBodyText(body, fallbackText);
         const id = typeof note.id === 'string' && note.id.trim() ? note.id : generateId();
         const updatedAt = isValidDateString(note.updatedAt) ? note.updatedAt : new Date().toISOString();
         if (!title && !body && !fallbackText) {
@@ -141,12 +151,12 @@ const normalizeNotes = (value) => {
       ? value.bodyHtml
       : typeof value.body === 'string'
         ? value.body
-        : '';
+        : typeof value.bodyText === 'string'
+          ? value.bodyText
+          : '';
     const fallbackText = typeof value.bodyText === 'string' ? value.bodyText : '';
     const body = normalizeBodyValue(rawBodyHtml || fallbackText);
-    const bodyText = fallbackText && fallbackText.trim().length
-      ? fallbackText.trim()
-      : extractPlainText(body);
+    const bodyText = deriveBodyText(body, fallbackText);
     if (!title && !body && !bodyText) {
       return [];
     }

--- a/js/modules/notes-sync.js
+++ b/js/modules/notes-sync.js
@@ -46,21 +46,24 @@ const mergeNotes = (localNotes = [], remoteNotes = []) => {
   return Array.from(merged.values()).sort((a, b) => toTimestamp(b?.updatedAt) - toTimestamp(a?.updatedAt));
 };
 
-  const mapRowToNoteFactory = (updatedAtColumn) => (row) => {
-    if (!row || typeof row !== 'object') {
-      return null;
-    }
-    const rawBodyHtml =
-      (typeof row.body_html === 'string' && row.body_html.length ? row.body_html : null) ?? row.body;
-    const overrides = {
-      id: typeof row.id === 'string' && row.id ? row.id : undefined,
-      updatedAt: typeof row[updatedAtColumn] === 'string' ? row[updatedAtColumn] : undefined,
-      folderId: typeof row.folder_id === 'string' && row.folder_id ? row.folder_id : undefined,
-      bodyHtml: rawBodyHtml,
-      bodyText: typeof row.body_text === 'string' ? row.body_text : undefined,
-    };
-  return createNote(row.title, rawBodyHtml, overrides);
+const mapRowToNoteFactory = (updatedAtColumn) => (row) => {
+  if (!row || typeof row !== 'object') {
+    return null;
+  }
+  const fallbackText = typeof row.body_text === 'string' ? row.body_text : undefined;
+  const rawBodyHtml =
+    (typeof row.body_html === 'string' && row.body_html.length ? row.body_html : null) ??
+    (typeof row.body === 'string' && row.body.length ? row.body : null) ??
+    fallbackText;
+  const overrides = {
+    id: typeof row.id === 'string' && row.id ? row.id : undefined,
+    updatedAt: typeof row[updatedAtColumn] === 'string' ? row[updatedAtColumn] : undefined,
+    folderId: typeof row.folder_id === 'string' && row.folder_id ? row.folder_id : undefined,
+    bodyHtml: rawBodyHtml,
+    bodyText: fallbackText,
   };
+  return createNote(row.title, rawBodyHtml, overrides);
+};
 
 export const initNotesSync = (options = {}) => {
   const {

--- a/mobile.js
+++ b/mobile.js
@@ -858,16 +858,6 @@ const initMobileNotes = () => {
     return extractPlainText(source);
   };
 
-  const getEditorValues = () => {
-    const bodyHtml = getEditorBodyHtml();
-    const bodyText = getEditorBodyText(bodyHtml);
-    return {
-      title: typeof titleInput.value === 'string' ? titleInput.value.trim() : '',
-      bodyHtml,
-      bodyText,
-    };
-  };
-
   const updateListSelection = () => {
     if (!listElement) {
       return;
@@ -2497,10 +2487,10 @@ const initMobileNotes = () => {
   saveButton.addEventListener('click', () => {
     const existingNotes = loadAllNotes();
     const notesArray = Array.isArray(existingNotes) ? [...existingNotes] : [];
-    const { title, bodyHtml, bodyText } = getEditorValues();
-    const noteBodyHtml = bodyHtml || '';
+    const noteBodyHtml = getEditorBodyHtml() || '';
     const noteBodyText = getEditorBodyText(noteBodyHtml);
-    const sanitizedTitle = title || 'Untitled note';
+    const rawTitle = typeof titleInput.value === 'string' ? titleInput.value.trim() : '';
+    const sanitizedTitle = rawTitle || 'Untitled note';
     const timestamp = new Date().toISOString();
     const normalizedFolderId =
       currentEditingNoteFolderId && currentEditingNoteFolderId !== 'all'
@@ -2523,7 +2513,6 @@ const initMobileNotes = () => {
         const newNote = createNote(sanitizedTitle, noteBodyHtml, {
           updatedAt: timestamp,
           folderId: normalizedFolderId,
-          bodyHtml: noteBodyHtml,
           bodyText: noteBodyText,
         });
         currentNoteId = newNote.id;
@@ -2532,7 +2521,6 @@ const initMobileNotes = () => {
     } else {
       const newNote = createNote(sanitizedTitle, noteBodyHtml, {
         folderId: normalizedFolderId,
-        bodyHtml: noteBodyHtml,
         bodyText: noteBodyText,
       });
       currentNoteId = newNote.id;


### PR DESCRIPTION
## Summary
- ensure the notebook editor reads and writes HTML consistently while deriving plain-text previews from the same source
- normalize stored and synced notes so legacy records populate both bodyHtml and bodyText for search and formatting preservation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fc77464948324aaa311e5cbed23c1)