### PR TITLE
Add move-to-folder sheet for saved notes

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -377,3 +377,117 @@ body.mobile-theme :focus-visible {
     padding: 0.5rem 1rem;
   }
 }
+
+.note-folder-sheet {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 40;
+
+  max-height: 70vh;
+  background: var(--surface-1, #ffffff);
+  border-top-left-radius: 1.2rem;
+  border-top-right-radius: 1.2rem;
+  box-shadow: 0 -10px 30px rgba(15, 23, 42, 0.18);
+
+  padding: 0.75rem 1rem 1rem;
+  transform: translateY(100%);
+  transition: transform 0.25s ease;
+}
+
+.note-folder-sheet.open {
+  transform: translateY(0);
+}
+
+.note-folder-sheet-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.4rem;
+}
+
+.note-folder-sheet-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.note-folder-sheet-list {
+  margin-top: 0.35rem;
+  padding: 0.25rem 0;
+  max-height: 50vh;
+  overflow-y: auto;
+}
+
+.note-folder-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  padding: 0.55rem 0.1rem;
+  border-radius: 0.65rem;
+  cursor: pointer;
+  transition: background 0.15s ease;
+  width: 100%;
+  border: none;
+  background: transparent;
+  text-align: left;
+}
+
+.note-folder-row:hover {
+  background: rgba(76, 29, 149, 0.04);
+}
+
+.note-folder-row-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.05rem;
+}
+
+.note-folder-row-name {
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.note-folder-row-count {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.note-folder-row-indicator {
+  font-size: 0.9rem;
+  color: var(--accent, #4c1d95);
+}
+
+.note-folder-row.is-current {
+  background: rgba(76, 29, 149, 0.06);
+}
+
+.note-folder-sheet-footer {
+  margin-top: 0.6rem;
+}
+
+.note-folder-new-btn {
+  width: 100%;
+  padding: 0.7rem 0.6rem;
+  border-radius: 0.75rem;
+  border: 1px dashed rgba(76, 29, 149, 0.35);
+  background: transparent;
+  font-size: 0.88rem;
+  font-weight: 500;
+}
+
+.note-folder-sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.25);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 39;
+}
+
+.note-folder-sheet-backdrop.open {
+  opacity: 1;
+  pointer-events: auto;
+}

--- a/mobile.html
+++ b/mobile.html
@@ -5370,6 +5370,19 @@
                   </div>
                 </div>
               </dialog>
+              <div id="note-folder-sheet" class="note-folder-sheet" aria-hidden="true">
+                <div class="note-folder-sheet-header">
+                  <span class="note-folder-sheet-title">Move to folder</span>
+                  <button class="note-folder-sheet-close" type="button" aria-label="Close">✕</button>
+                </div>
+                <div class="note-folder-sheet-list" role="list">
+                  <!-- folder rows injected by JS -->
+                </div>
+                <div class="note-folder-sheet-footer">
+                  <button class="note-folder-new-btn" type="button">+ New folder</button>
+                </div>
+              </div>
+              <div id="note-folder-sheet-backdrop" class="note-folder-sheet-backdrop" aria-hidden="true"></div>
               <div id="moveFolderSheet" class="sheet-backdrop hidden" aria-hidden="true">
                 <div
                   class="sheet-panel"

--- a/mobile.js
+++ b/mobile.js
@@ -438,6 +438,11 @@ const initMobileNotes = () => {
   const folderSelectorCreateBtn = document.getElementById('move-folder-create');
   const folderSelectorCancelBtn = document.getElementById('move-folder-cancel');
   const folderSelectorSheet = folderSelectorEl?.querySelector('.sheet-panel');
+  const noteFolderSheet = document.getElementById('note-folder-sheet');
+  const noteFolderSheetBackdrop = document.getElementById('note-folder-sheet-backdrop');
+  const noteFolderSheetList = noteFolderSheet?.querySelector('.note-folder-sheet-list');
+  const noteFolderSheetClose = noteFolderSheet?.querySelector('.note-folder-sheet-close');
+  const noteFolderSheetNewBtn = noteFolderSheet?.querySelector('.note-folder-new-btn');
   const ACTIVE_NOTE_SHADOW_CLASS = 'shadow-[0_0_0_3px_var(--accent-color)]';
 
   const createScratchNotesEditor = () => {
@@ -665,6 +670,7 @@ const initMobileNotes = () => {
   let currentFolderId = 'all';
   let currentEditingNoteFolderId = 'unsorted';
   let currentFolderMoveNoteId = null;
+  let currentMoveFolderSheetNoteId = null;
   let folderSelectorOnSelect = null;
   let activeFolderSheetOpener = null;
   let filterQuery = '';
@@ -1742,6 +1748,169 @@ const initMobileNotes = () => {
     closeOverflowMenu();
   };
 
+  const closeNoteFolderSheet = () => {
+    if (noteFolderSheet) {
+      noteFolderSheet.classList.remove('open');
+      noteFolderSheet.setAttribute('aria-hidden', 'true');
+    }
+    if (noteFolderSheetBackdrop) {
+      noteFolderSheetBackdrop.classList.remove('open');
+      noteFolderSheetBackdrop.setAttribute('aria-hidden', 'true');
+    }
+    currentMoveFolderSheetNoteId = null;
+    document.removeEventListener('keydown', handleNoteFolderSheetKeydown);
+    if (noteFolderSheetList) {
+      noteFolderSheetList.innerHTML = '';
+    }
+  };
+
+  const handleNoteFolderSelection = (folderId) => {
+    const targetNoteId = currentMoveFolderSheetNoteId || currentNoteId;
+    if (targetNoteId) {
+      handleMoveNoteToFolder(targetNoteId, folderId || 'unsorted');
+    }
+    closeNoteFolderSheet();
+  };
+
+  const handleNoteFolderSheetKeydown = (event) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeNoteFolderSheet();
+    }
+  };
+
+  const renderNoteFolderRows = (noteId) => {
+    if (!noteFolderSheetList) return;
+    noteFolderSheetList.innerHTML = '';
+
+    let folders = [];
+    try {
+      folders = Array.isArray(getFolders()) ? getFolders() : [];
+    } catch {
+      folders = [];
+    }
+
+    const unsortedFolder = { id: 'unsorted', name: getFolderNameById('unsorted') || 'Unsorted' };
+    const hasUnsorted = folders.some((f) => f && f.id === 'unsorted');
+    const normalizedFolders = hasUnsorted ? folders.filter(Boolean) : [unsortedFolder, ...folders.filter(Boolean)];
+
+    const sortedFolders = normalizedFolders
+      .filter((folder) => folder && folder.id !== 'unsorted')
+      .sort((a, b) => (Number(a.order) || 0) - (Number(b.order) || 0));
+
+    const folderListForCounts = [unsortedFolder, ...sortedFolders];
+    const counts = getNoteCountsByFolder(allNotes, folderListForCounts);
+
+    const activeNote = noteId ? allNotes.find((n) => n.id === noteId) || null : null;
+    const currentFolder =
+      activeNote && typeof activeNote.folderId === 'string' && activeNote.folderId
+        ? activeNote.folderId
+        : 'unsorted';
+
+    const createRow = (folder) => {
+      const row = document.createElement('button');
+      row.type = 'button';
+      row.className = 'note-folder-row';
+      row.dataset.folderId = folder.id || 'unsorted';
+      row.setAttribute('role', 'listitem');
+      row.tabIndex = 0;
+
+      const label = document.createElement('div');
+      label.className = 'note-folder-row-label';
+
+      const nameEl = document.createElement('span');
+      nameEl.className = 'note-folder-row-name';
+      nameEl.textContent = folder.name || String(folder.id);
+      label.appendChild(nameEl);
+
+      const countEl = document.createElement('span');
+      countEl.className = 'note-folder-row-count';
+      countEl.textContent = counts[folder.id] ?? 0;
+      label.appendChild(countEl);
+
+      row.appendChild(label);
+
+      const indicator = document.createElement('span');
+      indicator.className = 'note-folder-row-indicator';
+      indicator.textContent = folder.id === currentFolder ? '✓' : '';
+      row.appendChild(indicator);
+
+      if (folder.id === currentFolder) {
+        row.classList.add('is-current');
+        row.setAttribute('aria-current', 'true');
+      } else {
+        row.removeAttribute('aria-current');
+      }
+
+      return row;
+    };
+
+    const rows = [unsortedFolder, ...sortedFolders];
+    rows.forEach((folder) => {
+      if (!folder || typeof folder.id === 'undefined') return;
+      const row = createRow(folder);
+      noteFolderSheetList.appendChild(row);
+    });
+  };
+
+  const openMoveNoteToFolderSheet = (noteId) => {
+    if (!noteFolderSheet || !noteFolderSheetList) return;
+    currentMoveFolderSheetNoteId = noteId || null;
+    renderNoteFolderRows(noteId);
+    noteFolderSheet.classList.add('open');
+    noteFolderSheet.setAttribute('aria-hidden', 'false');
+    if (noteFolderSheetBackdrop) {
+      noteFolderSheetBackdrop.classList.add('open');
+      noteFolderSheetBackdrop.setAttribute('aria-hidden', 'false');
+    }
+    document.addEventListener('keydown', handleNoteFolderSheetKeydown);
+  };
+
+  if (noteFolderSheetList) {
+    noteFolderSheetList.addEventListener('click', (event) => {
+      const row = event.target instanceof HTMLElement ? event.target.closest('.note-folder-row') : null;
+      if (!row || !noteFolderSheetList.contains(row)) return;
+      event.preventDefault();
+      handleNoteFolderSelection(row.dataset.folderId || 'unsorted');
+    });
+
+    noteFolderSheetList.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      const row = event.target instanceof HTMLElement ? event.target.closest('.note-folder-row') : null;
+      if (!row || !noteFolderSheetList.contains(row)) return;
+      event.preventDefault();
+      handleNoteFolderSelection(row.dataset.folderId || 'unsorted');
+    });
+  }
+
+  if (noteFolderSheetClose) {
+    noteFolderSheetClose.addEventListener('click', (event) => {
+      event.preventDefault();
+      closeNoteFolderSheet();
+    });
+  }
+
+  if (noteFolderSheetBackdrop) {
+    noteFolderSheetBackdrop.addEventListener('click', (event) => {
+      event.preventDefault();
+      closeNoteFolderSheet();
+    });
+  }
+
+  if (noteFolderSheetNewBtn) {
+    noteFolderSheetNewBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      const targetNoteId = currentMoveFolderSheetNoteId || currentNoteId;
+      afterFolderCreated = (createdId) => {
+        if (targetNoteId) {
+          handleMoveNoteToFolder(targetNoteId, createdId || 'unsorted');
+        }
+        closeNoteFolderSheet();
+      };
+      openNewFolderDialog();
+    });
+  }
+
   const FOLDER_FOCUSABLE_SELECTOR = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
   const getFolderSelectorFocusables = () => {
@@ -2054,17 +2223,13 @@ const initMobileNotes = () => {
 
     const moveBtn = document.createElement('button');
     moveBtn.type = 'button';
-    moveBtn.className = 'w-full text-left px-3 py-2 btn-ghost rounded-xl';
-    moveBtn.textContent = 'Move to folder…';
+    moveBtn.className = 'note-action-btn note-action-move-folder w-full text-left px-3 py-2 btn-ghost rounded-xl';
+    moveBtn.textContent = 'Move to folder';
     moveBtn.setAttribute('role', 'menuitem');
     moveBtn.addEventListener('click', (e) => {
       e.preventDefault();
       closeOverflowMenu();
-      openFolderSelectorForNote(note.id, {
-        initialFolderId:
-          note.folderId && typeof note.folderId === 'string' ? note.folderId : 'unsorted',
-        triggerEl: moveBtn,
-      });
+      openMoveNoteToFolderSheet(note.id);
     });
 
     const deleteBtn = document.createElement('button');


### PR DESCRIPTION
## Summary
- add a dedicated bottom sheet for moving notes between folders with new markup and styling
- render folder options from existing folder data, including new folder creation and selection handling
- wire the saved-note overflow action to open the folder sheet for the chosen note

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693120bf72cc8324831d581efa013ba9)