### PR TITLE
Improve saved notes overlay layout

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -603,40 +603,60 @@
     transform: none;
   }
 
-  /* ===== Saved notes bottom sheet – flat, notebook-aligned ===== */
+  /* ===== Notebook / Saved notes overlay ===== */
+
+  /* Full-screen overlay, always fixed over the app */
   #savedNotesSheet {
     position: fixed;
     inset: 0;
     z-index: 80;
+    display: flex;
+    align-items: stretch;
+    justify-content: flex-end;
     opacity: 0;
     pointer-events: none;
-    display: flex;
-    align-items: flex-end;
-    justify-content: center;
-    padding: 0;
-    background: rgba(15, 23, 42, 0.26);  /* dimmed backdrop */
+    background: rgba(15, 23, 42, 0.26);
     transition: opacity 0.25s ease;
   }
 
-  #savedNotesSheet[data-open="true"] {
+  /* When JS opens the notebook */
+  #savedNotesSheet[data-open="true"],
+  #savedNotesSheet:not(.hidden)[data-open="true"] {
     opacity: 1;
     pointer-events: auto;
   }
 
+  /* Sidebar panel that sits on top of notes */
   #savedNotesSheet .saved-notes-panel {
     position: relative;
-    width: 100%;
+    height: 100dvh;
+    width: min(420px, 100vw); /* sidebar on desktop, full width on very small screens */
     max-width: 100vw;
-    box-sizing: border-box;
     margin: 0;
-    border-radius: 18px 18px 0 0;
+    box-sizing: border-box;
+    border-radius: 0; /* default; adjusted below in mobile media query */
     background: #ffffff;
-    box-shadow: 0 -4px 18px rgba(15, 23, 42, 0.12);
-    padding: 0.65rem 0.9rem env(safe-area-inset-bottom, 0.7rem);
-    max-height: 88dvh;
+    box-shadow: -10px 0 28px rgba(15, 23, 42, 0.18);
+    padding: 0.9rem 1rem env(safe-area-inset-bottom, 0.9rem);
     display: flex;
     flex-direction: column;
-    gap: 0.35rem;
+    gap: 0.45rem;
+
+    transform: translateX(100%);
+    transition:
+      transform 0.3s cubic-bezier(0.25, 0.8, 0.25, 1),
+      box-shadow 0.18s ease-out;
+  }
+
+  /* Slide the sidebar in when open */
+  #savedNotesSheet[data-open="true"] .saved-notes-panel {
+    transform: translateX(0);
+  }
+
+  /* Ensure header + list use the same white background */
+  #savedNotesSheet,
+  #savedNotesSheet .saved-notes-list-shell {
+    background-color: #ffffff;
   }
 
   /* Header area: handle, title, search, folder chips */
@@ -737,38 +757,42 @@
     box-shadow: 0 4px 12px rgba(81, 38, 99, 0.28);
   }
 
-  /* Scrollable list area */
-  #savedNotesSheet .saved-notes-list-shell {
+  /* Scrollable area inside the sidebar */
+  .saved-notes-list-shell {
     flex: 1 1 auto;
     min-height: 0;
     overflow-y: auto;
-    margin-top: 0.15rem;
+    margin-top: 0.25rem;
   }
 
-  .mobile-shell #notesListMobile {
+  /* Base: single column for very narrow screens */
+  #savedNotesSheet #notesListMobile {
     list-style: none;
     margin: 0;
     padding: 0;
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
   }
 
-  /* Saved notes list inside bottom sheet: flat, dense rows */
-  #savedNotesSheet .note-list-item,
-  #savedNotesSheet .note-row {
-    background: transparent;
-    border-radius: 0;
-    margin: 0;
-    padding: 0.65rem 0;
-    box-shadow: none;
+  /* Wider screens: grid of cards */
+  @media (min-width: 640px) {
+    #savedNotesSheet #notesListMobile {
+      grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+    }
   }
 
+  /* Remove old row dividers & stripes; use cards instead */
   #savedNotesSheet .note-item-mobile {
-    border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+    border-bottom: none;
   }
 
-  #savedNotesSheet .note-item-mobile:last-child {
-    border-bottom: none;
+  #savedNotesSheet .note-list-item {
+    background: #ffffff;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    padding: 0.65rem 0.75rem 0.6rem;
+    box-shadow: 0 4px 10px rgba(15, 23, 42, 0.04);
   }
 
   .note-list-item {
@@ -869,13 +893,16 @@
     opacity: 0.65;
   }
 
+  /* Selected note card: subtle accent, no heavy band */
   #savedNotesSheet .note-list-item.is-active,
