### PR TITLE
Optimize mobile notebook layout spacing

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -348,20 +348,16 @@ body.mobile-theme .text-secondary {
   gap: 0.35rem;
 }
 
+.scratch-notes-body-wrapper,
 .note-editor-content-wrapper {
   flex: 1 1 auto;
   min-height: 0;
-  overflow-y: auto;
-}
-
-.scratch-notes-body-wrapper {
-  flex: 1 1 auto;
-  min-height: 0;
   margin-top: 6px;
+  padding: 6px;              /* already fairly tight */
+  border-radius: 12px;
   box-sizing: border-box;
-  display: flex;
-  width: 100%;
-  max-width: 100%;
+  background: #fbf9ff;
+  overflow: hidden;          /* scroll happens inside body */
 }
 
 .note-editor-toolbar {
@@ -475,29 +471,6 @@ body.mobile-theme .text-secondary {
     padding-top: 0 !important;
   }
 
-  /* Scratch notes wrapper adjustments */
-  .scratch-notes-wrapper,
-  .note-sheet-wrapper {
-    margin-top: 0;
-    padding-top: 4px; /* tiny separation only */
-    display: flex;
-    justify-content: center;
-    box-sizing: border-box;
-  }
-
-  /* Make the scratch-notes card stretch and allow internal scrolling */
-  #scratch-notes-card,
-  .scratch-notes-card {
-    flex: 1 1 auto;
-    max-width: 640px;
-    display: flex;
-    flex-direction: column;
-    box-sizing: border-box;
-    padding-bottom: 0;
-    margin-left: 12px;
-    margin-right: 12px;
-  }
-
   .note-editor-card {
     display: flex;
     flex-direction: column;
@@ -508,19 +481,6 @@ body.mobile-theme .text-secondary {
 
   .scratch-notes-header-block {
     flex: 0 0 auto;
-  }
-
-  /* Outer panel around the contenteditable area */
-  .scratch-notes-body-wrapper,
-  .note-editor-content-wrapper {
-    flex: 1 1 auto;
-    min-height: 0;
-    margin-top: 6px;
-    padding: 8px;
-    border-radius: 12px;
-    box-sizing: border-box;
-    background: #fbf9ff;
-    overflow: hidden; /* scroll happens inside .scratch-notes-body */
   }
 
   /* Editable area */
@@ -541,10 +501,6 @@ body.mobile-theme .text-secondary {
     padding-bottom: calc(var(--mobile-bottom-nav-height, 80px) + 8px);
   }
 
-  /* Cap overall card height so it doesn't disappear behind the footer */
-  #scratch-notes-card {
-    max-height: calc(100vh - 120px);
-  }
 }
 
 .note-content-wrapper {
@@ -602,17 +558,21 @@ body.mobile-theme .text-secondary {
   min-height: 0;
   display: flex;
   flex-direction: column;
-  padding: 0 16px 16px;
+  justify-content: flex-start;  /* no centering that creates big gaps */
+  align-items: stretch;
+  padding: 0 8px 6px;           /* reduce side + bottom padding */
+  margin-top: 0;
   box-sizing: border-box;
 }
 
 .scratch-notes-card,
 #scratch-notes-card {
   flex: 1 1 auto;
-  min-height: 0;
-  max-width: 640px;
-  margin: 0 auto;
+  min-height: calc(100vh - 120px); /* header + bottom nav allowance */
+  max-height: none;
   width: 100%;
+  max-width: 100%;
+  margin: 0;
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
@@ -649,10 +609,9 @@ body.mobile-theme .text-secondary {
   padding-top: 0.25rem;
 }
 
-/* Cap the scratch-notes card height properly 
-   160px accounts for: header (80px) + bottom nav (80px) approximately */
+/* Allow the scratch-notes card to use the full vertical space */
 .mobile-shell #view-notebook #scratch-notes-card {
-  max-height: calc(100vh - 10rem);
+  max-height: none;
 }
 
 .note-editor-content.is-placeholder,


### PR DESCRIPTION
## Summary
- tighten scratch notes wrapper padding and alignment for mobile
- allow scratch-notes card to stretch vertically with reduced max-width limits
- expand note body area to fill available height with internal scrolling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6935e47808b88327ae861eb2b9ea629c)