### PR TITLE
Fix notebook layout overflow on mobile

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -7,6 +7,10 @@ body.mobile-theme {
   padding: 0;
 }
 
+body.mobile-shell {
+  overflow-x: hidden;
+}
+
 body.mobile-theme main,
 body.mobile-theme section,
 body.mobile-theme header,
@@ -160,6 +164,36 @@ body.mobile-theme .text-secondary {
   background: var(--surface-soft, #fff);
   padding: 0.9rem 1rem;
   box-shadow: 0 18px 45px rgba(15, 0, 65, 0.08);
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+}
+
+.mobile-shell #view-notebook .mobile-view-inner,
+.mobile-shell #view-notebook #scratch-notes-card {
+  width: 100%;
+  max-width: 100vw;
+  box-sizing: border-box;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.mobile-shell #savedNotesSheet,
+.mobile-shell #savedNotesSheet .saved-notes-panel {
+  width: 100%;
+  max-width: 100vw;
+  box-sizing: border-box;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+@media (min-width: 900px) {
+  .mobile-shell #view-notebook #scratch-notes-card {
+    max-width: 640px;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 .note-editor-inner {


### PR DESCRIPTION
## Summary
- constrain notebook editor and sheet containers to 100% width on mobile to prevent horizontal overflow
- reset margins and box sizing on the note editor card while keeping desktop max-width via media query
- hide horizontal overflow on the mobile shell to avoid stray scrollbars

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693145643ed0832488f73e3acaf288a3)