### PR TITLE
Fix mobile overflow menu button wiring

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5648,7 +5648,6 @@ body, main, section, div, p, span, li {
               </svg>
             </button>
             <button
-              id="overflowMenuBtn"
               type="button"
               class="icon-btn"
               aria-haspopup="true"
@@ -6043,7 +6042,12 @@ body, main, section, div, p, span, li {
                       </div>
                     </div>
                   </div>
-                  <button class="notebook-top-overflow" type="button" aria-label="Notebook options">
+                  <button
+                    id="overflowMenuBtn"
+                    class="notebook-top-overflow"
+                    type="button"
+                    aria-label="Notebook options"
+                  >
                     <svg
                       width="20"
                       height="20"


### PR DESCRIPTION
## Summary
- assign the overflow menu button id to the notebook header control so mobile JS can wire up the menu
- remove the old id from the quick action overflow button to keep a single target for the menu logic

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693896237310832a9a885bb4832e8eb8)