### PR TITLE
Make mobile icons black outlines

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -155,7 +155,7 @@
 
 .header-pill .header-icons svg,
 .header-pill .header-icons button {
-  color: #512663;
+  color: #000000 !important;
 }
 
 .mobile-footer {
@@ -209,8 +209,30 @@
 }
 
 /* Ensure the inner svg/icon contrasts when active */
-#mobile-footer-new-reminder[aria-expanded="true"] svg {
-  filter: brightness(0) invert(1) saturate(1.2);
+#mobile-footer-new-reminder[aria-expanded="true"] svg,
+.floating-footer #mobile-footer-new-reminder[aria-expanded="true"] svg {
+  stroke: #000000 !important;
+  fill: #000000 !important;
+  opacity: 1 !important;
+  filter: none !important;
+}
+
+.mobile-footer svg,
+.floating-footer svg,
+.footer-nav svg,
+.mobile-footer-nav svg,
+.footer-button svg {
+  stroke: #000000 !important;
+  fill: #000000 !important;
+  opacity: 1 !important;
+}
+
+.mobile-footer .mobile-footer-item--active svg,
+.floating-footer .floating-card.active svg,
+.floating-footer .floating-card.is-active svg {
+  stroke: #000000 !important;
+  fill: none !important;
+  opacity: 1 !important;
 }
 
 /* Soft-glass elevated card for mobile New Reminder form */

--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -174,8 +174,8 @@
     }
 
     .icon-btn svg {
-      stroke: #3C3A40; /* Graphite Neutral */
-      opacity: 0.9;
+      stroke: #000000 !important;
+      opacity: 1;
       width: 20px;
       height: 20px;
       transition: opacity 0.15s ease, transform 0.15s ease;
@@ -183,6 +183,7 @@
 
     .icon-btn:hover svg,
     .icon-btn:active svg {
+      stroke: #000000 !important;
       opacity: 1;
       transform: scale(1.04);
     }

--- a/mobile.html
+++ b/mobile.html
@@ -138,8 +138,8 @@
     }
 
     .icon-btn svg {
-      stroke: #3C3A40; /* Graphite Neutral */
-      opacity: 0.9;
+      stroke: #000000 !important;
+      opacity: 1;
       width: 20px;
       height: 20px;
       transition: opacity 0.15s ease, transform 0.15s ease;
@@ -147,6 +147,7 @@
 
     .icon-btn:hover svg,
     .icon-btn:active svg {
+      stroke: #000000 !important;
       opacity: 1;
       transform: scale(1.04);
     }
@@ -1548,8 +1549,8 @@
     }
 
     .icon-btn svg {
-      stroke: var(--accent-color, #512663);
-      opacity: 0.9;
+      stroke: #000000 !important;
+      opacity: 1;
       transition: opacity 0.15s ease, transform 0.15s ease, background-color 0.15s ease;
     }
 .reminders-top-row {
@@ -2636,6 +2637,21 @@
     width: 20px;
     height: 20px;
     display: block;
+  }
+
+  .floating-footer .floating-card svg {
+    stroke: #000000 !important;
+    fill: #000000 !important;
+    opacity: 1 !important;
+  }
+
+  .floating-footer .floating-card:hover svg,
+  .floating-footer .floating-card:active svg,
+  .floating-footer .floating-card.active svg,
+  .floating-footer .floating-card.is-active svg {
+    stroke: #000000 !important;
+    fill: none !important;
+    opacity: 1 !important;
   }
 
   #mobile-nav-shell .floating-fab {

--- a/styles/index.css
+++ b/styles/index.css
@@ -4949,14 +4949,14 @@ section[data-route="dashboard"] .dashboard-shortcuts {
 
 .header-pill .header-icons svg,
 .header-pill .header-icons button {
-  color: var(--accent-color) !important;
+  color: #000000 !important;
 }
 
 .header-pill svg,
 .nav-card svg,
 .fab-card svg,
 .floating-card svg {
-  color: var(--accent-color);
+  color: #000000 !important;
 }
 
 .header-pill svg {
@@ -4969,6 +4969,24 @@ section[data-route="dashboard"] .dashboard-shortcuts {
 .floating-card svg {
   width: 24px;
   height: 24px;
+}
+
+.mobile-footer svg,
+.floating-footer svg,
+.footer-nav svg,
+.mobile-footer-nav svg,
+.footer-button svg {
+  stroke: #000000 !important;
+  fill: #000000 !important;
+  opacity: 1 !important;
+}
+
+.mobile-footer .mobile-footer-item--active svg,
+.floating-footer .floating-card.active svg,
+.floating-footer .floating-card.is-active svg {
+  stroke: #000000 !important;
+  fill: none !important;
+  opacity: 1 !important;
 }
 
 .header-pill {


### PR DESCRIPTION
## Summary
- set mobile icon button strokes to pure black across documentation and main page
- force footer navigation icons to render with black strokes and keep them black in active or hover states
- update shared styles so header/footer icons default to black instead of accent colors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6935e78ae9008327bd4c8cf0b300bde5)