### PR TITLE
Adjust mobile header spacing and quick add bar

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -137,8 +137,8 @@ body.mobile-theme .top-bar h2 {
 }
 
 .header-pill {
-  padding: 6px 12px !important;
-  margin-right: 6px !important;
+  padding: 10px 14px !important;
+  margin-right: 4px !important;
   border-radius: 20px;
   font-size: 0.9rem;
 }

--- a/mobile.html
+++ b/mobile.html
@@ -4215,8 +4215,8 @@
       margin-inline: auto;
       display: flex;
       align-items: center;
-      gap: 0.375rem;
-      padding: 6px 12px;
+      gap: 0.35rem;
+      padding: 10px 14px;
       background: var(--surface-elevated);
       border: 1px solid var(--border-subtle);
       border-radius: 20px;
@@ -4230,9 +4230,9 @@
       min-width: 0;
       border: none;
       background: transparent;
-      padding: 0.25rem 0.35rem;
+      padding: 0.45rem 0.55rem;
       color: var(--text-main);
-      font-size: var(--font-size-body);
+      font-size: 0.95rem;
       font-family: var(--font-primary);
       font-weight: 400;
     }

--- a/styles/index.css
+++ b/styles/index.css
@@ -4052,7 +4052,7 @@ section[data-route="dashboard"] .dashboard-shortcuts {
 .reminders-top-bar {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.3rem;
   padding: 0.5rem 0.75rem 0.25rem;
   width: 100%;
 }
@@ -4066,7 +4066,7 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.25rem;
 }
 
 .reminders-quick-input {
@@ -4074,8 +4074,8 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   min-width: 0;
   display: flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.3rem 0.55rem;
+  gap: 0.45rem;
+  padding: 0.45rem 0.9rem;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.9);
   border: 1px solid var(--border-subtle);
@@ -4086,8 +4086,8 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   min-width: 0;
   border-radius: 999px;
   border: none;
-  padding: 0.3rem 0.35rem;
-  font-size: 0.9rem;
+  padding: 0.45rem 0.55rem;
+  font-size: 0.95rem;
   background: transparent;
   color: var(--text-main);
 }


### PR DESCRIPTION
## Summary
- reduce the gaps between header pills to reclaim space in the mobile header
- enlarge the quick add pill padding and text for a taller, more usable entry bar
- align the mobile theme pill spacing to match the updated sizing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69335cd79d2c8324b00da988a5f88b31)