### PR TITLE
Create single-row reminders header bar

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -49,55 +49,100 @@
       line-height: 1.5;
     }
 
-    /* Container for All / Today / overflow above quick-add */
-    .reminders-top-controls {
+    /* Single-row iOS-style reminders top bar */
+    .reminders-top-row {
       display: flex;
       align-items: center;
-      justify-content: space-between;
-      gap: 0.75rem;
-      padding: 0.4rem 1rem 0.25rem;
+      padding: 0.4rem 0.2rem;
+      gap: 0.5rem;
+      white-space: nowrap;
+      overflow: hidden;
+      flex-wrap: nowrap;
+      position: relative;
     }
 
-    /* Tabs group on the left */
+    .reminders-quick-bar {
+      display: flex;
+      align-items: center;
+      gap: 0.45rem;
+      flex: 1 1 auto;
+      min-width: 0;
+      padding: 0.45rem 0.7rem;
+      background: color-mix(in srgb, #f4f1fb 88%, #ffffff);
+      border: 1px solid color-mix(in srgb, #dcd3ec 65%, transparent);
+      border-radius: 999px;
+      box-shadow: 0 10px 25px rgba(81, 38, 99, 0.07);
+    }
+
+    .reminders-quick-bar input#quickAddInput {
+      flex: 1 1 auto;
+      min-width: 0;
+      border: none;
+      background: transparent;
+      font-size: 0.9rem;
+      color: var(--text-main);
+      padding: 0.3rem 0.2rem;
+    }
+
+    .reminders-quick-bar input#quickAddInput::placeholder {
+      color: var(--text-muted);
+    }
+
     .reminder-tabs {
       display: inline-flex;
       align-items: center;
-      gap: 0.25rem;
-      padding: 2px;
+      gap: 0.2rem;
+      padding: 0.12rem;
       border-radius: 999px;
-      background: color-mix(in srgb, var(--surface-elevated, #f9f9fb) 85%, transparent);
+      background: color-mix(in srgb, #e8e1f4 78%, #ffffff);
+      flex-shrink: 0;
     }
 
-    /* Individual tab buttons */
     .reminder-tab {
       border: none;
       background: transparent;
       padding: 0.25rem 0.7rem;
       border-radius: 999px;
-      font-size: 0.8rem;
-      font-weight: 500;
-      color: var(--text-secondary);
+      font-size: 0.82rem;
+      font-weight: 600;
+      color: color-mix(in srgb, var(--accent-color) 55%, #7b6a8b);
       cursor: pointer;
       transition: background 0.15s ease, color 0.15s ease;
+      white-space: nowrap;
     }
 
     .reminder-tab.reminders-tab-active,
     .reminder-tab.active,
     .reminder-tab[aria-pressed="true"] {
-      background: color-mix(in srgb, var(--accent-color) 16%, #ffffff);
-      color: var(--text-main);
+      background: var(--accent-color);
+      color: #ffffff;
     }
 
-    /* Overflow menu button aligned on the right */
-    .header-overflow-wrapper {
-      display: flex;
+    .reminders-quick-actions {
+      display: inline-flex;
       align-items: center;
+      gap: 0.25rem;
+      flex-shrink: 0;
     }
 
-    .reminders-top-overflow {
-      min-width: 2.5rem;
-      min-height: 2.5rem;
+    .reminders-quick-actions .icon-btn {
+      border: none;
+      background: transparent;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.32rem;
       border-radius: 999px;
+      cursor: pointer;
+      color: var(--accent-color);
+      transition: background-color 0.15s ease, transform 0.15s ease;
+      flex-shrink: 0;
+    }
+
+    .reminders-quick-actions .icon-btn:hover,
+    .reminders-quick-actions .icon-btn:focus-visible {
+      background: color-mix(in srgb, var(--accent-color) 12%, transparent);
+      outline: none;
     }
 
     /* Mobile reminder cards coloured by priority using existing tokens */
@@ -4102,36 +4147,6 @@
       }
     }
 
-    /* Tighter header sizing for small mobile viewports */
-    @media (max-width: 420px) {
-      /* Reduce gaps and overall pill sizes */
-      .reminders-top-bar { gap: 0.35rem; }
-      .reminders-quick-add { padding: 0.3rem 0.5rem; border-radius: 20px; }
-      .reminders-quick-add .quick-icon { width: 36px; height: 36px; }
-      .reminders-quick-add input { font-size: 0.88rem; padding: 0.45rem 0.6rem; }
-
-      /* Shrink action buttons (mic, save, notebook) */
-      .header-action-btn, .header-action-btn.icon-btn, .reminders-quick-add .quick-icon,
-      #reminders-slim-header .header-action-btn, .mc-quick-submit, .mc-quick-voice {
-        width: 36px; height: 36px; min-width: 36px; min-height: 36px; padding: 6px;
-      }
-
-      /* Make reminder tabs slightly smaller to match */
-      #reminders-slim-header .reminder-tab,
-      #reminders-slim-header .reminders-tab {
-        padding: 4px 10px;
-        min-height: 36px;
-        min-width: 36px;
-        font-size: 0.85rem;
-      }
-
-      /* Reduce gap between tabs and overflow */
-      #reminders-slim-header .reminder-tabs { gap: 0.25rem; }
-
-      /* Ensure header actions don't push layout vertically */
-      #reminders-slim-header .header-actions { gap: 0.25rem; }
-    }
-
     /* Header shadow when scrolled */
     .header-shadow {
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
@@ -4152,260 +4167,25 @@
       color: var(--text-strong, #34163f);
     }
 
-    /* Make the header-shell a full-width flex container that spaces children */
-    #reminders-slim-header .header-shell {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      width: 100%;
-      max-width: 1080px;
-    }
+    /* Tighter header sizing for small mobile viewports */
+    @media (max-width: 420px) {
+      .reminders-top-row {
+        padding: 0.25rem 0.1rem;
+      }
 
-    #reminders-slim-header .header-leading,
-    #reminders-slim-header .header-actions {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.375rem;
-      z-index: 65;
-    }
+      .reminders-quick-bar {
+        padding: 0.35rem 0.55rem;
+        gap: 0.35rem;
+      }
 
-    #reminders-slim-header .header-quick-add {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      padding: 0 0.5rem;
-      z-index: 62;
-      width: 100%;
-    }
+      .reminder-tab {
+        padding: 0.22rem 0.6rem;
+        font-size: 0.78rem;
+      }
 
-    /* Layout: place quick-add and reminder controls on the same row */
-    .reminders-top-bar {
-      display: flex;
-      align-items: center;
-      justify-content: space-between; /* ensure controls sit on right */
-      width: 100%;
-      gap: 0.5rem;
-      flex-wrap: nowrap;
-    }
-
-    .reminders-top-primary {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      flex: 1 1 auto; /* allow quick-add to take remaining space */
-      min-width: 0;
-    }
-
-    /* Make the quick-add take at least 50% of the header width (use 60% preferred)
-       so the control pills can live to the right and still align with the bar. */
-    .reminders-quick-add {
-      flex: 0 1 60%;
-      min-width: 50%;
-      display: flex;
-      align-items: center;
-    }
-
-    /* Push the tabs/overflow to the right end of the header row */
-    .reminders-top-controls {
-      /* keep controls on the same row; no auto margin required when parent uses space-between */
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      flex: 0 0 auto;
-      margin-left: 0;
-    }
-
-    /* Ensure reminder tabs visually match the quick-add height */
-    #reminders-slim-header .reminder-tab,
-    #reminders-slim-header .reminders-tab {
-      padding: 6px 12px;
-      min-height: 44px;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      border-radius: 20px;
-      box-sizing: border-box;
-    }
-
-    .reminders-quick-add {
-      width: 100%;
-      max-width: 820px;
-      background: #FBFBFD;
-      border-radius: 28px;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-      padding: 0.45rem 0.75rem;
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      color: #512663;
-      border: 1px solid rgba(81, 38, 99, 0.08);
-    }
-
-    #reminders-slim-header .reminder-tabs {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.375rem;
-      padding: 0;
-      flex-wrap: nowrap;
-      overflow-x: auto;
-    }
-
-    #reminders-slim-header .reminder-tab,
-    #reminders-slim-header .reminders-tab {
-      padding: 6px 12px;
-      min-height: 44px;
-      min-width: 44px;
-      border-radius: 20px;
-      font-size: 0.9rem;
-    }
-
-    .header-pill {
-      width: 100%;
-      margin-inline: auto;
-      display: flex;
-      align-items: center;
-      gap: 0.35rem;
-      padding: 6px 12px;
-      background: var(--surface-elevated);
-      border: 1px solid var(--border-subtle);
-      border-radius: 20px;
-      box-shadow: var(--mobile-quick-shadow);
-      color: var(--text-main);
-      font-size: 0.9rem;
-    }
-
-    .header-pill input.quick-reminder {
-      flex: 1 1 auto;
-      min-width: 0;
-      border: none;
-      background: transparent;
-      padding: 0.45rem 0.55rem;
-      color: var(--text-main);
-      font-size: 0.95rem;
-      font-family: var(--font-primary);
-      font-weight: 400;
-    }
-
-    .header-pill input.quick-reminder:focus {
-      outline: 2px solid rgba(81, 38, 99, 0.25);
-    }
-
-    .header-pill button {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 44px;
-      height: 44px;
-      min-width: 44px;
-      min-height: 44px;
-      padding: 6px;
-      border: none;
-      background: transparent;
-      color: var(--accent-color);
-      border-radius: 12px;
-      cursor: pointer;
-      transition: background-color 0.2s ease, color 0.2s ease;
-    }
-
-    .reminders-quick-actions {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.375rem;
-    }
-
-    .reminders-quick-add .quick-icon {
-      width: 42px;
-      height: 42px;
-      border-radius: 999px;
-      background: #F9F9F9;
-      color: #512663;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.04);
-      flex-shrink: 0;
-    }
-
-    .reminders-quick-add input {
-      border: none;
-      outline: none;
-      background: #F9F9F9;
-      width: 100%;
-      font-size: 0.95rem;
-      color: #512663;
-      padding: 0.55rem 0.9rem;
-      border-radius: 999px;
-      box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.04);
-    }
-
-    .reminders-quick-add input::placeholder {
-      color: color-mix(in srgb, #512663 38%, #8c77a3);
-    }
-
-    #reminders-slim-header .header-action-btn {
-      color: #512663;
-      background: transparent;
-      border: none;
-      border-radius: 16px;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 44px;
-      height: 44px;
-      min-width: 44px;
-      min-height: 44px;
-      padding: 6px;
-      transition: background-color 0.15s ease;
-    }
-
-    #reminders-slim-header .header-actions .icon-btn {
-      width: 44px;
-      height: 44px;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      border-radius: 16px;
-      background: transparent;
-      border: none;
-      color: #512663;
-      cursor: pointer;
-      padding: 6px;
-      transition: background-color 0.15s ease;
-    }
-
-    #reminders-slim-header .header-actions .icon-btn:hover {
-      background: rgba(81, 38, 99, 0.08);
-    }
-
-    #reminders-slim-header .header-actions .icon-btn:focus-visible {
-      outline: 2px solid rgba(81, 38, 99, 0.24);
-      outline-offset: 2px;
-    }
-
-    /* Hide inline Save/Notebook actions in notebook row */
-    .notebook-actions-row .notebook-action-btn.save,
-    .notebook-actions-row .notebook-action-btn.saved {
-      display: none !important;
-    }
-
-    /* Make the notebook Save icon clearly visible in the header */
-    #reminders-slim-header #noteSaveMobile {
-      background: transparent;
-      border: none;
-      color: #512663;
-      padding: 6px;
-      min-width: 44px;
-      min-height: 44px;
-      width: 44px;
-      height: 44px;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    #reminders-slim-header #noteSaveMobile:focus-visible {
-      outline: 2px solid rgba(81, 38, 99, 0.24);
-      outline-offset: 2px;
+      .reminders-quick-actions .icon-btn {
+        padding: 0.26rem;
+      }
     }
 
     /* Adjust main content to account for sticky header */
