### PR TITLE
Restore quick add header interactions

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -802,6 +802,8 @@ export async function initReminders(sel = {}) {
 
   applyStoredDefaultsToInputs();
 
+  const quickForm =
+    typeof document !== 'undefined' ? document.getElementById('quickAddForm') : null;
   const quickInput =
     typeof document !== 'undefined' ? document.getElementById('quickAddInput') : null;
   const quickBtn =
@@ -896,10 +898,15 @@ export async function initReminders(sel = {}) {
   });
 
   quickInput?.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' || e.key === 'NumpadEnter') {
       e.preventDefault();
       quickAddNow();
     }
+  });
+
+  quickForm?.addEventListener('submit', (event) => {
+    event.preventDefault();
+    quickAddNow();
   });
 
   function setupQuickAddVoiceSupport() {


### PR DESCRIPTION
## Summary
- ensure quick-add input, submit button, and form all trigger the existing quick-add logic
- prevent native form submission while supporting Enter/NumpadEnter keyboard activation

## Testing
- Not run (environment missing Node/npm binaries)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6933f7cb52488327960da2c40637f3ba)