### PR TITLE
Restyle mobile reminder tabs

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -3640,9 +3640,9 @@ export async function initReminders(sel = {}) {
         const isActive = mode === mobileRemindersFilterMode;
         button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
         if (isActive) {
-          button.classList.add('reminders-tab-active');
+          button.classList.add('reminders-tab-active', 'active');
         } else {
-          button.classList.remove('reminders-tab-active');
+          button.classList.remove('reminders-tab-active', 'active');
         }
       });
     };

--- a/mobile.html
+++ b/mobile.html
@@ -5362,19 +5362,21 @@
       <div class="mobile-view-inner mx-auto w-full px-4 pt-4 pb-4 space-y-2" style="background: var(--mobile-quick-surface);">
         <!-- header removed to keep view minimal -->
         <div class="reminders-tabs-wrapper">
-          <div class="tabs tabs-boxed w-full text-sm">
+          <div class="reminder-tabs" role="tablist" aria-label="Reminder filters">
             <button
               type="button"
-              class="tab flex-1 reminders-tab-active"
+              class="reminder-tab reminders-tab-active active"
               data-reminders-tab="all"
+              data-filter="all"
               aria-pressed="true"
             >
               All
             </button>
             <button
               type="button"
-              class="tab flex-1"
+              class="reminder-tab"
               data-reminders-tab="today"
+              data-filter="today"
               aria-pressed="false"
             >
               Today

--- a/styles/index.css
+++ b/styles/index.css
@@ -3712,6 +3712,55 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   display: none !important;
 }
 
+/* ====================== */
+/* Reminder Tabs (Pill) */
+/* ====================== */
+
+.reminders-tabs-wrapper {
+  width: 100%;
+}
+
+.reminder-tabs {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  justify-content: flex-start;
+  align-items: center;
+  flex-wrap: wrap;
+  background: transparent;
+  border: 0;
+}
+
+.reminder-tab {
+  border: none;
+  background: transparent;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  color: var(--text-muted);
+  transition: background-color 0.2s ease, color 0.2s ease;
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+.reminder-tab:hover {
+  background: var(--hover-bg);
+  color: var(--text-main);
+}
+
+.reminder-tab:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+}
+
+.reminder-tab.reminders-tab-active,
+.reminder-tab.active {
+  background: var(--accent-color);
+  color: #fff;
+  font-weight: 600;
+}
+
 /* Reminder list: premium SVG icon buttons */
 .reminder-icon-btn {
   min-width: 40px;


### PR DESCRIPTION
## Summary
- replace the reminders segmented control in the mobile view with a compact pill-style tab layout
- add pill tab styling to align with the updated minimalist reminder design
- ensure the tab activation logic also toggles the generic active class for the new UI treatment

## Testing
- Not run (UI-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693021aa0f088324ae3e041ddbc653d4)