@@ -5021,219 +4801,223 @@
     class="mobile-header px-3 py-2 pt-safe-top"
     role="banner"
   >
-    <div class="reminders-top-bar">
-      <div class="reminders-top-primary">
-        <div class="reminders-top-controls">
-          <div class="reminder-tabs" role="tablist" aria-label="Reminder filters">
-            <button
-              type="button"
-              class="reminder-tab reminders-tab reminders-tab-active active"
-              data-reminders-tab="all"
-              data-filter="all"
-              aria-pressed="true"
-            >
-              All
-            </button>
-            <button
-              type="button"
-              class="reminder-tab reminders-tab"
-              data-reminders-tab="today"
-              data-filter="today"
-              aria-pressed="false"
-            >
-              Today
-            </button>
-            <!-- Completed moved to overflow menu (kept there) -->
-          </div>
-          <div class="relative header-overflow-wrapper">
-            <button
-              id="headerMenuBtn"
-              type="button"
-              class="header-action-btn icon-btn quick-add-action reminders-top-overflow"
-              aria-label="More options"
-              aria-expanded="false"
-              aria-haspopup="true"
-            >
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <circle cx="12" cy="12" r="1"/>
-                <circle cx="12" cy="5" r="1"/>
-                <circle cx="12" cy="19" r="1"/>
-              </svg>
-            </button>
+    <div class="reminders-top-row">
+      <form id="quickAddForm" class="reminders-quick-bar" onsubmit="return false;">
+        <input
+          id="quickAddInput"
+          type="text"
+          placeholder="Quick reminder…"
+          class="quick-reminder quick-add-input w-full text-sm"
+          autocomplete="off"
+          aria-label="Quick add reminder"
+        />
 