-  #savedNotesSheet .note-item-mobile.is-active {
-    background: rgba(15, 23, 42, 0.03);
-    box-shadow: none;
+  #savedNotesSheet .note-item-mobile.is-active .note-list-item {
+    background: color-mix(in srgb, #ffffff 88%, var(--accent-color, #6b46c1) 12%);
+    border-color: color-mix(in srgb, var(--accent-color, #6b46c1) 55%, #e5e7eb 45%);
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent-color, #6b46c1) 45%, transparent);
   }
 
-  #savedNotesSheet .note-list-item.is-active .note-list-title {
+  #savedNotesSheet .note-list-item.is-active .note-list-title,
+  #savedNotesSheet .note-item-mobile.is-active .note-list-title {
     color: var(--text-main, #231B2E);
     font-weight: 600;
   }
@@ -903,82 +930,21 @@
     margin: 0;
   }
 
-  /* Ensure notebook overlay + list share the same white background */
-  #savedNotesSheet,
-  #savedNotesSheet .saved-notes-panel,
-  #savedNotesSheet .saved-notes-list-shell {
-    background-color: #ffffff;
-  }
-
-  /* ===== Notebook sidebar + grid layout on wide screens ===== */
-  @media (min-width: 900px) {
-
-    /* Let the overlay cover the screen but push the panel to the right */
-    body:not(.mobile-shell) #savedNotesSheet {
-      align-items: stretch;
-      justify-content: flex-end;
+  /* On smaller screens, sidebar behaves like a full-width sheet but still overlays */
+  @media (max-width: 640px) {
+    #savedNotesSheet {
+      align-items: flex-end;
+      justify-content: center;
     }
 
-    body:not(.mobile-shell) #savedNotesSheet .saved-notes-panel {
-      width: min(420px, 38vw);
-      max-width: 420px;
-      height: 100dvh;
-      max-height: 100dvh;
-      border-radius: 0;                  /* flush with top/bottom */
-      border-left: 1px solid rgba(15,23,42,0.08);
-      box-shadow: -10px 0 28px rgba(15,23,42,0.16);
-      padding: 0.9rem 1rem 1rem;
-      gap: 0.5rem;
-    }
-
-    /* Make header compact inside sidebar */
-    body:not(.mobile-shell) #savedNotesSheet .saved-notes-header {
-      gap: 0.25rem;
-      margin-bottom: 0.15rem;
-    }
-
-    /* The list shell fills sidebar height and scrolls */
-    body:not(.mobile-shell) #savedNotesSheet .saved-notes-list-shell {
-      margin-top: 0.25rem;
-      padding-bottom: 0.25rem;
-    }
-
-    /* Turn the notes list into a responsive grid */
-    body:not(.mobile-shell) #savedNotesSheet #notesListMobile {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
-      gap: 0.6rem;
-      padding: 0;
-    }
-
-    /* Grid tiles: remove row dividers; use card borders instead */
-    body:not(.mobile-shell) #savedNotesSheet .note-item-mobile {
-      border-bottom: none;
-    }
-
-    body:not(.mobile-shell) #savedNotesSheet .note-list-item {
-      background: #ffffff;
-      border-radius: 0.75rem;
-      border: 1px solid rgba(15, 23, 42, 0.08);
-      padding: 0.65rem 0.75rem 0.6rem;
-      box-shadow: 0 4px 12px rgba(15, 23, 42, 0.04);
-    }
-
-    /* Compact title row in cards */
-    body:not(.mobile-shell) #savedNotesSheet .note-list-title-row {
-      margin-bottom: 0.15rem;
-    }
-
-    /* Active card: subtle tint, not a full grey band */
-    body:not(.mobile-shell) #savedNotesSheet .note-list-item.is-active,
-    body:not(.mobile-shell) #savedNotesSheet .note-item-mobile.is-active {
-      background: color-mix(in srgb, #ffffff 88%, var(--accent-color, #6b46c1) 12%);
-      border-color: color-mix(in srgb, var(--accent-color, #6b46c1) 55%, #e5e7eb 45%);
-      box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent-color, #6b46c1) 45%, transparent);
+    #savedNotesSheet .saved-notes-panel {
+      width: 100vw;
+      border-radius: 18px 18px 0 0;
+      box-shadow: 0 -6px 24px rgba(15, 23, 42, 0.2);
     }
   }
 
-      /* ===== Move to folder sheet – right-side sidebar ===== */
+  /* ===== Move to folder sheet – right-side sidebar ===== */
   #note-folder-sheet,
   #moveFolderSheet {
     position: fixed;


### PR DESCRIPTION
## Summary
- convert the saved notes sheet into a fixed overlay sidebar
- update the saved notes list to a responsive grid with card styling
- adjust mobile behavior for full-width bottom-sheet style overlay

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6937f67044a4832aaaa317bd8a545e68)