### PR TITLE
Refine reminder card styling

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -90,10 +90,12 @@ body.mobile-theme .reminder-card {
   flex-direction: row !important;
   align-items: center !important;
   justify-content: flex-start !important;
-  gap: 0.75rem;
-  padding: 0.6rem 0.9rem;
-  border-radius: 0.9rem;
+  gap: 0.55rem;
+  padding: 0.45rem 0.85rem;
+  border-radius: 0.8rem;
   background: var(--surface-soft, rgba(255, 255, 255, 0.7));
+  border-left: 3px solid color-mix(in srgb, var(--accent-color, #5080BF) 55%, transparent);
+  margin-bottom: 0.35rem;
   text-align: left !important;
 }
 
@@ -106,7 +108,7 @@ body.mobile-theme .reminder-card {
 
 .reminder-title {
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -115,6 +117,7 @@ body.mobile-theme .reminder-card {
 .reminder-date {
   font-size: 0.78rem;
   color: var(--text-muted);
+  line-height: 1.2;
 }
 
 .reminder-card * {
@@ -314,9 +317,14 @@ body.mobile-theme :focus-visible {
     padding: 1.25rem 1.5rem;
   }
   body.mobile-theme .card,
-  body.mobile-theme .note-card,
-  body.mobile-theme .reminder-card {
+  body.mobile-theme .note-card {
     padding: 1.15rem 1.35rem;
+  }
+
+  body.mobile-theme .reminder-card {
+    padding: 0.5rem 0.95rem;
+    gap: 0.55rem;
+    border-radius: 0.8rem;
   }
   body.mobile-theme .btn-primary,
   body.mobile-theme button.btn-primary,
@@ -327,5 +335,11 @@ body.mobile-theme :focus-visible {
   }
   body.mobile-theme .card-grid {
     gap: 1.25rem;
+  }
+}
+
+@media (min-width: 900px) {
+  body.desktop-theme .reminder-card {
+    padding: 0.5rem 1rem;
   }
 }


### PR DESCRIPTION
## Summary
- tighten reminder card padding and spacing for a slimmer, sleeker card layout
- soften the left accent stripe and adjust typography for title and date
- align responsive reminder card overrides across breakpoints

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69309e31f6bc8324b917ffcff4a6c7b7)