### PR TITLE
Create unified reminders top bar

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1425,6 +1425,85 @@
         display: none;
       }
     }
+
+    /* iOS-style reminders top bar */
+    .reminders-top-row {
+      display: flex;
+      padding: 0.75rem 1rem 0.25rem;
+    }
+
+    .reminders-quick-bar {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+      flex: 1;
+      min-width: 0;
+      padding: 0.6rem 0.75rem;
+      border-radius: 999px;
+      background: #f8f6ff;
+      border: 1px solid rgba(81, 38, 99, 0.08);
+      box-shadow:
+        0 0 0 1px rgba(255, 255, 255, 0.9),
+        0 10px 24px rgba(20, 6, 44, 0.06);
+      white-space: nowrap;
+      overflow: hidden;
+    }
+
+    .reminders-quick-bar #quickAddInput {
+      flex: 1;
+      min-width: 0;
+      border: none;
+      outline: none;
+      background: transparent;
+      font-size: 0.9rem;
+    }
+
+    .reminder-tabs {
+      display: inline-flex;
+      align-items: center;
+      flex-shrink: 0;
+      padding: 3px;
+      border-radius: 999px;
+      background: #efe6ff;
+    }
+
+    .reminder-tab {
+      border: none;
+      background: transparent;
+      padding: 0.25rem 0.7rem;
+      border-radius: 999px;
+      font-size: 0.8rem;
+      font-weight: 500;
+      color: #5c4b75;
+      cursor: pointer;
+      transition: background 0.15s ease, color 0.15s ease;
+    }
+
+    .reminder-tab.reminders-tab-active,
+    .reminder-tab[aria-pressed="true"] {
+      background: #512663;
+      color: #ffffff;
+    }
+
+    .reminders-quick-actions {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      flex-shrink: 0;
+    }
+
+    .icon-btn {
+      border: none;
+      background: transparent;
+      padding: 0.3rem;
+      border-radius: 999px;
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+
+    .icon-btn svg {
+      display: block;
+    }
   </style>
   <meta charset="UTF-8" />
   <meta
@@ -4767,21 +4846,23 @@
     class="mobile-header px-3 py-2 pt-safe-top"
     role="banner"
   >
+    <!-- REMINDERS TOP BAR - START -->
     <div class="reminders-top-row">
       <form id="quickAddForm" class="reminders-quick-bar" onsubmit="return false;">
+        <!-- Left: quick reminder field -->
         <input
           id="quickAddInput"
           type="text"
-          placeholder="Quick reminder…"
-          class="quick-reminder quick-add-input w-full text-sm"
+          placeholder="Quick reminder..."
           autocomplete="off"
-          aria-label="Quick add reminder"
+          aria-label="Quick reminder"
         />
 
+        <!-- Middle: All / Today segmented control -->
         <div class="reminder-tabs" role="tablist" aria-label="Reminder filters">
           <button
             type="button"
-            class="reminder-tab reminders-tab reminders-tab-active active"
+            class="reminder-tab reminders-tab reminders-tab-active"
             data-reminders-tab="all"
             data-filter="all"
             aria-pressed="true"
@@ -4799,42 +4880,51 @@
           </button>
         </div>
 
+        <!-- Right: saved, mic, save, overflow -->
         <div class="reminders-quick-actions">
+          <!-- Saved notes / bookmark -->
           <button
             id="savedNotesShortcut"
             type="button"
             class="icon-btn"
-            aria-label="Open notebook"
-            title="Open notebook"
+            aria-label="Saved notes"
           >
-            <svg class="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
-              <path d="M6 2h9a2 2 0 012 2v16a1 1 0 01-1.5.86L12 19l-3.5 1.86A1 1 0 017 20V4a2 2 0 012-2z" fill="currentColor"/>
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M6 4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v17l-7-4-7 4V4z" />
             </svg>
           </button>
+
+          <!-- Microphone -->
           <button
             id="quickAddVoice"
             type="button"
-            class="icon-btn quick-add-action"
-            aria-label="Dictate reminder"
-            title="Dictate reminder"
+            class="icon-btn"
+            aria-label="Dictate quick reminder"
           >
-            <svg viewBox="0 0 24 24" class="w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
-              <path d="M12 16a4 4 0 004-4V6a4 4 0 10-8 0v6a4 4 0 004 4Z" fill="currentColor"/>
-              <path d="M19 10v2a7 7 0 11-14 0v-2" fill="none" stroke="currentColor" stroke-width="1.5"/>
-              <path d="M12 17v4m0 0H9m3 0h3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 3a3 3 0 0 0-3 3v6a3 3 0 0 0 6 0V6a3 3 0 0 0-3-3z" />
+              <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+              <line x1="12" y1="19" x2="12" y2="22" />
+              <line x1="8"  y1="22" x2="16" y2="22" />
             </svg>
           </button>
+
+          <!-- Save reminder -->
           <button
             id="quickAddSubmit"
             type="button"
-            class="icon-btn quick-add-action"
-            aria-label="Save quick reminder"
-            title="Save quick reminder"
+            class="icon-btn"
+            aria-label="Save reminder"
           >
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="20 6 9 17 4 12" />
             </svg>
           </button>
+
+          <!-- Overflow menu -->
           <button
             id="headerMenuBtn"
             type="button"
@@ -4843,14 +4933,17 @@
             aria-expanded="false"
             aria-haspopup="true"
           >
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <circle cx="12" cy="12" r="1"/>
-              <circle cx="12" cy="5" r="1"/>
-              <circle cx="12" cy="19" r="1"/>
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="12" cy="5" r="1.5" />
+              <circle cx="12" cy="12" r="1.5" />
+              <circle cx="12" cy="19" r="1.5" />
             </svg>
           </button>
         </div>
       </form>
+    </div>
+    <!-- REMINDERS TOP BAR - END -->
 
       <!-- Dropdown menu -->
       <div


### PR DESCRIPTION
## Summary
- replace the reminders header content with a single pill containing the quick reminder input, filter tabs, and action icons
- add iOS-style pill styling to keep the bar on one line and shrink the input first on narrow screens

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6933fbed7f108327bd5f96bad1cd0a84)