### PR TITLE
Fix scratch notes layout on mobile

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -3,6 +3,7 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  overflow-x: hidden;
 }
 
 body.mobile-theme {
@@ -278,6 +279,8 @@ body.mobile-theme .text-secondary {
 }
 
 .scratch-notes-wrapper {
+  width: 100%;
+  max-width: 100vw;
   margin: 0;
   padding: 0 16px;
   box-sizing: border-box;
@@ -314,7 +317,7 @@ body.mobile-theme .text-secondary {
 
 .mobile-shell #view-notebook #scratch-notes-card {
   width: 100%;
-  max-width: 640px;
+  max-width: 100%;
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
@@ -326,6 +329,9 @@ body.mobile-theme .text-secondary {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 .mobile-shell #savedNotesSheet {
@@ -433,6 +439,8 @@ body.mobile-theme .text-secondary {
   margin-top: 12px;
   box-sizing: border-box;
   display: flex;
+  width: 100%;
+  max-width: 100%;
 }
 
 .note-editor-toolbar {
@@ -551,6 +559,9 @@ body.mobile-theme .text-secondary {
 
 .scratch-notes-body {
   max-height: 100%;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 .note-editor-content textarea {


### PR DESCRIPTION
## Summary
- ensure scratch notes wrapper, card, and body use full-width border-box sizing to avoid overflow
- constrain notebook view to viewport and hide horizontal overflow on mobile

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932017f5a448324aa0b2e9c390f8827)