### PR TITLE
Polish mobile notebook sheet layout

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -160,14 +160,52 @@ body.mobile-theme .text-secondary {
 
 /* Notebook editor layout */
 .note-editor-card {
-  border-radius: 1rem;
-  background: var(--surface-soft, #fff);
-  padding: 0.9rem 1rem;
-  box-shadow: 0 18px 45px rgba(15, 0, 65, 0.08);
   width: 100%;
   max-width: 100%;
+  padding: 16px;
+
+  border-radius: 14px;
+  margin: 12px 0;
+
   box-sizing: border-box;
-  margin: 0;
+  background: var(--surface-soft, #fff);
+  box-shadow: 0 18px 45px rgba(15, 0, 65, 0.08);
+}
+
+.notebook-sheet {
+  width: 100%;
+  max-width: 100vw;
+
+  background: var(--surface-1, #fff);
+
+  border-radius: 22px 22px 0 0;
+  overflow: hidden;
+
+  padding: 0;
+
+  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.12);
+
+  display: flex;
+  flex-direction: column;
+}
+
+.notebook-header {
+  padding: 16px 20px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.notebook-tabs {
+  padding: 0 16px;
+  margin-bottom: 12px;
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+}
+
+.notebook-search-container {
+  padding: 0 16px 12px;
 }
 
 .mobile-shell #view-notebook .mobile-view-inner,
@@ -498,22 +536,18 @@ body.mobile-theme :focus-visible {
 
 .note-row,
 .note-list-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
   width: 100%;
-  padding: 12px 16px;
-  margin: 0;
-  background: transparent;
-  border-radius: 0;
-  border-bottom: 1px solid var(--border-color, #e5e7eb);
-  cursor: pointer;
-}
+  background: white;
+  padding: 12px 14px;
 
-.note-list-item:last-child,
-.note-row:last-child {
-  border-bottom: none;
+  border-radius: 12px;
+  margin-bottom: 8px;
+
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  gap: 0.35rem;
+  cursor: pointer;
 }
 
 .note-list-main,
@@ -523,6 +557,13 @@ body.mobile-theme :focus-visible {
   display: flex;
   flex-direction: column;
   gap: 2px;
+}
+
+.saved-notes-list {
+  padding: 0 12px 8px;
+  margin: 0;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .note-list-title,
@@ -583,6 +624,12 @@ body.mobile-theme :focus-visible {
   align-items: center;
   margin-left: auto;
   gap: 0.25rem;
+}
+
+.note-list-item .note-actions {
+  margin-left: auto;
+  align-self: flex-start;
+  padding-top: 4px;
 }
 
 /* Media Queries */

--- a/mobile.html
+++ b/mobile.html
@@ -5177,10 +5177,10 @@
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: notebook view -->
     <section data-view="notebook" id="view-notebook" class="view-panel hidden mobile-panel--notes mobile-panel--notes-size-small">
-        <div class="mobile-view-inner mx-auto w-full px-0 pt-2 pb-2 space-y-0" style="background: var(--mobile-quick-surface); color: var(--text-body);">
+        <div class="mobile-view-inner mx-auto w-full px-0 pt-2 pb-2 space-y-0">
         <!-- notebook view header removed to keep UI minimal -->
         <!-- Enhanced Notebook Card -->
-        <div id="scratch-notes-card" class="writing-panel premium-gradient scratch-notes-card memory-glass-card p-4 space-y-3 pb-3" style="color: var(--text-body);">
+        <div id="scratch-notes-card" class="writing-panel premium-gradient scratch-notes-card memory-glass-card p-4 space-y-3 pb-3">
           <div class="note-editor-card">
             <div class="flex items-center justify-between gap-2 pb-0 border-b border-base-200/70">
               <div class="flex flex-col">
@@ -5249,7 +5249,7 @@
         </div>
           <div
             id="savedNotesSheet"
-            class="fixed inset-0 z-40 hidden bg-base-300/40 backdrop-blur-sm"
+            class="fixed inset-0 z-40 hidden bg-base-300/40 backdrop-blur-sm flex items-end justify-center"
             aria-hidden="true"
             aria-modal="true"
             role="dialog"
@@ -5258,15 +5258,15 @@
           >
           <div
             id="saved-notes-panel"
-            class="saved-notes-panel fixed left-1/2 top-1/2 z-50 flex max-h-[80vh] max-w-md flex-col space-y-2 rounded-3xl border border-base-300 bg-base-100 px-4 py-3 shadow-xl transition-transform"
+            class="saved-notes-panel notebook-sheet"
           >
             <div class="flex flex-col max-h-[70vh]">
               <div class="flex justify-center pt-2 pb-1">
                 <div class="h-1.5 w-10 rounded-full bg-base-300"></div>
               </div>
 
-              <div class="px-2 pb-3 overflow-y-auto">
-                <div class="notebook-top-bar">
+              <div class="overflow-y-auto">
+                <div class="notebook-top-bar notebook-header">
                   <div class="notebook-top-left">
                     <button
                       id="closeSavedNotesSheet"
@@ -5311,7 +5311,7 @@
                   </button>
                 </div>
 
-                <div class="px-3 pb-1">
+                <div class="notebook-search-container">
                   <input
                     id="notebook-search-input"
                     type="search"
@@ -5322,7 +5322,7 @@
 
                 <div
                   id="notesListMobile"
-                  class="notebook-list notebook-notes-list text-sm"
+                  class="notebook-list notebook-notes-list saved-notes-list text-sm"
                   aria-label="Saved scratch notes"
                 >
                   <!-- Note items are rendered here by JS -->
@@ -5341,7 +5341,7 @@
                       </div>
                       <button
                         type="button"
-                        class="note-row-overflow note-list-overflow note-options-button"
+                        class="note-row-overflow note-list-overflow note-options-button note-actions"
                         aria-label="More"
                         data-role="note-menu"
                         data-note-id=""


### PR DESCRIPTION
## Summary
- normalize the notebook sheet container, header, tabs, and search padding for a tighter mobile layout
- align saved note list cards and actions with consistent spacing and rounded corners
- clean up inline styling in the notebook view to rely on the updated CSS

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69314660bf6c832494f1657cfe7638ff)