### PR TITLE
Simplify saved notes layout

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -963,11 +963,17 @@
     background: #ffffff;
   }
 
+  .saved-notes-list-container {
+    overflow-y: auto;
+    padding: 12px;
+    flex: 1;
+    min-height: 0;
+  }
+
   /* Scrollable area inside the sidebar */
   .saved-notes-list-shell {
     flex: 1 1 auto;
     min-height: 0;
-    overflow-y: auto;
     margin-top: 0;
   }
 
@@ -976,16 +982,9 @@
     list-style: none;
     margin: 0;
     padding: 0;
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 0.75rem;
-  }
-
-  /* Wider screens: grid of cards */
-  @media (min-width: 640px) {
-    .saved-notes-list {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
   }
 
   /* Remove old row dividers & stripes; use cards instead */
@@ -995,22 +994,12 @@
   }
 
   #savedNotesSheet .note-card {
+    padding: 12px 16px;
+    background: rgba(255, 255, 255, 0.04);
     border-radius: 12px;
-    padding: 14px 16px;
-    background: var(--note-card-bg, rgba(255, 255, 255, 0.03));
-    border: 1px solid rgba(148, 163, 184, 0.25);
-    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.25);
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    width: 100%;
-    margin-bottom: 10px;
-    transition: transform 0.1s ease, background 0.1s ease;
-  }
-
-  #savedNotesSheet .note-card:hover {
-    transform: translateY(-2px);
-    background: rgba(255, 255, 255, 0.06);
+    margin-bottom: 8px;
+    font-size: 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
   }
 
   #savedNotesSheet .note-card-header {
@@ -6077,17 +6066,9 @@ body, main, section, div, p, span, li {
                     </div>
                   </div>
 
-                  <div class="notebook-search-container">
-                    <input
-                      id="notebook-search-input"
-                      type="search"
-                      placeholder="Search notes…"
-                      class="notebook-search-bar notebook-notes-search"
-                    />
-                  </div>
                 </div>
 
-                <div class="saved-notes-list-shell">
+                <div class="saved-notes-list-container saved-notes-list-shell">
                   <div class="saved-notes-list">
                     <ul
                       id="notesListMobile"

--- a/mobile.js
+++ b/mobile.js
@@ -1473,12 +1473,12 @@ const initMobileNotes = () => {
     const fab = document.createElement('button');
     fab.id = 'fabNewFolder';
     fab.type = 'button';
-    fab.className = 'fab-new-folder';
+    fab.className = 'fab-new-folder fab-button';
     fab.setAttribute('aria-label', 'Create new folder');
     fab.setAttribute('title', 'Create new folder');
     fab.innerHTML = `
-      <span class="fab-icon" aria-hidden="true">+</span>
-      <span class="fab-label">New folder</span>
+      <span aria-hidden="true">+</span>
+      <span class="sr-only">New folder</span>
     `;
     fab.addEventListener('click', (ev) => {
       ev.preventDefault();

--- a/styles/index.css
+++ b/styles/index.css
@@ -34,38 +34,28 @@ html {
   margin-bottom: 8px;
 }
 
-.saved-notes-list {
-  flex: 1;
+.saved-notes-list-container {
   overflow-y: auto;
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 0.75rem;
-  padding-bottom: 12px;
+  padding: 12px;
+  flex: 1;
 }
 
-@media (min-width: 640px) {
-  .saved-notes-list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+.saved-notes-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .saved-notes-list .note-card {
+  padding: 12px 16px;
+  background: rgba(255, 255, 255, 0.04);
   border-radius: 12px;
-  padding: 14px 16px;
-  background: var(--note-card-bg, rgba(255, 255, 255, 0.03));
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.25);
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  width: 100%;
-  margin-bottom: 10px;
-  transition: transform 0.1s ease, background 0.1s ease;
-}
-
-.saved-notes-list .note-card:hover {
-  transform: translateY(-2px);
-  background: rgba(255, 255, 255, 0.06);
+  margin-bottom: 8px;
+  font-size: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .saved-notes-list .note-card-header {
@@ -123,6 +113,21 @@ html {
   border-radius: 999px;
   background: currentColor;
   opacity: 0.7;
+}
+
+.fab-button {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: var(--primary, #512663);
+  color: #ffffff;
+  font-size: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 :root {
@@ -1037,53 +1042,9 @@ input.notebook-notes-search::placeholder {
 
 /* Floating Action Button for New Folder */
 .fab-new-folder {
-  position: absolute;
-  bottom: 1rem; /* bottom-4 */
-  right: 1rem;  /* right-4 */
   z-index: 1100;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem; /* p-3-ish */
-  border-radius: 9999px;
-  background: #ffffff; /* white background to match minimal theme */
-  color: #6b46c1; /* purple-600 */
-  border: 1px solid rgba(188, 164, 237, 0.9); /* purple-200-ish */
   box-shadow: 0 8px 22px rgba(81, 38, 99, 0.12);
-  font-weight: 600;
-  font-size: 0.95rem;
-  transition: transform 0.12s ease, box-shadow 0.12s ease, opacity 0.12s ease;
-}
-
-.fab-new-folder:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 14px 34px rgba(81, 38, 99, 0.16);
-}
-
-.fab-new-folder .fab-icon {
-  width: 20px;
-  height: 20px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: inherit;
-}
-
-.fab-new-folder .fab-label {
-  display: inline-block;
-}
-
-/* Icon-only on small screens to conserve space */
-@media (max-width: 640px) {
-  .fab-new-folder {
-    width: 44px;
-    height: 44px;
-    padding: 0.5rem;
-    justify-content: center;
-  }
-  .fab-new-folder .fab-label {
-    display: none;
-  }
+  border: none;
 }
 
 .notebook-note-row {


### PR DESCRIPTION
## Summary
- remove the saved notes search bar and wrap the list in a scrollable container
- simplify saved note cards into a single-column stack with lighter styling
- restyle the floating add button with the new minimal fab treatment outside the scroll area

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a54d1938c8324a45929bd19236ed3)