### PR TITLE
Tighten notebook spacing on mobile

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -364,7 +364,7 @@ body.mobile-theme .text-secondary {
 .note-editor-inner {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.4rem;   /* tighter vertical rhythm */
   flex: 1 1 auto;
   min-height: 0;
 }
@@ -373,7 +373,7 @@ body.mobile-theme .text-secondary {
   flex: 0 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.22rem;  /* title → folder label → toolbar closer together */
 }
 
 .scratch-notes-body-wrapper,
@@ -399,8 +399,8 @@ body.mobile-theme .text-secondary {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 0;
-  margin: 6px 0;
+  padding: 2px 0;   /* less internal padding */
+  margin: 3px 0;    /* less space above/below */
   background: transparent;
   border-radius: 0;
   overflow-x: auto;
@@ -648,7 +648,7 @@ body.mobile-theme .text-secondary {
 /* Make the scratch-notes wrapper fill and the card extend properly */
 #view-notebook .scratch-notes-wrapper {
   margin-top: 0;
-  padding-top: 0.25rem;
+  padding-top: 0.12rem;
 }
 
 /* Allow the scratch-notes card to use the full vertical space */

--- a/mobile.html
+++ b/mobile.html
@@ -373,9 +373,9 @@
     min-height: 0 !important;
   }
 
-  /* Let notebook content run almost edge-to-edge */
+  /* Let notebook content sit closer to the header */
   body[data-active-view="notebook"] #view-notebook .card-body {
-    padding: 0.4rem 0.75rem 0.6rem;
+    padding: 0.2rem 0.75rem 0.6rem;
     margin-top: 0 !important;
     min-height: calc(100dvh - var(--mobile-bottom-nav-height, 80px));
   }
@@ -389,7 +389,7 @@
     width: 100%;
     max-width: 100%;
     margin: 0;
-    padding: 0.75rem 0.9rem 1rem;
+    padding: 0.4rem 0.9rem 0.9rem;  /* reduced top + bottom */
     position: relative;
 
     border-radius: 0;
@@ -409,7 +409,7 @@
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.25rem; /* was 0.5rem */
     padding-bottom: clamp(0.35rem, 1.5vh, 1rem);
   }
 
@@ -418,7 +418,7 @@
   }
 
   #view-notebook #scratch-notes-card > * + * {
-    margin-top: 0.25rem;
+    margin-top: 0.18rem;
   }
 
   .mobile-panel--notes #scratch-notes-card .notes-editor {


### PR DESCRIPTION
## Summary
- reduce top padding and gaps around the notebook card and sheet in the mobile view
- tighten vertical spacing within the notebook header, toolbar, and wrapper for a closer layout under the reminders pill

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693738df2dd4832a84b5be1f52ab444d)