### PR TITLE
Simplify move-to-folder new folder action

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -671,18 +671,31 @@ body.mobile-theme :focus-visible {
   background: rgba(76, 29, 149, 0.06);
 }
 
-.note-folder-sheet-footer {
-  margin-top: 0.6rem;
+.note-folder-row-new {
+  border: 1px dashed rgba(76, 29, 149, 0.35);
+  border-radius: 0.75rem;
+  padding: 0.55rem 0.75rem;
+  margin-top: 0.5rem;
+
+  background: transparent;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  justify-content: flex-start;
 }
 
-.note-folder-new-btn {
-  width: 100%;
-  padding: 0.7rem 0.6rem;
-  border-radius: 0.75rem;
-  border: 1px dashed rgba(76, 29, 149, 0.35);
-  background: transparent;
-  font-size: 0.88rem;
+.note-folder-row-new .note-folder-row-prefix {
+  font-size: 0.9rem;
+  color: var(--accent, #4c1d95);
+}
+
+.note-folder-row-new .note-folder-row-name {
+  font-size: 0.9rem;
   font-weight: 500;
+}
+
+.note-folder-row-new:hover {
+  background: rgba(76, 29, 149, 0.04);
 }
 
 .note-folder-sheet-backdrop {

--- a/mobile.html
+++ b/mobile.html
@@ -5388,9 +5388,6 @@
                 <div class="note-folder-sheet-list" role="list">
                   <!-- folder rows injected by JS -->
                 </div>
-                <div class="note-folder-sheet-footer">
-                  <button class="note-folder-new-btn" type="button">+ New folder</button>
-                </div>
               </div>
               <div id="note-folder-sheet-backdrop" class="note-folder-sheet-backdrop" aria-hidden="true"></div>
               <div id="moveFolderSheet" class="sheet-backdrop hidden" aria-hidden="true">

--- a/mobile.js
+++ b/mobile.js
@@ -442,7 +442,6 @@ const initMobileNotes = () => {
   const noteFolderSheetBackdrop = document.getElementById('note-folder-sheet-backdrop');
   const noteFolderSheetList = noteFolderSheet?.querySelector('.note-folder-sheet-list');
   const noteFolderSheetClose = noteFolderSheet?.querySelector('.note-folder-sheet-close');
-  const noteFolderSheetNewBtn = noteFolderSheet?.querySelector('.note-folder-new-btn');
   const ACTIVE_NOTE_SHADOW_CLASS = 'shadow-[0_0_0_3px_var(--accent-color)]';
 
   const createScratchNotesEditor = () => {
@@ -1962,6 +1961,22 @@ const initMobileNotes = () => {
     closeNoteFolderSheet();
   };
 
+  const handleCreateNewFolderFromSheet = (event) => {
+    if (event) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+
+    const targetNoteId = currentMoveFolderSheetNoteId || currentNoteId;
+    afterFolderCreated = (createdId) => {
+      if (targetNoteId) {
+        handleMoveNoteToFolder(targetNoteId, createdId || 'unsorted');
+      }
+      closeNoteFolderSheet();
+    };
+    openNewFolderDialog();
+  };
+
   const handleNoteFolderSheetKeydown = (event) => {
     if (event.key === 'Escape') {
       event.preventDefault();
@@ -2041,6 +2056,30 @@ const initMobileNotes = () => {
       const row = createRow(folder);
       noteFolderSheetList.appendChild(row);
     });
+
+    const newRow = document.createElement('button');
+    newRow.type = 'button';
+    newRow.className = 'note-folder-row note-folder-row-new';
+    newRow.setAttribute('role', 'listitem');
+    newRow.tabIndex = 0;
+
+    const prefix = document.createElement('span');
+    prefix.className = 'note-folder-row-prefix';
+    prefix.textContent = '+';
+    newRow.appendChild(prefix);
+
+    const nameEl = document.createElement('span');
+    nameEl.className = 'note-folder-row-name';
+    nameEl.textContent = 'New folder';
+    newRow.appendChild(nameEl);
+
+    newRow.addEventListener('click', handleCreateNewFolderFromSheet);
+    newRow.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      handleCreateNewFolderFromSheet(event);
+    });
+
+    noteFolderSheetList.appendChild(newRow);
   };
 
   const openMoveNoteToFolderSheet = (noteId) => {
@@ -2060,6 +2099,10 @@ const initMobileNotes = () => {
     noteFolderSheetList.addEventListener('click', (event) => {
       const row = event.target instanceof HTMLElement ? event.target.closest('.note-folder-row') : null;
       if (!row || !noteFolderSheetList.contains(row)) return;
+      if (row.classList.contains('note-folder-row-new')) {
+        handleCreateNewFolderFromSheet(event);
+        return;
+      }
       event.preventDefault();
       handleNoteFolderSelection(row.dataset.folderId || 'unsorted');
     });
@@ -2068,6 +2111,10 @@ const initMobileNotes = () => {
       if (event.key !== 'Enter' && event.key !== ' ') return;
       const row = event.target instanceof HTMLElement ? event.target.closest('.note-folder-row') : null;
       if (!row || !noteFolderSheetList.contains(row)) return;
+      if (row.classList.contains('note-folder-row-new')) {
+        handleCreateNewFolderFromSheet(event);
+        return;
+      }
       event.preventDefault();
       handleNoteFolderSelection(row.dataset.folderId || 'unsorted');
     });
@@ -2084,20 +2131,6 @@ const initMobileNotes = () => {
     noteFolderSheetBackdrop.addEventListener('click', (event) => {
       event.preventDefault();
       closeNoteFolderSheet();
-    });
-  }
-
-  if (noteFolderSheetNewBtn) {
-    noteFolderSheetNewBtn.addEventListener('click', (event) => {
-      event.preventDefault();
-      const targetNoteId = currentMoveFolderSheetNoteId || currentNoteId;
-      afterFolderCreated = (createdId) => {
-        if (targetNoteId) {
-          handleMoveNoteToFolder(targetNoteId, createdId || 'unsorted');
-        }
-        closeNoteFolderSheet();
-      };
-      openNewFolderDialog();
     });
   }
 


### PR DESCRIPTION
## Summary
- remove the footer pill button from the mobile move-to-folder sheet and keep a single new-folder entry
- restyle the inline new-folder row to be a dashed, full-width call to action consistent with folder rows
- wire the new-folder row to the existing folder creation flow directly in the sheet list

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69314307846083249b237fbcda89e046)