### PR TITLE
Fix mobile add reminder view

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -6904,19 +6904,22 @@
       const setActiveView = (target) => {
         if (!order.includes(target)) return;
 
+        const displayTarget = target === 'new' ? 'reminders' : target;
+
         order.forEach((key, index) => {
           const view = views[key];
           const button = buttons[index];
-          const isActive = key === target;
+          const isViewActive = key === displayTarget;
+          const isButtonActive = key === target;
 
           if (view) {
-            view.classList.toggle('hidden', !isActive);
-            view.setAttribute('aria-hidden', String(!isActive));
+            view.classList.toggle('hidden', !isViewActive);
+            view.setAttribute('aria-hidden', String(!isViewActive));
           }
 
           if (button) {
-            button.setAttribute('aria-current', isActive ? 'page' : 'false');
-            button.classList.toggle('active', Boolean(isActive));
+            button.setAttribute('aria-current', isButtonActive ? 'page' : 'false');
+            button.classList.toggle('active', Boolean(isButtonActive));
           }
         });
 


### PR DESCRIPTION
## Summary
- Map the mobile "new" view to keep the reminders content visible while highlighting the add button
- Prevent the Add Reminder footer action from hiding all main views when opening the reminder sheet

## Testing
- npm test -- --runInBand --testPathPattern "mobile.new-folder.test.js|mobile.auth.test.js" *(fails: existing wiring expectations for new folder dialog and auth mocks)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693012cf303883249621a508eb06e764)