### PR TITLE
Tighten notebook spacing on mobile

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -286,6 +286,16 @@
     padding-bottom: 0;
   }
 
+  /* Ensure notebook content hugs the header with a micro-gap */
+  body[data-active-view="notebook"] #main {
+    padding-top: 3px !important;
+    margin-top: 0 !important;
+  }
+
+  body[data-active-view="notebook"] #view-notebook .card-body {
+    margin-top: 0 !important;
+  }
+
   body[data-active-view="notebook"] #view-notebook {
     background: var(--card-bg);
   }
@@ -306,6 +316,11 @@
     padding: clamp(1.25rem, 5vw, 2rem);
     padding-bottom: clamp(5rem, 10vw, 6rem);
     min-height: calc(100dvh - 4rem);
+  }
+
+  body[data-active-view="notebook"] #view-notebook .card-body {
+    padding-top: 0.25rem !important; /* micro gap inside notebook card */
+    margin-top: 0 !important;
   }
 
   .mobile-shell #view-notebook .card {
@@ -3851,7 +3866,7 @@
     </div>
   </div>
   <div id="mobile-shell" class="mobile-shell max-w-md mx-auto w-full px-4 pb-16">
-    <main id="main" class="mx-auto pt-4 pb-4 w-full max-w-none sm:max-w-lg" tabindex="-1" data-active-view="reminders">
+    <main id="main" class="mx-auto pt-4 pb-4 w-full max-w-none sm:max-w-lg" tabindex="-1" data-active-view="reminders" style="background: rgb(251, 251, 251); padding-top: 3px;">
     <!-- BEGIN GPT CHANGE: create form moved to bottom sheet -->
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: reminders view -->

--- a/mobile.html
+++ b/mobile.html
@@ -296,6 +296,16 @@
     padding-bottom: 0;
   }
 
+  /* Ensure notebook content hugs the header with a micro-gap */
+  body[data-active-view="notebook"] #main {
+    padding-top: 3px !important;
+    margin-top: 0 !important;
+  }
+
+  body[data-active-view="notebook"] #view-notebook .card-body {
+    margin-top: 0 !important;
+  }
+
   body[data-active-view="notebook"] #view-notebook {
     background: #FBFBFB;
   }
@@ -329,6 +339,11 @@
     padding: clamp(0.75rem, 4vw, 1.25rem);
     padding-bottom: clamp(3rem, 8vw, 4.5rem);
     min-height: calc(100dvh - 4rem);
+  }
+
+  body[data-active-view="notebook"] #view-notebook .card-body {
+    padding-top: 0.25rem !important; /* micro gap inside notebook card */
+    margin-top: 0 !important;
   }
 
   .mobile-panel--notes {
@@ -5221,7 +5236,7 @@
         class="mx-auto pt-4 pb-4 w-full max-w-none sm:max-w-lg"
         tabindex="-1"
         data-active-view="reminders"
-        style="background: #FBFBFB;"
+        style="background: rgb(251, 251, 251); padding-top: 3px;"
       >
     <!-- BEGIN GPT CHANGE: create form moved to bottom sheet -->
     <!-- END GPT CHANGE -->


### PR DESCRIPTION
## Summary
- reduce the inline main padding to a small gap in the mobile notebook view
- add CSS overrides to keep the notebook header and card tightly aligned without extra spacing
- adjust notebook card body spacing to maintain the micro-gap while preventing top margins

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6935644591048327baea11e884997c36)