### PR TITLE
Restyle saved notes list as cards

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -632,69 +632,96 @@
     list-style: none;
     margin: 0;
     padding: 0;
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+  }
+
+  @media (min-width: 640px) {
+    .mobile-shell #notesListMobile {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
   }
 
   /* Each note row – flat, full-width, compact */
   .mobile-shell #notesListMobile .note-item-mobile {
-    border-bottom: 1px solid rgba(15, 23, 42, 0.06);
-  }
-
-  .mobile-shell #notesListMobile .note-item-mobile:last-child {
     border-bottom: none;
+    margin: 0;
   }
 
-  .note-list-item {
+  .mobile-shell #notesListMobile .note-card {
+    border-radius: 12px;
+    padding: 14px 16px;
+    background: var(--note-card-bg, rgba(255, 255, 255, 0.03));
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.25);
     display: flex;
     flex-direction: column;
-    gap: 3px;
-    padding: 0.7rem 0.1rem;
-    text-align: left;
+    gap: 0.35rem;
     width: 100%;
+    transition: transform 0.1s ease, background 0.1s ease;
   }
 
-  .note-list-title {
-    font-size: 0.96rem;
+  .mobile-shell #notesListMobile .note-card:hover {
+    transform: translateY(-2px);
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .mobile-shell #notesListMobile .note-card-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.5rem;
+    min-width: 0;
+  }
+
+  .mobile-shell #notesListMobile .note-card-title {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-size: 1rem;
     font-weight: 600;
