### PR TITLE
Fix mobile header overflow menu wiring

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -3159,27 +3159,27 @@
           <span class="mc-add-btn-icon" aria-hidden="true">＋</span>
           <span class="mc-add-btn-label">Add reminder</span>
         </button>
-        <div class="relative">
+        <div class="relative header-overflow-wrapper">
           <button
-            id="overflowMenuBtn"
+            id="headerMenuBtn"
             type="button"
             class="header-icon-btn inline-flex items-center justify-center w-10 h-10 rounded-full transition"
             aria-label="Open quick settings"
             aria-haspopup="menu"
-            aria-controls="overflowMenu"
+            aria-controls="headerMenu"
             aria-expanded="false"
           >
             <span class="text-xl leading-none" aria-hidden="true">⚙️</span>
           </button>
 
           <div
-            id="overflowMenu"
-            class="hidden quick-actions-panel absolute right-0 mt-2"
+            id="headerMenu"
+            class="overflow-menu hidden quick-actions-panel absolute right-0 mt-2"
             role="menu"
             aria-hidden="true"
-            aria-labelledby="overflowMenuHeading"
+            aria-labelledby="headerMenuHeading"
           >
-            <h2 id="overflowMenuHeading" class="sr-only">Quick settings</h2>
+            <h2 id="headerMenuHeading" class="sr-only">Quick settings</h2>
             <ul class="quick-actions" role="presentation">
               <li role="none">
                 <button id="voiceAddBtn" type="button" class="quick-action-btn" title="Dictate reminder" role="menuitem">
@@ -3622,18 +3622,18 @@
     </div>
     <div class="header-actions">
       <div class="header-overflow-wrapper">
-        <button id="overflowMenuBtn" type="button" class="header-btn header-btn-icon" aria-label="Open quick settings" aria-haspopup="menu" aria-controls="overflowMenu" aria-expanded="false">
+        <button id="headerMenuBtn" type="button" class="header-btn header-btn-icon" aria-label="Open quick settings" aria-haspopup="menu" aria-controls="headerMenu" aria-expanded="false">
           <span class="text-xl leading-none" aria-hidden="true">⚙️</span>
         </button>
 
         <div
-          id="overflowMenu"
-          class="hidden quick-actions-panel absolute right-0 mt-2"
+          id="headerMenu"
+          class="overflow-menu hidden quick-actions-panel absolute right-0 mt-2"
           role="menu"
           aria-hidden="true"
-          aria-labelledby="overflowMenuHeading"
+          aria-labelledby="headerMenuHeading"
         >
-          <h2 id="overflowMenuHeading" class="sr-only">Quick settings</h2>
+          <h2 id="headerMenuHeading" class="sr-only">Quick settings</h2>
           <ul class="quick-actions" role="presentation">
             <li role="none">
               <button id="voiceAddBtn" type="button" class="quick-action-btn" title="Dictate reminder" role="menuitem">
@@ -6510,6 +6510,7 @@
 
         // Look for Overflow/More menu button
         const overflowBtnSelectors = [
+          '#headerMenuBtn',
           '#overflowMenuBtn',
           'button[aria-label*="settings" i]',
           'button[aria-label*="menu" i]',
@@ -6560,6 +6561,45 @@
         document.body.insertBefore(fallbackHeader, document.body.firstChild);
       }
     });
