### PR TITLE
Refine saved notes list layout

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -773,51 +773,66 @@
   }
 
   .note-list-item {
-    background: rgba(255, 255, 255, 0.72);
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
-    border-radius: 14px;
-    padding: 10px 12px;
-    box-shadow:
-      0 2px 6px rgba(0, 0, 0, 0.05),
-      0 0 0 1px rgba(255, 255, 255, 0.7);
-    border: 1px solid rgba(230, 224, 242, 0.9);
     display: flex;
-    flex-direction: column;
-    gap: 2px;
-    transition:
-      transform 0.16s ease,
-      box-shadow 0.2s ease,
-      background-color 0.18s ease;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1rem;
+    margin-bottom: 0.35rem;
+    background: var(--surface-1);
+    border-radius: 0.9rem;
+    transition: background 0.15s ease;
   }
 
   .note-list-item:hover {
-    transform: translateY(-1px);
-    box-shadow:
-      0 6px 16px rgba(0, 0, 0, 0.08),
-      0 2px 4px rgba(0, 0, 0, 0.04);
+    background: rgba(80, 20, 120, 0.06);
+  }
+
+  .note-list-main {
+    flex: 1 1 auto;
+    min-width: 0;
   }
 
   .note-list-title {
-    font-size: 0.98rem;
+    font-size: 0.95rem;
     font-weight: 600;
-    color: var(--text-strong);
-    margin-bottom: 1px;
-  }
-
-  .note-list-preview {
-    font-size: 0.86rem;
-    color: var(--text-body);
-    line-height: 1.3;
-    max-height: 2.6em;
+    color: var(--text-primary);
+    white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
   .note-list-meta {
-    font-size: 0.75rem;
+    margin-top: 0.2rem;
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.78rem;
     color: var(--text-muted);
-    margin-top: 2px;
+  }
+
+  .note-list-folder {
+    text-decoration: underline;
+  }
+
+  .note-list-dot {
+    opacity: 0.7;
+  }
+
+  .note-list-overflow {
+    background: none;
+    border: none;
+    padding: 0.35rem;
+    font-size: 1.1rem;
+    color: var(--text-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    transition: background 0.12s ease;
+  }
+
+  .note-list-overflow:hover {
+    background: rgba(80, 20, 120, 0.1);
   }
 
   .mobile-shell #savedNotesSheet {
@@ -5294,7 +5309,7 @@
                     id="notebook-search-input"
                     type="search"
                     placeholder="Search notes…"
-                    class="notebook-search-bar"
+                    class="notebook-search-bar notebook-notes-search"
                   />
                 </div>
 
@@ -5310,7 +5325,7 @@
                         <div class="note-row-title note-list-title">Untitled</div>
                         <div class="note-row-meta note-list-meta">
                           <button class="note-row-folder note-list-folder" type="button">Folder</button>
-                          <span class="note-row-dot note-list-dot">·</span>
+                          <span class="note-row-dot note-list-dot">•</span>
                           <span class="note-row-timestamp note-list-date">Date</span>
                         </div>
                       </div>
@@ -5321,11 +5336,7 @@
                         data-role="note-menu"
                         data-note-id=""
                       >
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                          <circle cx="5" cy="12" r="1.5" />
-                          <circle cx="12" cy="12" r="1.5" />
-                          <circle cx="19" cy="12" r="1.5" />
-                        </svg>
+                        ⋯
                       </button>
                     </div>
                   </template>

--- a/mobile.js
+++ b/mobile.js
@@ -1183,7 +1183,7 @@ const initMobileNotes = () => {
       if (timestamp) {
         const separator = document.createElement('span');
         separator.className = 'note-row-dot note-list-dot';
-        separator.textContent = '·';
+        separator.textContent = '•';
         const timeSpan = document.createElement('span');
         timeSpan.className = 'note-row-timestamp note-list-date';
         timeSpan.textContent = timestamp;
@@ -1202,13 +1202,7 @@ const initMobileNotes = () => {
       actionBtn.setAttribute('aria-label', 'Note actions');
       actionBtn.tabIndex = 0;
       actionBtn.setAttribute('aria-haspopup', 'true');
-      actionBtn.innerHTML = `
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <circle cx="5" cy="12" r="1.5" />
-          <circle cx="12" cy="12" r="1.5" />
-          <circle cx="19" cy="12" r="1.5" />
-        </svg>
-      `;
+      actionBtn.textContent = '⋯';
 
       listItem.appendChild(cardMain);
       listItem.appendChild(actionBtn);

--- a/styles/index.css
+++ b/styles/index.css
@@ -604,6 +604,7 @@ html[data-theme="dracula"] .notebook-folder-scroll-wrap::after {
   gap: 0.35rem;
   overflow-x: auto;
   padding: 0.1rem;
+  margin-bottom: 0.4rem;
 }
 
 .notebook-tab,
@@ -641,6 +642,10 @@ html[data-theme="dracula"] .notebook-folder-scroll-wrap::after {
   font-weight: 600;
 }
 
+.notebook-notes-search {
+  margin-bottom: 0.6rem;
+}
+
 .notebook-top-overflow {
   border: none;
   background: transparent;
@@ -657,11 +662,12 @@ html[data-theme="dracula"] .notebook-folder-scroll-wrap::after {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.65rem;
-  padding: 0.55rem 0.85rem;
-  border-radius: 0.8rem;
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.35rem;
+  background: var(--surface-1);
+  border-radius: 0.9rem;
   cursor: pointer;
-  transition: background 0.15s ease, box-shadow 0.15s ease;
+  transition: background 0.15s ease;
 }
 
 .note-row-main,
@@ -675,7 +681,7 @@ html[data-theme="dracula"] .notebook-folder-scroll-wrap::after {
 .note-row-title,
 .note-list-title {
   font-size: 0.95rem;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
@@ -684,12 +690,12 @@ html[data-theme="dracula"] .notebook-folder-scroll-wrap::after {
 
 .note-row-meta,
 .note-list-meta {
-  margin-top: 0.1rem;
+  margin-top: 0.2rem;
   font-size: 0.78rem;
   color: var(--text-muted);
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.35rem;
 }
 
 .note-row-folder,
@@ -718,21 +724,24 @@ html[data-theme="dracula"] .notebook-folder-scroll-wrap::after {
 .note-list-overflow {
   border: none;
   background: transparent;
-  padding: 0.25rem;
-  border-radius: 999px;
+  padding: 0.35rem;
+  border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
+  font-size: 1.1rem;
+  color: var(--text-muted);
+  transition: background 0.12s ease;
 }
 
-.note-row + .note-row,
-.note-list-item + .note-list-item {
-  margin-top: 0.15rem;
+.note-row-overflow:hover,
+.note-list-overflow:hover {
+  background: rgba(80, 20, 120, 0.1);
 }
 
 .note-row:hover {
-  background: rgba(76, 29, 149, 0.03);
+  background: rgba(80, 20, 120, 0.06);
 }
 
 .note-row.selected,


### PR DESCRIPTION
## Summary
- update saved note row template to keep title/meta and overflow actions on a single flex row
- refresh note list styling to the compact layout used by reminders and remove the old standalone ellipsis
- tighten spacing between notebook tabs, search, and the saved notes list

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930f94b26e4832493ff6015b3b59543)