### PR TITLE
Simplify notebook editor card layout

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -154,6 +154,40 @@ body.mobile-theme .text-secondary {
   color: #6B7280;
 }
 
+/* Notebook editor layout */
+.note-editor-card {
+  border-radius: 1rem;
+  background: var(--surface-soft, #fff);
+  padding: 0.9rem 1rem;
+  box-shadow: 0 18px 45px rgba(15, 0, 65, 0.08);
+}
+
+.note-editor-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.note-toolbar {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(76, 29, 149, 0.04);
+}
+
+.note-editor-content {
+  min-height: 220px;
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.8rem;
+  border: 1px solid rgba(76, 29, 149, 0.12);
+  background: #fff;
+  overflow-y: auto;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
 /* Buttons */
 body.mobile-theme .btn-primary,
 body.mobile-theme button.btn-primary,

--- a/mobile.html
+++ b/mobile.html
@@ -1811,8 +1811,8 @@
       box-shadow: none;
       transition: all 0.2s ease;
       line-height: 1.45;
-      min-height: calc(100vh - 220px);
-      max-height: calc(100vh - 120px);
+      min-height: 220px;
+      max-height: none;
       overflow-y: auto;
       background: rgba(249, 249, 252, 0.96);
       color: var(--text-body, #4a3c57);
@@ -1861,14 +1861,13 @@
 
     .note-toolbar,
     .formatting-toolbar-strip {
-      display: flex;
+      display: inline-flex;
       align-items: center;
-      gap: 0.35rem;
-      padding: 0.25rem 0.4rem;
-      margin-bottom: 0.5rem;
-      border-radius: 12px;
-      background: rgba(249, 249, 252, 0.82);
-      border: 1px solid rgba(230, 225, 240, 0.85);
+      gap: 0.4rem;
+      padding: 0.35rem 0.5rem;
+      border-radius: 999px;
+      background: rgba(76, 29, 149, 0.04);
+      border: none;
       box-shadow: none;
       min-height: auto;
     }
@@ -5158,74 +5157,62 @@
                 </button>
               </div>
 
-            <!-- Single-row formatting toolbar with reduced spacing -->
-            <div
-              id="scratchNotesToolbar"
-              class="formatting-toolbar-strip flex items-center gap-2 px-0 py-0 bg-transparent rounded-lg border-0 shadow-none"
-              role="toolbar"
-              aria-label="Formatting options"
-            >
-              <button type="button" class="formatting-btn notebook-format-button" data-format="bold" aria-label="Bold" aria-controls="notebook-editor-body">
-                <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M7 4h6a4 4 0 0 1 0 8H7V4zm0 8h7a4 4 0 0 1 0 8H7v-8z" fill="currentColor" />
-                </svg>
-              </button>
-
-          <!-- Single-row formatting toolbar with reduced spacing -->
-          <div
-            id="scratchNotesToolbar"
-            class="note-toolbar formatting-toolbar-strip flex items-center gap-2 px-0 py-0 bg-transparent rounded-lg border-0 shadow-none"
-            role="toolbar"
-            aria-label="Formatting options"
-          >
-            <button type="button" class="formatting-btn note-toolbar-button notebook-format-button" data-format="bold" aria-label="Bold" aria-controls="notebook-editor-body">
-              <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M7 4h6a4 4 0 0 1 0 8H7V4zm0 8h7a4 4 0 0 1 0 8H7v-8z" fill="currentColor" />
-              </svg>
-            </button>
-
-            <button type="button" class="formatting-btn note-toolbar-button notebook-format-button" data-format="italic" aria-label="Italic" aria-controls="notebook-editor-body">
-              <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M10 4h9v2h-3.6l-3.8 12H16v2H7v-2h3.6l3.8-12H10V4z" fill="currentColor" />
-              </svg>
-            </button>
-
-            <button type="button" class="formatting-btn note-toolbar-button notebook-format-button" data-format="underline" aria-label="Underline" aria-controls="notebook-editor-body">
-              <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M7 4h2v7a3 3 0 0 0 6 0V4h2v7a5 5 0 0 1-10 0V4z" fill="currentColor" />
-                <path d="M5 19h14v2H5z" fill="currentColor" />
-              </svg>
-            </button>
-
-            <button type="button" class="formatting-btn note-toolbar-button notebook-format-button" data-format="bullet-list" aria-label="Bullet list" aria-controls="notebook-editor-body">
-              <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M7 6h13v2H7V6zm0 5h13v2H7v-2zm0 5h13v2H7v-2z" fill="currentColor" />
-                <circle cx="4" cy="7" r="1.25" fill="currentColor" />
-                <circle cx="4" cy="12" r="1.25" fill="currentColor" />
-                <circle cx="4" cy="17" r="1.25" fill="currentColor" />
-              </svg>
-            </button>
-
-            <button type="button" class="formatting-btn note-toolbar-button notebook-format-button" data-format="numbered-list" aria-label="Numbered list" aria-controls="notebook-editor-body">
-              <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M9 6h11v2H9V6zm0 5h11v2H9v-2zm0 5h11v2H9v-2z" fill="currentColor" />
-                <path d="M4 6.5V8h2V4H4v1.5h1v1H4zm1.5 4H4a.5.5 0 0 0-.5.5v.75H4V12h1v2H3.5v1H6v-3.5a1 1 0 0 0-1-1Zm.5 5H4v1h1v1H4v1h2v-3Z" fill="currentColor" />
-              </svg>
-            </button>
-          </div>
-
-            <!-- Minimal main editor with soft styling -->
-            <div class="distraction-free-editor-container">
+            <div class="note-editor-inner">
               <div
-                id="notebook-editor-body"
-                class="note-editor-area notebook-editor-body minimal-editor px-3 py-3 text-base leading-relaxed focus:outline-none rounded-lg"
-                contenteditable="true"
-                spellcheck="true"
-                data-placeholder="Start typing your note…"
-                role="textbox"
-                aria-label="Note body"
-                aria-multiline="true"
-              ></div>
+                id="scratchNotesToolbar"
+                class="note-toolbar formatting-toolbar-strip flex items-center gap-2 px-0 py-0 bg-transparent rounded-lg border-0 shadow-none"
+                role="toolbar"
+                aria-label="Formatting options"
+              >
+                <button type="button" class="formatting-btn note-toolbar-button notebook-format-button" data-format="bold" aria-label="Bold" aria-controls="notebook-editor-body">
+                  <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M7 4h6a4 4 0 0 1 0 8H7V4zm0 8h7a4 4 0 0 1 0 8H7v-8z" fill="currentColor" />
+                  </svg>
+                </button>
+
+                <button type="button" class="formatting-btn note-toolbar-button notebook-format-button" data-format="italic" aria-label="Italic" aria-controls="notebook-editor-body">
+                  <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M10 4h9v2h-3.6l-3.8 12H16v2H7v-2h3.6l3.8-12H10V4z" fill="currentColor" />
+                  </svg>
+                </button>
+
+                <button type="button" class="formatting-btn note-toolbar-button notebook-format-button" data-format="underline" aria-label="Underline" aria-controls="notebook-editor-body">
+                  <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M7 4h2v7a3 3 0 0 0 6 0V4h2v7a5 5 0 0 1-10 0V4z" fill="currentColor" />
+                    <path d="M5 19h14v2H5z" fill="currentColor" />
+                  </svg>
+                </button>
+
+                <button type="button" class="formatting-btn note-toolbar-button notebook-format-button" data-format="bullet-list" aria-label="Bullet list" aria-controls="notebook-editor-body">
+                  <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M7 6h13v2H7V6zm0 5h13v2H7v-2zm0 5h13v2H7v-2z" fill="currentColor" />
+                    <circle cx="4" cy="7" r="1.25" fill="currentColor" />
+                    <circle cx="4" cy="12" r="1.25" fill="currentColor" />
+                    <circle cx="4" cy="17" r="1.25" fill="currentColor" />
+                  </svg>
+                </button>
+
+                <button type="button" class="formatting-btn note-toolbar-button notebook-format-button" data-format="numbered-list" aria-label="Numbered list" aria-controls="notebook-editor-body">
+                  <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M9 6h11v2H9V6zm0 5h11v2H9v-2zm0 5h11v2H9v-2z" fill="currentColor" />
+                    <path d="M4 6.5V8h2V4H4v1.5h1v1H4zm1.5 4H4a.5.5 0 0 0-.5.5v.75H4V12h1v2H3.5v1H6v-3.5a1 1 0 0 0-1-1Zm.5 5H4v1h1v1H4v1h2v-3Z" fill="currentColor" />
+                  </svg>
+                </button>
+              </div>
+
+              <!-- Minimal main editor with soft styling -->
+              <div class="distraction-free-editor-container">
+                <div
+                  id="notebook-editor-body"
+                  class="note-editor-content note-editor-area notebook-editor-body minimal-editor px-3 py-3 text-base leading-relaxed focus:outline-none rounded-lg"
+                  contenteditable="true"
+                  spellcheck="true"
+                  data-placeholder="Start typing your note…"
+                  role="textbox"
+                  aria-label="Note body"
+                  aria-multiline="true"
+                ></div>
+              </div>
             </div>
           </div>
         </div>

--- a/styles/index.css
+++ b/styles/index.css
@@ -4899,6 +4899,21 @@ body {
   box-shadow: 0 18px 45px rgba(15, 0, 65, 0.08);
 }
 
+.note-editor-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.note-toolbar {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(76, 29, 149, 0.04);
+}
+
 .note-title-input {
   width: 100%;
   padding: 0.5rem 0.65rem;
@@ -4914,12 +4929,16 @@ body {
   outline-offset: 1px;
 }
 
+.note-editor-content,
 .note-editor-card .note-editor-area {
-  border: 1px solid var(--border-subtle, #e3d9f4);
-  border-radius: 0.9rem;
+  min-height: 220px;
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.8rem;
+  border: 1px solid rgba(76, 29, 149, 0.12);
   background: #fff;
-  padding: 0.85rem 0.9rem;
-  min-height: 180px;
+  overflow-y: auto;
+  font-size: 0.95rem;
+  line-height: 1.5;
 }
 
 /* Move-to-folder bottom sheet */


### PR DESCRIPTION
## Summary
- reorganize the notebook editor markup into a single-column layout with a single toolbar and full-width content area
- add shared styles for the new note editor layout in the mobile theme and main stylesheet, updating toolbar and editor sizing
- align inline toolbar and editor sizing styles with the simplified layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930a168fe548324a5845cfc18e8adac)