### PR TITLE
Refine saved notes sheet layout

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -665,13 +665,16 @@
     list-style: none;
     margin: 0;
     padding: 0;
+    display: flex;
+    flex-direction: column;
   }
 
   .notebook-list {
     display: flex;
     flex-direction: column;
-    gap: 8px;
-    padding: 8px 0 16px;
+    gap: 0.15rem;
+    padding: 0;
+    margin: 0;
   }
 
   .notebook-folder-filter-bar {
@@ -878,6 +881,10 @@
     padding: 0.5rem 0.75rem 0.75rem;
   }
 
+  .mobile-shell #savedNotesSheet .notebook-top-bar {
+    margin-bottom: 0.4rem;
+  }
+
   .mobile-shell #savedNotesSheet .notebook-folder-filter-bar {
     padding: 3px;
     gap: 6px;
@@ -903,6 +910,7 @@
     font-size: 0.85rem;
     color: var(--text-main, #231b2e);
     transition: border-color 0.18s ease, background-color 0.18s ease;
+    margin-bottom: 0.4rem;
   }
 
   .mobile-shell #savedNotesSheet .notebook-search-bar:focus {
@@ -5292,19 +5300,23 @@
 
                 <div
                   id="notesListMobile"
-                  class="notebook-list text-sm"
+                  class="notebook-list notebook-notes-list text-sm"
                   aria-label="Saved scratch notes"
                 >
                   <!-- Note items are rendered here by JS -->
                   <template id="notesListMobileItemTemplate">
-                    <div class="note-row" data-note-id="" data-role="open-note">
-                      <div class="note-row-main" data-note-id="" data-role="open-note">
-                        <div class="note-row-title">Untitled</div>
-                        <div class="note-row-meta">Folder · Date</div>
+                    <div class="note-row note-list-item" data-note-id="" data-role="open-note">
+                      <div class="note-row-main note-list-main" data-note-id="" data-role="open-note">
+                        <div class="note-row-title note-list-title">Untitled</div>
+                        <div class="note-row-meta note-list-meta">
+                          <button class="note-row-folder note-list-folder" type="button">Folder</button>
+                          <span class="note-row-dot note-list-dot">·</span>
+                          <span class="note-row-timestamp note-list-date">Date</span>
+                        </div>
                       </div>
                       <button
                         type="button"
-                        class="note-row-overflow note-options-button"
+                        class="note-row-overflow note-list-overflow note-options-button"
                         aria-label="More"
                         data-role="note-menu"
                         data-note-id=""

