### PR TITLE
Fix saved notes sheet overlay position

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -748,7 +748,7 @@ const initMobileNotes = () => {
     savedNotesSheet.setAttribute('aria-hidden', 'false');
     document.body.dataset.savedNotesOpen = 'true';
     document.documentElement.dataset.savedNotesOpen = 'true';
-    window.scrollTo({ top: 0, left: 0, behavior: 'instant' || 'auto' });
+    window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
     // Sidebar is now the primary folder selector; just render notes and ensure FAB exists
     try {
       renderFilteredNotes();
@@ -1460,7 +1460,7 @@ const initMobileNotes = () => {
 
     // ensure the sheet can anchor absolute children
     try {
-      savedNotesSheet.style.position = savedNotesSheet.style.position || 'relative';
+      savedNotesSheet.style.position = savedNotesSheet.style.position || 'fixed';
     } catch (e) {
       /* ignore */
     }
@@ -3915,3 +3915,9 @@ document.addEventListener('click', (ev) => {
   });
 })();
 /* END GPT CHANGE */
+// DIAGNOSIS (HTML): #savedNotesSheet is a fixed, full-viewport overlay (z-index 95) with no top padding; nothing else in the markup has a higher z-index in this scope.
+// DIAGNOSIS (CSS): The sheet is styled to cover the viewport with a 100dvh panel and no top margin; scrolling is meant to occur inside .saved-notes-list-shell, not on the body.
+// DIAGNOSIS (JS): showSavedNotesSheet() marks the overlay open but ensureFloatingNewFolderFab() later forces savedNotesSheet.style.position = 'relative', removing its fixed overlay behavior; window.scrollTo uses a behavior value ('instant') that browsers ignore.
+// ROOT CAUSE:
+// 1) ensureFloatingNewFolderFab() overrides the #savedNotesSheet position to relative, pulling the overlay into normal flow so it appears lower on the page when the body is scrolled.
+// 2) The attempted scrollTo uses an unsupported behavior value and may not reliably reset scroll before opening, reinforcing the impression that the sheet opens from the current scroll position.


### PR DESCRIPTION
## Summary
- document why the saved notes sheet fails to stay pinned to the viewport
- keep the sheet fixed in place when adding the floating folder button
- reset scroll with a supported behavior when opening the sheet

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939d19cdc088324a38a53834aa3980a)