### PR TITLE
Tighten notebook spacing on mobile

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -341,6 +341,11 @@
     margin-top: 0 !important;
   }
 
+  #view-notebook .scratch-notes-wrapper {
+    margin-top: 0;
+    padding-top: 0rem;
+  }
+
   /* Hide notebook action buttons: top "Saved notes" pill and bottom New/Save bar */
   #view-notebook .note-actions-top,
   #view-notebook .note-actions.fixed-bottom,
@@ -373,9 +378,9 @@
     min-height: 0 !important;
   }
 
-  /* Let notebook content sit closer to the header */
+  /* Notebook: no extra top padding from card-body */
   body[data-active-view="notebook"] #view-notebook .card-body {
-    padding: 0.2rem 0.75rem 0.6rem;
+    padding: 0rem 0.75rem 0.6rem;
     margin-top: 0 !important;
     min-height: calc(100dvh - var(--mobile-bottom-nav-height, 80px));
   }
@@ -389,7 +394,7 @@
     width: 100%;
     max-width: 100%;
     margin: 0;
-    padding: 0.4rem 0.9rem 0.9rem;  /* reduced top + bottom */
+    padding: 0rem 0.9rem 0.9rem;  /* no extra top padding */
     position: relative;
 
     border-radius: 0;
@@ -405,11 +410,12 @@
     flex-direction: column;
   }
 
+  /* Single intentional gap between header + notebook */
   .mobile-panel--notes .mobile-view-inner {
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 0.25rem; /* was 0.5rem */
+    gap: 0.25rem; /* ~4px breathing space */
     padding-bottom: clamp(0.35rem, 1.5vh, 1rem);
   }
 


### PR DESCRIPTION
## Summary
- remove top padding around the notebook card body and scratch wrapper to pull the content closer to the header
- set a consistent 0.25rem gap for the notebook inner layout
- eliminate extra top padding on the scratch notes card so the title sits nearer to the header pill

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69373b5f2da4832aaa21fbb9022712fb)