### PR TITLE
Remove completed reminder filter from mobile

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -81,6 +81,13 @@ body.mobile-theme footer {
   overflow-x: hidden;
 }
 
+.mobile-shell #view-reminders .reminder-tabs {
+  justify-content: center;
+  margin-left: auto;
+  margin-right: auto;
+  gap: 0.35rem;
+}
+
 body.mobile-shell #mobile-shell #reminderList {
   width: 100%;
   max-width: 100%;

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -577,8 +577,6 @@ export async function initReminders(sel = {}) {
     let baseText;
     if (mobileRemindersFilterMode === 'today') {
       baseText = `Today\u2019s reminders \u2022 ${todayLabel}`;
-    } else if (mobileRemindersFilterMode === 'completed') {
-      baseText = `Completed reminders \u2022 ${todayLabel}`;
     } else {
       baseText = `All reminders \u2022 ${todayLabel}`;
     }
@@ -3620,7 +3618,9 @@ export async function initReminders(sel = {}) {
     }
 
     const isCompletedMode = filterMode === 'completed';
-    const filteredByStatus = rows.filter((entry) => !!entry?.done === isCompletedMode);
+    const filteredByStatus = isCompletedMode
+      ? rows.filter((entry) => !!entry?.done)
+      : rows.filter((entry) => !entry?.done);
 
     if (filterMode === 'today') {
       return filteredByStatus.filter((entry) => isReminderForTodayMobile(entry, todayRange));
@@ -3634,7 +3634,7 @@ export async function initReminders(sel = {}) {
       return false;
     }
 
-    if (!['all', 'today', 'completed'].includes(mode)) {
+    if (!['all', 'today'].includes(mode)) {
       return false;
     }
 

--- a/mobile.html
+++ b/mobile.html
@@ -4990,15 +4990,6 @@
           >
             Today
           </button>
-          <button
-            type="button"
-            class="reminder-tab reminders-tab"
-            data-reminders-tab="completed"
-            data-filter="completed"
-            aria-pressed="false"
-          >
-            Completed
-          </button>
         </div>
         <div class="relative header-overflow-wrapper">
           <button
@@ -5067,18 +5058,6 @@
             >
               <span aria-hidden="true">🔓</span>
               Sign out
-            </button>
-
-            <button
-              type="button"
-              class="overflow-item w-full"
-              role="menuitem"
-              data-reminders-tab="completed"
-            >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <polyline points="20 6 9 17 4 12" />
-              </svg>
-              Completed
             </button>
 
             <button


### PR DESCRIPTION
## Summary
- remove the Completed reminder filter button from the mobile tab row and overflow menu
- center remaining All and Today tabs in mobile layout without leftover spacing
- adjust mobile reminder filtering logic to handle only all/today modes gracefully

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69333f5197f08324a52d18a03e77d674)