### PR TITLE
Reduce mobile main padding gap

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -46,6 +46,11 @@ body.mobile-theme footer {
   overflow-y: auto;
 }
 
+/* Micro-gap under the mobile header so content sits just below the quick bar */
+body.mobile-shell #mobile-shell #main {
+  padding-top: 3px !important;
+}
+
 .app-main {
   flex: 1 1 auto;
   display: flex;

--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -3866,7 +3866,7 @@
     </div>
   </div>
   <div id="mobile-shell" class="mobile-shell max-w-md mx-auto w-full px-4 pb-16">
-    <main id="main" class="mx-auto pt-4 pb-4 w-full max-w-none sm:max-w-lg" tabindex="-1" data-active-view="reminders" style="background: rgb(251, 251, 251); padding-top: 3px;">
+    <main id="main" class="mx-auto pt-4 pb-4 w-full max-w-none sm:max-w-lg" tabindex="-1" data-active-view="reminders" style="background: rgb(251, 251, 251);">
     <!-- BEGIN GPT CHANGE: create form moved to bottom sheet -->
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: reminders view -->

--- a/mobile.html
+++ b/mobile.html
@@ -5236,7 +5236,7 @@
         class="mx-auto pt-4 pb-4 w-full max-w-none sm:max-w-lg"
         tabindex="-1"
         data-active-view="reminders"
-        style="background: rgb(251, 251, 251); padding-top: 3px;"
+        style="background: rgb(251, 251, 251);"
       >
     <!-- BEGIN GPT CHANGE: create form moved to bottom sheet -->
     <!-- END GPT CHANGE -->


### PR DESCRIPTION
## Summary
- remove inline top padding from the main container in mobile pages to eliminate large header gap
- add a CSS micro-gap rule to keep minimal spacing below the mobile quick-add header

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693565844d5c832794caae504b70614d)