### PR TITLE
Tighten mobile header pill spacing

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -137,8 +137,8 @@ body.mobile-theme .top-bar h2 {
 }
 
 .header-pill {
-  padding: 10px 14px !important;
-  margin-right: 4px !important;
+  padding: 6px 12px !important;
+  margin-right: 6px !important;
   border-radius: 20px;
   font-size: 0.9rem;
 }

--- a/mobile.html
+++ b/mobile.html
@@ -4216,7 +4216,7 @@
       display: flex;
       align-items: center;
       gap: 0.35rem;
-      padding: 10px 14px;
+      padding: 6px 12px;
       background: var(--surface-elevated);
       border: 1px solid var(--border-subtle);
       border-radius: 20px;


### PR DESCRIPTION
## Summary
- reduce mobile header pill padding to meet 6px by 12px sizing and keep 0.9rem typography
- adjust mobile theme pill spacing to keep compact gaps and consistent margins

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69337de9610883248213d79d53b567bf)