-    color: var(--text-strong, #231B2E);
-    margin-bottom: 1px;
+    color: var(--text-primary, #e5e7eb);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    margin: 0;
   }
 
-  .note-list-preview {
-    font-size: 0.84rem;
-    color: var(--text-body, #4a3c57);
-    line-height: 1.3;
-    max-height: 2.6em;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .note-list-meta {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.5rem;
-    margin-top: 2px;
-    font-size: 0.74rem;
-    color: var(--text-muted, #9a8bb0);
-  }
-
-  .note-list-meta-left {
+  .mobile-shell #notesListMobile .note-card-action {
     display: inline-flex;
     align-items: center;
-    gap: 0.35rem;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 999px;
+    border: 0;
+    background: transparent;
+    padding: 0;
+    font-size: 1.1rem;
+    line-height: 1;
+    color: var(--text-secondary, #cbd5e1);
   }
 
-  .note-list-meta-dot {
-    width: 3px;
-    height: 3px;
+  .mobile-shell #notesListMobile .note-card-action:hover,
+  .mobile-shell #notesListMobile .note-card-action:focus-visible {
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  .mobile-shell #notesListMobile .note-card-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-top: 2px;
+    font-size: 0.85rem;
+    color: var(--text-secondary, #cbd5e1);
+  }
+
+  .mobile-shell #notesListMobile .note-card-meta-dot {
+    width: 4px;
+    height: 4px;
     border-radius: 999px;
     background: currentColor;
-    opacity: 0.65;
+    opacity: 0.7;
   }
 
   .mobile-shell #notesListMobile .note-item-mobile button[data-role="delete-note"]:focus-visible {
@@ -4613,9 +4640,36 @@
                   <div class="saved-notes-list">
                     <ul
                       id="notesListMobile"
-                      class="notebook-list text-sm"
+                      class="saved-notes-list notebook-list text-sm"
                       aria-label="Saved scratch notes"
-                    ></ul>
+                    >
+                      <template id="notesListMobileItemTemplate">
+                        <li class="note-item-mobile">
+                          <div class="note-card note-row note-list-item" data-note-id="" data-role="open-note">
+                            <div class="note-row-main note-list-main note-card-main" data-note-id="" data-role="open-note">
+                              <div class="note-row-title-row note-list-title-row note-card-header">
+                                <div class="note-row-title note-list-title note-card-title">Untitled</div>
+                                <span class="note-list-pin-icon" aria-hidden="true" hidden>📌</span>
+                                <button
+                                  type="button"
+                                  class="note-row-overflow note-list-overflow note-card-action note-options-button note-actions"
+                                  aria-label="More"
+                                  data-role="note-menu"
+                                  data-note-id=""
+                                >
+                                  ⋯
+                                </button>
+                              </div>
+                              <div class="note-row-meta note-list-meta note-card-meta">
+                                <button class="note-row-folder note-list-folder note-card-folder" type="button">Folder</button>
+                                <span class="note-row-dot note-list-dot note-card-meta-dot">•</span>
+                                <span class="note-row-timestamp note-list-date note-card-timestamp">Date</span>
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                      </template>
+                    </ul>
                   </div>
                 </div>
               </div>

--- a/mobile.html
+++ b/mobile.html
@@ -971,125 +971,95 @@
     padding: 0;
     display: grid;
     grid-template-columns: 1fr;
-    gap: 0.5rem;
+    gap: 0.75rem;
   }
 
   /* Wider screens: grid of cards */
   @media (min-width: 640px) {
     #savedNotesSheet #notesListMobile {
-      grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
 
   /* Remove old row dividers & stripes; use cards instead */
   #savedNotesSheet .note-item-mobile {
     border-bottom: none;
+    margin: 0;
   }
 
-  #savedNotesSheet .note-list-item {
-    background: #ffffff;
-    border-radius: 0.75rem;
-    border: 1px solid rgba(15, 23, 42, 0.08);
-    padding: 0.65rem 0.75rem 0.6rem;
-    box-shadow: 0 4px 10px rgba(15, 23, 42, 0.04);
-  }
-
-  .note-list-item {
+  #savedNotesSheet .note-card {
+    border-radius: 12px;
+    padding: 14px 16px;
+    background: var(--note-card-bg, rgba(255, 255, 255, 0.03));
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.25);
     display: flex;
     flex-direction: column;
-    gap: 3px;
-    padding: 0.7rem 0.1rem;
-    text-align: left;
+    gap: 0.35rem;
     width: 100%;
+    transition: transform 0.1s ease, background 0.1s ease;
   }
 
-  #savedNotesSheet .note-list-title-row {
+  #savedNotesSheet .note-card:hover {
+    transform: translateY(-2px);
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  #savedNotesSheet .note-card-header {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
     gap: 0.5rem;
     min-width: 0;
   }
 
-  #savedNotesSheet .note-list-title {
+  #savedNotesSheet .note-card-title {
     flex: 1 1 auto;
     min-width: 0;
-    font-size: 0.96rem;
+    font-size: 1rem;
     font-weight: 600;
-    color: var(--text-strong, #231B2E);
+    color: var(--text-primary, #e5e7eb);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    margin: 0;
   }
 
-  #savedNotesSheet .note-list-right {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.15rem;
-    margin-left: 0;
-  }
-
-  #savedNotesSheet .note-list-overflow {
+  #savedNotesSheet .note-card-action {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 28px;
-    height: 28px;
+    width: 32px;
+    height: 32px;
     border-radius: 999px;
     border: 0;
     background: transparent;
     padding: 0;
     font-size: 1.1rem;
     line-height: 1;
-    color: var(--text-secondary, #4A4153);
+    color: var(--text-secondary, #cbd5e1);
   }
 
-  #savedNotesSheet .note-list-overflow:hover,
-  #savedNotesSheet .note-list-overflow:focus-visible {
-    background: rgba(15, 23, 42, 0.06);
+  #savedNotesSheet .note-card-action:hover,
+  #savedNotesSheet .note-card-action:focus-visible {
+    background: rgba(255, 255, 255, 0.08);
   }
 
-  .note-list-title {
-    font-size: 0.96rem;
-    font-weight: 600;
-    color: var(--text-strong, #231B2E);
-    margin-bottom: 1px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  #savedNotesSheet .note-list-preview {
-    font-size: 0.84rem;
-    color: var(--text-body, #4a3c57);
-    line-height: 1.3;
-    max-height: 2.6em;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  #savedNotesSheet .note-list-meta {
+  #savedNotesSheet .note-card-meta {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    gap: 0.5rem;
+    gap: 0.4rem;
     margin-top: 2px;
-    font-size: 0.74rem;
-    color: var(--text-muted, #9a8bb0);
+    font-size: 0.85rem;
+    color: var(--text-secondary, #cbd5e1);
   }
 
-  #savedNotesSheet .note-list-meta-left {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-  }
-
-  #savedNotesSheet .note-list-meta-dot {
-    width: 3px;
-    height: 3px;
+  #savedNotesSheet .note-card-meta-dot {
+    width: 4px;
+    height: 4px;
     border-radius: 999px;
     background: currentColor;
-    opacity: 0.65;
+    opacity: 0.7;
   }
 
   /* Selected note card: subtle accent, no heavy band */
@@ -6113,33 +6083,35 @@ body, main, section, div, p, span, li {
                   <div class="saved-notes-list">
                     <ul
                       id="notesListMobile"
-                      class="notebook-list notebook-notes-list text-sm"
+                      class="saved-notes-list notebook-list notebook-notes-list text-sm"
                       aria-label="Saved scratch notes"
                     >
                       <!-- Note items are rendered here by JS -->
                       <template id="notesListMobileItemTemplate">
-                        <div class="note-row note-list-item" data-note-id="" data-role="open-note">
-                          <div class="note-row-main note-list-main" data-note-id="" data-role="open-note">
-                            <div class="note-row-title-row note-list-title-row">
-                              <div class="note-row-title note-list-title">Untitled</div>
-                              <span class="note-list-pin-icon" aria-hidden="true" hidden>📌</span>
-                            </div>
-                            <div class="note-row-meta note-list-meta">
-                              <button class="note-row-folder note-list-folder" type="button">Folder</button>
-                              <span class="note-row-dot note-list-dot">•</span>
-                              <span class="note-row-timestamp note-list-date">Date</span>
+                        <li class="note-item-mobile">
+                          <div class="note-card note-row note-list-item" data-note-id="" data-role="open-note">
+                            <div class="note-row-main note-list-main note-card-main" data-note-id="" data-role="open-note">
+                              <div class="note-row-title-row note-list-title-row note-card-header">
+                                <div class="note-row-title note-list-title note-card-title">Untitled</div>
+                                <span class="note-list-pin-icon" aria-hidden="true" hidden>📌</span>
+                                <button
+                                  type="button"
+                                  class="note-row-overflow note-list-overflow note-card-action note-options-button note-actions"
+                                  aria-label="More"
+                                  data-role="note-menu"
+                                  data-note-id=""
+                                >
+                                  ⋯
+                                </button>
+                              </div>
+                              <div class="note-row-meta note-list-meta note-card-meta">
+                                <button class="note-row-folder note-list-folder note-card-folder" type="button">Folder</button>
+                                <span class="note-row-dot note-list-dot note-card-meta-dot">•</span>
+                                <span class="note-row-timestamp note-list-date note-card-timestamp">Date</span>
+                              </div>
                             </div>
                           </div>
-                          <button
-                            type="button"
-                            class="note-row-overflow note-list-overflow note-options-button note-actions"
-                            aria-label="More"
-                            data-role="note-menu"
-                            data-note-id=""
-                          >
-                            ⋯
-                          </button>
-                        </div>
+                        </li>
                       </template>
                     </ul>
                   </div>

--- a/mobile.js
+++ b/mobile.js
@@ -1233,30 +1233,33 @@ const initMobileNotes = () => {
     }
 
     notes.forEach((note) => {
-      const listItem = document.createElement('div');
+      const listItem = document.createElement('li');
       const isActiveNote = String(note.id) === String(currentNoteId);
       const isPinned = Boolean(note?.pinned);
-      listItem.className = 'note-row note-list-item';
-      listItem.classList.toggle('selected', isActiveNote);
-      listItem.classList.toggle('is-active', isActiveNote);
-      listItem.dataset.noteId = note.id;
-      listItem.dataset.role = 'open-note';
-      listItem.setAttribute('role', 'button');
-      listItem.tabIndex = 0;
+      listItem.className = 'note-item-mobile';
+
+      const noteCard = document.createElement('div');
+      noteCard.className = 'note-card note-row note-list-item';
+      noteCard.classList.toggle('selected', isActiveNote);
+      noteCard.classList.toggle('is-active', isActiveNote);
+      noteCard.dataset.noteId = note.id;
+      noteCard.dataset.role = 'open-note';
+      noteCard.setAttribute('role', 'button');
+      noteCard.tabIndex = 0;
 
       const cardMain = document.createElement('div');
-      cardMain.className = 'note-row-main note-list-main';
+      cardMain.className = 'note-row-main note-list-main note-card-main';
       cardMain.dataset.role = 'open-note';
       cardMain.dataset.noteId = note.id;
 
       const noteTitle = (typeof note.title === 'string' && note.title.trim()) || 'Untitled';
       const titleEl = document.createElement('div');
-      titleEl.className = 'note-row-title note-list-title';
+      titleEl.className = 'note-row-title note-list-title note-card-title';
       titleEl.textContent = noteTitle;
       titleEl.setAttribute('title', noteTitle);
 
       const titleRow = document.createElement('div');
-      titleRow.className = 'note-row-title-row note-list-title-row';
+      titleRow.className = 'note-row-title-row note-list-title-row note-card-header';
       titleRow.appendChild(titleEl);
 
       if (isPinned) {
@@ -1272,11 +1275,11 @@ const initMobileNotes = () => {
       const timestamp = formatNoteTimestamp(note.updatedAt);
 
       const metaRow = document.createElement('div');
-      metaRow.className = 'note-row-meta note-list-meta';
+      metaRow.className = 'note-row-meta note-list-meta note-card-meta';
 
       const folderButton = document.createElement('button');
       folderButton.type = 'button';
-      folderButton.className = 'note-row-folder note-list-folder';
+      folderButton.className = 'note-row-folder note-list-folder note-card-folder';
       folderButton.textContent = folderName;
       folderButton.setAttribute('aria-label', 'Move note to folder');
       folderButton.addEventListener('click', (event) => {
@@ -1291,10 +1294,10 @@ const initMobileNotes = () => {
       metaRow.appendChild(folderButton);
       if (timestamp) {
         const separator = document.createElement('span');
-        separator.className = 'note-row-dot note-list-dot';
+        separator.className = 'note-row-dot note-list-dot note-card-meta-dot';
         separator.textContent = '•';
         const timeSpan = document.createElement('span');
-        timeSpan.className = 'note-row-timestamp note-list-date';
+        timeSpan.className = 'note-row-timestamp note-list-date note-card-timestamp';
         timeSpan.textContent = timestamp;
         metaRow.appendChild(separator);
         metaRow.appendChild(timeSpan);
@@ -1307,14 +1310,16 @@ const initMobileNotes = () => {
       actionBtn.type = 'button';
       actionBtn.dataset.noteId = note.id;
       actionBtn.dataset.role = 'note-menu';
-      actionBtn.className = 'note-row-overflow note-list-overflow note-options-button';
+      actionBtn.className = 'note-row-overflow note-list-overflow note-options-button note-card-action';
       actionBtn.setAttribute('aria-label', 'Note actions');
       actionBtn.tabIndex = 0;
       actionBtn.setAttribute('aria-haspopup', 'true');
       actionBtn.textContent = '⋯';
 
-      listItem.appendChild(cardMain);
-      listItem.appendChild(actionBtn);
+      titleRow.appendChild(actionBtn);
+
+      noteCard.appendChild(cardMain);
+      listItem.appendChild(noteCard);
       listElement.appendChild(listItem);
     });
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -31,8 +31,90 @@ html {
 .saved-notes-list {
   flex: 1;
   overflow-y: auto;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .saved-notes-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.saved-notes-list .note-card {
+  border-radius: 12px;
+  padding: 14px 16px;
+  background: var(--note-card-bg, rgba(255, 255, 255, 0.03));
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.25);
   display: flex;
   flex-direction: column;
+  gap: 0.35rem;
+  width: 100%;
+  transition: transform 0.1s ease, background 0.1s ease;
+}
+
+.saved-notes-list .note-card:hover {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.saved-notes-list .note-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.saved-notes-list .note-card-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary, #e5e7eb);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0;
+}
+
+.saved-notes-list .note-card-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  font-size: 1.1rem;
+  line-height: 1;
+  color: var(--text-secondary, #cbd5e1);
+}
+
+.saved-notes-list .note-card-action:hover,
+.saved-notes-list .note-card-action:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.saved-notes-list .note-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 2px;
+  font-size: 0.85rem;
+  color: var(--text-secondary, #cbd5e1);
+}
+
+.saved-notes-list .note-card-meta-dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.7;
 }
 
 :root {


### PR DESCRIPTION
## Summary
- wrap saved note items in a dedicated note card container with title, metadata, and actions
- update saved notes layouts in mobile and docs views to use a responsive grid
- add shared card styling in the main stylesheet for consistent padding, borders, and hover states

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939fa236c708324b4862a0dc886109c)