### PR TITLE
Remove notebook-specific overflow menu button

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -6042,27 +6042,6 @@ body, main, section, div, p, span, li {
                       </div>
                     </div>
                   </div>
-                  <button
-                    id="overflowMenuBtn"
-                    class="notebook-top-overflow"
-                    type="button"
-                    aria-label="Notebook options"
-                  >
-                    <svg
-                      width="20"
-                      height="20"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.75"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    >
-                      <circle cx="5" cy="12" r="1.5" />
-                      <circle cx="12" cy="12" r="1.5" />
-                      <circle cx="19" cy="12" r="1.5" />
-                    </svg>
-                  </button>
                 </div>
 
                 <div class="notebook-search-container">


### PR DESCRIPTION
## Summary
- remove the notebook header overflow button so the saved notes sheet uses only the global menu

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6938a041c8ec832aa04a19e7659a8a12)