### PR TITLE
Implement unified reminders top bar

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -4958,8 +4958,8 @@
     class="mobile-header px-3 py-2 pt-safe-top"
     role="banner"
   >
-    <div class="reminders-topbar">
-      <div class="reminders-topbar-left">
+    <div class="reminders-top-bar">
+      <div class="reminders-top-primary">
         <div class="reminders-quick-input header-pill">
           <input
             id="quickAddInput"
@@ -4976,7 +4976,7 @@
               title="Open Notebook"
             >
               <svg class="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
-                <path d="M6 2h9a2 2 0 012 2v16a1 1 0 01-1.5.86L12 19l-3.5 1.86A1 1 0 017 20V4a2 2 0 012-2z" fill="currentColor" />
+                <path d="M6 2h9a2 2 0 012 2v16a1 1 0 01-1.5.86L12 19l-3.5 1.86A1 1 0 017 20V4a2 2 0 012-2z" fill="currentColor"/>
               </svg>
             </button>
 
@@ -4999,11 +4999,11 @@
           </div>
         </div>
       </div>
-      <div class="reminders-topbar-center">
-        <div class="reminders-tabs" role="tablist" aria-label="Reminder filters">
+      <div class="reminders-top-controls">
+        <div class="reminder-tabs" role="tablist" aria-label="Reminder filters">
           <button
             type="button"
-            class="reminders-tab reminder-tab reminders-tab-active active"
+            class="reminder-tab reminders-tab reminders-tab-active active"
             data-reminders-tab="all"
             data-filter="all"
             aria-pressed="true"
@@ -5012,7 +5012,7 @@
           </button>
           <button
             type="button"
-            class="reminders-tab reminder-tab"
+            class="reminder-tab reminders-tab"
             data-reminders-tab="today"
             data-filter="today"
             aria-pressed="false"
@@ -5020,13 +5020,11 @@
             Today
           </button>
         </div>
-      </div>
-      <div class="reminders-topbar-right">
         <div class="relative header-overflow-wrapper">
           <button
             id="headerMenuBtn"
             type="button"
-            class="header-action-btn icon-btn quick-add-action"
+            class="header-action-btn icon-btn quick-add-action reminders-top-overflow"
             aria-label="More options"
             aria-expanded="false"
             aria-haspopup="true"

--- a/styles/index.css
+++ b/styles/index.css
@@ -3713,43 +3713,28 @@ section[data-route="dashboard"] .dashboard-shortcuts {
 }
 
 /* ====================== */
-/* Reminders Top Bar      */
+/* ====================== */
+/* Reminders Unified Top Bar */
 /* ====================== */
 
-.reminders-topbar {
+.reminders-top-bar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.6rem;
-  padding: 0.5rem 0.75rem;
-  border-radius: 999px;
-  background: var(--topbar-bg, rgba(255, 255, 255, 0.86));
-  box-shadow: var(--topbar-shadow, 0 8px 24px rgba(0, 0, 0, 0.04));
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  margin-bottom: 0.75rem;
-  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem 0.25rem;
+  width: 100%;
 }
 