+  </script>
+
+  <script>
+    (function () {
+      const menuBtn = document.getElementById('headerMenuBtn');
+      const menu    = document.getElementById('headerMenu');
+      if (!menuBtn || !menu) return;
+
+      const closeMenu = () => {
+        menu.classList.add('hidden');
+        menu.setAttribute('aria-hidden', 'true');
+        menuBtn.setAttribute('aria-expanded', 'false');
+      };
+
+      const openMenu = () => {
+        menu.classList.remove('hidden');
+        menu.setAttribute('aria-hidden', 'false');
+        menuBtn.setAttribute('aria-expanded', 'true');
+      };
+
+      // expose a closer for other code (footer nav, etc.)
+      window.closeOverflowMenu = closeMenu;
+
+      menuBtn.addEventListener('click', (ev) => {
+        ev.preventDefault();
+        const isOpen = menuBtn.getAttribute('aria-expanded') === 'true';
+        if (isOpen) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      document.addEventListener('click', (ev) => {
+        if (!menu.contains(ev.target) && ev.target !== menuBtn) {
+          closeMenu();
+        }
+      }, true);
+    })();
   </script>
 
 </body>

--- a/mobile.html
+++ b/mobile.html
@@ -4974,7 +4974,73 @@
             <button id="savedNotesShortcut" type="button" class="icon-btn" aria-label="Saved notes"><span class="material-symbols-rounded">auto_stories</span></button>
             <button id="quickAddVoice"       type="button" class="icon-btn" aria-label="Dictate"><span class="material-symbols-rounded">mic</span></button>
             <button id="quickAddSubmit"     type="button" class="icon-btn" aria-label="Save reminder"><span class="material-symbols-rounded">add_circle</span></button>
-            <button id="headerMenuBtn"      type="button" class="icon-btn" aria-label="More options"><span class="material-symbols-rounded">more_vert</span></button>
+            <div class="header-overflow-wrapper">
+              <button
+                id="headerMenuBtn"
+                type="button"
+                class="icon-btn"
+                aria-label="More options"
+                aria-expanded="false"
+              >
+                <span class="material-symbols-rounded">more_vert</span>
+              </button>
+
+              <div
+                id="headerMenu"
+                class="overflow-menu hidden quick-actions-panel absolute right-0 mt-2"
+                role="menu"
+                aria-hidden="true"
+                aria-labelledby="headerMenuHeading"
+              >
+                <h2 id="headerMenuHeading" class="sr-only">Quick settings</h2>
+                <ul class="quick-actions" role="presentation">
+                  <li role="none">
+                    <button id="voiceAddBtn" type="button" class="quick-action-btn" title="Dictate reminder" role="menuitem">
+                      <span class="quick-action-icon" aria-hidden="true">🎤</span>
+                      <span class="sr-only">Dictate reminder</span>
+                    </button>
+                  </li>
+                  <li role="none">
+                    <button
+                      id="viewToggleMenu"
+                      type="button"
+                      class="quick-action-btn"
+                      title="Toggle layout"
+                      role="menuitem"
+                      aria-pressed="false"
+                      data-layout="list"
+                    >
+                      <span class="quick-action-icon" aria-hidden="true">🗂</span>
+                      <span id="viewToggleLabel" class="sr-only">View layout: Stacked</span>
+                    </button>
+                  </li>
+                  <li role="none">
+                    <button id="openSettings" type="button" class="quick-action-btn" data-open="settings" title="Open settings" role="menuitem">
+                      <span class="quick-action-icon" aria-hidden="true">⚙️</span>
+                      <span class="sr-only">Open settings</span>
+                    </button>
+                  </li>
+                  <li role="none">
+                    <button id="themeToggle" type="button" class="quick-action-btn" title="Toggle theme" role="menuitem">
+                      <span class="quick-action-icon" aria-hidden="true">🌗</span>
+                      <span class="sr-only">Toggle theme</span>
+                    </button>
+                  </li>
+                  <li role="none">
+                    <button id="googleSignInBtn" type="button" class="quick-action-btn" title="Sign in" role="menuitem">
+                      <span class="quick-action-icon" aria-hidden="true">🔐</span>
+                      <span class="sr-only">Sign in</span>
+                    </button>
+                  </li>
+                  <li role="none">
+                    <button id="googleSignOutBtn" type="button" class="quick-action-btn hidden" title="Sign out" role="menuitem">
+                      <span class="quick-action-icon" aria-hidden="true">🔓</span>
+                      <span class="sr-only">Sign out</span>
+                    </button>
+                  </li>
+                </ul>
+              </div>
+            </div>
           </div>
 
         </form>
@@ -8251,33 +8317,9 @@
       }
 
       if (overflowBtn && overflowMenu) {
-        const toggleMenu = (forceOpen) => {
-          const isHidden = overflowMenu.classList.contains('hidden');
-          const shouldOpen = typeof forceOpen === 'boolean' ? forceOpen : isHidden;
-          overflowMenu.classList.toggle('hidden', !shouldOpen);
-          overflowMenu.setAttribute('aria-hidden', shouldOpen ? 'false' : 'true');
-          overflowBtn.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
-          // debug log to help diagnose clicks not opening the menu
-          try {
-            console.debug('[slimHeader] overflowMenu toggled:', shouldOpen);
-          } catch (e) {
-            /* ignore */
-          }
-        };
-
-        overflowBtn.addEventListener('click', function(event) {
-          event.preventDefault();
-          event.stopPropagation();
-          toggleMenu();
-        });
-
-        document.addEventListener('click', (event) => {
-          if (overflowMenu.classList.contains('hidden')) return;
-          const wrapper = event.target instanceof Element ? event.target.closest('.header-overflow-wrapper') : null;
-          if (!wrapper) {
-            toggleMenu(false);
-          }
-        });
+        const isHidden = overflowMenu.classList.contains('hidden');
+        overflowMenu.setAttribute('aria-hidden', isHidden ? 'true' : 'false');
+        overflowBtn.setAttribute('aria-expanded', isHidden ? 'false' : 'true');
       }
 
       /* home button removed: no scroll-home handler needed */
@@ -8312,6 +8354,45 @@
         }
       }
     });
