### PR TITLE
Refine mobile note editor layout

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -347,15 +347,64 @@ body.mobile-theme .text-secondary {
   background: rgba(76, 29, 149, 0.04);
 }
 
+.note-content-wrapper {
+  margin-top: 8px;
+  border-radius: 14px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  background: #f9f7ff;
+  padding: 10px 12px;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
 .note-editor-content {
-  min-height: 200px;
-  padding: 1rem;
-  border-radius: 0.8rem;
-  border: 1px solid rgba(76, 29, 149, 0.12);
-  background: #fff;
-  overflow-y: auto;
-  font-size: 0.95rem;
+  width: 100%;
+  max-width: 100%;
+  min-height: 140px;
+  box-sizing: border-box;
+  border: none;
+  background: transparent;
+  outline: none;
+  overflow-x: hidden;
+  font-size: 15px;
   line-height: 1.5;
+  font-weight: 400;
+  color: #1f1633;
+  padding: 0;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+.note-editor-content textarea {
+  resize: none;
+}
+
+.note-editor-content.is-placeholder,
+.note-editor-content[data-placeholder]:empty::before {
+  content: attr(data-placeholder);
+  color: rgba(31, 22, 51, 0.35);
+  font-style: italic;
+}
+
+.note-editor-content ul,
+.note-editor-content ol {
+  margin: 0 0 0.4rem 1.1rem;
+  padding-left: 0;
+}
+
+.note-editor-content li {
+  margin-bottom: 0.25rem;
+}
+
+.note-editor-content p {
+  margin: 0 0 0.35rem;
+}
+
+.note-editor-content * {
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 /* Buttons */

--- a/mobile.html
+++ b/mobile.html
@@ -1847,12 +1847,16 @@
     }
 
     .distraction-free-editor-container {
-      margin-top: 0;
-      background: rgba(249, 249, 252, 0.66);
-      border: 1px solid rgba(230, 225, 240, 0.75);
-      color: var(--text-body);
+      margin-top: 8px;
       border-radius: 14px;
-      padding: 0.35rem;
+      border: 1px solid rgba(0, 0, 0, 0.08);
+      background: #f9f7ff;
+      padding: 10px 12px;
+      box-sizing: border-box;
+      width: 100%;
+      max-width: 100%;
+      overflow-x: hidden;
+      color: var(--text-body);
       transition: box-shadow 0.18s ease, border-color 0.18s ease;
     }
 
@@ -1863,35 +1867,40 @@
     }
 
     .minimal-editor {
-      border: 1px solid rgba(220, 214, 233, 0.9);
+      width: 100%;
+      max-width: 100%;
+      min-height: 140px;
+      box-sizing: border-box;
+      border: none;
+      background: transparent;
       box-shadow: none;
       transition: all 0.2s ease;
-      line-height: 1.45;
-      min-height: 220px;
+      line-height: 1.5;
       max-height: none;
       overflow-y: auto;
-      background: rgba(249, 249, 252, 0.96);
-      color: var(--text-body, #4a3c57);
+      color: #1f1633;
       border-radius: 12px;
       font-family: var(--font-primary);
-      font-size: var(--font-size-body);
+      font-size: 15px;
       font-weight: 400;
-      padding: 10px 12px;
+      padding: 0;
+      white-space: pre-wrap;
+      word-wrap: break-word;
     }
 
     .minimal-editor:focus,
     .minimal-editor[contenteditable="true"]:focus {
-      border-color: rgba(81, 38, 99, 0.22);
+      border-color: transparent;
       box-shadow: none;
       outline: none;
     }
 
     .minimal-editor textarea {
       font-family: var(--font-primary);
-      font-size: var(--font-size-body);
+      font-size: 15px;
       font-weight: 400;
-      color: var(--text-body);
-      line-height: 1.45;
+      color: #1f1633;
+      line-height: 1.5;
     }
 
     .minimal-editor textarea:focus {
@@ -1901,12 +1910,12 @@
     .minimal-editor textarea,
     .minimal-editor[contenteditable="true"] {
       background-color: transparent;
-      color: var(--text-body);
+      color: #1f1633;
     }
 
     .minimal-editor:empty::before {
       content: attr(data-placeholder);
-      color: var(--text-muted, #9a8bb0);
+      color: rgba(31, 22, 51, 0.35);
       font-style: italic;
     }
 
@@ -5260,7 +5269,7 @@
               </div>
 
               <!-- Minimal main editor with soft styling -->
-              <div class="distraction-free-editor-container">
+              <div class="distraction-free-editor-container note-content-wrapper">
                 <div
                   id="notebook-editor-body"
                   class="note-editor-content note-editor-area notebook-editor-body minimal-editor px-3 py-3 text-base leading-relaxed focus:outline-none rounded-lg"


### PR DESCRIPTION
## Summary
- restyle the mobile note content wrapper for better alignment and overflow handling
- tune note editor typography, spacing, and placeholders for readability on mobile
- adjust list and paragraph spacing to keep bullets and text aligned within the card

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931723623788324bbafab95ce2f2c93)