### PR TITLE
Add classroom widget presets and search interface

### DIFF
--- a/classroom.html
+++ b/classroom.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en" data-theme="professional">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Custom Classroom Screen</title>
+  <link rel="stylesheet" href="./styles/tokens.css" />
+  <link rel="stylesheet" href="./styles/a11y.css" />
+  <link rel="stylesheet" href="./styles/index.css" />
+  <style>
+    .widget-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; }
+    .widget-card { border: 1px solid rgba(0,0,0,0.06); border-radius: 0.75rem; padding: 1rem; background: #fff; box-shadow: 0 1px 3px rgba(0,0,0,0.06); }
+    .widget-card h3 { margin: 0 0 0.25rem; font-size: 1rem; }
+    .widget-card p { margin: 0 0 0.75rem; color: #4b5563; font-size: 0.95rem; }
+    .widget-badges { display: flex; flex-wrap: wrap; gap: 0.35rem; margin-bottom: 0.5rem; }
+    .badge { padding: 0.2rem 0.55rem; border-radius: 9999px; background: #eef2ff; color: #1f2937; font-size: 0.8rem; border: 1px solid #e5e7eb; }
+    .layout-slot { border: 1px dashed #cbd5e1; border-radius: 0.75rem; padding: 0.75rem; display: flex; justify-content: space-between; align-items: center; gap: 0.75rem; background: #f8fafc; }
+    .preset-list { display: grid; gap: 0.5rem; }
+    .pill { border: 1px solid #d1d5db; border-radius: 9999px; padding: 0.25rem 0.75rem; background: #fff; cursor: pointer; }
+    .pill[aria-pressed="true"] { background: #1d4ed8; color: #fff; border-color: #1d4ed8; }
+    .toolbar { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
+    .muted { color: #6b7280; }
+  </style>
+  <script type="module" src="./js/classroom-widgets.js" defer></script>
+</head>
+<body class="min-h-screen bg-base-200">
+  <header class="p-4 bg-base-100 shadow-sm">
+    <div class="max-w-5xl mx-auto flex items-center justify-between gap-3">
+      <div>
+        <p class="text-sm text-slate-500">Custom Classroom Screen</p>
+        <h1 class="text-2xl font-bold">Widget Manager</h1>
+      </div>
+      <a href="./index.html" class="btn">Back to Memory Cue</a>
+    </div>
+  </header>
+
+  <main class="max-w-5xl mx-auto p-4 space-y-6" id="widgetApp" aria-live="polite">
+    <section class="card bg-base-100 shadow-sm">
+      <div class="card-body space-y-4">
+        <div class="toolbar" id="widgetFilters">
+          <label class="input input-bordered flex items-center gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-5 h-5 text-slate-500"><path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 105.65 5.65a7.5 7.5 0 0010.6 10.6z"/></svg>
+            <input id="widgetSearch" type="search" class="grow" placeholder="Search widgets" />
+          </label>
+          <div id="categoryFilters" class="flex gap-2 flex-wrap" aria-label="Widget categories"></div>
+        </div>
+
+        <div class="widget-grid" id="widgetCatalog" aria-live="polite"></div>
+      </div>
+    </section>
+
+    <section class="card bg-base-100 shadow-sm">
+      <div class="card-body space-y-3">
+        <div class="flex items-center justify-between gap-3">
+          <div>
+            <p class="text-sm text-slate-500">Preset-ready arrangement</p>
+            <h2 class="text-xl font-semibold">Current Layout</h2>
+          </div>
+          <button id="clearLayout" class="btn btn-ghost">Clear layout</button>
+        </div>
+        <div id="layoutSlots" class="space-y-2" aria-live="polite"></div>
+        <p class="muted" id="layoutEmpty">Add widgets from the catalog to build your layout.</p>
+      </div>
+    </section>
+
+    <section class="card bg-base-100 shadow-sm">
+      <div class="card-body space-y-4">
+        <div class="flex items-center justify-between gap-3">
+          <div>
+            <p class="text-sm text-slate-500">Save and reuse common arrangements</p>
+            <h2 class="text-xl font-semibold">Widget Presets</h2>
+          </div>
+          <form id="presetForm" class="flex gap-2 flex-wrap items-center" autocomplete="off">
+            <label class="input input-bordered flex items-center gap-2">
+              <span>Name</span>
+              <input id="presetName" name="presetName" required class="grow" type="text" placeholder="Morning Routine" />
+            </label>
+            <button class="btn btn-primary" type="submit">Save preset</button>
+          </form>
+        </div>
+        <div id="presetList" class="preset-list" aria-live="polite"></div>
+        <p class="muted" id="presetsEmpty">No presets yet. Build a layout and save it for quick access.</p>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/js/classroom-widgets.js
+++ b/js/classroom-widgets.js
@@ -1,0 +1,326 @@
+const WIDGETS = [
+  {
+    id: 'timer',
+    name: 'Timer',
+    description: 'Count down or up to keep activities on schedule.',
+    categories: ['Focus', 'Time Management'],
+  },
+  {
+    id: 'noise-meter',
+    name: 'Noise Meter',
+    description: 'Visualizes classroom noise levels to encourage quieter work.',
+    categories: ['Awareness', 'Classroom Climate'],
+  },
+  {
+    id: 'name-picker',
+    name: 'Name Picker',
+    description: 'Randomly selects students to boost participation.',
+    categories: ['Engagement'],
+  },
+  {
+    id: 'qr-code',
+    name: 'QR Code',
+    description: 'Displays QR codes for quick resource sharing.',
+    categories: ['Resources'],
+  },
+  {
+    id: 'drawing-tool',
+    name: 'Drawing Tool',
+    description: 'Lightweight whiteboard for quick sketches.',
+    categories: ['Collaboration', 'Visual'],
+  },
+  {
+    id: 'instructions',
+    name: 'Class Instructions',
+    description: 'Pin reminders and expectations for the current activity.',
+    categories: ['Awareness', 'Classroom Climate'],
+  },
+];
+
+const PRESET_STORAGE_KEY = 'widgetPresets';
+
+function safeReadPresets() {
+  try {
+    const raw = window.localStorage.getItem(PRESET_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.warn('Widget presets: unable to read storage', error);
+    return [];
+  }
+}
+
+function safeWritePresets(presets) {
+  try {
+    window.localStorage.setItem(PRESET_STORAGE_KEY, JSON.stringify(presets));
+  } catch (error) {
+    console.warn('Widget presets: unable to write storage', error);
+  }
+}
+
+function createWidgetManager() {
+  const catalogContainer = document.getElementById('widgetCatalog');
+  const searchInput = document.getElementById('widgetSearch');
+  const categoryContainer = document.getElementById('categoryFilters');
+  const layoutSlots = document.getElementById('layoutSlots');
+  const layoutEmpty = document.getElementById('layoutEmpty');
+  const clearLayoutButton = document.getElementById('clearLayout');
+  const presetForm = document.getElementById('presetForm');
+  const presetNameInput = document.getElementById('presetName');
+  const presetList = document.getElementById('presetList');
+  const presetsEmpty = document.getElementById('presetsEmpty');
+
+  let selectedWidgets = [];
+  let activeCategory = 'All';
+  let presets = safeReadPresets();
+
+  const allCategories = Array.from(
+    new Set(WIDGETS.flatMap((widget) => widget.categories || []))
+  ).sort();
+
+  function renderCategories() {
+    const categories = ['All', ...allCategories];
+    categoryContainer.innerHTML = '';
+    categories.forEach((category) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'pill';
+      button.textContent = category;
+      button.setAttribute('aria-pressed', category === activeCategory ? 'true' : 'false');
+      button.addEventListener('click', () => {
+        activeCategory = category;
+        renderCategories();
+        renderCatalog();
+      });
+      categoryContainer.appendChild(button);
+    });
+  }
+
+  function matchesFilters(widget, query) {
+    const matchesCategory =
+      activeCategory === 'All' || (widget.categories || []).includes(activeCategory);
+    if (!matchesCategory) return false;
+    if (!query) return true;
+    const term = query.toLowerCase();
+    return (
+      widget.name.toLowerCase().includes(term) ||
+      widget.description.toLowerCase().includes(term) ||
+      (widget.categories || []).some((cat) => cat.toLowerCase().includes(term))
+    );
+  }
+
+  function renderCatalog() {
+    const query = (searchInput.value || '').trim().toLowerCase();
+    catalogContainer.innerHTML = '';
+    const filtered = WIDGETS.filter((widget) => matchesFilters(widget, query));
+
+    if (!filtered.length) {
+      const empty = document.createElement('p');
+      empty.className = 'muted';
+      empty.textContent = 'No widgets match your filters.';
+      catalogContainer.appendChild(empty);
+      return;
+    }
+
+    filtered.forEach((widget) => {
+      const card = document.createElement('article');
+      card.className = 'widget-card';
+
+      const title = document.createElement('h3');
+      title.textContent = widget.name;
+      card.appendChild(title);
+
+      const badgeRow = document.createElement('div');
+      badgeRow.className = 'widget-badges';
+      (widget.categories || []).forEach((cat) => {
+        const badge = document.createElement('span');
+        badge.className = 'badge';
+        badge.textContent = cat;
+        badgeRow.appendChild(badge);
+      });
+      card.appendChild(badgeRow);
+
+      const description = document.createElement('p');
+      description.textContent = widget.description;
+      card.appendChild(description);
+
+      const action = document.createElement('button');
+      action.type = 'button';
+      action.className = 'btn btn-sm btn-primary';
+      action.textContent = 'Add to layout';
+      action.addEventListener('click', () => {
+        selectedWidgets.push(widget.id);
+        renderLayout();
+      });
+      card.appendChild(action);
+
+      catalogContainer.appendChild(card);
+    });
+  }
+
+  function renderLayout() {
+    layoutSlots.innerHTML = '';
+    if (!selectedWidgets.length) {
+      layoutEmpty.hidden = false;
+      return;
+    }
+
+    layoutEmpty.hidden = true;
+    selectedWidgets.forEach((widgetId, index) => {
+      const widget = WIDGETS.find((item) => item.id === widgetId);
+      const container = document.createElement('div');
+      container.className = 'layout-slot';
+
+      const details = document.createElement('div');
+      details.className = 'flex-1';
+      const title = document.createElement('h3');
+      title.className = 'font-semibold';
+      title.textContent = widget ? widget.name : widgetId;
+      details.appendChild(title);
+
+      if (widget?.description) {
+        const description = document.createElement('p');
+        description.className = 'muted text-sm';
+        description.textContent = widget.description;
+        details.appendChild(description);
+      }
+
+      const controls = document.createElement('div');
+      controls.className = 'flex items-center gap-2';
+
+      const moveUp = document.createElement('button');
+      moveUp.type = 'button';
+      moveUp.className = 'btn btn-ghost btn-sm';
+      moveUp.textContent = '↑';
+      moveUp.title = 'Move up';
+      moveUp.disabled = index === 0;
+      moveUp.addEventListener('click', () => {
+        selectedWidgets.splice(index - 1, 0, selectedWidgets.splice(index, 1)[0]);
+        renderLayout();
+      });
+
+      const moveDown = document.createElement('button');
+      moveDown.type = 'button';
+      moveDown.className = 'btn btn-ghost btn-sm';
+      moveDown.textContent = '↓';
+      moveDown.title = 'Move down';
+      moveDown.disabled = index === selectedWidgets.length - 1;
+      moveDown.addEventListener('click', () => {
+        selectedWidgets.splice(index + 1, 0, selectedWidgets.splice(index, 1)[0]);
+        renderLayout();
+      });
+
+      const remove = document.createElement('button');
+      remove.type = 'button';
+      remove.className = 'btn btn-ghost btn-sm text-error';
+      remove.textContent = 'Remove';
+      remove.addEventListener('click', () => {
+        selectedWidgets.splice(index, 1);
+        renderLayout();
+      });
+
+      controls.appendChild(moveUp);
+      controls.appendChild(moveDown);
+      controls.appendChild(remove);
+      container.appendChild(details);
+      container.appendChild(controls);
+      layoutSlots.appendChild(container);
+    });
+  }
+
+  function renderPresets() {
+    presetList.innerHTML = '';
+    if (!presets.length) {
+      presetsEmpty.hidden = false;
+      return;
+    }
+
+    presetsEmpty.hidden = true;
+    presets.forEach((preset, index) => {
+      const row = document.createElement('div');
+      row.className = 'layout-slot bg-white';
+
+      const details = document.createElement('div');
+      details.className = 'flex-1';
+      const title = document.createElement('h3');
+      title.className = 'font-semibold';
+      title.textContent = preset.name;
+      details.appendChild(title);
+
+      const meta = document.createElement('p');
+      meta.className = 'muted text-sm';
+      meta.textContent = `${preset.widgets.length} widget${preset.widgets.length === 1 ? '' : 's'}`;
+      details.appendChild(meta);
+
+      const buttons = document.createElement('div');
+      buttons.className = 'flex items-center gap-2';
+
+      const apply = document.createElement('button');
+      apply.type = 'button';
+      apply.className = 'btn btn-primary btn-sm';
+      apply.textContent = 'Apply';
+      apply.addEventListener('click', () => {
+        selectedWidgets = [...preset.widgets];
+        renderLayout();
+      });
+
+      const remove = document.createElement('button');
+      remove.type = 'button';
+      remove.className = 'btn btn-ghost btn-sm text-error';
+      remove.textContent = 'Delete';
+      remove.addEventListener('click', () => {
+        presets.splice(index, 1);
+        safeWritePresets(presets);
+        renderPresets();
+      });
+
+      buttons.appendChild(apply);
+      buttons.appendChild(remove);
+      row.appendChild(details);
+      row.appendChild(buttons);
+      presetList.appendChild(row);
+    });
+  }
+
+  function initEvents() {
+    searchInput?.addEventListener('input', renderCatalog);
+    clearLayoutButton?.addEventListener('click', () => {
+      selectedWidgets = [];
+      renderLayout();
+    });
+
+    presetForm?.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const name = (presetNameInput.value || '').trim();
+      if (!name || !selectedWidgets.length) {
+        return;
+      }
+      presets = presets.filter((preset) => preset.name !== name);
+      presets.push({ name, widgets: [...selectedWidgets] });
+      safeWritePresets(presets);
+      renderPresets();
+      presetForm.reset();
+      presetNameInput.focus();
+    });
+  }
+
+  renderCategories();
+  renderCatalog();
+  renderLayout();
+  renderPresets();
+  initEvents();
+}
+
+function init() {
+  if (typeof document === 'undefined') return;
+  const appRoot = document.getElementById('widgetApp');
+  if (!appRoot) return;
+  createWidgetManager();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}


### PR DESCRIPTION
## Summary
- add a dedicated classroom widget manager page with catalog, layout, and preset controls
- implement vanilla JS widget management with search, category filters, reordering, and preset persistence in localStorage

## Testing
- npm test -- --runInBand *(fails on existing mobile/reminder suites in baseline)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69325a719b9c83249029b3bb7aa85e70)