### PR TITLE
Guard mobile overflow menu against duplicate handlers

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -9066,7 +9066,9 @@ body, main, section, div, p, span, li {
         document.getElementById('headerMenuSlim') ||
         document.getElementById('headerMenu');
 
-      if (!menuBtn || !menu) return;
+      // Skip binding if the mobile.js controller has already taken over to
+      // prevent duplicate toggle listeners firing on tap.
+      if (!menuBtn || !menu || menuBtn.dataset.overflowMenuHandled === 'mobile-js') return;
 
       var isOpen = function () {
         return menuBtn.getAttribute('aria-expanded') === 'true';

--- a/mobile.js
+++ b/mobile.js
@@ -2866,9 +2866,13 @@ function wireMobileNotesSupabaseAuth() {
   const menuBtn = document.getElementById('overflowMenuBtn');
   const menu = document.getElementById('overflowMenu');
 
-  if (!(menuBtn instanceof HTMLElement) || !(menu instanceof HTMLElement)) {
+  if (!(menuBtn instanceof HTMLElement) || !(menu instanceof HTMLElement)) { 
     return;
   }
+
+  // Mark that the robust overflow menu controller is active so inline fallbacks
+  // avoid double-binding click handlers that cause immediate close-on-open.
+  menuBtn.dataset.overflowMenuHandled = 'mobile-js';
 
   const FOCUSABLE_SELECTOR =
     'button:not([disabled]):not([tabindex="-1"]), [href]:not([tabindex="-1"]), input:not([disabled]):not([tabindex="-1"]), select:not([disabled]):not([tabindex="-1"]), textarea:not([disabled]):not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])';


### PR DESCRIPTION
## Summary
- mark the mobile overflow menu button when the mobile.js controller attaches
- skip the inline overflow menu fallback when mobile.js is present to avoid double toggle listeners

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6938d0865a98832a88b67b1ce4a82333)