### PR TITLE
Make saved notes controls sticky

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -4571,48 +4571,52 @@
 
               <!-- Main notebook content -->
               <div class="notebook-sidebar-main">
-                <div class="flex items-start justify-between gap-3">
-                  <div id="saved-notes-header" class="space-y-1 mb-1">
-                    <h3 id="savedNotesSheetTitle" class="text-sm font-semibold text-base-content/90">Saved notes</h3>
-                    <p class="text-xs text-base-content/70">Tap a note to load it here.</p>
+                <div class="saved-notes-controls">
+                  <div class="flex items-start justify-between gap-3">
+                    <div id="saved-notes-header" class="space-y-1 mb-1">
+                      <h3 id="savedNotesSheetTitle" class="text-sm font-semibold text-base-content/90">Saved notes</h3>
+                      <p class="text-xs text-base-content/70">Tap a note to load it here.</p>
+                    </div>
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-circle"
+                      data-action="close-saved-notes"
+                      aria-label="Close saved notes"
+                    >
+                      ✕
+                    </button>
                   </div>
-                  <button
-                    type="button"
-                    class="btn btn-ghost btn-circle"
-                    data-action="close-saved-notes"
-                    aria-label="Close saved notes"
-                  >
-                    ✕
-                  </button>
-                </div>
 
-                <div class="flex items-center justify-between gap-2 text-[11px] text-base-content/60" data-note-detail-list>
-                  <p id="notesStatusText" class="text-[11px] text-base-content/60 truncate"></p>
-                  <span class="flex items-center gap-1 whitespace-nowrap">
-                    <span id="notesSyncStatus" class="sync-dot ready" aria-hidden="true"></span>
-                  </span>
-                </div>
+                  <div class="flex items-center justify-between gap-2 text-[11px] text-base-content/60" data-note-detail-list>
+                    <p id="notesStatusText" class="text-[11px] text-base-content/60 truncate"></p>
+                    <span class="flex items-center gap-1 whitespace-nowrap">
+                      <span id="notesSyncStatus" class="sync-dot ready" aria-hidden="true"></span>
+                    </span>
+                  </div>
 
-                <div class="space-y-2 border border-base-200/70 rounded-2xl bg-base-100/80 px-3 py-3">
-                  <label class="sr-only" for="notesFilterMobile">Filter notes</label>
-                  <input
-                    id="notesFilterMobile"
-                    type="search"
-                    class="input input-bordered input-sm w-full text-sm text-base-content bg-base-200/80 placeholder:text-base-content/70 placeholder:opacity-80"
-                    placeholder="Search saved notes…"
-                  />
-                  <div class="flex items-center justify-between text-xs font-semibold text-base-content/70">
-                    <span class="text-base-content/60 font-medium">Showing</span>
-                    <span id="notesCountMobile" class="text-sm font-semibold whitespace-nowrap"></span>
+                  <div class="space-y-2 border border-base-200/70 rounded-2xl bg-base-100/80 px-3 py-3">
+                    <label class="sr-only" for="notesFilterMobile">Filter notes</label>
+                    <input
+                      id="notesFilterMobile"
+                      type="search"
+                      class="input input-bordered input-sm w-full text-sm text-base-content bg-base-200/80 placeholder:text-base-content/70 placeholder:opacity-80"
+                      placeholder="Search saved notes…"
+                    />
+                    <div class="flex items-center justify-between text-xs font-semibold text-base-content/70">
+                      <span class="text-base-content/60 font-medium">Showing</span>
+                      <span id="notesCountMobile" class="text-sm font-semibold whitespace-nowrap"></span>
+                    </div>
                   </div>
                 </div>
 
                 <div class="saved-notes-list-shell mt-1 max-h-56 overflow-y-auto flex-1 w-full">
-                  <ul
-                    id="notesListMobile"
-                    class="notebook-list text-sm"
-                    aria-label="Saved scratch notes"
-                  ></ul>
+                  <div class="saved-notes-list">
+                    <ul
+                      id="notesListMobile"
+                      class="notebook-list text-sm"
+                      aria-label="Saved scratch notes"
+                    ></ul>
+                  </div>
                 </div>
               </div>
             </div>