-            <!-- Dropdown menu -->
-            <div
-              id="headerMenu"
-              class="overflow-menu hidden"
-              role="menu"
-              aria-labelledby="headerMenuBtn"
-            >
-              <button
-                id="notifHeaderBtn"
-                type="button"
-                class="overflow-item w-full"
-                role="menuitem"
-              >
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/>
-                  <path d="m13.73 21a2 2 0 0 1-3.46 0"/>
-                </svg>
-                Notifications
-              </button>
-
-              <button
-                type="button"
-                class="overflow-item w-full"
-                role="menuitem"
-                onclick="window.location.href='/'"
-              >
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
-                  <polyline points="9,22 9,12 15,12 15,22"/>
-                </svg>
-                Home
-              </button>
-
-              <button
-                id="googleSignInBtn"
-                type="button"
-                class="overflow-item w-full"
-                role="menuitem"
-              >
-                <span aria-hidden="true">🔐</span>
-                Sign in
-              </button>
-
-              <button
-                id="googleSignOutBtn"
-                type="button"
-                class="overflow-item w-full hidden"
-                role="menuitem"
-              >
-                <span aria-hidden="true">🔓</span>
-                Sign out
-              </button>
-
-              <button
-                id="openSettings"
-                type="button"
-                class="overflow-item w-full"
-                role="menuitem"
-              >
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
-                  <circle cx="12" cy="12" r="3"/>
-                </svg>
-                Settings
-              </button>
-
-              <button
-                id="viewToggleMenu"
-                type="button"
-                class="overflow-item w-full justify-between"
-                role="menuitem"
-                aria-pressed="false"
-                aria-live="polite"
-              >
-                <span class="flex items-center gap-3">
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <rect x="3" y="4" width="7" height="6" rx="1" />
-                    <rect x="14" y="4" width="7" height="6" rx="1" />
-                    <rect x="3" y="14" width="7" height="6" rx="1" />
-                    <rect x="14" y="14" width="7" height="6" rx="1" />
-                  </svg>
-                  Layout
-                </span>
-                <span id="viewToggleLabel" class="text-xs font-semibold tracking-wide text-gray-600">View layout: Stacked</span>
-              </button>
-
-              <button
-                id="btn-theme"
-                type="button"
-                class="overflow-item w-full"
-                role="menuitem"
-              >
-                <svg
-                  id="icon-sun"
-                  width="16"
-                  height="16"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                >
-                  <circle cx="12" cy="12" r="4" />
-                  <path d="M12 2v2m0 16v2m10-10h-2M4 12H2m15.657-7.657-1.414 1.414M7.757 16.243l-1.414 1.414m0-12.728 1.414 1.414m8.486 8.486 1.414 1.414" />
-                </svg>
-                <svg
-                  id="icon-moon"
-                  class="hidden"
-                  width="16"
-                  height="16"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                >
-                  <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-                </svg>
-                Toggle theme
-              </button>
-
-              <button
-                type="button"
-                class="overflow-item w-full"
-                role="menuitem"
-                onclick="window.open('https://github.com/dmaher42/memory-cue', '_blank')"
-              >
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <circle cx="12" cy="12" r="10"/>
-                  <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
-                  <path d="M12 17h.01"/>
-                </svg>
-                About
-              </button>
-            </div>
-          </div>
+        <div class="reminder-tabs" role="tablist" aria-label="Reminder filters">
+          <button
+            type="button"
+            class="reminder-tab reminders-tab reminders-tab-active active"
+            data-reminders-tab="all"
+            data-filter="all"
+            aria-pressed="true"
+          >
+            All
+          </button>
+          <button
+            type="button"
+            class="reminder-tab reminders-tab"
+            data-reminders-tab="today"
+            data-filter="today"
+            aria-pressed="false"
+          >
+            Today
+          </button>
         </div>
