### PR TITLE
Restore legacy saved notes in mobile

### DIFF
--- a/js/modules/notes-storage.js
+++ b/js/modules/notes-storage.js
@@ -1,6 +1,6 @@
 const NOTES_STORAGE_KEY = 'memoryCueNotes';
 const FOLDERS_STORAGE_KEY = 'memoryCueFolders';
-const LEGACY_NOTE_KEYS = ['mobileNotes'];
+const LEGACY_NOTE_KEYS = ['mobileNotes', 'memory-cue-notes'];
 
 const hasLocalStorage = () => typeof localStorage !== 'undefined';
 


### PR DESCRIPTION
## Summary
- include the legacy `memory-cue-notes` localStorage key when importing existing notes
- migrate those saved entries into the current notebook storage so they appear in mobile

## Testing
- npm test --silent


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6939255a9c20832a999e420fa61c1d81)