### PR TITLE
Refine mobile saved notes sheet layout

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -349,8 +349,7 @@ body.mobile-theme .text-secondary {
   width: 100%;
   max-width: 100vw;
   box-sizing: border-box;
-  margin-left: 0;
-  margin-right: 0;
+  margin: 0;
 }
 
 @media (min-width: 900px) {

--- a/mobile.html
+++ b/mobile.html
@@ -604,16 +604,17 @@
   }
 
   #savedNotesSheet {
+    position: fixed;
+    inset: 0;
+    z-index: 80;
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.25s ease;
-  }
-
-  #savedNotesSheet:not(.hidden) {
     display: flex;
-    align-items: center;
+    align-items: flex-end;
     justify-content: center;
-    padding: 1rem;
+    padding: 0;
+    background: rgba(15, 23, 42, 0.26);
   }
 
   #savedNotesSheet[data-open="true"] {
@@ -623,20 +624,23 @@
 
   #savedNotesSheet .saved-notes-panel {
     position: relative;
-    width: min(92vw, 28rem);
+    width: 100%;
     max-width: 100vw;
     box-sizing: border-box;
-    margin: 0 auto;
-    transform: translateY(24px) scale(0.96);
-    opacity: 0;
+    margin: 0;
+    border-radius: 18px 18px 0 0;
+    background: #ffffff;
+    box-shadow: 0 -4px 18px rgba(15, 23, 42, 0.12);
+    padding-bottom: env(safe-area-inset-bottom, 0.5rem);
+    max-height: 88dvh;
+    transform: translateY(100%);
+    opacity: 1;
     transition:
-      transform 0.35s cubic-bezier(0.25, 0.8, 0.25, 1),
-      opacity 0.25s ease;
+      transform 0.35s cubic-bezier(0.25, 0.8, 0.25, 1);
   }
 
   #savedNotesSheet[data-open="true"] .saved-notes-panel {
-    transform: translateY(0) scale(1);
-    opacity: 1;
+    transform: translateY(0);
   }
 
   .note-body-field {
@@ -825,7 +829,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 12px 16px;
+    padding: 10px 14px;
     margin: 0;
     width: 100%;
     background: transparent;
@@ -848,19 +852,19 @@
   }
 
   .note-list-title {
-    font-size: 15px;
+    font-size: 0.94rem;
     font-weight: 600;
     color: var(--text-primary);
-    line-height: 1.2;
+    line-height: 1.25;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
   .note-list-subtitle {
-    font-size: 13px;
+    font-size: 0.8rem;
     color: var(--text-secondary);
-    margin-top: 2px;
+    margin-top: 1px;
   }
 
   .note-list-meta {
@@ -908,39 +912,22 @@
   }
 
   .mobile-shell #savedNotesSheet {
-    transition: opacity 0.25s ease;
-    opacity: 0;
-    align-items: center;
+    width: 100%;
+    max-width: 100vw;
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    align-items: flex-end;
     justify-content: center;
-    padding: 1rem;
-  }
-
-  .mobile-shell #savedNotesSheet[data-open="true"] {
-    opacity: 1;
   }
 
   .mobile-shell #savedNotesSheet .saved-notes-panel {
-    position: relative;
-    width: min(92vw, 28rem);
+    width: 100%;
     max-width: 100vw;
-    box-sizing: border-box;
-    margin: 0 auto;
-    transform: translateY(24px) scale(0.96);
-    opacity: 0;
-    transition:
-      transform 0.35s cubic-bezier(0.25, 0.8, 0.25, 1),
-      opacity 0.25s ease;
-    /* Premium glassy card styling */
-    background: rgba(255, 255, 255, 0.9);
-    backdrop-filter: blur(16px);
-    -webkit-backdrop-filter: blur(16px);
-    border-radius: 22px;
-    box-shadow: 0 20px 40px rgba(81, 38, 99, 0.16), 0 0 0 1px rgba(255, 255, 255, 0.5);
-  }
-
-  .mobile-shell #savedNotesSheet[data-open="true"] .saved-notes-panel {
-    transform: translateY(0) scale(1);
-    opacity: 1;
+    margin: 0;
+    border-radius: 18px 18px 0 0;
+    background: #ffffff;
+    box-shadow: 0 -4px 18px rgba(15, 23, 42, 0.12);
   }
 
   /* Saved Notes Sheet Title Styling */


### PR DESCRIPTION
## Summary
- convert the Saved Notes overlay into a full-width bottom sheet with a slide-up animation and dimmed backdrop
- simplify mobile-specific styling to match the flat notebook look without glass effects
- tighten Saved Notes list spacing and ensure theme-level sizing stays aligned

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693754bdfcd4832a89b97630639ce223)