### PR TITLE
Fix saved note overflow menu clicks

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5302,7 +5302,13 @@
                         <div class="note-row-title">Untitled</div>
                         <div class="note-row-meta">Folder · Date</div>
                       </div>
-                      <button type="button" class="note-row-overflow" aria-label="More" data-role="note-menu">
+                      <button
+                        type="button"
+                        class="note-row-overflow note-options-button"
+                        aria-label="More"
+                        data-role="note-menu"
+                        data-note-id=""
+                      >
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                           <circle cx="5" cy="12" r="1.5" />
                           <circle cx="12" cy="12" r="1.5" />

--- a/mobile.js
+++ b/mobile.js
@@ -1196,7 +1196,7 @@ const initMobileNotes = () => {
       actionBtn.type = 'button';
       actionBtn.dataset.noteId = note.id;
       actionBtn.dataset.role = 'note-menu';
-      actionBtn.className = 'note-row-overflow';
+      actionBtn.className = 'note-row-overflow note-options-button';
       actionBtn.setAttribute('aria-label', 'Note actions');
       actionBtn.tabIndex = 0;
       actionBtn.setAttribute('aria-haspopup', 'true');
@@ -2426,10 +2426,12 @@ const initMobileNotes = () => {
         return;
       }
 
-      const menuTrigger = target.closest('button[data-role="note-menu"]');
+      const menuTrigger = target.closest('.note-options-button, button[data-role="note-menu"]');
       if (menuTrigger && listElement.contains(menuTrigger)) {
         event.preventDefault();
-        const noteId = menuTrigger.getAttribute('data-note-id');
+        const noteId =
+          menuTrigger.getAttribute('data-note-id')
+          || (menuTrigger.closest('[data-note-id]') || menuTrigger).getAttribute('data-note-id');
         if (!noteId) {
           return;
         }
@@ -2465,10 +2467,12 @@ const initMobileNotes = () => {
       const target = event.target instanceof HTMLElement ? event.target : null;
       if (!target) return;
 
-      const menuTrigger = target.closest('button[data-role="note-menu"]');
+      const menuTrigger = target.closest('.note-options-button, button[data-role="note-menu"]');
       if (menuTrigger && listElement.contains(menuTrigger)) {
         event.preventDefault();
-        const noteId = menuTrigger.getAttribute('data-note-id');
+        const noteId =
+          menuTrigger.getAttribute('data-note-id')
+          || (menuTrigger.closest('[data-note-id]') || menuTrigger).getAttribute('data-note-id');
         if (!noteId) return;
         const note = allNotes.find((item) => item.id === noteId);
         if (note) {


### PR DESCRIPTION
## Summary
- add a dedicated `note-options-button` class and data attribute to the saved note overflow control
- adjust mobile note list event delegation to detect the overflow trigger reliably and pull the correct note id
- keep existing menu behavior intact while restoring the overflow affordance

## Testing
- npm test -- --runInBand *(fails: existing suite failures in reminders and mobile auth/new-folder tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930aede81048324b5c53e2d48f59f42)