--- a/mobile.js
+++ b/mobile.js
@@ -1139,21 +1139,22 @@ const initMobileNotes = () => {
     notes.forEach((note) => {
       const listItem = document.createElement('div');
       const isActiveNote = String(note.id) === String(currentNoteId);
-      listItem.className = 'note-row';
+      listItem.className = 'note-row note-list-item';
       listItem.classList.toggle('selected', isActiveNote);
+      listItem.classList.toggle('is-active', isActiveNote);
       listItem.dataset.noteId = note.id;
       listItem.dataset.role = 'open-note';
       listItem.setAttribute('role', 'button');
       listItem.tabIndex = 0;
 
       const cardMain = document.createElement('div');
-      cardMain.className = 'note-row-main';
+      cardMain.className = 'note-row-main note-list-main';
       cardMain.dataset.role = 'open-note';
       cardMain.dataset.noteId = note.id;
 
       const noteTitle = note.title || 'Untitled';
       const titleEl = document.createElement('div');
-      titleEl.className = 'note-row-title';
+      titleEl.className = 'note-row-title note-list-title';
       titleEl.textContent = noteTitle;
       titleEl.setAttribute('title', noteTitle);
 
@@ -1162,11 +1163,11 @@ const initMobileNotes = () => {
       const timestamp = formatNoteTimestamp(note.updatedAt);
 
       const metaRow = document.createElement('div');
-      metaRow.className = 'note-row-meta';
+      metaRow.className = 'note-row-meta note-list-meta';
 
       const folderButton = document.createElement('button');
       folderButton.type = 'button';
-      folderButton.className = 'note-row-folder';
+      folderButton.className = 'note-row-folder note-list-folder';
       folderButton.textContent = folderName;
       folderButton.setAttribute('aria-label', 'Move note to folder');
       folderButton.addEventListener('click', (event) => {
@@ -1181,9 +1182,10 @@ const initMobileNotes = () => {
       metaRow.appendChild(folderButton);
       if (timestamp) {
         const separator = document.createElement('span');
-        separator.textContent = ' · ';
+        separator.className = 'note-row-dot note-list-dot';
+        separator.textContent = '·';
         const timeSpan = document.createElement('span');
-        timeSpan.className = 'note-row-timestamp';
+        timeSpan.className = 'note-row-timestamp note-list-date';
         timeSpan.textContent = timestamp;
         metaRow.appendChild(separator);
         metaRow.appendChild(timeSpan);
@@ -1196,7 +1198,7 @@ const initMobileNotes = () => {
       actionBtn.type = 'button';
       actionBtn.dataset.noteId = note.id;
       actionBtn.dataset.role = 'note-menu';
-      actionBtn.className = 'note-row-overflow note-options-button';
+      actionBtn.className = 'note-row-overflow note-list-overflow note-options-button';
       actionBtn.setAttribute('aria-label', 'Note actions');
       actionBtn.tabIndex = 0;
       actionBtn.setAttribute('aria-haspopup', 'true');

--- a/styles/index.css
+++ b/styles/index.css
@@ -652,25 +652,28 @@ html[data-theme="dracula"] .notebook-folder-scroll-wrap::after {
   color: var(--text-main);
 }
 
-.note-row {
+.note-row,
+.note-list-item {
   display: flex;
   align-items: center;
-  padding: 0.55rem 0.9rem;
-  border-radius: 0.9rem;
-  background: var(--surface-soft, rgba(255,255,255,0.7));
-  margin-bottom: 0.3rem;
-  gap: 0.6rem;
+  justify-content: space-between;
+  gap: 0.65rem;
+  padding: 0.55rem 0.85rem;
+  border-radius: 0.8rem;
   cursor: pointer;
+  transition: background 0.15s ease, box-shadow 0.15s ease;
 }
 
-.note-row-main {
+.note-row-main,
+.note-list-main {
   flex: 1 1 auto;
   min-width: 0;
   display: flex;
   flex-direction: column;
 }
 
-.note-row-title {
+.note-row-title,
+.note-list-title {
   font-size: 0.95rem;
   font-weight: 500;
   color: var(--text-primary);
@@ -679,13 +682,18 @@ html[data-theme="dracula"] .notebook-folder-scroll-wrap::after {
   text-overflow: ellipsis;
 }
 
-.note-row-meta {
+.note-row-meta,
+.note-list-meta {
   margin-top: 0.1rem;
-  font-size: 0.75rem;
+  font-size: 0.78rem;
   color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 
-.note-row-folder {
+.note-row-folder,
+.note-list-folder {
   border: none;
   background: transparent;
   padding: 0;
@@ -696,11 +704,18 @@ html[data-theme="dracula"] .notebook-folder-scroll-wrap::after {
   text-decoration-thickness: from-font;
 }
 
-.note-row-timestamp {
+.note-row-dot,
+.note-list-dot {
+  opacity: 0.7;
+}
+
+.note-row-timestamp,
+.note-list-date {
   color: inherit;
 }
 
-.note-row-overflow {
+.note-row-overflow,
+.note-list-overflow {
   border: none;
   background: transparent;
   padding: 0.25rem;
@@ -708,11 +723,26 @@ html[data-theme="dracula"] .notebook-folder-scroll-wrap::after {
   display: flex;
   align-items: center;
   justify-content: center;
+  flex: 0 0 auto;
 }
 
-.note-row.selected {
-  box-shadow: 0 0 0 1px var(--primary-soft, rgba(81, 38, 99, 0.18));
-  background: var(--surface-selected, rgba(0,0,0,0.02));
+.note-row + .note-row,
+.note-list-item + .note-list-item {
+  margin-top: 0.15rem;
+}
+
+.note-row:hover {
+  background: rgba(76, 29, 149, 0.03);
+}
+
+.note-row.selected,
+.note-row.is-active {
+  background: rgba(76, 29, 149, 0.06);
+}
+
+.notebook-notes-list {
+  display: flex;
+  flex-direction: column;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- normalize saved note row markup to include separate title, meta, folder, and options button blocks for consistent alignment
- update notebook note list styling for compact padding, hover/active cues, and truncated titles
- tighten saved notes sheet spacing around tabs and search to match the refreshed notebook aesthetic

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930f66d1b848324af607f5a3b980454)