### PR TITLE
Fix mobile reminder tabs selection

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -3628,7 +3628,9 @@ export async function initReminders(sel = {}) {
     if (setupMobileReminderTabs._wired) {
       return;
     }
-    const tabButtons = document.querySelectorAll('#view-reminders [data-reminders-tab]');
+    const tabButtons = document.querySelectorAll(
+      '#view-reminders [data-reminders-tab], #reminders-slim-header [data-reminders-tab]'
+    );
     if (!tabButtons.length) {
       return;
     }


### PR DESCRIPTION
## Summary
- wire the mobile reminders header tab buttons into the shared reminders tab logic

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69302d141358832497be19995ee3f6be)