### PR TITLE
Make saved notes controls sticky on mobile

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -956,12 +956,19 @@
     display: none !important;
   }
 
+  .saved-notes-controls {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background: #ffffff;
+  }
+
   /* Scrollable area inside the sidebar */
   .saved-notes-list-shell {
     flex: 1 1 auto;
     min-height: 0;
     overflow-y: auto;
-    margin-top: 0.25rem;
+    margin-top: 0;
   }
 
   /* Base: single column for very narrow screens */

--- a/styles/mobile-compact.css
+++ b/styles/mobile-compact.css
@@ -49,6 +49,17 @@
     overflow: hidden;
   }
 
+  .saved-notes-controls {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background: #fff;
+  }
+
+  .saved-notes-list-shell {
+    margin-top: 0;
+  }
+
   .editor, .note-editor {
     flex: 1 1 auto;
     height: auto;


### PR DESCRIPTION
## Summary
- remove excess spacing below the saved notes search bar on mobile
- pin saved notes controls to the top of the sheet while scrolling in both standard and compact mobile styles

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a4ca202d08324bd7aaa9799ba89bb)