### PR TITLE
Modernize mobile notebook controls

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -325,7 +325,7 @@
     gap: 0;
     max-width: 640px;
     margin: 0 auto;
-    padding: 0.75rem 1rem calc(1.25rem + env(safe-area-inset-bottom, 0.75rem));
+    padding: 0.75rem 1rem calc(1.35rem + env(safe-area-inset-bottom, 0.75rem));
     position: relative;
     border-radius: 18px;
     background: rgba(255, 255, 255, 0.78);
@@ -347,107 +347,73 @@
     overflow-y: auto;
   }
 
-  .mobile-panel--notes #scratch-notes-card .note-actions.fixed-bottom {
-    margin-top: auto;
-    padding-top: 0.5rem;
-    padding-bottom: env(safe-area-inset-bottom, 0.75rem);
-  }
-
   /* Keep note action buttons fixed and accessible without scrolling on all viewports */
   .mobile-panel--notes #scratch-notes-card {
     /* make room for the fixed action bar so content isn't hidden */
-    padding-bottom: calc(env(safe-area-inset-bottom, 0.75rem) + 3rem);
+    padding-bottom: calc(env(safe-area-inset-bottom, 0.75rem) + 4.5rem);
   }
 
   .mobile-panel--notes #scratch-notes-card .note-actions.fixed-bottom {
     position: fixed;
-    left: 0.5rem;
-    right: 0.5rem;
+    left: 0.85rem;
+    right: 0.85rem;
     /* Position above the bottom navigation bar so buttons don't overlap the footer */
-    bottom: calc(env(safe-area-inset-bottom, 0.75rem) + 4.25rem);
+    bottom: calc(env(safe-area-inset-bottom, 0.85rem) + 4.1rem);
     display: flex;
+    align-items: center;
     justify-content: space-between;
-    gap: 0.5rem;
-    padding: 0.5rem 0.6rem;
-    background: linear-gradient(to top, rgba(0,0,0,0.02), transparent);
-    box-shadow: 0 -6px 18px rgba(0,0,0,0.06);
-    border-radius: 0.6rem;
-    z-index: 60;
+    gap: 0.65rem;
+    padding: 0.6rem 0.65rem;
+    background: color-mix(in srgb, #ffffff 90%, #f3eefc 10%);
+    border: 1px solid color-mix(in srgb, var(--card-border) 78%, transparent);
+    border-radius: 999px;
+    box-shadow: 0 12px 32px rgba(17, 17, 26, 0.12);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    z-index: 70;
   }
 
   .mobile-panel--notes #scratch-notes-card .note-actions.fixed-bottom .btn {
-    /* keep New and Save visually identical: fixed width */
-    width: 3.6rem;
+    flex: 1 1 0;
     box-sizing: border-box;
-    padding: 0.35rem 0;
+    padding: 0.55rem 0.95rem;
     text-align: center;
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: 0.95rem;
+    font-weight: 700;
+    border-radius: 999px;
   }
 
   /* Top-right compact actions (aligned with Title input) */
   .mobile-panel--notes #scratch-notes-card .note-actions-top {
     position: absolute;
-    top: 0.6rem;
+    top: 0.65rem;
     right: 0.85rem;
     display: flex;
     gap: 0.5rem;
     align-items: center;
-    z-index: 70;
+    z-index: 80;
   }
 
   .mobile-panel--notes #scratch-notes-card .note-actions-top .btn {
-    min-width: 2.6rem;
-    padding: 0.25rem 0.6rem;
-    font-size: 0.95rem;
+    min-width: auto;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.9rem;
     font-weight: 600;
+    border-radius: 999px;
+    background: color-mix(in srgb, #ffffff 90%, #ece6f7 10%);
+    border: 1px solid color-mix(in srgb, var(--card-border) 80%, transparent);
+    color: color-mix(in srgb, var(--accent-color) 82%, #4a4153);
+    box-shadow: 0 6px 18px rgba(81, 38, 99, 0.08);
   }
 
-  /* Shrink the mobile Save button by 75% (reduce to 25% scale) */
+  .mobile-panel--notes #scratch-notes-card .note-actions-top .btn:hover,
+  .mobile-panel--notes #scratch-notes-card .note-actions-top .btn:focus-visible {
+    background: color-mix(in srgb, var(--accent-color) 12%, #ffffff 88%);
+    outline: none;
+  }
+
   #noteSaveMobile {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    transform: none;
-    padding: 0.35rem 0;
-    font-size: 1rem;
-    font-weight: 600;
-    width: 3.6rem;
-    box-sizing: border-box;
-    border-radius: 0.45rem;
-    line-height: 1;
-    z-index: 70;
-  }
-
-  @media (max-width: 640px) {
-    .mobile-panel--notes #scratch-notes-card {
-      /* make room for the fixed action bar so content isn't hidden */
-      padding-bottom: calc(env(safe-area-inset-bottom, 0.75rem) + 3rem);
-    }
-
-    .mobile-panel--notes #scratch-notes-card .note-actions.fixed-bottom {
-      position: fixed;
-      left: 0.5rem;
-      right: 0.5rem;
-      /* Position above the bottom navigation bar so buttons don't overlap the footer */
-      bottom: calc(env(safe-area-inset-bottom, 0.75rem) + 4.25rem);
-      display: flex;
-      justify-content: space-between;
-      gap: 0.5rem;
-      padding: 0.5rem 0.6rem;
-      background: linear-gradient(to top, rgba(0,0,0,0.02), transparent);
-      box-shadow: 0 -6px 18px rgba(0,0,0,0.06);
-      border-radius: 0.6rem;
-      z-index: 60;
-    }
-
-    .mobile-panel--notes #scratch-notes-card .note-actions.fixed-bottom .btn {
-      width: 3.6rem;
-      box-sizing: border-box;
-      padding: 0.35rem 0;
-      font-size: 1rem;
-      font-weight: 600;
-    }
+    min-width: 4.25rem;
   }
 
   .mobile-shell #view-notebook .card {


### PR DESCRIPTION
## Summary
- refresh the Saved notes pill in the mobile notebook to sit at the top right with softer styling
- redesign the fixed bottom note action bar with rounded buttons that sit above mobile navigation
- clean up duplicate styles while keeping existing notebook interactions intact

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6933f8cf0fbc83279aecef39a27517bb)