### PR TITLE
Move reminder controls above quick add on mobile

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -42,94 +42,62 @@
       --icon-inactive: #4c5c7a;
       --icon-active: #512663;
       --true-blue: #0073cf;
-        </div>
-        <!-- move reminder controls inside the top primary so they align with the quick-add -->
-        <div class="reminders-top-controls">
-          <div class="reminder-tabs" role="tablist" aria-label="Reminder filters">
-            <button
-              type="button"
-              class="reminder-tab reminders-tab reminders-tab-active active"
-              data-reminders-tab="all"
-              data-filter="all"
-              aria-pressed="true"
-            >
-              All
-            </button>
-            <button
-              type="button"
-              class="reminder-tab reminders-tab"
-              data-reminders-tab="today"
-              data-filter="today"
-              aria-pressed="false"
-            >
-              Today
-            </button>
-            <!-- Completed moved to overflow menu (kept there) -->
-          </div>
-          <div class="relative header-overflow-wrapper">
-            <button
-              id="headerMenuBtn"
-              type="button"
-              class="header-action-btn icon-btn quick-add-action reminders-top-overflow"
-              aria-label="More options"
-              aria-expanded="false"
-              aria-haspopup="true"
-            >
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <circle cx="12" cy="12" r="1"/>
-                <circle cx="12" cy="5" r="1"/>
-                <circle cx="12" cy="19" r="1"/>
-              </svg>
-            </button>
+    }
 
