### PR TITLE
Restore overflow menu trigger in mobile header

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5648,6 +5648,7 @@ body, main, section, div, p, span, li {
               </svg>
             </button>
             <button
+              id="overflowMenuBtn"
               type="button"
               class="icon-btn"
               aria-haspopup="true"


### PR DESCRIPTION
## Summary
- add the missing overflowMenuBtn id to the main reminders header three-dot button
- ensure the existing overflow menu wiring targets the correct button

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6938c017d528832ab1dba860a5f34b39)