### PR TITLE
Fix mobile saved notes layout spacing

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -461,9 +461,62 @@ body.mobile-theme :focus-visible {
   color: var(--error, #b91c1c);
 }
 
+
 .note-row,
 .note-list-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 0.5rem;
+  width: 100%;
+  padding: 12px 16px;
+  margin: 0;
+  background: transparent;
+  border-radius: 0;
+  border-bottom: 1px solid var(--border-color, #e5e7eb);
+  cursor: pointer;
+}
+
+.note-list-item:last-child,
+.note-row:last-child {
+  border-bottom: none;
+}
+
+.note-list-main,
+.note-row-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.note-list-title,
+.note-row-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.note-list-subtitle {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.note-list-meta,
+.note-row-meta {
+  margin-top: 2px;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.3;
 }
 
 .note-options-button,
@@ -471,7 +524,15 @@ body.mobile-theme :focus-visible {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  margin-left: 0.35rem;
+  margin-left: 0.75rem;
+  flex-shrink: 0;
+}
+
+.note-list-right {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+  gap: 0.25rem;
 }
 
 /* Media Queries */

--- a/mobile.html
+++ b/mobile.html
@@ -672,8 +672,8 @@
   .notebook-list {
     display: flex;
     flex-direction: column;
-    gap: 0.15rem;
-    padding: 0;
+    gap: 0;
+    padding: 0.25rem 0 0;
     margin: 0;
   }
 
@@ -776,11 +776,14 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0.75rem 1rem;
-    margin-bottom: 0.35rem;
-    background: var(--surface-1);
-    border-radius: 0.9rem;
+    padding: 12px 16px;
+    margin: 0;
+    width: 100%;
+    background: transparent;
+    border-radius: 0;
+    border-bottom: 1px solid var(--border-color, rgba(0, 0, 0, 0.06));
     transition: background 0.15s ease;
+    cursor: pointer;
   }
 
   .note-list-item:hover {
@@ -790,24 +793,35 @@
   .note-list-main {
     flex: 1 1 auto;
     min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
   }
 
   .note-list-title {
-    font-size: 0.95rem;
+    font-size: 15px;
     font-weight: 600;
     color: var(--text-primary);
+    line-height: 1.2;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
+  .note-list-subtitle {
+    font-size: 13px;
+    color: var(--text-secondary);
+    margin-top: 2px;
+  }
+
   .note-list-meta {
-    margin-top: 0.2rem;
+    margin-top: 2px;
     display: flex;
     align-items: center;
     gap: 0.35rem;
-    font-size: 0.78rem;
-    color: var(--text-muted);
+    font-size: 13px;
+    color: var(--text-secondary);
+    line-height: 1.3;
   }
 
   .note-list-folder {
@@ -827,12 +841,21 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    margin-left: 0.75rem;
+    flex-shrink: 0;
     border-radius: 50%;
     transition: background 0.12s ease;
   }
 
   .note-list-overflow:hover {
     background: rgba(80, 20, 120, 0.1);
+  }
+
+  .note-list-right {
+    display: flex;
+    align-items: center;
+    margin-left: auto;
+    gap: 0.25rem;
   }
 
   .mobile-shell #savedNotesSheet {
@@ -5288,7 +5311,7 @@
                   </button>
                 </div>
 
-                <div class="px-3 pb-2">
+                <div class="px-3 pb-1">
                   <input
                     id="notebook-search-input"
                     type="search"


### PR DESCRIPTION
## Summary
- tighten saved notes list spacing and remove excess gaps before the first item
- update note row styling with full-width tappable rows, aligned overflow menu, and refreshed typography
- adjust search padding for a more compact header-to-list transition in the saved notes sheet

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69314170791c8324b97d3d7fa6f28a40)