### PR TITLE
Normalize mobile icon styling

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -185,6 +185,31 @@ body.mobile-theme .top-bar .icon-button {
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 
+.icon-btn svg {
+  stroke: currentColor;
+  fill: none;
+  width: 20px;
+  height: 20px;
+  opacity: 1;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.icon-btn:hover svg,
+.icon-btn:active svg {
+  transform: scale(1.04);
+}
+
+.icon-btn:active {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+.reminders-quick-actions .icon-btn,
+.mobile-footer-nav button,
+.mobile-footer-nav .footer-button,
+.footer-nav button {
+  color: #111111;
+}
+
 body.mobile-theme .app-header button:focus-visible,
 body.mobile-theme .top-bar button:focus-visible,
 body.mobile-theme header button:focus-visible {

--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -174,7 +174,8 @@
     }
 
     .icon-btn svg {
-      stroke: #000000 !important;
+      stroke: currentColor;
+      fill: none;
       opacity: 1;
       width: 20px;
       height: 20px;
@@ -183,13 +184,24 @@
 
     .icon-btn:hover svg,
     .icon-btn:active svg {
-      stroke: #000000 !important;
       opacity: 1;
       transform: scale(1.04);
     }
 
     .icon-btn:active {
-      background-color: rgba(74, 46, 96, 0.08);
+      background-color: rgba(0, 0, 0, 0.04);
+    }
+
+    .reminders-quick-actions .icon-btn,
+    .mobile-footer-nav button,
+    .mobile-footer-nav .footer-button,
+    .footer-nav button {
+      color: #111111;
+    }
+
+    .mobile-footer-nav button.active,
+    .footer-button.active {
+      color: #111111;
     }
 
     @media (max-width: 380px) {
@@ -3424,7 +3436,17 @@
         aria-label="Close menu"
         data-close-drawer
       >
-        <svg viewBox="0 0 24 24" class="size-5" fill="none" stroke="currentColor" stroke-width="2">
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.75"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="size-5"
+        >
           <path d="M6 6l12 12M6 18 18 6" />
         </svg>
       </button>
@@ -3857,15 +3879,40 @@
       </div>
       <!-- Notebook opener + Save (check) button moved into header for quick access -->
       <button id="openSavedNotesSheet" type="button" class="header-btn header-btn-icon" aria-label="Open Notebook" title="Open Notebook">
-        <svg class="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
-          <path d="M6 2h9a2 2 0 012 2v16a1 1 0 01-1.5.86L12 19l-3.5 1.86A1 1 0 017 20V4a2 2 0 012-2z" fill="currentColor" />
+        <svg
+          class="w-5 h-5"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.75"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M7 3.5h8.5a1.5 1.5 0 0 1 1.5 1.5v14.5L12 17.7 6.5 19.5V5a1.5 1.5 0 0 1 1.5-1.5Z" />
         </svg>
       </button>
 
       <!-- Save (check) button moved into header for quick access -->
       <button id="noteSaveMobile" type="button" class="header-btn header-btn-icon" aria-label="Save note">
-        <svg class="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg">
-          <path d="M20.285 6.708a1 1 0 0 0-1.414-1.416L9 15.164l-3.871-3.87a1 1 0 1 0-1.414 1.415l4.578 4.579a1 1 0 0 0 1.414 0l10.478-10.479z" fill="currentColor" />
+        <svg
+          class="w-5 h-5"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.75"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+          focusable="false"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M5.5 12.5 10 17l8.5-8.5" />
         </svg>
       </button>
 
@@ -3948,10 +3995,10 @@
                     <svg
                       width="20"
                       height="20"
-                      viewBox="0 0 20 20"
+                      viewBox="0 0 24 24"
                       fill="none"
                       stroke="currentColor"
-                      stroke-width="1.8"
+                      stroke-width="1.75"
                       stroke-linecap="round"
                       stroke-linejoin="round"
                       aria-hidden="true"
@@ -3968,10 +4015,10 @@
                     <svg
                       width="20"
                       height="20"
-                      viewBox="0 0 20 20"
+                      viewBox="0 0 24 24"
                       fill="none"
                       stroke="currentColor"
-                      stroke-width="1.8"
+                      stroke-width="1.75"
                       stroke-linecap="round"
                       stroke-linejoin="round"
                       aria-hidden="true"
@@ -3991,10 +4038,10 @@
                     <svg
                       width="20"
                       height="20"
-                      viewBox="0 0 20 20"
+                      viewBox="0 0 24 24"
                       fill="none"
                       stroke="currentColor"
-                      stroke-width="1.8"
+                      stroke-width="1.75"
                       stroke-linecap="round"
                       stroke-linejoin="round"
                       aria-hidden="true"
@@ -4016,10 +4063,10 @@
                     <svg
                       width="20"
                       height="20"
-                      viewBox="0 0 20 20"
+                      viewBox="0 0 24 24"
                       fill="none"
                       stroke="currentColor"
-                      stroke-width="1.8"
+                      stroke-width="1.75"
                       stroke-linecap="round"
                       stroke-linejoin="round"
                       aria-hidden="true"

--- a/mobile.html
+++ b/mobile.html
@@ -40,7 +40,7 @@
       --hover-bg: rgba(81, 38, 99, 0.06);
       --shadow-color: rgba(81, 38, 99, 0.12);
       --icon-inactive: #4c5c7a;
-      --icon-active: #512663;
+      --icon-active: #111111;
       --true-blue: #0073cf;
     }
 
@@ -138,7 +138,8 @@
     }
 
     .icon-btn svg {
-      stroke: #000000 !important;
+      stroke: currentColor;
+      fill: none;
       opacity: 1;
       width: 20px;
       height: 20px;
@@ -147,13 +148,24 @@
 
     .icon-btn:hover svg,
     .icon-btn:active svg {
-      stroke: #000000 !important;
       opacity: 1;
       transform: scale(1.04);
     }
 
     .icon-btn:active {
-      background-color: rgba(74, 46, 96, 0.08);
+      background-color: rgba(0, 0, 0, 0.04);
+    }
+
+    .reminders-quick-actions .icon-btn,
+    .mobile-footer-nav button,
+    .mobile-footer-nav .footer-button,
+    .footer-nav button {
+      color: #111111;
+    }
+
+    .mobile-footer-nav button.active,
+    .footer-button.active {
+      color: #111111;
     }
 
     @media (max-width: 380px) {
@@ -1549,7 +1561,8 @@
     }
 
     .icon-btn svg {
-      stroke: #000000 !important;
+      stroke: currentColor;
+      fill: none;
       opacity: 1;
       transition: opacity 0.15s ease, transform 0.15s ease, background-color 0.15s ease;
     }
@@ -2162,15 +2175,15 @@
     .note-toolbar-button:focus-visible,
     .formatting-btn:hover,
     .formatting-btn:focus-visible {
-      background: var(--hover-bg, rgba(81, 38, 99, 0.08));
-      color: var(--icon-active, #512663);
+      background: rgba(0, 0, 0, 0.04);
+      color: #111111;
       outline: none;
     }
 
     .note-toolbar-button:active,
     .formatting-btn:active {
-      background: rgba(81, 38, 99, 0.12);
-      color: var(--icon-active, #512663);
+      background: rgba(0, 0, 0, 0.06);
+      color: #111111;
     }
 
     .note-toolbar-button svg,
@@ -2181,8 +2194,8 @@
 
     .note-toolbar-button.active,
     .formatting-btn.active {
-      background: rgba(81, 38, 99, 0.1);
-      color: var(--icon-active, #512663);
+      background: rgba(0, 0, 0, 0.08);
+      color: #111111;
     }
     
     /* Enhance the overall scratch notes card for seamless flow */
@@ -2591,7 +2604,7 @@
     font-size: 0.85rem;
     font-family: var(--font-primary);
     font-weight: 500;
-    color: var(--icon-inactive);
+    color: #111111;
     transition:
       background-color 0.18s ease,
       transform 0.15s ease,
@@ -2629,7 +2642,7 @@
     height: 20px;
     stroke: currentColor;
     fill: none;
-    stroke-width: 1.8;
+    stroke-width: 1.75;
     stroke-linecap: round;
     stroke-linejoin: round;
     display: block;
@@ -2645,8 +2658,8 @@
   }
 
   .floating-footer .floating-card svg {
-    stroke: #000000 !important;
-    fill: #000000 !important;
+    stroke: currentColor;
+    fill: none;
     opacity: 1 !important;
   }
 
@@ -2654,8 +2667,8 @@
   .floating-footer .floating-card:active svg,
   .floating-footer .floating-card.active svg,
   .floating-footer .floating-card.is-active svg {
-    stroke: #000000 !important;
-    fill: none !important;
+    stroke: currentColor;
+    fill: none;
     opacity: 1 !important;
   }
 
@@ -4447,7 +4460,17 @@
         aria-label="Close menu"
         data-close-drawer
       >
-        <svg viewBox="0 0 24 24" class="size-5" fill="none" stroke="currentColor" stroke-width="2">
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.75"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="size-5"
+        >
           <path d="M6 6l12 12M6 18 18 6" />
         </svg>
       </button>
@@ -5045,10 +5068,10 @@
               <svg
                 width="20"
                 height="20"
-                viewBox="0 0 20 20"
+                viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
-                stroke-width="1.8"
+                stroke-width="1.75"
                 stroke-linecap="round"
                 stroke-linejoin="round"
                 aria-hidden="true"
@@ -5065,10 +5088,10 @@
               <svg
                 width="20"
                 height="20"
-                viewBox="0 0 20 20"
+                viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
-                stroke-width="1.8"
+                stroke-width="1.75"
                 stroke-linecap="round"
                 stroke-linejoin="round"
                 aria-hidden="true"
@@ -5088,10 +5111,10 @@
               <svg
                 width="20"
                 height="20"
-                viewBox="0 0 20 20"
+                viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
-                stroke-width="1.8"
+                stroke-width="1.75"
                 stroke-linecap="round"
                 stroke-linejoin="round"
                 aria-hidden="true"
@@ -5113,10 +5136,10 @@
               <svg
                 width="20"
                 height="20"
-                viewBox="0 0 20 20"
+                viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
-                stroke-width="1.8"
+                stroke-width="1.75"
                 stroke-linecap="round"
                 stroke-linejoin="round"
                 aria-hidden="true"
@@ -5458,7 +5481,16 @@
       </div>
                   </div>
                   <button class="notebook-top-overflow" type="button" aria-label="Notebook options">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <svg
+                      width="20"
+                      height="20"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="1.75"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
                       <circle cx="5" cy="12" r="1.5" />
                       <circle cx="12" cy="12" r="1.5" />
                       <circle cx="19" cy="12" r="1.5" />
@@ -5653,7 +5685,18 @@
         data-nav-target="reminders"
         aria-label="Go to Reminders"
       >
-        <svg class="icon icon-clock" viewBox="0 0 24 24" aria-hidden="true">
+        <svg
+          class="icon icon-clock"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.75"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
           <circle cx="12" cy="12" r="7" />
           <path d="M12 9v3.5l2 1.5" />
         </svg>
@@ -5667,7 +5710,18 @@
         data-open-add-task
         aria-label="Add reminder"
       >
-        <svg class="icon icon-plus" viewBox="0 0 24 24" aria-hidden="true">
+        <svg
+          class="icon icon-plus"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.75"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
           <circle cx="12" cy="12" r="7" />
           <path d="M12 9v6" />
           <path d="M9 12h6" />
@@ -5681,7 +5735,18 @@
         data-nav-target="add-note"
         aria-label="Add note"
       >
-        <svg class="icon icon-pencil" viewBox="0 0 24 24" aria-hidden="true">
+        <svg
+          class="icon icon-pencil"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.75"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
           <path d="M6 17.5 6.7 14l6.9-6.9a1.6 1.6 0 0 1 2.3 0l1.9 1.9a1.6 1.6 0 0 1 0 2.3L11 18.1 7.5 18.8z" />
           <path d="M13.2 7.8 16.2 10.8" />
         </svg>
@@ -5694,7 +5759,18 @@
         data-nav-target="notebook"
         aria-label="Go to Notes"
       >
-        <svg class="icon icon-notebook" viewBox="0 0 24 24" aria-hidden="true">
+        <svg
+          class="icon icon-notebook"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.75"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
           <rect x="7" y="4" width="10" height="16" rx="2" />
           <path d="M10 4v16" />
           <path d="M10 8h4" />


### PR DESCRIPTION
## Summary
- update mobile HTML and docs mobile icons to use consistent SF Symbols-style outlines
- standardize icon button styling and default colors to use currentColor black outlines
- align shared mobile theme styles with the new icon sizing and interactions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6935ea9133a88327979f13b9d7e4d81d)