### PR TITLE
Fix reminder card horizontal layout

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -73,8 +73,7 @@ body.mobile-theme .top-bar button.is-active {
 
 /* Card Styles */
 body.mobile-theme .card,
-body.mobile-theme .note-card,
-body.mobile-theme .reminder-card {
+body.mobile-theme .note-card {
   background-color: #FFFFFF;
   border: 1px solid #E5E7EB;
   border-radius: 0.75rem;
@@ -84,6 +83,49 @@ body.mobile-theme .reminder-card {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+}
+
+body.mobile-theme .reminder-card {
+  display: flex !important;
+  flex-direction: row !important;
+  align-items: center !important;
+  justify-content: flex-start !important;
+  gap: 0.75rem;
+  padding: 0.6rem 0.9rem;
+  border-radius: 0.9rem;
+  background: var(--surface-soft, rgba(255, 255, 255, 0.7));
+  text-align: left !important;
+}
+
+.reminder-card-main {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.reminder-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.reminder-date {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.reminder-card * {
+  text-align: left !important;
+}
+
+.reminder-complete-btn {
+  flex: 0 0 auto !important;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 body.mobile-theme .card h2,

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -3864,7 +3864,7 @@ export async function initReminders(sel = {}) {
 
       const desktopCardClasses =
         'reminder-item task-item reminder-card desktop-task-card grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-4 text-sm shadow-sm transition hover:border-base-300 hover:bg-base-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60';
-      const mobileCardClasses = 'reminder-row w-full text-base-content';
+      const mobileCardClasses = 'reminder-row reminder-card w-full text-base-content';
 
       const itemEl = document.createElement(elementTag);
       itemEl.className = isMobile ? mobileCardClasses : desktopCardClasses;
@@ -3976,10 +3976,10 @@ export async function initReminders(sel = {}) {
 
       if (isMobile) {
         const rowMain = document.createElement('div');
-        rowMain.className = 'reminder-row-main';
+        rowMain.className = 'reminder-card-main reminder-row-main';
 
         const titleWrapper = document.createElement('div');
-        titleWrapper.className = 'reminder-row-title';
+        titleWrapper.className = 'reminder-title reminder-row-title';
         titleWrapper.dataset.reminderTitle = 'true';
         const titleToggle = document.createElement('span');
         titleToggle.dataset.role = 'reminder-today-toggle';
@@ -3993,7 +3993,7 @@ export async function initReminders(sel = {}) {
 
         if (dueLabel) {
           const metaText = document.createElement('div');
-          metaText.className = 'reminder-row-meta';
+          metaText.className = 'reminder-date reminder-row-meta';
           metaText.textContent = dueLabel;
           rowMain.appendChild(metaText);
         }
@@ -4004,7 +4004,7 @@ export async function initReminders(sel = {}) {
           itemEl.classList.add('reminder-row-overdue');
         }
 
-        toggleBtn.classList.add('reminder-row-complete');
+        toggleBtn.classList.add('reminder-row-complete', 'reminder-complete-btn');
         itemEl.append(toggleBtn, rowMain);
 
         itemEl.addEventListener('click', (event) => {


### PR DESCRIPTION
## Summary
- update mobile reminder card styling to use a horizontal reminder-card layout with left-aligned content
- add reminder-card-main, title, and date styling plus non-stretch checkbox controls
- update mobile reminder rendering to apply the new wrapper and class names for titles and due dates

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69309aa47b888324b3a0dcb6b2b9e946)