### PR TITLE
Move mobile theme toggle to overflow menu

### DIFF
--- a/js/mobile-theme-toggle.js
+++ b/js/mobile-theme-toggle.js
@@ -1,15 +1,19 @@
-const themeToggleButton = document.getElementById('theme-toggle-button');
+const themeToggleButton =
+  document.getElementById('themeToggle') || document.getElementById('theme-toggle-button');
 const htmlElement = document.documentElement;
 const themeStorageKey = 'memory-cue-theme';
 
 if (themeToggleButton) {
-  const themeIcon = themeToggleButton.querySelector('.material-symbols-rounded');
+  const themeIcon =
+    themeToggleButton.querySelector('.quick-action-icon') ||
+    themeToggleButton.querySelector('.material-symbols-rounded');
 
   const updateIcon = (theme) => {
+    if (!themeIcon) return;
     if (theme === 'professional-dark') {
-      themeIcon.textContent = 'light_mode';
+      themeIcon.textContent = themeIcon.classList.contains('quick-action-icon') ? '🌞' : 'light_mode';
     } else {
-      themeIcon.textContent = 'dark_mode';
+      themeIcon.textContent = themeIcon.classList.contains('quick-action-icon') ? '🌗' : 'dark_mode';
     }
   };
 
@@ -19,7 +23,8 @@ if (themeToggleButton) {
   updateIcon(savedTheme);
 
   themeToggleButton.addEventListener('click', () => {
-    const newTheme = htmlElement.getAttribute('data-theme') === 'light' ? 'professional-dark' : 'light';
+    const newTheme =
+      htmlElement.getAttribute('data-theme') === 'light' ? 'professional-dark' : 'light';
     htmlElement.setAttribute('data-theme', newTheme);
     localStorage.setItem(themeStorageKey, newTheme);
     updateIcon(newTheme);

--- a/mobile.html
+++ b/mobile.html
@@ -5128,9 +5128,6 @@ body {
 
           <!-- Right: saved, mic, save, overflow -->
           <div class="reminders-quick-actions">
-            <button id="theme-toggle-button" class="icon-btn" aria-label="Toggle theme">
-              <span class="material-symbols-rounded">dark_mode</span>
-            </button>
             <button
               id="openSavedNotesGlobal"
               type="button"


### PR DESCRIPTION
## Summary
- remove the standalone theme toggle icon from the mobile header actions and rely on the overflow menu entry
- retarget the mobile theme toggle script to the overflow button and update its icon handling for both button styles

## Testing
- npm test -- theme-toggle.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69364ef82964832790bd6725acd99ac6)