### PR TITLE
Add pinning support to mobile saved notes

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -423,6 +423,22 @@ body.mobile-theme :focus-visible {
   gap: 0.5rem;
 }
 
+.note-list-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.note-list-title {
+  flex: 1 1 auto;
+}
+
+.note-list-pin-icon {
+  font-size: 0.75rem;
+  opacity: 0.8;
+}
+
 .note-options-button,
 .note-list-overflow {
   display: inline-flex;

--- a/js/modules/notes-storage.js
+++ b/js/modules/notes-storage.js
@@ -102,6 +102,7 @@ export const createNote = (title, bodyHtml, overrides = {}) => {
     body: normalizedBodyHtml,
     bodyHtml: normalizedBodyHtml,
     bodyText: normalizedBodyText,
+    pinned: typeof overrides.pinned === 'boolean' ? overrides.pinned : false,
     updatedAt:
       overrides.updatedAt && isValidDateString(overrides.updatedAt)
         ? overrides.updatedAt
@@ -131,6 +132,7 @@ const normalizeNotes = (value) => {
         const bodyText = deriveBodyText(body, fallbackText);
         const id = typeof note.id === 'string' && note.id.trim() ? note.id : generateId();
         const updatedAt = isValidDateString(note.updatedAt) ? note.updatedAt : new Date().toISOString();
+        const pinned = typeof note.pinned === 'boolean' ? note.pinned : false;
         if (!title && !body && !fallbackText) {
           return null;
         }
@@ -140,6 +142,7 @@ const normalizeNotes = (value) => {
           folderId: typeof note.folderId === 'string' && note.folderId ? note.folderId : null,
           bodyHtml: body,
           bodyText,
+          pinned,
         });
       })
       .filter(Boolean);
@@ -157,6 +160,7 @@ const normalizeNotes = (value) => {
     const fallbackText = typeof value.bodyText === 'string' ? value.bodyText : '';
     const body = normalizeBodyValue(rawBodyHtml || fallbackText);
     const bodyText = deriveBodyText(body, fallbackText);
+    const pinned = typeof value.pinned === 'boolean' ? value.pinned : false;
     if (!title && !body && !bodyText) {
       return [];
     }
@@ -167,6 +171,7 @@ const normalizeNotes = (value) => {
         folderId: typeof value.folderId === 'string' ? value.folderId : undefined,
         bodyHtml: body,
         bodyText,
+        pinned,
       }),
     ];
   }
@@ -249,6 +254,7 @@ export const saveAllNotes = (notes, options = {}) => {
     const out = normalized[0];
     if (out) {
       out.folderId = typeof note.folderId === 'string' && note.folderId ? note.folderId : out.folderId || null;
+      out.pinned = typeof note.pinned === 'boolean' ? note.pinned : Boolean(out.pinned);
     }
     return out;
   }).filter(Boolean);

--- a/js/modules/notes-sync.js
+++ b/js/modules/notes-sync.js
@@ -61,6 +61,7 @@ const mapRowToNoteFactory = (updatedAtColumn) => (row) => {
     folderId: typeof row.folder_id === 'string' && row.folder_id ? row.folder_id : undefined,
     bodyHtml: rawBodyHtml,
     bodyText: fallbackText,
+    pinned: typeof row.pinned === 'boolean' ? row.pinned : undefined,
   };
   return createNote(row.title, rawBodyHtml, overrides);
 };

--- a/mobile.html
+++ b/mobile.html
@@ -5322,7 +5322,10 @@
                   <template id="notesListMobileItemTemplate">
                     <div class="note-row note-list-item" data-note-id="" data-role="open-note">
                       <div class="note-row-main note-list-main" data-note-id="" data-role="open-note">
-                        <div class="note-row-title note-list-title">Untitled</div>
+                        <div class="note-row-title-row note-list-title-row">
+                          <div class="note-row-title note-list-title">Untitled</div>
+                          <span class="note-list-pin-icon" aria-hidden="true" hidden>📌</span>
+                        </div>
                         <div class="note-row-meta note-list-meta">
                           <button class="note-row-folder note-list-folder" type="button">Folder</button>
                           <span class="note-row-dot note-list-dot">•</span>
@@ -5469,6 +5472,7 @@
             <div id="note-options-sheet" class="note-options-sheet" role="menu" aria-hidden="true">
               <div class="note-options-grip" aria-hidden="true"></div>
               <div class="note-options-actions">
+                <button type="button" class="note-action-btn note-action-toggle-pin">Pin note</button>
                 <button type="button" class="note-action-btn note-action-move">Move to folder</button>
                 <button type="button" class="note-action-btn note-action-delete">Delete note</button>
               </div>

--- a/mobile.js
+++ b/mobile.js
@@ -783,6 +783,19 @@ const initMobileNotes = () => {
     });
   };
 
