### PR TITLE
Upgrade mobile notebook toolbar

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -168,6 +168,49 @@ body.mobile-theme .text-secondary {
   gap: 0.6rem;
 }
 
+.note-editor-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.45rem 0.4rem;
+  background: var(--surface-2, #f7f7fa);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  overflow-x: auto;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+
+.rte-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.55rem;
+  font-size: 0.85rem;
+  background: #ffffff;
+  border-radius: 0.55rem;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.rte-btn:hover {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.rte-btn.active {
+  background: rgba(76, 29, 149, 0.12);
+  border-color: rgba(76, 29, 149, 0.3);
+  color: var(--accent, #4c1d95);
+}
+
+.rte-divider {
+  width: 1px;
+  height: 1.2rem;
+  background: rgba(0, 0, 0, 0.12);
+  margin: 0 0.2rem;
+}
+
 .note-toolbar {
   display: inline-flex;
   align-items: center;
@@ -178,8 +221,8 @@ body.mobile-theme .text-secondary {
 }
 
 .note-editor-content {
-  min-height: 220px;
-  padding: 0.75rem 0.85rem;
+  min-height: 200px;
+  padding: 1rem;
   border-radius: 0.8rem;
   border: 1px solid rgba(76, 29, 149, 0.12);
   background: #fff;

--- a/mobile.html
+++ b/mobile.html
@@ -5184,44 +5184,28 @@
             <div class="note-editor-inner">
               <div
                 id="scratchNotesToolbar"
-                class="note-toolbar formatting-toolbar-strip flex items-center gap-2 px-0 py-0 bg-transparent rounded-lg border-0 shadow-none"
+                class="note-editor-toolbar"
                 role="toolbar"
                 aria-label="Formatting options"
               >
-                <button type="button" class="formatting-btn note-toolbar-button notebook-format-button" data-format="bold" aria-label="Bold" aria-controls="notebook-editor-body">
-                  <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M7 4h6a4 4 0 0 1 0 8H7V4zm0 8h7a4 4 0 0 1 0 8H7v-8z" fill="currentColor" />
-                  </svg>
-                </button>
+                <button class="rte-btn" data-cmd="bold"><span class="icon">B</span></button>
+                <button class="rte-btn" data-cmd="italic"><span class="icon">I</span></button>
+                <button class="rte-btn" data-cmd="underline"><span class="icon">U</span></button>
 
-                <button type="button" class="formatting-btn note-toolbar-button notebook-format-button" data-format="italic" aria-label="Italic" aria-controls="notebook-editor-body">
-                  <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M10 4h9v2h-3.6l-3.8 12H16v2H7v-2h3.6l3.8-12H10V4z" fill="currentColor" />
-                  </svg>
-                </button>
+                <div class="rte-divider"></div>
 
-                <button type="button" class="formatting-btn note-toolbar-button notebook-format-button" data-format="underline" aria-label="Underline" aria-controls="notebook-editor-body">
-                  <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M7 4h2v7a3 3 0 0 0 6 0V4h2v7a5 5 0 0 1-10 0V4z" fill="currentColor" />
-                    <path d="M5 19h14v2H5z" fill="currentColor" />
-                  </svg>
-                </button>
+                <button class="rte-btn" data-cmd="insertUnorderedList"><span class="icon">• List</span></button>
+                <button class="rte-btn" data-cmd="insertOrderedList"><span class="icon">1.</span></button>
 
-                <button type="button" class="formatting-btn note-toolbar-button notebook-format-button" data-format="bullet-list" aria-label="Bullet list" aria-controls="notebook-editor-body">
-                  <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M7 6h13v2H7V6zm0 5h13v2H7v-2zm0 5h13v2H7v-2z" fill="currentColor" />
-                    <circle cx="4" cy="7" r="1.25" fill="currentColor" />
-                    <circle cx="4" cy="12" r="1.25" fill="currentColor" />
-                    <circle cx="4" cy="17" r="1.25" fill="currentColor" />
-                  </svg>
-                </button>
+                <div class="rte-divider"></div>
 
-                <button type="button" class="formatting-btn note-toolbar-button notebook-format-button" data-format="numbered-list" aria-label="Numbered list" aria-controls="notebook-editor-body">
-                  <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M9 6h11v2H9V6zm0 5h11v2H9v-2zm0 5h11v2H9v-2z" fill="currentColor" />
-                    <path d="M4 6.5V8h2V4H4v1.5h1v1H4zm1.5 4H4a.5.5 0 0 0-.5.5v.75H4V12h1v2H3.5v1H6v-3.5a1 1 0 0 0-1-1Zm.5 5H4v1h1v1H4v1h2v-3Z" fill="currentColor" />
-                  </svg>
-                </button>
+                <button class="rte-btn" data-cmd="indent"><span class="icon">→</span></button>
+                <button class="rte-btn" data-cmd="outdent"><span class="icon">←</span></button>
+
+                <div class="rte-divider"></div>
+
+                <button class="rte-btn" data-cmd="undo"><span class="icon">↺</span></button>
+                <button class="rte-btn" data-cmd="redo"><span class="icon">↻</span></button>
               </div>
 
               <!-- Minimal main editor with soft styling -->

--- a/mobile.js
+++ b/mobile.js
@@ -496,6 +496,33 @@ const initMobileNotes = () => {
     return;
   }
 
+  const TOGGLE_COMMANDS = new Set([
+    'bold',
+    'italic',
+    'underline',
+    'insertunorderedlist',
+    'insertorderedlist',
+    'indent',
+    'outdent',
+  ]);
+
+  function updateToolbarState() {
+    const buttons = document.querySelectorAll('.rte-btn[data-cmd]');
+    buttons.forEach((button) => {
+      const command = (button.dataset.cmd || '').toLowerCase();
+      if (!command || !TOGGLE_COMMANDS.has(command)) {
+        button.classList.remove('active');
+        return;
+      }
+      try {
+        const active = document.queryCommandState(command);
+        button.classList.toggle('active', !!active);
+      } catch (err) {
+        button.classList.remove('active');
+      }
+    });
+  }
+
   const applyFormatCommand = (command) => {
     if (!command || !scratchNotesEditorElement) return;
     try {
@@ -503,25 +530,29 @@ const initMobileNotes = () => {
     } catch {
       /* ignore focus errors */
     }
-    document.execCommand(command, false, null);
+    try {
+      document.execCommand(command, false, null);
+    } catch (err) {
+      /* ignore execCommand errors */
+    }
+    updateToolbarState();
+    try {
+      const syntheticInput = new Event('input', { bubbles: true });
+      scratchNotesEditorElement.dispatchEvent(syntheticInput);
+    } catch {
+      /* ignore synthetic event errors */
+    }
   };
 
-  const FORMAT_COMMANDS = {
-    bold: 'bold',
-    italic: 'italic',
-    underline: 'underline',
-    'bullet-list': 'insertUnorderedList',
-    'numbered-list': 'insertOrderedList',
-  };
-
-  // Wire up formatting toolbar (bold, italic, underline, ul, ol) for the rich text editor
+  // Wire up formatting toolbar (bold, italic, underline, lists, indent/outdent, undo/redo)
   const toolbarEl = document.getElementById('scratchNotesToolbar');
   if (toolbarEl && scratchNotesEditorElement) {
     toolbarEl.addEventListener('click', (event) => {
-      const button = event.target.closest('.notebook-format-button[data-format]');
+      const button = event.target.closest('.rte-btn[data-cmd]');
       if (!button) return;
-      const format = button.getAttribute('data-format');
-      const command = format ? FORMAT_COMMANDS[format] : null;
+      event.preventDefault();
+      event.stopPropagation();
+      const command = button.getAttribute('data-cmd');
       if (command) {
         applyFormatCommand(command);
       }
@@ -569,6 +600,7 @@ const initMobileNotes = () => {
   const setEditorContent = (value = '') => {
     const normalizedValue = typeof value === 'string' ? value : '';
     setEditorBodyHtml(normalizedValue);
+    updateToolbarState();
   };
 
   const getEditorHTML = () => getEditorBodyHtml();
@@ -2841,6 +2873,9 @@ const initMobileNotes = () => {
   try {
     // contenteditable should emit input events
     scratchNotesEditorElement.addEventListener('input', debouncedAutoSave);
+    scratchNotesEditorElement.addEventListener('input', updateToolbarState);
+    scratchNotesEditorElement.addEventListener('keyup', updateToolbarState);
+    scratchNotesEditorElement.addEventListener('mouseup', updateToolbarState);
     scratchNotesEditorElement.addEventListener('keydown', handleListShortcuts);
     scratchNotesEditorElement.addEventListener('keydown', handleFormattingShortcuts);
     // also save on blur (user leaving editor)
@@ -2867,6 +2902,7 @@ const initMobileNotes = () => {
     });
   }
 
+  updateToolbarState();
   applyInitialSelection();
 
   if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- replace the mobile notebook toolbar markup with the richer set of formatting actions
- style the toolbar with modern rounded buttons, dividers, and updated editor padding
- wire toolbar actions to execCommand, update active states, and trigger autosave hooks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69313b5a11dc8324b37294c49ac16dec)