### PR TITLE
Fix mobile header reminder tab text visibility

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -4924,6 +4924,18 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   box-shadow: 0 10px 24px rgba(81, 38, 99, 0.12);
 }
 
+/* Ensure reminder tab text stays visible on the mobile header */
+.mobile-header .reminder-tab,
+.mobile-header .reminders-tab {
+  color: var(--text-main) !important;
+}
+
+.mobile-header .reminder-tab.reminders-tab-active,
+.mobile-header .reminder-tab.active,
+.mobile-header .reminders-tab.active {
+  color: #fff !important;
+}
+
 .header-pill .quick-reminder {
   background: transparent !important;
   color: var(--text-main);


### PR DESCRIPTION
## Summary
- ensure reminder tab labels in the mobile header inherit readable text color
- keep active tab text white against the accent background for contrast

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69327ab539948324973e0b6037a5a0f7)