-        <div class="reminders-quick-input header-pill">
-          <input
-            id="quickAddInput"
-            type="text"
-            placeholder="Quick reminder…"
-            class="quick-reminder quick-add-input w-full text-sm"
-          />
-          <div class="reminders-quick-actions">
-            <button
-              id="openSavedNotesSheet"
-              type="button"
-              class="header-action-btn icon-btn quick-add-action"
-              aria-label="Open Notebook"
-              title="Open Notebook"
-            >
-              <svg class="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
-                <path d="M6 2h9a2 2 0 012 2v16a1 1 0 01-1.5.86L12 19l-3.5 1.86A1 1 0 017 20V4a2 2 0 012-2z" fill="currentColor"/>
-              </svg>
-            </button>
 
-            <button class="pill-voice-btn quick-add-mic" aria-label="Voice Input">
-              <svg xmlns="http://www.w3.org/2000/svg" height="20" width="20" viewBox="0 0 24 24">
-                <path fill="currentColor" d="M12 14q-1.25 0-2.125-.875T9 11V6q0-1.25.875-2.125T12 3q1.25 0 2.125.875T15 6v5q0 1.25-.875 2.125T12 14Zm-1 7v-3.1q-3.05-.35-5.025-2.5T4 10h2q0 2.3 1.6 3.9T12 15.5q2.3 0 3.9-1.6T17.5 10h2q0 2.8-1.975 4.95T12 17.9V21Z"/>
-              </svg>
-            </button>
-
-            <button
-              id="noteSaveMobile"
-              type="button"
-              class="header-action-btn icon-btn quick-add-action"
-              aria-label="Save note"
-            >
-              <svg class="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg">
-                <path d="M20.285 6.708a1 1 0 0 0-1.414-1.416L9 15.164l-3.871-3.87a1 1 0 1 0-1.414 1.415l4.578 4.579a1 1 0 0 0 1.414 0l10.478-10.479z" fill="currentColor" />
-              </svg>
-            </button>
-          </div>
+        <div class="reminders-quick-actions">
+          <button
+            id="savedNotesShortcut"
+            type="button"
+            class="icon-btn"
+            aria-label="Open notebook"
+            title="Open notebook"
+          >
+            <svg class="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+              <path d="M6 2h9a2 2 0 012 2v16a1 1 0 01-1.5.86L12 19l-3.5 1.86A1 1 0 017 20V4a2 2 0 012-2z" fill="currentColor"/>
+            </svg>
+          </button>
+          <button
+            id="quickAddVoice"
+            type="button"
+            class="icon-btn quick-add-action"
+            aria-label="Dictate reminder"
+            title="Dictate reminder"
+          >
+            <svg viewBox="0 0 24 24" class="w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+              <path d="M12 16a4 4 0 004-4V6a4 4 0 10-8 0v6a4 4 0 004 4Z" fill="currentColor"/>
+              <path d="M19 10v2a7 7 0 11-14 0v-2" fill="none" stroke="currentColor" stroke-width="1.5"/>
+              <path d="M12 17v4m0 0H9m3 0h3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            </svg>
+          </button>
+          <button
+            id="quickAddSubmit"
+            type="button"
+            class="icon-btn quick-add-action"
+            aria-label="Save quick reminder"
+            title="Save quick reminder"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+            </svg>
+          </button>
+          <button
+            id="headerMenuBtn"
+            type="button"
+            class="icon-btn"
+            aria-label="More options"
+            aria-expanded="false"
+            aria-haspopup="true"
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="12" cy="12" r="1"/>
+              <circle cx="12" cy="5" r="1"/>
+              <circle cx="12" cy="19" r="1"/>
+            </svg>
+          </button>
         </div>
