### PR TITLE
Clean up notebook toolbar styling

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -272,44 +272,55 @@ body.mobile-theme .text-secondary {
 .note-editor-toolbar {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.45rem 0.4rem;
-  background: var(--surface-2, #f7f7fa);
-  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  gap: 4px;
+  padding: 6px 10px;
+  background: #f8f5ff;
+  border-radius: 10px;
+  margin-bottom: 10px;
   overflow-x: auto;
-  position: sticky;
-  top: 0;
-  z-index: 20;
 }
 
 .rte-btn {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.35rem 0.55rem;
-  font-size: 0.85rem;
+  width: 32px;
+  height: 32px;
+  padding: 0;
   background: #ffffff;
-  border-radius: 0.55rem;
-  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
   cursor: pointer;
-  transition: background 0.15s ease, border-color 0.15s ease;
+  flex: 0 0 auto;
+  transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .rte-btn:hover {
-  background: rgba(0, 0, 0, 0.06);
+  background: rgba(76, 29, 149, 0.04);
 }
 
 .rte-btn.active {
   background: rgba(76, 29, 149, 0.12);
-  border-color: rgba(76, 29, 149, 0.3);
-  color: var(--accent, #4c1d95);
+  border-color: rgba(76, 29, 149, 0.35);
+  color: #4c1d95;
+}
+
+.rte-icon {
+  font-size: 0.85rem;
+  line-height: 1;
+  pointer-events: none;
 }
 
 .rte-divider {
   width: 1px;
-  height: 1.2rem;
+  height: 20px;
   background: rgba(0, 0, 0, 0.12);
-  margin: 0 0.2rem;
+  margin: 0 2px;
+}
+
+.note-editor-toolbar span {
+  text-decoration: none;
+  color: inherit;
 }
 
 .note-toolbar {

--- a/mobile.html
+++ b/mobile.html
@@ -5221,24 +5221,42 @@
                 role="toolbar"
                 aria-label="Formatting options"
               >
-                <button class="rte-btn" data-cmd="bold"><span class="icon">B</span></button>
-                <button class="rte-btn" data-cmd="italic"><span class="icon">I</span></button>
-                <button class="rte-btn" data-cmd="underline"><span class="icon">U</span></button>
+                <button class="rte-btn" data-cmd="bold" type="button">
+                  <span class="rte-icon">B</span>
+                </button>
+                <button class="rte-btn" data-cmd="italic" type="button">
+                  <span class="rte-icon">I</span>
+                </button>
+                <button class="rte-btn" data-cmd="underline" type="button">
+                  <span class="rte-icon">U</span>
+                </button>
 
                 <div class="rte-divider"></div>
 
-                <button class="rte-btn" data-cmd="insertUnorderedList"><span class="icon">• List</span></button>
-                <button class="rte-btn" data-cmd="insertOrderedList"><span class="icon">1.</span></button>
+                <button class="rte-btn" data-cmd="insertUnorderedList" type="button">
+                  <span class="rte-icon">•</span>
+                </button>
+                <button class="rte-btn" data-cmd="insertOrderedList" type="button">
+                  <span class="rte-icon">1.</span>
+                </button>
 
                 <div class="rte-divider"></div>
 
-                <button class="rte-btn" data-cmd="indent"><span class="icon">→</span></button>
-                <button class="rte-btn" data-cmd="outdent"><span class="icon">←</span></button>
+                <button class="rte-btn" data-cmd="indent" type="button">
+                  <span class="rte-icon">→</span>
+                </button>
+                <button class="rte-btn" data-cmd="outdent" type="button">
+                  <span class="rte-icon">←</span>
+                </button>
 
                 <div class="rte-divider"></div>
 
-                <button class="rte-btn" data-cmd="undo"><span class="icon">↺</span></button>
-                <button class="rte-btn" data-cmd="redo"><span class="icon">↻</span></button>
+                <button class="rte-btn" data-cmd="undo" type="button">
+                  <span class="rte-icon">↺</span>
+                </button>
+                <button class="rte-btn" data-cmd="redo" type="button">
+                  <span class="rte-icon">↻</span>
+                </button>
               </div>
 
               <!-- Minimal main editor with soft styling -->


### PR DESCRIPTION
## Summary
- simplify notebook toolbar markup to compact icon-only buttons
- refresh toolbar styling for consistent spacing, sizing, and divider appearance
- ensure toolbar text inherits styling to avoid link-like appearance

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69316cf1f3d08324a88fbc8d8584d075)