### PR TITLE
Center mobile note sheet

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -1,4 +1,10 @@
 /* Base Styles */
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
 body.mobile-theme {
   background-color: #F3F4F6;
   color: #111827;
@@ -9,9 +15,6 @@ body.mobile-theme {
 
 body.mobile-shell {
   overflow-x: hidden;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
 }
 
 body.mobile-theme main,
@@ -19,6 +22,11 @@ body.mobile-theme section,
 body.mobile-theme header,
 body.mobile-theme footer {
   color: inherit;
+}
+
+.mobile-header,
+.app-header {
+  flex: 0 0 auto;
 }
 
 #mobile-shell {
@@ -33,6 +41,22 @@ body.mobile-theme footer {
   flex-direction: column;
   box-sizing: border-box;
   padding-bottom: 80px;
+}
+
+.app-main {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 16px 0;
+  box-sizing: border-box;
+  overflow-y: auto;
+}
+
+.bottom-nav,
+#mobile-nav-shell {
+  flex: 0 0 auto;
 }
 
 /* Header / Top Bar */
@@ -181,8 +205,8 @@ body.mobile-theme .text-secondary {
 .note-editor-card {
   position: relative;
   width: 100%;
-  max-width: 600px;
-  margin: 24px 0;
+  max-width: 640px;
+  margin: 0;
   padding: 16px;
   border-radius: 18px;
   box-sizing: border-box;
@@ -192,15 +216,18 @@ body.mobile-theme .text-secondary {
   flex-direction: column;
   min-height: 0;
   flex: 1 1 auto;
+  max-height: calc(100vh - var(--header-height, 120px) - var(--bottom-nav-height, 96px) - 32px);
 }
 
 .note-sheet-wrapper {
   display: flex;
   justify-content: center;
+  align-items: center;
   padding: 0 16px;
   box-sizing: border-box;
   flex: 1 1 auto;
   width: 100%;
+  min-height: 0;
 }
 
 .mobile-panel--notes {
@@ -229,10 +256,13 @@ body.mobile-theme .text-secondary {
 }
 
 .mobile-shell #view-notebook #scratch-notes-card {
-  max-width: 600px;
+  width: 100%;
+  max-width: 640px;
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .mobile-shell #savedNotesSheet {
@@ -319,6 +349,12 @@ body.mobile-theme .text-secondary {
   gap: 0.6rem;
   flex: 1 1 auto;
   min-height: 0;
+}
+
+.note-editor-content-wrapper {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .note-editor-toolbar {

--- a/mobile.html
+++ b/mobile.html
@@ -311,7 +311,7 @@
     flex-direction: column;
     gap: 0;
     max-width: 640px;
-    margin: 12px auto 0;
+    margin: 0 auto;
     padding: 0.75rem 1rem calc(1.25rem + env(safe-area-inset-bottom, 0.75rem));
     position: relative;
     border-radius: 18px;
@@ -5156,18 +5156,19 @@
   </script>
 
   <!-- quickAddBar is now integrated in the header -->
-  <div
-    id="mobile-shell"
-    class="mobile-shell mx-auto w-full px-4 pb-16"
-    style="background: #FBFBFB; padding-top: env(safe-area-inset-top, 0);"
-  >
-    <main
-      id="main"
-      class="mx-auto pt-4 pb-4 w-full max-w-none sm:max-w-lg"
-      tabindex="-1"
-      data-active-view="reminders"
-      style="background: #FBFBFB;"
+  <div class="app-main">
+    <div
+      id="mobile-shell"
+      class="mobile-shell mx-auto w-full px-4 pb-16"
+      style="background: #FBFBFB; padding-top: env(safe-area-inset-top, 0);"
     >
+      <main
+        id="main"
+        class="mx-auto pt-4 pb-4 w-full max-w-none sm:max-w-lg"
+        tabindex="-1"
+        data-active-view="reminders"
+        style="background: #FBFBFB;"
+      >
     <!-- BEGIN GPT CHANGE: create form moved to bottom sheet -->
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: reminders view -->
@@ -5196,11 +5197,12 @@
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: notebook view -->
     <section data-view="notebook" id="view-notebook" class="view-panel hidden mobile-panel--notes mobile-panel--notes-size-small">
-        <div class="mobile-view-inner mx-auto w-full px-0 pt-2 pb-2 space-y-0 note-sheet-wrapper">
+        <div class="mobile-view-inner mx-auto w-full px-0 pt-2 pb-2 space-y-0">
         <!-- notebook view header removed to keep UI minimal -->
         <!-- Enhanced Notebook Card -->
-        <div id="scratch-notes-card" class="writing-panel premium-gradient scratch-notes-card memory-glass-card p-4 space-y-3 pb-3">
-          <div class="note-editor-card">
+        <div class="note-sheet-wrapper">
+          <div id="scratch-notes-card" class="writing-panel premium-gradient scratch-notes-card memory-glass-card p-4 space-y-3 pb-3">
+            <div class="note-editor-card">
             <div class="flex items-center justify-between gap-2 pb-0 border-b border-base-200/70">
               <div class="flex flex-col">
                 <span class="sr-only">Notebook</span>
@@ -5269,7 +5271,7 @@
               </div>
 
               <!-- Minimal main editor with soft styling -->
-              <div class="distraction-free-editor-container note-content-wrapper">
+              <div class="distraction-free-editor-container note-content-wrapper note-editor-content-wrapper">
                 <div
                   id="notebook-editor-body"
                   class="note-editor-content note-editor-area notebook-editor-body minimal-editor px-3 py-3 text-base leading-relaxed focus:outline-none rounded-lg"
@@ -5283,6 +5285,7 @@
               </div>
             </div>
           </div>
+        </div>
         </div>
           <div
             id="savedNotesSheet"
@@ -5523,6 +5526,7 @@
       </section>
       <!-- END GPT CHANGE -->
       </main>
+    </div>
   </div>
 
   <div id="mobile-nav-shell" class="sticky inset-x-0 bottom-0 z-50 flex justify-center pointer-events-none px-2 pb-3">


### PR DESCRIPTION
## Summary
- add a dedicated main flex container so the mobile layout balances between the header and bottom nav
- center the notebook sheet wrapper and card with responsive max widths to remove top anchoring and horizontal scroll
- cap the editor card height and make its content area scroll so long notes remain usable

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69317aa4c50c8324a80b5e28707c64d7)