### PR TITLE
Adjust saved notes sheet layout

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -4563,7 +4563,7 @@
         >
           <div
             id="saved-notes-panel"
-            class="saved-notes-panel notebook-sheet"
+            class="saved-notes-panel notebook-sheet saved-notes-container"
           >
             <div class="notebook-sidebar-layout">
               <!-- Left sidebar nav -->
@@ -4637,7 +4637,7 @@
                   </div>
                 </div>
 
-                <div class="saved-notes-list-shell mt-1 max-h-56 overflow-y-auto flex-1 w-full">
+                <div class="saved-notes-list-shell mt-1 flex-1 w-full">
                   <div class="saved-notes-list">
                     <ul
                       id="notesListMobile"

--- a/mobile.html
+++ b/mobile.html
@@ -6004,7 +6004,7 @@ body, main, section, div, p, span, li {
           >
           <div
             id="saved-notes-panel"
-            class="saved-notes-panel notebook-sheet"
+            class="saved-notes-panel notebook-sheet saved-notes-container"
           >
             <div class="notebook-sidebar-layout">
               <!-- Left sidebar nav -->

--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,12 @@ html {
   scroll-behavior: smooth;
 }
 
+.saved-notes-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
 .saved-notes-panel {
   display: flex;
   flex-direction: column;
@@ -34,6 +40,7 @@ html {
   display: grid;
   grid-template-columns: 1fr;
   gap: 0.75rem;
+  padding-bottom: 12px;
 }
 
 @media (min-width: 640px) {


### PR DESCRIPTION
## Summary
- add a saved-notes-container wrapper class to the saved notes sheet so the content can use a flexible column layout
- let the saved notes list area fill remaining space with scroll padding and sync the docs example markup

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a382db5308324b443505bfc7981bf)