### PR TITLE
Fix reminder header tab text visibility

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -4202,7 +4202,7 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   padding: 0.2rem 0.9rem;
   font-size: 0.82rem;
   font-weight: 600;
-  color: var(--text-muted);
+  color: var(--text-main, #0f172a);
   cursor: pointer;
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- update reminder tab styling to use the primary text color so labels stay visible in the header

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693279f509f0832494b79c9235bcae46)