### PR TITLE
Fix scratch notes card layout on mobile

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -47,15 +47,11 @@ body.mobile-theme footer {
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: 16px 0;
+  justify-content: flex-start;
+  align-items: stretch;
+  padding: 8px 0 80px;
   box-sizing: border-box;
   overflow-y: auto;
-}
-
-body.mobile-shell .app-main {
-  align-items: stretch;
 }
 
 /* Reminders layout (mobile) */
@@ -273,12 +269,20 @@ body.mobile-theme .text-secondary {
 .note-sheet-wrapper {
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: stretch;
   padding: 0 16px;
   box-sizing: border-box;
   flex: 1 1 auto;
   width: 100%;
   min-height: 0;
+}
+
+.scratch-notes-wrapper {
+  margin: 0;
+  padding: 0 16px;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
 }
 
 .mobile-panel--notes {
@@ -291,9 +295,11 @@ body.mobile-theme .text-secondary {
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   padding-left: 16px;
   padding-right: 16px;
+  padding-top: 8px;
+  padding-bottom: 80px;
   box-sizing: border-box;
 }
 
@@ -312,8 +318,14 @@ body.mobile-theme .text-secondary {
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
-  margin-left: auto;
-  margin-right: auto;
+  margin: 0;
+  max-height: calc(100vh - var(--header-height, 120px) - var(--bottom-nav-height, 96px) - 16px);
+}
+
+.scratch-notes-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .mobile-shell #savedNotesSheet {
@@ -402,10 +414,25 @@ body.mobile-theme .text-secondary {
   min-height: 0;
 }
 
+.scratch-notes-header-block {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
 .note-editor-content-wrapper {
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
+}
+
+.scratch-notes-body-wrapper {
+  flex: 1 1 auto;
+  min-height: 0;
+  margin-top: 12px;
+  box-sizing: border-box;
+  display: flex;
 }
 
 .note-editor-toolbar {
@@ -520,6 +547,10 @@ body.mobile-theme .text-secondary {
   flex: 1 1 auto;
   min-height: 100%;
   overflow-y: auto;
+}
+
+.scratch-notes-body {
+  max-height: 100%;
 }
 
 .note-editor-content textarea {

--- a/mobile.html
+++ b/mobile.html
@@ -5200,18 +5200,19 @@
         <div class="mobile-view-inner mx-auto w-full px-0 pt-2 pb-2 space-y-0">
         <!-- notebook view header removed to keep UI minimal -->
         <!-- Enhanced Notebook Card -->
-        <div class="note-sheet-wrapper">
+        <div class="note-sheet-wrapper scratch-notes-wrapper">
           <div id="scratch-notes-card" class="writing-panel premium-gradient scratch-notes-card memory-glass-card p-4 space-y-3 pb-3">
             <div class="note-editor-card">
-            <div class="flex items-center justify-between gap-2 pb-0 border-b border-base-200/70">
-              <div class="flex flex-col">
-                <span class="sr-only">Notebook</span>
+            <div class="scratch-notes-header-block">
+              <div class="flex items-center justify-between gap-2 pb-0 border-b border-base-200/70">
+                <div class="flex flex-col">
+                  <span class="sr-only">Notebook</span>
+                </div>
+
+                <!-- saved notes button moved into the sub-header for compact layout -->
               </div>
 
-              <!-- saved notes button moved into the sub-header for compact layout -->
-            </div>
-
-            <!-- Seamless title field -->
+              <!-- Seamless title field -->
               <div class="flex flex-col items-stretch gap-2 px-1 py-1 rounded-md notebook-actions-row">
                 <input
                   id="noteTitleMobile"
@@ -5225,7 +5226,6 @@
                 </button>
               </div>
 
-            <div class="note-editor-inner">
               <div
                 id="scratchNotesToolbar"
                 class="note-editor-toolbar"
@@ -5269,12 +5269,14 @@
                   <span class="rte-icon">↻</span>
                 </button>
               </div>
+            </div>
 
+            <div class="note-editor-inner">
               <!-- Minimal main editor with soft styling -->
-              <div class="distraction-free-editor-container note-content-wrapper note-editor-content-wrapper">
+              <div class="distraction-free-editor-container note-content-wrapper note-editor-content-wrapper scratch-notes-body-wrapper">
                 <div
                   id="notebook-editor-body"
-                  class="note-editor-content note-editor-area notebook-editor-body minimal-editor px-3 py-3 text-base leading-relaxed focus:outline-none rounded-lg"
+                  class="note-editor-content note-editor-area notebook-editor-body minimal-editor px-3 py-3 text-base leading-relaxed focus:outline-none rounded-lg scratch-notes-body"
                   contenteditable="true"
                   spellcheck="true"
                   data-placeholder="Start typing your note…"


### PR DESCRIPTION
## Summary
- reposition the scratch notes card under the header and center it horizontally on mobile
- adjust layout wrappers to stretch the note body toward the bottom navigation area
- ensure the note editor body fills available space and scrolls internally when content grows

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931ec5b4ee88324a603f014f64b5736)