+  const sortNotesForDisplay = (notes = []) => {
+    return [...notes].sort((a, b) => {
+      const aPinned = Boolean(a?.pinned);
+      const bPinned = Boolean(b?.pinned);
+
+      if (aPinned !== bPinned) {
+        return aPinned ? -1 : 1;
+      }
+
+      return getNoteTimestamp(b) - getNoteTimestamp(a);
+    });
+  };
+
   const getVisibleNotes = (source = allNotes) => {
     if (!Array.isArray(source)) return [];
     // Apply folder filtering first
@@ -795,7 +808,7 @@ const initMobileNotes = () => {
       filteredByFolder = source.filter((note) => note.folderId === currentFolderId);
     }
     // Then apply search filter
-    return getFilteredNotes(filteredByFolder);
+    return sortNotesForDisplay(getFilteredNotes(filteredByFolder));
   };
 
   const getNoteCountsByFolder = (allNotesArray = [], folders = []) => {
@@ -1172,6 +1185,7 @@ const initMobileNotes = () => {
     notes.forEach((note) => {
       const listItem = document.createElement('div');
       const isActiveNote = String(note.id) === String(currentNoteId);
+      const isPinned = Boolean(note?.pinned);
       listItem.className = 'note-row note-list-item';
       listItem.classList.toggle('selected', isActiveNote);
       listItem.classList.toggle('is-active', isActiveNote);
@@ -1190,6 +1204,18 @@ const initMobileNotes = () => {
       titleEl.className = 'note-row-title note-list-title';
       titleEl.textContent = noteTitle;
       titleEl.setAttribute('title', noteTitle);
+
+      const titleRow = document.createElement('div');
+      titleRow.className = 'note-row-title-row note-list-title-row';
+      titleRow.appendChild(titleEl);
+
+      if (isPinned) {
+        const pinIcon = document.createElement('span');
+        pinIcon.className = 'note-list-pin-icon';
+        pinIcon.textContent = '📌';
+        pinIcon.setAttribute('aria-hidden', 'true');
+        titleRow.appendChild(pinIcon);
+      }
 
       const folderId = note.folderId && typeof note.folderId === 'string' ? note.folderId : 'unsorted';
       const folderName = getFolderNameById(folderId) || 'Unsorted';
@@ -1224,7 +1250,7 @@ const initMobileNotes = () => {
         metaRow.appendChild(timeSpan);
       }
 
-      cardMain.appendChild(titleEl);
+      cardMain.appendChild(titleRow);
       cardMain.appendChild(metaRow);
 
       const actionBtn = document.createElement('button');
@@ -1740,6 +1766,7 @@ const initMobileNotes = () => {
   const noteOptionsOverlay = document.getElementById('note-options-overlay');
   const noteOptionsSheet = document.getElementById('note-options-sheet');
   const noteActionMoveBtn = noteOptionsSheet?.querySelector('.note-action-move');
+  const noteActionTogglePinBtn = noteOptionsSheet?.querySelector('.note-action-toggle-pin');
   const noteActionDeleteBtn = noteOptionsSheet?.querySelector('.note-action-delete');
   let currentNoteOptionsNoteId = null;
 
@@ -1773,6 +1800,11 @@ const initMobileNotes = () => {
     closeNoteOptionsMenu();
     closeOverflowMenu();
     currentNoteOptionsNoteId = noteId;
+    const note = allNotes.find((item) => item.id === noteId);
+    if (noteActionTogglePinBtn) {
+      const isPinned = Boolean(note?.pinned);
+      noteActionTogglePinBtn.textContent = isPinned ? 'Unpin note' : 'Pin note';
+    }
     noteOptionsSheet.classList.add('open');
     noteOptionsSheet.setAttribute('aria-hidden', 'false');
     noteOptionsSheet.setAttribute('data-note-id', noteId);
@@ -1800,6 +1832,30 @@ const initMobileNotes = () => {
             : 'unsorted',
         triggerEl: noteActionMoveBtn,
       });
+    });
+  }
+
+  if (noteOptionsSheet && noteActionTogglePinBtn) {
+    noteActionTogglePinBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      if (!currentNoteOptionsNoteId) {
+        return;
+      }
+      const existingNotes = loadAllNotes();
+      let changed = false;
+      const updatedNotes = (Array.isArray(existingNotes) ? existingNotes : []).map((note) => {
+        if (note && note.id === currentNoteOptionsNoteId) {
+          changed = true;
+          const nextPinned = !Boolean(note.pinned);
+          return { ...note, pinned: nextPinned, updatedAt: new Date().toISOString() };
+        }
+        return note;
+      });
+      if (changed) {
+        saveAllNotes(updatedNotes);
+        refreshFromStorage({ preserveDraft: true });
+      }
+      closeNoteOptionsMenu();
     });
   }
 


### PR DESCRIPTION
## Summary
- add a pinned flag to stored notes with normalization defaults
- sort and render mobile saved notes with pinned items first and show a pin marker
- add pin/unpin control to the mobile note options sheet with persistence

## Testing
- npm test -- sample.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69313c3d730483249c6e362e1322e644)