### PR TITLE
Center notebook saved notes sheet on mobile

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -7,6 +7,10 @@ body.mobile-theme {
   padding: 0;
 }
 
+body.mobile-shell {
+  overflow-x: hidden;
+}
+
 body.mobile-theme main,
 body.mobile-theme section,
 body.mobile-theme header,
@@ -160,6 +164,35 @@ body.mobile-theme .text-secondary {
   background: var(--surface-soft, #fff);
   padding: 0.9rem 1rem;
   box-shadow: 0 18px 45px rgba(15, 0, 65, 0.08);
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+}
+
+.mobile-shell #view-notebook .mobile-view-inner,
+.mobile-shell #view-notebook #scratch-notes-card {
+  width: 100%;
+  max-width: 100vw;
+  box-sizing: border-box;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.mobile-shell #savedNotesSheet {
+  width: 100%;
+  max-width: 100vw;
+  box-sizing: border-box;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+@media (min-width: 900px) {
+  .mobile-shell #view-notebook #scratch-notes-card {
+    max-width: 640px;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 .note-editor-inner {

--- a/mobile.html
+++ b/mobile.html
@@ -568,17 +568,25 @@
     transition: opacity 0.25s ease;
   }
 
+  #savedNotesSheet:not(.hidden) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+  }
+
   #savedNotesSheet[data-open="true"] {
     opacity: 1;
     pointer-events: auto;
   }
 
   #savedNotesSheet .saved-notes-panel {
-    position: fixed;
-    top: 50%;
-    left: 50%;
+    position: relative;
     width: min(92vw, 28rem);
-    transform: translate(-50%, calc(-50% + 24px)) scale(0.96);
+    max-width: 100vw;
+    box-sizing: border-box;
+    margin: 0 auto;
+    transform: translateY(24px) scale(0.96);
     opacity: 0;
     transition:
       transform 0.35s cubic-bezier(0.25, 0.8, 0.25, 1),
@@ -586,7 +594,7 @@
   }
 
   #savedNotesSheet[data-open="true"] .saved-notes-panel {
-    transform: translate(-50%, -50%) scale(1);
+    transform: translateY(0) scale(1);
     opacity: 1;
   }
 
@@ -861,6 +869,9 @@
   .mobile-shell #savedNotesSheet {
     transition: opacity 0.25s ease;
     opacity: 0;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
   }
 
   .mobile-shell #savedNotesSheet[data-open="true"] {
@@ -868,11 +879,12 @@
   }
 
   .mobile-shell #savedNotesSheet .saved-notes-panel {
-    position: fixed;
-    top: 50%;
-    left: 50%;
+    position: relative;
     width: min(92vw, 28rem);
-    transform: translate(-50%, calc(-50% + 24px)) scale(0.96);
+    max-width: 100vw;
+    box-sizing: border-box;
+    margin: 0 auto;
+    transform: translateY(24px) scale(0.96);
     opacity: 0;
     transition:
       transform 0.35s cubic-bezier(0.25, 0.8, 0.25, 1),
@@ -886,7 +898,7 @@
   }
 
   .mobile-shell #savedNotesSheet[data-open="true"] .saved-notes-panel {
-    transform: translate(-50%, -50%) scale(1);
+    transform: translateY(0) scale(1);
     opacity: 1;
   }
 


### PR DESCRIPTION
## Summary
- center the saved notes modal by flex-centering the overlay and using relative positioning for the panel
- preserve width constraints and entry animation while preventing horizontal offset

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693145643ed0832488f73e3acaf288a3)