-            <!-- Dropdown menu -->
-            <div
-              id="headerMenu"
-              class="overflow-menu hidden"
-              role="menu"
-              aria-labelledby="headerMenuBtn"
-            >
-              <button
-                id="notifHeaderBtn"
-                type="button"
-                class="overflow-item w-full"
-                role="menuitem"
-              >
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/>
-                  <path d="m13.73 21a2 2 0 0 1-3.46 0"/>
-                </svg>
-                Notifications
-              </button>
-
-              <button
-                type="button"
-                class="overflow-item w-full"
-                role="menuitem"
-                onclick="window.location.href='/'"
-              >
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
-                  <polyline points="9,22 9,12 15,12 15,22"/>
-                </svg>
-                Home
-              </button>
-
-              <button
-                id="googleSignInBtn"
-                type="button"
-                class="overflow-item w-full"
-                role="menuitem"
-              >
-                <span aria-hidden="true">🔐</span>
-                Sign in
-              </button>
-
-            </div>
-          </div>
-
+    body {
       font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
       line-height: 1.5;
+    }
+
+    /* Container for All / Today / overflow above quick-add */
+    .reminders-top-controls {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      padding: 0.4rem 1rem 0.25rem;
+    }
+
+    /* Tabs group on the left */
+    .reminder-tabs {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 2px;
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--surface-elevated, #f9f9fb) 85%, transparent);
+    }
+
+    /* Individual tab buttons */
+    .reminder-tab {
+      border: none;
+      background: transparent;
+      padding: 0.25rem 0.7rem;
+      border-radius: 999px;
+      font-size: 0.8rem;
+      font-weight: 500;
+      color: var(--text-secondary);
+      cursor: pointer;
+      transition: background 0.15s ease, color 0.15s ease;
+    }
+
+    .reminder-tab.reminders-tab-active,
+    .reminder-tab.active,
+    .reminder-tab[aria-pressed="true"] {
+      background: color-mix(in srgb, var(--accent-color) 16%, #ffffff);
+      color: var(--text-main);
+    }
+
+    /* Overflow menu button aligned on the right */
+    .header-overflow-wrapper {
+      display: flex;
+      align-items: center;
+    }
+
+    .reminders-top-overflow {
+      min-width: 2.5rem;
+      min-height: 2.5rem;
+      border-radius: 999px;
     }
 
     /* Mobile reminder cards coloured by priority using existing tokens */
@@ -5055,6 +5023,179 @@
   >
     <div class="reminders-top-bar">
       <div class="reminders-top-primary">
+        <div class="reminders-top-controls">
+          <div class="reminder-tabs" role="tablist" aria-label="Reminder filters">
+            <button
+              type="button"
+              class="reminder-tab reminders-tab reminders-tab-active active"
+              data-reminders-tab="all"
+              data-filter="all"
+              aria-pressed="true"
+            >
+              All
+            </button>
+            <button
+              type="button"
+              class="reminder-tab reminders-tab"
+              data-reminders-tab="today"
+              data-filter="today"
+              aria-pressed="false"
+            >
+              Today
+            </button>
+            <!-- Completed moved to overflow menu (kept there) -->
+          </div>
+          <div class="relative header-overflow-wrapper">
+            <button
+              id="headerMenuBtn"
+              type="button"
+              class="header-action-btn icon-btn quick-add-action reminders-top-overflow"
+              aria-label="More options"
+              aria-expanded="false"
+              aria-haspopup="true"
+            >
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <circle cx="12" cy="12" r="1"/>
+                <circle cx="12" cy="5" r="1"/>
+                <circle cx="12" cy="19" r="1"/>
+              </svg>
+            </button>
+
+            <!-- Dropdown menu -->
+            <div
+              id="headerMenu"
+              class="overflow-menu hidden"
+              role="menu"
+              aria-labelledby="headerMenuBtn"
+            >
+              <button
+                id="notifHeaderBtn"
+                type="button"
+                class="overflow-item w-full"
+                role="menuitem"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/>
+                  <path d="m13.73 21a2 2 0 0 1-3.46 0"/>
+                </svg>
+                Notifications
+              </button>
+
+              <button
+                type="button"
+                class="overflow-item w-full"
+                role="menuitem"
+                onclick="window.location.href='/'"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+                  <polyline points="9,22 9,12 15,12 15,22"/>
+                </svg>
+                Home
+              </button>
+
+              <button
+                id="googleSignInBtn"
+                type="button"
+                class="overflow-item w-full"
+                role="menuitem"
+              >
+                <span aria-hidden="true">🔐</span>
+                Sign in
+              </button>
+
+              <button
+                id="googleSignOutBtn"
+                type="button"
+                class="overflow-item w-full hidden"
+                role="menuitem"
+              >
+                <span aria-hidden="true">🔓</span>
+                Sign out
+              </button>
+
+              <button
+                id="openSettings"
+                type="button"
+                class="overflow-item w-full"
+                role="menuitem"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
+                  <circle cx="12" cy="12" r="3"/>
+                </svg>
+                Settings
+              </button>
+
+              <button
+                id="viewToggleMenu"
+                type="button"
+                class="overflow-item w-full justify-between"
+                role="menuitem"
+                aria-pressed="false"
+                aria-live="polite"
+              >
+                <span class="flex items-center gap-3">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <rect x="3" y="4" width="7" height="6" rx="1" />
+                    <rect x="14" y="4" width="7" height="6" rx="1" />
+                    <rect x="3" y="14" width="7" height="6" rx="1" />
+                    <rect x="14" y="14" width="7" height="6" rx="1" />
+                  </svg>
+                  Layout
+                </span>
+                <span id="viewToggleLabel" class="text-xs font-semibold tracking-wide text-gray-600">View layout: Stacked</span>
+              </button>
+
+              <button
+                id="btn-theme"
+                type="button"
+                class="overflow-item w-full"
+                role="menuitem"
+              >
+                <svg
+                  id="icon-sun"
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <circle cx="12" cy="12" r="4" />
+                  <path d="M12 2v2m0 16v2m10-10h-2M4 12H2m15.657-7.657-1.414 1.414M7.757 16.243l-1.414 1.414m0-12.728 1.414 1.414m8.486 8.486 1.414 1.414" />
+                </svg>
+                <svg
+                  id="icon-moon"
+                  class="hidden"
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+                </svg>
+                Toggle theme
+              </button>
+
+              <button
+                type="button"
+                class="overflow-item w-full"
+                role="menuitem"
+                onclick="window.open('https://github.com/dmaher42/memory-cue', '_blank')"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <circle cx="12" cy="12" r="10"/>
+                  <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
+                  <path d="M12 17h.01"/>
+                </svg>
+                About
+              </button>
+            </div>
+          </div>
+        </div>
         <div class="reminders-quick-input header-pill">
           <input
             id="quickAddInput"
@@ -5090,179 +5231,6 @@
               <svg class="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg">
                 <path d="M20.285 6.708a1 1 0 0 0-1.414-1.416L9 15.164l-3.871-3.87a1 1 0 1 0-1.414 1.415l4.578 4.579a1 1 0 0 0 1.414 0l10.478-10.479z" fill="currentColor" />
               </svg>
-            </button>
-          </div>
-        </div>
-      </div>
-      <div class="reminders-top-controls">
-        <div class="reminder-tabs" role="tablist" aria-label="Reminder filters">
-          <button
-            type="button"
-            class="reminder-tab reminders-tab reminders-tab-active active"
-            data-reminders-tab="all"
-            data-filter="all"
-            aria-pressed="true"
-          >
-            All
-          </button>
-          <button
-            type="button"
-            class="reminder-tab reminders-tab"
-            data-reminders-tab="today"
-            data-filter="today"
-            aria-pressed="false"
-          >
-            Today
-          </button>
-          <!-- Completed moved to overflow menu (kept there) -->
-        </div>
-        <div class="relative header-overflow-wrapper">
-          <button
-            id="headerMenuBtn"
-            type="button"
-            class="header-action-btn icon-btn quick-add-action reminders-top-overflow"
-            aria-label="More options"
-            aria-expanded="false"
-            aria-haspopup="true"
-          >
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <circle cx="12" cy="12" r="1"/>
-              <circle cx="12" cy="5" r="1"/>
-              <circle cx="12" cy="19" r="1"/>
-            </svg>
-          </button>
-
-          <!-- Dropdown menu -->
-          <div
-            id="headerMenu"
-            class="overflow-menu hidden"
-            role="menu"
-            aria-labelledby="headerMenuBtn"
-          >
-            <button
-              id="notifHeaderBtn"
-              type="button"
-              class="overflow-item w-full"
-              role="menuitem"
-            >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/>
-                <path d="m13.73 21a2 2 0 0 1-3.46 0"/>
-              </svg>
-              Notifications
-            </button>
-
-            <button
-              type="button"
-              class="overflow-item w-full"
-              role="menuitem"
-              onclick="window.location.href='/'"
-            >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
-                <polyline points="9,22 9,12 15,12 15,22"/>
-              </svg>
-              Home
-            </button>
-
-            <button
-              id="googleSignInBtn"
-              type="button"
-              class="overflow-item w-full"
-              role="menuitem"
-            >
-              <span aria-hidden="true">🔐</span>
-              Sign in
-            </button>
-
-            <button
-              id="googleSignOutBtn"
-              type="button"
-              class="overflow-item w-full hidden"
-              role="menuitem"
-            >
-              <span aria-hidden="true">🔓</span>
-              Sign out
-            </button>
-
-            <button
-              id="openSettings"
-              type="button"
-              class="overflow-item w-full"
-              role="menuitem"
-            >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
-                <circle cx="12" cy="12" r="3"/>
-              </svg>
-              Settings
-            </button>
-
-            <button
-              id="viewToggleMenu"
-              type="button"
-              class="overflow-item w-full justify-between"
-              role="menuitem"
-              aria-pressed="false"
-              aria-live="polite"
-            >
-              <span class="flex items-center gap-3">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <rect x="3" y="4" width="7" height="6" rx="1" />
-                  <rect x="14" y="4" width="7" height="6" rx="1" />
-                  <rect x="3" y="14" width="7" height="6" rx="1" />
-                  <rect x="14" y="14" width="7" height="6" rx="1" />
-                </svg>
-                Layout
-              </span>
-              <span id="viewToggleLabel" class="text-xs font-semibold tracking-wide text-gray-600">View layout: Stacked</span>
-            </button>
-
-            <button
-              id="btn-theme"
-              type="button"
-              class="overflow-item w-full"
-              role="menuitem"
-            >
-              <svg
-                id="icon-sun"
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <circle cx="12" cy="12" r="4" />
-                <path d="M12 2v2m0 16v2m10-10h-2M4 12H2m15.657-7.657-1.414 1.414M7.757 16.243l-1.414 1.414m0-12.728 1.414 1.414m8.486 8.486 1.414 1.414" />
-              </svg>
-              <svg
-                id="icon-moon"
-                class="hidden"
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-              </svg>
-              Toggle theme
-            </button>
-
-            <button
-              type="button"
-              class="overflow-item w-full"
-              role="menuitem"
-              onclick="window.open('https://github.com/dmaher42/memory-cue', '_blank')"
-            >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <circle cx="12" cy="12" r="10"/>
-                <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
-                <path d="M12 17h.01"/>
-              </svg>
-              About
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- place the reminder filter tabs and overflow menu above the mobile quick-add bar
- add styling so the new controls align with the quick-add layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6933ed5fa7908327bfb8cfdd05ae9570)