### PR TITLE
Tighten mobile header pill spacing

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -136,6 +136,21 @@ body.mobile-theme .top-bar h2 {
   font-weight: 600;
 }
 
+.header-pill {
+  padding: 6px 12px !important;
+  margin-right: 6px !important;
+  border-radius: 20px;
+  font-size: 0.9rem;
+}
+
+.header-pill.active {
+  font-weight: 600;
+}
+
+.header-filter-container {
+  gap: 6px !important;
+}
+
 body.mobile-theme .app-header button,
 body.mobile-theme .top-bar button,
 body.mobile-theme header button,

--- a/mobile.html
+++ b/mobile.html
@@ -1273,13 +1273,14 @@
       flex: 1;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
-      padding: 0.35rem 0.75rem;
+      gap: 0.375rem;
+      padding: 6px 12px;
       background: var(--surface-elevated);
       border: 1px solid var(--border-subtle);
-      border-radius: 9999px;
+      border-radius: 20px;
       box-shadow: 0 2px 6px rgba(81, 38, 99, 0.15);
       color: var(--text-main);
+      font-size: 0.9rem;
     }
 
     #slimMobileHeader .header-pill svg {
@@ -1292,7 +1293,7 @@
       flex: 1;
       border: none;
       background: transparent;
-      padding: 0.25rem 0.5rem;
+      padding: 0.25rem 0.35rem;
       color: var(--text-main);
       font-size: 0.9rem;
     }
@@ -1302,12 +1303,15 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      width: 2rem;
-      height: 2rem;
+      width: 44px;
+      height: 44px;
+      min-width: 44px;
+      min-height: 44px;
+      padding: 6px;
       border: none;
       background: transparent;
       color: var(--accent-color);
-      border-radius: 0.5rem;
+      border-radius: 12px;
       cursor: pointer;
       transition: background-color 0.2s ease;
     }
@@ -1316,14 +1320,16 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      width: 2rem;
-      height: 2rem;
+      width: 44px;
+      height: 44px;
+      min-width: 44px;
+      min-height: 44px;
       border: none;
       background: transparent;
       color: var(--accent-color);
-      border-radius: 0.5rem;
+      border-radius: 12px;
       cursor: pointer;
-      padding: 0;
+      padding: 6px;
       transition:
         background-color 0.15s ease,
         box-shadow 0.15s ease,
@@ -4159,7 +4165,7 @@
     #reminders-slim-header .header-actions {
       display: inline-flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.375rem;
       z-index: 65;
     }
 
@@ -4181,9 +4187,27 @@
       padding: 0.45rem 0.75rem;
       display: flex;
       align-items: center;
-      gap: 0.75rem;
+      gap: 0.5rem;
       color: #512663;
       border: 1px solid rgba(81, 38, 99, 0.08);
+    }
+
+    #reminders-slim-header .reminder-tabs {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+      padding: 0;
+      flex-wrap: nowrap;
+      overflow-x: auto;
+    }
+
+    #reminders-slim-header .reminder-tab,
+    #reminders-slim-header .reminders-tab {
+      padding: 6px 12px;
+      min-height: 44px;
+      min-width: 44px;
+      border-radius: 20px;
+      font-size: 0.9rem;
     }
 
     .header-pill {
@@ -4191,13 +4215,14 @@
       margin-inline: auto;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
-      padding: 0.35rem 0.75rem;
+      gap: 0.375rem;
+      padding: 6px 12px;
       background: var(--surface-elevated);
       border: 1px solid var(--border-subtle);
-      border-radius: 9999px;
+      border-radius: 20px;
       box-shadow: var(--mobile-quick-shadow);
       color: var(--text-main);
+      font-size: 0.9rem;
     }
 
     .header-pill input.quick-reminder {
@@ -4205,7 +4230,7 @@
       min-width: 0;
       border: none;
       background: transparent;
-      padding: 0.25rem 0.5rem;
+      padding: 0.25rem 0.35rem;
       color: var(--text-main);
       font-size: var(--font-size-body);
       font-family: var(--font-primary);
@@ -4220,14 +4245,23 @@
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 2rem;
-      height: 2rem;
+      width: 44px;
+      height: 44px;
+      min-width: 44px;
+      min-height: 44px;
+      padding: 6px;
       border: none;
       background: transparent;
       color: var(--accent-color);
-      border-radius: 0.5rem;
+      border-radius: 12px;
       cursor: pointer;
       transition: background-color 0.2s ease, color 0.2s ease;
+    }
+
+    .reminders-quick-actions {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
     }
 
     .reminders-quick-add .quick-icon {
@@ -4263,26 +4297,30 @@
       color: #512663;
       background: transparent;
       border: none;
-      border-radius: 999px;
+      border-radius: 16px;
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      min-width: 36px;
-      min-height: 36px;
+      width: 44px;
+      height: 44px;
+      min-width: 44px;
+      min-height: 44px;
+      padding: 6px;
       transition: background-color 0.15s ease;
     }
 
     #reminders-slim-header .header-actions .icon-btn {
-      width: 36px;
-      height: 36px;
+      width: 44px;
+      height: 44px;
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      border-radius: 999px;
+      border-radius: 16px;
       background: transparent;
       border: none;
       color: #512663;
       cursor: pointer;
+      padding: 6px;
       transition: background-color 0.15s ease;
     }
 
@@ -4306,9 +4344,11 @@
       background: transparent;
       border: none;
       color: #512663;
-      padding: 0.15rem;
-      min-width: 36px;
-      min-height: 36px;
+      padding: 6px;
+      min-width: 44px;
+      min-height: 44px;
+      width: 44px;
+      height: 44px;
       display: inline-flex;
       align-items: center;
       justify-content: center;


### PR DESCRIPTION
## Summary
- reduce padding and gaps on mobile header pills and reminder filters while keeping touch targets at least 44px
- add compact spacing styles for header buttons and quick actions on mobile
- update mobile theme overrides to enforce consistent pill sizing and active weight

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933424d6094832489c9fe260aed0e6c)