### PR TITLE
Make saved notes sheet overlay full screen

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -456,7 +456,7 @@
     right: 0;
     bottom: 0;
     left: 0;                     /* cover full viewport */
-    z-index: 80;
+    z-index: 95;
     opacity: 0;
     pointer-events: none;
     display: flex;
@@ -1920,6 +1920,11 @@
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
       touch-action: manipulation;
+    }
+
+    body[data-saved-notes-open="true"],
+    html[data-saved-notes-open="true"] {
+      overflow: hidden;
     }
 
     /* Mobile main container */

--- a/mobile.html
+++ b/mobile.html
@@ -76,6 +76,11 @@
       line-height: 1.5;
     }
 
+    body[data-saved-notes-open="true"],
+    html[data-saved-notes-open="true"] {
+      overflow: hidden;
+    }
+
     /* Single-row iOS-style reminders top bar */
     .reminders-top-row {
       display: flex;
@@ -615,7 +620,7 @@
     right: 0;
     bottom: 0;
     left: 0;                     /* cover full viewport */
-    z-index: 80;
+    z-index: 95;
     opacity: 0;
     pointer-events: none;
     display: flex;

--- a/mobile.js
+++ b/mobile.js
@@ -746,6 +746,9 @@ const initMobileNotes = () => {
     savedNotesSheet.classList.remove('hidden');
     savedNotesSheet.dataset.open = 'true';
     savedNotesSheet.setAttribute('aria-hidden', 'false');
+    document.body.dataset.savedNotesOpen = 'true';
+    document.documentElement.dataset.savedNotesOpen = 'true';
+    window.scrollTo({ top: 0, left: 0, behavior: 'instant' || 'auto' });
     // Sidebar is now the primary folder selector; just render notes and ensure FAB exists
     try {
       renderFilteredNotes();
@@ -766,6 +769,8 @@ const initMobileNotes = () => {
     }
     savedNotesSheet.dataset.open = 'false';
     savedNotesSheet.setAttribute('aria-hidden', 'true');
+    delete document.body.dataset.savedNotesOpen;
+    delete document.documentElement.dataset.savedNotesOpen;
     if (savedNotesSheetHideTimeout) {
       clearTimeout(savedNotesSheetHideTimeout);
     }


### PR DESCRIPTION
## Summary
- lock scroll and reset viewport when opening the saved notes sheet to keep the overlay at the top
- raise the saved notes sheet z-index and add data-driven scroll locking styles in mobile and docs builds
- keep the saved notes list scrolling region while preventing background page scroll

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69388d031c50832a8f7a961dfd2d1a59)