### PR TITLE
Refine mobile note editor toolbar styling

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -273,8 +273,8 @@ body.mobile-theme .text-secondary {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 6px;
-  margin: 4px 0 6px;
+  padding: 4px 0;
+  margin: 6px 0;
   background: transparent;
   border-radius: 0;
   overflow-x: auto;
@@ -282,19 +282,19 @@ body.mobile-theme .text-secondary {
   white-space: nowrap;
 }
 
-.rte-btn {
+.note-editor-toolbar .rte-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 32px;
-  height: 32px;
+  min-width: 30px;
+  height: 30px;
   padding: 0 8px;
-  background: #ffffff;
   border-radius: 999px;
   border: 1px solid rgba(0, 0, 0, 0.12);
+  background: #ffffff;
   color: #4b286d;
   font-size: 0.8rem;
-  font-weight: 600;
+  font-weight: 500;
   line-height: 1;
   cursor: pointer;
   flex: 0 0 auto;
@@ -303,11 +303,11 @@ body.mobile-theme .text-secondary {
   transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease, color 0.15s ease;
 }
 
-.rte-btn:hover {
+.note-editor-toolbar .rte-btn:hover {
   background: rgba(76, 29, 149, 0.08);
 }
 
-.rte-btn.active {
+.note-editor-toolbar .rte-btn.active {
   background: rgba(76, 29, 149, 0.08);
   border-color: rgba(76, 29, 149, 0.4);
   color: #4c1d95;


### PR DESCRIPTION
## Summary
- adjust the mobile note editor toolbar spacing to align with the card padding and keep the strip slim and scrollable
- restyle formatting buttons as compact pill controls with subtle active state

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931710d68788324b561074de1307657)