### PR TITLE
Fix mobile note editor card alignment and toolbar

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -159,30 +159,30 @@ body.mobile-theme .text-secondary {
 }
 
 /* Notebook editor layout */
+
 .note-editor-card {
+  position: relative;
   width: 100%;
-  max-width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
   padding: 16px;
-
-  border-radius: 14px;
-  margin: 12px 0;
-
+  border-radius: 18px;
   box-sizing: border-box;
   background: var(--surface-soft, #fff);
   box-shadow: 0 18px 45px rgba(15, 0, 65, 0.08);
-  width: 100%;
-  max-width: 100%;
-  box-sizing: border-box;
-  margin: 0;
 }
 
 .mobile-shell #view-notebook .mobile-view-inner,
 .mobile-shell #view-notebook #scratch-notes-card {
   width: 100%;
-  max-width: 100vw;
+  max-width: 100%;
   box-sizing: border-box;
-  margin-left: 0;
-  margin-right: 0;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.mobile-shell #view-notebook #scratch-notes-card {
+  max-width: 600px;
 }
 
 .mobile-shell #savedNotesSheet {
@@ -240,10 +240,10 @@ body.mobile-theme .text-secondary {
 .mobile-shell #view-notebook .mobile-view-inner,
 .mobile-shell #view-notebook #scratch-notes-card {
   width: 100%;
-  max-width: 100vw;
+  max-width: 100%;
   box-sizing: border-box;
-  margin-left: 0;
-  margin-right: 0;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .mobile-shell #savedNotesSheet,
@@ -272,26 +272,32 @@ body.mobile-theme .text-secondary {
 .note-editor-toolbar {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 6px 10px;
-  background: #f8f5ff;
-  border-radius: 10px;
+  gap: 6px;
+  padding: 8px 10px;
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 12px;
   margin-bottom: 10px;
   overflow-x: auto;
+  white-space: nowrap;
+  box-sizing: border-box;
 }
 
 .rte-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
-  padding: 0;
+  min-width: 34px;
+  height: 34px;
+  padding: 0 10px;
   background: #ffffff;
   border-radius: 10px;
-  border: 1px solid rgba(0, 0, 0, 0.08);
+  border: 1px solid rgba(0, 0, 0, 0.12);
   cursor: pointer;
   flex: 0 0 auto;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #4b286d;
+  box-sizing: border-box;
   transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
@@ -301,7 +307,7 @@ body.mobile-theme .text-secondary {
 
 .rte-btn.active {
   background: rgba(76, 29, 149, 0.12);
-  border-color: rgba(76, 29, 149, 0.35);
+  border-color: rgba(76, 29, 149, 0.4);
   color: #4c1d95;
 }
 
@@ -321,6 +327,10 @@ body.mobile-theme .text-secondary {
 .note-editor-toolbar span {
   text-decoration: none;
   color: inherit;
+}
+
+.note-editor-toolbar .list-label {
+  display: none;
 }
 
 .note-toolbar {


### PR DESCRIPTION
## Summary
- center the mobile note editor card within the viewport and constrain its width for small screens
- refresh the mobile formatting toolbar styling for consistent spacing and tidy alignment
- hide any stray list labels that might appear under the toolbar buttons

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69316e1cfc348324a8936668c24beb5e)