### PR TITLE
Fix mobile note toolbar lists

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1859,66 +1859,62 @@
       color: var(--text-muted, #9a8bb0);
     }
 
+    .note-toolbar,
     .formatting-toolbar-strip {
       display: flex;
-      gap: 6px;
-      padding: 4px 6px;
-      margin-bottom: 6px;
-      border-radius: 999px;
-      background: rgba(247, 247, 250, 0.96);
-      border: 1px solid rgba(230, 225, 240, 0.9);
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.25rem 0.4rem;
+      margin-bottom: 0.5rem;
+      border-radius: 12px;
+      background: rgba(249, 249, 252, 0.82);
+      border: 1px solid rgba(230, 225, 240, 0.85);
       box-shadow: none;
       min-height: auto;
     }
 
+    .note-toolbar-button,
     .formatting-btn {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 32px;
-      height: 32px;
-      border-radius: 50%;
+      width: 30px;
+      height: 30px;
+      padding: 0.25rem;
+      border-radius: 10px;
       border: none;
       background: transparent;
-      color: var(--accent-color, #512663);
+      color: var(--icon-inactive, #4c5c7a);
       cursor: pointer;
       transition: background-color 0.18s ease, color 0.18s ease;
       margin: 0;
     }
 
+    .note-toolbar-button:hover,
+    .note-toolbar-button:focus-visible,
     .formatting-btn:hover,
     .formatting-btn:focus-visible {
-      background: rgba(81, 38, 99, 0.08);
-      color: var(--accent-color, #512663);
+      background: var(--hover-bg, rgba(81, 38, 99, 0.08));
+      color: var(--icon-active, #512663);
       outline: none;
     }
 
+    .note-toolbar-button:active,
+    .formatting-btn:active {
+      background: rgba(81, 38, 99, 0.12);
+      color: var(--icon-active, #512663);
+    }
+
+    .note-toolbar-button svg,
     .formatting-btn svg {
       width: 18px;
       height: 18px;
     }
 
-    .format-toolbar svg,
-    .editor-toolbar svg {
-      width: 18px;
-      height: 18px;
-    }
-
-    .formatting-btn:hover {
-      background: rgba(81, 38, 99, 0.12);
-      color: #3d1e4a; /* Darker Deep Violet */
-      transform: translateY(-1px);
-    }
-
-    .formatting-btn:active {
-      transform: translateY(0);
-      background: rgba(81, 38, 99, 0.18);
-      color: #3d1e4a;
-    }
-
-    .formatting-btn:focus-visible {
-      outline: 2px solid rgba(81, 38, 99, 0.4);
-      outline-offset: 2px;
+    .note-toolbar-button.active,
+    .formatting-btn.active {
+      background: rgba(81, 38, 99, 0.1);
+      color: var(--icon-active, #512663);
     }
     
     /* Enhance the overall scratch notes card for seamless flow */
@@ -5192,30 +5188,30 @@
           <!-- Single-row formatting toolbar with reduced spacing -->
           <div
             id="scratchNotesToolbar"
-            class="formatting-toolbar-strip flex items-center gap-2 px-0 py-0 bg-transparent rounded-lg border-0 shadow-none"
+            class="note-toolbar formatting-toolbar-strip flex items-center gap-2 px-0 py-0 bg-transparent rounded-lg border-0 shadow-none"
             role="toolbar"
             aria-label="Formatting options"
           >
-            <button type="button" class="formatting-btn notebook-format-button" data-format="bold" aria-label="Bold" aria-controls="notebook-editor-body">
+            <button type="button" class="formatting-btn note-toolbar-button notebook-format-button" data-format="bold" aria-label="Bold" aria-controls="notebook-editor-body">
               <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M7 4h6a4 4 0 0 1 0 8H7V4zm0 8h7a4 4 0 0 1 0 8H7v-8z" fill="currentColor" />
               </svg>
             </button>
 
-            <button type="button" class="formatting-btn notebook-format-button" data-format="italic" aria-label="Italic" aria-controls="notebook-editor-body">
+            <button type="button" class="formatting-btn note-toolbar-button notebook-format-button" data-format="italic" aria-label="Italic" aria-controls="notebook-editor-body">
               <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M10 4h9v2h-3.6l-3.8 12H16v2H7v-2h3.6l3.8-12H10V4z" fill="currentColor" />
               </svg>
             </button>
 
-            <button type="button" class="formatting-btn notebook-format-button" data-format="underline" aria-label="Underline" aria-controls="notebook-editor-body">
+            <button type="button" class="formatting-btn note-toolbar-button notebook-format-button" data-format="underline" aria-label="Underline" aria-controls="notebook-editor-body">
               <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M7 4h2v7a3 3 0 0 0 6 0V4h2v7a5 5 0 0 1-10 0V4z" fill="currentColor" />
                 <path d="M5 19h14v2H5z" fill="currentColor" />
               </svg>
             </button>
 
-            <button type="button" class="formatting-btn notebook-format-button" data-format="bullet-list" aria-label="Bullet list" aria-controls="notebook-editor-body">
+            <button type="button" class="formatting-btn note-toolbar-button notebook-format-button" data-format="bullet-list" aria-label="Bullet list" aria-controls="notebook-editor-body">
               <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M7 6h13v2H7V6zm0 5h13v2H7v-2zm0 5h13v2H7v-2z" fill="currentColor" />
                 <circle cx="4" cy="7" r="1.25" fill="currentColor" />
@@ -5224,7 +5220,7 @@
               </svg>
             </button>
 
-            <button type="button" class="formatting-btn notebook-format-button" data-format="numbered-list" aria-label="Numbered list" aria-controls="notebook-editor-body">
+            <button type="button" class="formatting-btn note-toolbar-button notebook-format-button" data-format="numbered-list" aria-label="Numbered list" aria-controls="notebook-editor-body">
               <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M9 6h11v2H9V6zm0 5h11v2H9v-2zm0 5h11v2H9v-2z" fill="currentColor" />
                 <path d="M4 6.5V8h2V4H4v1.5h1v1H4zm1.5 4H4a.5.5 0 0 0-.5.5v.75H4V12h1v2H3.5v1H6v-3.5a1 1 0 0 0-1-1Zm.5 5H4v1h1v1H4v1h2v-3Z" fill="currentColor" />

--- a/styles/index.css
+++ b/styles/index.css
@@ -206,8 +206,16 @@ html[data-theme="professional"] {
 
 #notebook-editor-body ul,
 #notebook-editor-body ol {
-  padding-left: 1.25rem;
-  margin: 0.2rem 0 0.4rem;
+  padding-left: 1.2rem;
+  margin: 0.25rem 0 0.45rem;
+}
+
+#notebook-editor-body ul {
+  list-style: disc;
+}
+
+#notebook-editor-body ol {
+  list-style: decimal;
 }
 
 #notebook-editor-body li {


### PR DESCRIPTION
## Summary
- ensure notebook lists render with proper bullet and number styling in the editor
- refresh the mobile note toolbar styling to match the simplified layout

## Testing
- npm test -- --runInBand *(fails: existing mobile.new-folder, mobile.auth, and reminders.quick-add tests in current tree)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69302dc2290c8324a8d3d00763d5bb4a)