### PR TITLE
Fix mobile new reminder sheet

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5823,20 +5823,12 @@
         }
 
         if (view === 'new') {
-          window.dispatchEvent(
-            new CustomEvent('app:navigate', {
-              detail: { view }
-            })
-          );
-
+          const detail = { mode: 'create', trigger: button };
           const sheet = document.getElementById('create-sheet');
+
           if (sheet) {
-            document.dispatchEvent(
-              new CustomEvent('cue:prepare', { detail: { mode: 'create', trigger: button } })
-            );
-            document.dispatchEvent(
-              new CustomEvent('cue:open', { detail: { mode: 'create', trigger: button } })
-            );
+            document.dispatchEvent(new CustomEvent('cue:prepare', { detail }));
+            document.dispatchEvent(new CustomEvent('cue:open', { detail }));
           } else {
             triggerAddReminder();
           }


### PR DESCRIPTION
## Summary
- update the mobile footer add reminder handler to open the creation sheet directly
- avoid navigating to the unused `new` view when tapping the footer plus button

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930163dd478832483cdcd1684850f43)