+  </script>
+
+  <script>
+    (function () {
+      const menuBtn = document.getElementById('headerMenuBtn');
+      const menu    = document.getElementById('headerMenu');
+      if (!menuBtn || !menu) return;
+
+      const closeMenu = () => {
+        menu.classList.add('hidden');
+        menu.setAttribute('aria-hidden', 'true');
+        menuBtn.setAttribute('aria-expanded', 'false');
+      };
+
+      const openMenu = () => {
+        menu.classList.remove('hidden');
+        menu.setAttribute('aria-hidden', 'false');
+        menuBtn.setAttribute('aria-expanded', 'true');
+      };
+
+      // expose a closer for other code (footer nav, etc.)
+      window.closeOverflowMenu = closeMenu;
+
+      menuBtn.addEventListener('click', (ev) => {
+        ev.preventDefault();
+        const isOpen = menuBtn.getAttribute('aria-expanded') === 'true';
+        if (isOpen) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      document.addEventListener('click', (ev) => {
+        if (!menu.contains(ev.target) && ev.target !== menuBtn) {
+          closeMenu();
+        }
+      }, true);
+    })();
   </script>
 
 </body>

--- a/mobile.js
+++ b/mobile.js
@@ -3145,8 +3145,9 @@ if (supabaseAuthController?.supabase) {
 }
 
 (() => {
-  const menuBtn = document.getElementById('overflowMenuBtn');
-  const menu = document.getElementById('overflowMenu');
+  const menuBtn =
+    document.getElementById('headerMenuBtn') || document.getElementById('overflowMenuBtn');
+  const menu = document.getElementById('headerMenu') || document.getElementById('overflowMenu');
 
   if (!(menuBtn instanceof HTMLElement) || !(menu instanceof HTMLElement)) {
     return;


### PR DESCRIPTION
## Summary
- add header overflow menu container and accessible button ids to mobile and docs pages
- wire up overflow menu toggle script for headerMenu elements and align ids with tests
- update mobile.js to recognize new header menu ids while retaining legacy fallback

## Testing
- npm test -- js/__tests__/mobile.header.test.js *(fails: npm not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6934ac502e408327be3a3d26e1ff1059)