+      </form>
+
+      <!-- Dropdown menu -->
+      <div
+        id="headerMenu"
+        class="overflow-menu hidden"
+        role="menu"
+        aria-labelledby="headerMenuBtn"
+      >
+        <button
+          id="notifHeaderBtn"
+          type="button"
+          class="overflow-item w-full"
+          role="menuitem"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/>
+            <path d="m13.73 21a2 2 0 0 1-3.46 0"/>
+          </svg>
+          Notifications
+        </button>
+
+        <button
+          type="button"
+          class="overflow-item w-full"
+          role="menuitem"
+          onclick="window.location.href='/'"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+            <polyline points="9,22 9,12 15,12 15,22"/>
+          </svg>
+          Home
+        </button>
+
+        <button
+          id="googleSignInBtn"
+          type="button"
+          class="overflow-item w-full"
+          role="menuitem"
+        >
+          <span aria-hidden="true">🔐</span>
+          Sign in
+        </button>
+
+        <button
+          id="googleSignOutBtn"
+          type="button"
+          class="overflow-item w-full hidden"
+          role="menuitem"
+        >
+          <span aria-hidden="true">🔓</span>
+          Sign out
+        </button>
+
+        <button
+          id="openSettings"
+          type="button"
+          class="overflow-item w-full"
+          role="menuitem"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
+            <circle cx="12" cy="12" r="3"/>
+          </svg>
+          Settings
+        </button>
+
+        <button
+          id="viewToggleMenu"
+          type="button"
+          class="overflow-item w-full justify-between"
+          role="menuitem"
+          aria-pressed="false"
+          aria-live="polite"
+        >
+          <span class="flex items-center gap-3">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <rect x="3" y="4" width="7" height="6" rx="1" />
+              <rect x="14" y="4" width="7" height="6" rx="1" />
+              <rect x="3" y="14" width="7" height="6" rx="1" />
+              <rect x="14" y="14" width="7" height="6" rx="1" />
+            </svg>
+            Layout
+          </span>
+          <span id="viewToggleLabel" class="text-xs font-semibold tracking-wide text-gray-600">View layout: Stacked</span>
+        </button>
+
+        <button
+          id="btn-theme"
+          type="button"
+          class="overflow-item w-full"
+          role="menuitem"
+        >
+          <svg
+            id="icon-sun"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <circle cx="12" cy="12" r="4" />
+            <path d="M12 2v2m0 16v2m10-10h-2M4 12H2m15.657-7.657-1.414 1.414M7.757 16.243l-1.414 1.414m0-12.728 1.414 1.414m8.486 8.486 1.414 1.414" />
+          </svg>
+          <svg
+            id="icon-moon"
+            class="hidden"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+          </svg>
+          Toggle theme
+        </button>
+
+        <button
+          type="button"
+          class="overflow-item w-full"
+          role="menuitem"
+          onclick="window.open('https://github.com/dmaher42/memory-cue', '_blank')"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <circle cx="12" cy="12" r="10"/>
+            <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
+            <path d="M12 17h.01"/>
+          </svg>
+          About
+        </button>
       </div>
     </div>
   </header>