--- a/mobile.html
+++ b/mobile.html
@@ -6069,26 +6069,28 @@ body, main, section, div, p, span, li {
 
               <!-- Main notebook content -->
               <div class="notebook-sidebar-main">
-                <div class="notebook-top-bar notebook-header">
-                  <div class="notebook-top-left">
-                    <button
-                      id="closeSavedNotesSheet"
-                      class="btn btn-xs btn-ghost"
-                      type="button"
-                      data-action="close-saved-notes"
-                      aria-label="Close Notebook"
-                    >
-                      Close
-                    </button>
-                    <h3 class="text-sm font-semibold" id="savedNotesSheetTitle">Notebook</h3>
-                  </div>
-                    <div class="notebook-top-center">
-                      <div class="notebook-tabs">
-                        <div id="notebook-folder-bar" class="notebook-folder-bar px-0 py-0">
-                          <div class="notebook-folder-header">
-                            <div class="folder-chips">
-                              <div class="notebook-folder-scroll-wrap">
-                                <!-- Folder chip bar removed; sidebar handles folder selection -->
+                <div class="saved-notes-controls">
+                  <div class="notebook-top-bar notebook-header">
+                    <div class="notebook-top-left">
+                      <button
+                        id="closeSavedNotesSheet"
+                        class="btn btn-xs btn-ghost"
+                        type="button"
+                        data-action="close-saved-notes"
+                        aria-label="Close Notebook"
+                      >
+                        Close
+                      </button>
+                      <h3 class="text-sm font-semibold" id="savedNotesSheetTitle">Notebook</h3>
+                    </div>
+                      <div class="notebook-top-center">
+                        <div class="notebook-tabs">
+                          <div id="notebook-folder-bar" class="notebook-folder-bar px-0 py-0">
+                            <div class="notebook-folder-header">
+                              <div class="folder-chips">
+                                <div class="notebook-folder-scroll-wrap">
+                                  <!-- Folder chip bar removed; sidebar handles folder selection -->
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -6096,49 +6098,51 @@ body, main, section, div, p, span, li {
                       </div>
                     </div>
                   </div>
-                </div>
 
-                <div class="notebook-search-container">
-                  <input
-                    id="notebook-search-input"
-                    type="search"
-                    placeholder="Search notes…"
-                    class="notebook-search-bar notebook-notes-search"
-                  />
+                  <div class="notebook-search-container">
+                    <input
+                      id="notebook-search-input"
+                      type="search"
+                      placeholder="Search notes…"
+                      class="notebook-search-bar notebook-notes-search"
+                    />
+                  </div>
                 </div>
 
                 <div class="saved-notes-list-shell">
-                  <ul
-                    id="notesListMobile"
-                    class="notebook-list notebook-notes-list saved-notes-list text-sm"
-                    aria-label="Saved scratch notes"
-                  >
-                    <!-- Note items are rendered here by JS -->
-                    <template id="notesListMobileItemTemplate">
-                      <div class="note-row note-list-item" data-note-id="" data-role="open-note">
-                        <div class="note-row-main note-list-main" data-note-id="" data-role="open-note">
-                          <div class="note-row-title-row note-list-title-row">
-                            <div class="note-row-title note-list-title">Untitled</div>
-                            <span class="note-list-pin-icon" aria-hidden="true" hidden>📌</span>
+                  <div class="saved-notes-list">
+                    <ul
+                      id="notesListMobile"
+                      class="notebook-list notebook-notes-list text-sm"
+                      aria-label="Saved scratch notes"
+                    >
+                      <!-- Note items are rendered here by JS -->
+                      <template id="notesListMobileItemTemplate">
+                        <div class="note-row note-list-item" data-note-id="" data-role="open-note">
+                          <div class="note-row-main note-list-main" data-note-id="" data-role="open-note">
+                            <div class="note-row-title-row note-list-title-row">
+                              <div class="note-row-title note-list-title">Untitled</div>
+                              <span class="note-list-pin-icon" aria-hidden="true" hidden>📌</span>
+                            </div>
+                            <div class="note-row-meta note-list-meta">
+                              <button class="note-row-folder note-list-folder" type="button">Folder</button>
+                              <span class="note-row-dot note-list-dot">•</span>
+                              <span class="note-row-timestamp note-list-date">Date</span>
+                            </div>
                           </div>
-                          <div class="note-row-meta note-list-meta">
-                            <button class="note-row-folder note-list-folder" type="button">Folder</button>
-                            <span class="note-row-dot note-list-dot">•</span>
-                            <span class="note-row-timestamp note-list-date">Date</span>
-                          </div>
+                          <button
+                            type="button"
+                            class="note-row-overflow note-list-overflow note-options-button note-actions"
+                            aria-label="More"
+                            data-role="note-menu"
+                            data-note-id=""
+                          >
+                            ⋯
+                          </button>
                         </div>
-                        <button
-                          type="button"
-                          class="note-row-overflow note-list-overflow note-options-button note-actions"
-                          aria-label="More"
-                          data-role="note-menu"
-                          data-note-id=""
-                        >
-                          ⋯
-                        </button>
-                      </div>
-                    </template>
-                  </ul>
+                      </template>
+                    </ul>
+                  </div>
                 </div>
               </div>
               <!-- New Folder Modal -->

--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,30 @@ html {
   scroll-behavior: smooth;
 }
 
+.saved-notes-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--saved-notes-panel-bg, rgba(255, 255, 255, 0.92));
+  backdrop-filter: var(--saved-notes-panel-blur, blur(14px));
+}
+
+.saved-notes-controls {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  background: inherit;
+  padding-bottom: 4px;
+  margin-bottom: 8px;
+}
+
+.saved-notes-list {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
 :root {
   --font-heading: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   --font-heading-weight: 600;


### PR DESCRIPTION
## Summary
- wrap the saved notes folder controls and search into a sticky header container
- give the saved notes list its own scrollable container within a flex layout
- mirror the saved notes markup updates in the documentation page

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939d63c14908324ba44fb589ca36c9c)