### PR TITLE
Remove completed button from daily header

### DIFF
--- a/404.html
+++ b/404.html
@@ -1065,9 +1065,6 @@
                 <button type="submit" class="btn btn-primary sm:w-auto">Add</button>
               </form>
               <div id="daily-tasks-container" class="mt-4 space-y-3"></div>
-              <button id="clear-completed-btn" type="button" class="btn btn-sm btn-outline mt-4" disabled>
-                Clear Completed Tasks
-              </button>
             </div>
           </section>
         </div>

--- a/docs/404.html
+++ b/docs/404.html
@@ -1065,9 +1065,6 @@
                 <button type="submit" class="btn btn-primary sm:w-auto">Add</button>
               </form>
               <div id="daily-tasks-container" class="mt-4 space-y-3"></div>
-              <button id="clear-completed-btn" type="button" class="btn btn-sm btn-outline mt-4" disabled>
-                Clear Completed Tasks
-              </button>
             </div>
           </section>
         </div>

--- a/js/tests/daily-tasks.test.js
+++ b/js/tests/daily-tasks.test.js
@@ -84,7 +84,6 @@ function setupDailyDom() {
         </form>
         <div id="daily-list-permission-notice" class="hidden">Permission required</div>
         <div id="daily-tasks-container"></div>
-        <button id="clear-completed-btn" type="button">Clear</button>
       </section>
     </div>
   `;
@@ -98,8 +97,7 @@ function setupDailyDom() {
     quickAddInput: document.getElementById('quick-add-input'),
     voiceButton: document.getElementById('daily-voice-btn'),
     permissionNotice: document.getElementById('daily-list-permission-notice'),
-    container: document.getElementById('daily-tasks-container'),
-    clearButton: document.getElementById('clear-completed-btn')
+    container: document.getElementById('daily-tasks-container')
   };
 }
 
@@ -116,7 +114,6 @@ function createManager(overrides = {}) {
     quickAddInput: elements.quickAddInput,
     quickAddVoiceButton: elements.voiceButton,
     dailyTasksContainer: elements.container,
-    clearCompletedButton: elements.clearButton,
     dailyListPermissionNotice: elements.permissionNotice,
     storage,
     window,


### PR DESCRIPTION
## Summary
- remove the clear completed tasks control from the daily tasks header markup
- align daily tasks tests with the removed control so they no longer expect the button

## Testing
- npm test *(fails in existing suites related to mobile auth/reminders quick add; see test output)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69328b660e708324820305288a2dae50)