### PR TITLE
Refine mobile reminders header spacing

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -450,6 +450,14 @@ body.mobile-theme .text-secondary {
     padding-top: 0;
   }
 
+  #remindersSummary,
+  .reminders-summary,
+  .reminders-top-controls,
+  .reminders-list-container {
+    margin-top: 0 !important;
+    padding-top: 0 !important;
+  }
+
   /* Scratch notes wrapper adjustments */
   .scratch-notes-wrapper,
   .note-sheet-wrapper {

--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -90,6 +90,7 @@
       display: flex;
       align-items: center;
       padding: 0.5rem 1rem 0rem; /* reduce bottom padding to zero */
+      margin-bottom: 0 !important;
       gap: 0.5rem;
       white-space: nowrap;
       overflow: hidden;
@@ -148,12 +149,6 @@
       white-space: nowrap;
     }
 
-    .reminders-summary,
-    #remindersSummary,
-    #mobileRemindersHeaderSubtitle {
-      margin-top: 0.25rem !important;
-    }
-
     .reminder-tab.reminders-tab-active,
     .reminder-tab.active,
     .reminder-tab[aria-pressed="true"] {
@@ -192,6 +187,7 @@
       .reminders-top-row {
         gap: 0.35rem;
         padding: 0.35rem 0.15rem 0;
+        margin-bottom: 0 !important;
       }
 
       .reminders-quick-bar {
@@ -984,6 +980,14 @@
       #slimMobileHeader .header-btn .btn-label {
         display: none;
       }
+    }
+
+    /* Remove gap between header bar and first reminder */
+    #reminderList,
+    #remindersWrapper,
+    .reminders-list-container {
+      margin-top: 0 !important;
+      padding-top: 0 !important;
     }
   </style>
   <meta charset="UTF-8" />
@@ -3960,7 +3964,6 @@
               </ul>
             </div>
 
-            <p id="mobileRemindersHeaderSubtitle" class="text-xs text-slate-500"></p>
           </div>
         </header>
 

--- a/mobile.html
+++ b/mobile.html
@@ -54,6 +54,7 @@
       display: flex;
       align-items: center;
       padding: 0.5rem 1rem 0rem; /* reduce bottom padding to zero */
+      margin-bottom: 0 !important;
       gap: 0.5rem;
       white-space: nowrap;
       overflow: hidden;
@@ -150,6 +151,7 @@
       .reminders-top-row {
         gap: 0.35rem;
         padding: 0.35rem 0.15rem 0;
+        margin-bottom: 0 !important;
       }
 
       .reminders-quick-bar {
@@ -1451,6 +1453,7 @@
     .reminders-top-row {
       display: flex;
       padding: 0.5rem 1rem 0rem; /* reduce bottom padding to zero */
+      margin-bottom: 0 !important;
     }
 
     .reminders-quick-bar {
@@ -1500,12 +1503,6 @@
       transition: background 0.15s ease, color 0.15s ease;
     }
 
-    .reminders-summary,
-    #remindersSummary,
-    #mobileRemindersHeaderSubtitle {
-      margin-top: 0.25rem !important;
-    }
-
     .reminder-tab.reminders-tab-active,
     .reminder-tab[aria-pressed="true"] {
       background: #512663;
@@ -1534,6 +1531,7 @@
 .reminders-top-row {
   display: flex;
   padding: 0.5rem 1rem 0rem; /* reduce bottom padding to zero */
+  margin-bottom: 0 !important;
 }
 
 .reminders-quick-bar {
@@ -1598,6 +1596,14 @@
   font-size: 1rem;
   padding: 0.35rem;
   border-radius: 999px;
+}
+
+/* Remove gap between header bar and first reminder */
+#reminderList,
+#remindersWrapper,
+.reminders-list-container {
+  margin-top: 0 !important;
+  padding-top: 0 !important;
 }
   </style>
   <meta charset="UTF-8" />
@@ -4312,6 +4318,7 @@
     @media (max-width: 420px) {
       .reminders-top-row {
         padding: 0.25rem 0.1rem 0;
+        margin-bottom: 0 !important;
       }
 
       .reminders-quick-bar {
@@ -5057,7 +5064,6 @@
         </ul>
       </div>
 
-      <p id="mobileRemindersHeaderSubtitle" class="text-xs text-slate-500"></p>
     </div>
   </header>
 
@@ -6039,6 +6045,7 @@
     .reminders-top-row {
       display: flex;
       padding: 0.5rem 1rem 0rem; /* reduce bottom padding to zero */
+      margin-bottom: 0 !important;
     }
 
     .reminders-quick-bar {


### PR DESCRIPTION
## Summary
- remove the mobile reminders subtitle block so the header no longer renders the date line
- tighten reminders header spacing with zero bottom margin and no gap before the first card
- enforce zero top spacing for reminder summary containers in the mobile theme CSS

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693544b51cfc832791155821d8e29fa6)