### PR TITLE
Add separate modes for new and edit reminder sheet

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5823,14 +5823,18 @@
         }
 
         if (view === 'new') {
-          const detail = { mode: 'create', trigger: button };
-          const sheet = document.getElementById('create-sheet');
-
-          if (sheet) {
-            document.dispatchEvent(new CustomEvent('cue:prepare', { detail }));
-            document.dispatchEvent(new CustomEvent('cue:open', { detail }));
+          if (typeof window.openNewReminderSheet === 'function') {
+            window.openNewReminderSheet(button);
           } else {
-            triggerAddReminder();
+            const detail = { mode: 'create', trigger: button };
+            const sheet = document.getElementById('create-sheet');
+
+            if (sheet) {
+              document.dispatchEvent(new CustomEvent('cue:prepare', { detail }));
+              document.dispatchEvent(new CustomEvent('cue:open', { detail }));
+            } else {
+              triggerAddReminder();
+            }
           }
 
           return;

--- a/mobile.js
+++ b/mobile.js
@@ -240,6 +240,10 @@ initViewportHeight();
     };
 
     const triggerCueOpen = (trigger) => {
+      if (typeof window !== 'undefined' && typeof window.openNewReminderSheet === 'function') {
+        window.openNewReminderSheet(trigger);
+        return;
+      }
       const detail = { mode: 'create', trigger };
       dispatchSheetEvent('cue:prepare', detail);
       dispatchSheetEvent('cue:open', detail);


### PR DESCRIPTION
## Summary
- add explicit new/edit mode state for the reminder sheet and update headers accordingly
- expose helpers to open the sheet in new or edit mode and wire footer + and row taps to them
- branch save handling based on mode to create or update reminders appropriately

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69301d4d06ac83249699f7c6c9f8b4eb)