### PR TITLE
Tighten spacing under reminders header

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -445,9 +445,10 @@ body.mobile-theme .text-secondary {
 
   /* Normalise any accidental large top spacing */
   .mobile-view-inner .reminders-content-shell,
-  .reminders-content-shell {
-    margin-top: 0;
-    padding-top: 0;
+  .reminders-content-shell,
+  .reminders-list-container {
+    margin-top: 0 !important;
+    padding-top: 0 !important;
   }
 
   #remindersSummary,

--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -89,7 +89,7 @@
     .reminders-top-row {
       display: flex;
       align-items: center;
-      padding: 0.5rem 1rem 0rem; /* reduce bottom padding to zero */
+      padding: 0.35rem 1rem 0rem; /* slightly tighter overall, 0 bottom padding */
       margin-bottom: 0 !important;
       gap: 0.5rem;
       white-space: nowrap;
@@ -662,7 +662,8 @@
 
   /* Reminders wrapper spacing on mobile */
   #remindersWrapper {
-    margin-top: 0.75rem;
+    margin-top: 0 !important;
+    padding-top: 0 !important;
   }
 
   /* Main reminders list container */

--- a/mobile.html
+++ b/mobile.html
@@ -53,7 +53,7 @@
     .reminders-top-row {
       display: flex;
       align-items: center;
-      padding: 0.5rem 1rem 0rem; /* reduce bottom padding to zero */
+      padding: 0.35rem 1rem 0rem; /* slightly tighter overall, 0 bottom padding */
       margin-bottom: 0 !important;
       gap: 0.5rem;
       white-space: nowrap;
@@ -1074,7 +1074,8 @@
 
   /* Reminders wrapper spacing on mobile */
   #remindersWrapper {
-    margin-top: 0.5rem;
+    margin-top: 0 !important;
+    padding-top: 0 !important;
   }
 
   /* Main reminders list container */
@@ -1460,7 +1461,7 @@
     /* iOS-style reminders top bar */
     .reminders-top-row {
       display: flex;
-      padding: 0.5rem 1rem 0rem; /* reduce bottom padding to zero */
+      padding: 0.35rem 1rem 0rem; /* slightly tighter overall, 0 bottom padding */
       margin-bottom: 0 !important;
     }
 
@@ -1541,7 +1542,7 @@
     }
 .reminders-top-row {
   display: flex;
-  padding: 0.5rem 1rem 0rem; /* reduce bottom padding to zero */
+  padding: 0.35rem 1rem 0rem; /* slightly tighter overall, 0 bottom padding */
   margin-bottom: 0 !important;
 }
 
@@ -6120,7 +6121,7 @@
 
     .reminders-top-row {
       display: flex;
-      padding: 0.5rem 1rem 0rem; /* reduce bottom padding to zero */
+      padding: 0.35rem 1rem 0rem; /* slightly tighter overall, 0 bottom padding */
       margin-bottom: 0 !important;
     }
 


### PR DESCRIPTION
## Summary
- remove top spacing on the reminders wrapper and content shells for mobile layouts
- tighten the reminders header padding to eliminate extra gap above the list
- mirror the spacing tweaks in the docs mobile preview

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69355d7c13048327a82396da06ddff4d)