@@ -5271,48 +5055,6 @@
       <div class="mobile-view-inner mx-auto w-full px-4 pt-2 pb-4 space-y-2" style="background: var(--mobile-quick-surface);">
         <!-- header removed to keep view minimal -->
         <div class="reminders-content-shell space-y-2">
-
-          <!-- Quick-add bar for reminders -->
-          <div class="mt-3 px-4" id="remindersQuickAddBar">
-            <form id="quickAddForm" class="flex items-center gap-2" onsubmit="return false;">
-              <!-- Text input -->
-              <div class="flex-1">
-                <input
-                  id="quickAddInput"
-                  type="text"
-                  class="input input-sm w-full"
-                  placeholder="Add a reminder…"
-                  autocomplete="off"
-                  aria-label="Quick add reminder"
-                />
-              </div>
-
-              <!-- Voice (microphone) button -->
-              <button
-                id="quickAddVoice"
-                type="button"
-                class="icon-btn quick-add-action"
-                aria-label="Dictate quick reminder"
-              >
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
-                     stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M12 3a3 3 0 0 0-3 3v6a3 3 0 0 0 6 0V6a3 3 0 0 0-3-3z"/>
-                  <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
-                  <line x1="12" y1="19" x2="12" y2="22"/>
-                  <line x1="8" y1="22" x2="16" y2="22"/>
-                </svg>
-              </button>
-
-              <!-- Save reminder button -->
-              <button
-                id="quickAddSubmit"
-                type="button"
-                class="btn btn-sm btn-primary"
-              >
-                Save
-              </button>
-            </form>
-          </div>
 
           <div id="remindersListMobile" class="space-y-2">
             <section

