### PR TITLE
Reduce spacing between mobile header and reminders list

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1006,7 +1006,7 @@
 
   /* Reminders wrapper spacing on mobile */
   #remindersWrapper {
-    margin-top: 0.75rem;
+    margin-top: 0.5rem;
   }
 
   /* Main reminders list container */
@@ -3131,6 +3131,7 @@
   <style id="empty-state-compact-css">
     #emptyState {
       text-align: left;
+      margin-top: 0.5rem;
     }
     #emptyState .empty-state-compact {
       display: grid;
@@ -5081,7 +5082,7 @@
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: reminders view -->
     <section data-view="reminders" id="view-reminders" class="view-panel" style="background: #FBFBFB;">
-      <div class="mobile-view-inner mx-auto w-full px-4 pt-4 pb-4 space-y-2" style="background: var(--mobile-quick-surface);">
+      <div class="mobile-view-inner mx-auto w-full px-4 pt-2 pb-4 space-y-2" style="background: var(--mobile-quick-surface);">
         <!-- header removed to keep view minimal -->
         <div class="reminders-content-shell space-y-2">
 


### PR DESCRIPTION
## Summary
- tighten spacing above the mobile reminders list to sit closer under the header
- align the reminders empty state with the new spacing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930a0bd28fc83248e7e943f97318f0b)