### PR TITLE
Restore reminders layout toggle

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5831,6 +5831,24 @@ body, main, section, div, p, span, li {
         <!-- header removed to keep view minimal -->
         <div class="reminders-content-shell space-y-2">
 
+          <div class="flex items-center justify-between gap-2 px-1">
+            <div class="flex items-center gap-2 text-base-content/70">
+              <span class="text-sm font-semibold text-base-content">Reminders</span>
+            </div>
+            <button
+              type="button"
+              id="viewToggleMenu"
+              class="btn btn-ghost btn-xs"
+              aria-pressed="false"
+              aria-live="polite"
+              data-layout="list"
+            >
+              <span class="flex items-center gap-2 text-xs font-semibold text-base-content" id="viewToggleLabel">
+                View layout: Stacked
+              </span>
+            </button>
+          </div>
+
           <div id="remindersListMobile" class="space-y-2">
             <section
               id="reminderListSection"


### PR DESCRIPTION
## Summary
- reintroduce the reminders layout toggle button on mobile so users can switch list, grid, and row views
- provide default label and accessibility attributes for the layout control

## Testing
- npm test -- --runInBand *(fails: existing failures in mobile.new-folder, mobile.auth, and service-worker tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6938bd92c86c832aa93b5049d4a8434a)