### PR TITLE
Reduce spacing under mobile reminders header

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -71,8 +71,10 @@ body.mobile-theme footer {
 
 .mobile-shell #view-reminders .mobile-view-inner,
 .mobile-shell #view-reminders .reminders-content-shell {
+  padding-top: 0 !important;
   padding-left: 0;
   padding-right: 0;
+  margin-top: 0 !important;
 }
 
 .mobile-shell #reminderListSection {

--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -104,6 +104,7 @@
       flex: 1 1 auto;
       min-width: 0;
       padding: 0.45rem 0.7rem;
+      margin-bottom: 0;
       background: color-mix(in srgb, #f4f1fb 88%, #ffffff);
       border: 1px solid color-mix(in srgb, #dcd3ec 65%, transparent);
       border-radius: 999px;
@@ -145,6 +146,12 @@
       cursor: pointer;
       transition: background 0.15s ease, color 0.15s ease;
       white-space: nowrap;
+    }
+
+    .reminders-summary,
+    #remindersSummary,
+    #mobileRemindersHeaderSubtitle {
+      margin-top: 0.25rem !important;
     }
 
     .reminder-tab.reminders-tab-active,
@@ -637,7 +644,7 @@
 
   .menu-heading {
     margin: 0;
-    padding: 0.75rem 1rem 0.25rem;
+    padding: 0.5rem 1rem 0rem; /* reduce bottom padding to zero */
     font-size: 0.75rem;
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -3953,7 +3960,7 @@
               </ul>
             </div>
 
-            <p id="mobileRemindersHeaderSubtitle" class="mt-2 text-xs text-slate-500"></p>
+            <p id="mobileRemindersHeaderSubtitle" class="text-xs text-slate-500"></p>
           </div>
         </header>
 

--- a/mobile.html
+++ b/mobile.html
@@ -68,6 +68,7 @@
       flex: 1 1 auto;
       min-width: 0;
       padding: 0.45rem 0.7rem;
+      margin-bottom: 0;
       background: color-mix(in srgb, #f4f1fb 88%, #ffffff);
       border: 1px solid color-mix(in srgb, #dcd3ec 65%, transparent);
       border-radius: 999px;
@@ -1049,7 +1050,7 @@
 
   .menu-heading {
     margin: 0;
-    padding: 0.75rem 1rem 0.25rem;
+    padding: 0.5rem 1rem 0rem; /* reduce bottom padding to zero */
     font-size: 0.75rem;
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -1449,7 +1450,7 @@
     /* iOS-style reminders top bar */
     .reminders-top-row {
       display: flex;
-      padding: 0.75rem 1rem 0.25rem;
+      padding: 0.5rem 1rem 0rem; /* reduce bottom padding to zero */
     }
 
     .reminders-quick-bar {
@@ -1499,6 +1500,12 @@
       transition: background 0.15s ease, color 0.15s ease;
     }
 
+    .reminders-summary,
+    #remindersSummary,
+    #mobileRemindersHeaderSubtitle {
+      margin-top: 0.25rem !important;
+    }
+
     .reminder-tab.reminders-tab-active,
     .reminder-tab[aria-pressed="true"] {
       background: #512663;
@@ -1526,7 +1533,7 @@
     }
 .reminders-top-row {
   display: flex;
-  padding: 0.75rem 1rem 0.25rem;
+  padding: 0.5rem 1rem 0rem; /* reduce bottom padding to zero */
 }
 
 .reminders-quick-bar {
@@ -5050,7 +5057,7 @@
         </ul>
       </div>
 
-      <p id="mobileRemindersHeaderSubtitle" class="mt-2 text-xs text-slate-500"></p>
+      <p id="mobileRemindersHeaderSubtitle" class="text-xs text-slate-500"></p>
     </div>
   </header>
 
@@ -6031,7 +6038,7 @@
 
     .reminders-top-row {
       display: flex;
-      padding: 0.75rem 1rem 0.25rem;
+      padding: 0.5rem 1rem 0rem; /* reduce bottom padding to zero */
     }
 
     .reminders-quick-bar {


### PR DESCRIPTION
## Summary
- reduce padding on the reminders header row and remove quick bar bottom margin
- tighten spacing for the reminders summary line beneath the header
- ensure the mobile reminders layout has zero top padding/margin around the list

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6934bac339ec832794dd1612dc90ad26)