-.reminders-topbar-left,
-.reminders-topbar-center,
-.reminders-topbar-right {
-  display: flex;
-  align-items: center;
-}
-
-.reminders-topbar-left {
+.reminders-top-primary {
   flex: 1 1 auto;
   min-width: 0;
-  gap: 0.4rem;
 }
 
-.reminders-topbar-center {
-  flex: 0 1 auto;
-}
-
-.reminders-topbar-right {
+.reminders-top-controls {
   flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
 }
 
 .reminders-quick-input {
@@ -3757,8 +3742,8 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   min-width: 0;
   display: flex;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.35rem 0.6rem;
+  gap: 0.35rem;
+  padding: 0.3rem 0.55rem;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.9);
   border: 1px solid var(--border-subtle);
@@ -3766,9 +3751,10 @@ section[data-route="dashboard"] .dashboard-shortcuts {
 
 .reminders-quick-input input {
   width: 100%;
+  min-width: 0;
   border-radius: 999px;
   border: none;
-  padding: 0.35rem 0.4rem;
+  padding: 0.3rem 0.35rem;
   font-size: 0.9rem;
   background: transparent;
   color: var(--text-main);
@@ -3785,42 +3771,28 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   flex-shrink: 0;
 }
 
-.reminders-topbar .header-action-btn,
-.reminders-topbar .pill-voice-btn {
+.reminders-top-overflow {
   border: none;
   background: transparent;
-  padding: 0.35rem;
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: center;
+  padding: 0.3rem;
   border-radius: 999px;
-  color: var(--accent-color, #512663);
   cursor: pointer;
-  transition: background-color 0.16s ease, transform 0.14s ease, color 0.16s ease;
+  transition: background 0.15s ease;
 }
 
-.reminders-topbar .header-action-btn:hover,
-.reminders-topbar .pill-voice-btn:hover {
-  background-color: rgba(81, 38, 99, 0.06);
-  transform: translateY(-1px);
+.reminders-top-overflow:hover,
+.reminders-top-overflow:focus-visible {
+  background: var(--surface-hover, rgba(0, 0, 0, 0.04));
 }
 
-.reminders-topbar .header-action-btn:focus-visible,
-.reminders-topbar .pill-voice-btn:focus-visible {
-  outline: 2px solid rgba(81, 38, 99, 0.26);
-  outline-offset: 2px;
-}
-
-.reminders-topbar .header-action-btn:active,
-.reminders-topbar .pill-voice-btn:active {
-  transform: scale(0.96);
-}
-
-.reminders-topbar .header-overflow-wrapper {
+.header-overflow-wrapper {
   position: relative;
 }
 
-.reminders-topbar .overflow-menu {
+.header-overflow-wrapper .overflow-menu {
   position: absolute;
   top: 100%;
   right: 0;
@@ -3837,13 +3809,13 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   z-index: 60;
 }
 
-.reminders-topbar .overflow-menu.hidden {
+.header-overflow-wrapper .overflow-menu.hidden {
   display: none;
 }
 
-.reminders-topbar .overflow-menu button,
-.reminders-topbar .overflow-menu a,
-.reminders-topbar .overflow-menu .overflow-item {
+.header-overflow-wrapper .overflow-menu button,
+.header-overflow-wrapper .overflow-menu a,
+.header-overflow-wrapper .overflow-menu .overflow-item {
   display: flex;
   align-items: center;
   gap: 0.4rem;
@@ -3857,19 +3829,18 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   white-space: nowrap;
 }
 
-.reminders-topbar .overflow-menu button:hover,
-.reminders-topbar .overflow-menu a:hover,
-.reminders-topbar .overflow-menu .overflow-item:hover {
-  background-color: rgba(81, 38, 99, 0.06);
+.header-overflow-wrapper .overflow-menu button:hover,
+.header-overflow-wrapper .overflow-menu a:hover,
+.header-overflow-wrapper .overflow-menu .overflow-item:hover {
+  background: rgba(81, 38, 99, 0.06);
 }
 
-.reminders-topbar .overflow-menu svg {
+.header-overflow-wrapper .overflow-menu svg {
   width: 18px;
   height: 18px;
   color: var(--accent-color);
   flex-shrink: 0;
 }
-
 /* ====================== */
 /* Reminder Tabs (Pill) */
 /* ====================== */
@@ -3881,7 +3852,7 @@ section[data-route="dashboard"] .dashboard-shortcuts {
 .reminder-tabs,
 .reminders-tabs {
   display: flex;
-  gap: 0.3rem;
+  gap: 0.25rem;
   padding: 0;
   justify-content: center;
   align-items: center;
@@ -3894,12 +3865,12 @@ section[data-route="dashboard"] .dashboard-shortcuts {
 .reminders-tab {
   border: none;
   background: transparent;
-  padding: 0.25rem 0.75rem;
+  padding: 0.25rem 0.7rem;
   border-radius: 999px;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   cursor: pointer;
   color: var(--text-muted);
-  transition: background-color 0.2s ease, color 0.2s ease;
+  transition: background 0.15s ease, color 0.15s ease;
   flex: 0 0 auto;
   white-space: nowrap;
 }
@@ -3919,11 +3890,17 @@ section[data-route="dashboard"] .dashboard-shortcuts {
 .reminder-tab.reminders-tab-active,
 .reminder-tab.active,
 .reminders-tab.active {
-  background: var(--accent-color);
-  color: #fff;
+  background: var(--primary-soft, rgba(81, 38, 99, 0.12));
+  color: var(--primary-on-soft, #fff);
   font-weight: 600;
 }
 
+@media (max-width: 360px) {
+  .reminder-tabs,
+  .reminders-tabs {
+    overflow-x: auto;
+  }
+}
 /* Reminder list: premium SVG icon buttons */
 .reminder-icon-btn {
   min-width: 40px;


### PR DESCRIPTION
## Summary
- unify the reminders header into a single top bar combining quick add, filter tabs, and overflow controls
- restyle reminder tabs as compact pills and adjust quick add input for tighter layout
- maintain overflow menu styling within the streamlined header

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930293e94648324a67b146ea2b85e24)