--- a/mobile.js
+++ b/mobile.js
@@ -430,7 +430,9 @@ const initMobileNotes = () => {
   const countElement = document.getElementById('notesCountMobile');
   const filterInput = document.getElementById('notebook-search-input');
   const savedNotesSheet = document.getElementById('savedNotesSheet');
-  const openSavedNotesButton = document.getElementById('openSavedNotesSheet');
+  const openSavedNotesButton =
+    document.getElementById('savedNotesShortcut') ||
+    document.getElementById('openSavedNotesSheet');
   const closeSavedNotesButton = document.querySelector('[data-action="close-saved-notes"]');
   const folderSelectorEl = document.getElementById('moveFolderSheet');
   const folderSelectorUnsortedBtn = document.getElementById('move-folder-unsorted');

--- a/scripts/e2e-header-check.mjs
+++ b/scripts/e2e-header-check.mjs
@@ -100,6 +100,21 @@ const URL = process.env.URL || 'http://localhost:3000/mobile.html';
         console.log('Fallback #openSavedNotesSheet click failed:', e && e.message ? e.message : e);
       }
     }
+
+    if (!savedOpen) {
+      try {
+        const shortcutBtn = await page.$('#savedNotesShortcut');
+        if (shortcutBtn) {
+          console.log('Clicking fallback #savedNotesShortcut');
+          await shortcutBtn.click();
+          await page.waitForTimeout(200);
+          savedOpen = await page.$eval('#savedNotesSheet', (el) => el.dataset.open === 'true');
+          console.log('savedNotesSheet open after fallback shortcutBtn:', savedOpen);
+        }
+      } catch (e) {
+        console.log('Fallback #savedNotesShortcut click failed:', e && e.message ? e.message : e);
+      }
+    }
     if (!savedOpen) {
       try {
         const globalAlt = await page.$('.open-saved-notes-global');


### PR DESCRIPTION
## Summary
- redesign the mobile reminders header into a single iOS-style quick bar with tabs and actions
- refresh styling to keep the quick bar on one row and adjust small-screen spacing
- hook up the saved notes shortcut and update the header e2e fallback to match the new control

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6933f511bf0c8327aa6a857253fad1a3)