### PR TITLE
Add contextual overflow menus to mobile note cards

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -1197,6 +1197,57 @@ const initMobileNotes = () => {
     refreshFromStorage({ preserveDraft: false });
   };
 
+  let activeNoteCardMenu = null;
+  let activeNoteCardMenuButton = null;
+
+  const closeActiveNoteMenu = () => {
+    if (activeNoteCardMenu) {
+      activeNoteCardMenu.classList.remove('open');
+    }
+    if (activeNoteCardMenuButton) {
+      activeNoteCardMenuButton.setAttribute('aria-expanded', 'false');
+    }
+    activeNoteCardMenu = null;
+    activeNoteCardMenuButton = null;
+  };
+
+  const openNoteCardMenu = (menuEl, triggerEl) => {
+    if (!menuEl || !triggerEl) return;
+    if (activeNoteCardMenu === menuEl) {
+      closeActiveNoteMenu();
+      return;
+    }
+    closeActiveNoteMenu();
+    activeNoteCardMenu = menuEl;
+    activeNoteCardMenuButton = triggerEl;
+    triggerEl.setAttribute('aria-expanded', 'true');
+    menuEl.classList.add('open');
+  };
+
+  const handleGlobalNoteMenuClose = (event) => {
+    if (!activeNoteCardMenu || !activeNoteCardMenuButton) {
+      return;
+    }
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+    if (
+      activeNoteCardMenu.contains(target)
+      || activeNoteCardMenuButton.contains(target)
+    ) {
+      return;
+    }
+    closeActiveNoteMenu();
+  };
+
+  document.addEventListener('click', handleGlobalNoteMenuClose);
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      closeActiveNoteMenu();
+    }
+  });
+
   const renderNotesList = (notes = [], { withTransition = true } = {}) => {
     if (withTransition) {
       runNotebookListTransition(() => renderNotesList(notes, { withTransition: false }));
@@ -1207,6 +1258,7 @@ const initMobileNotes = () => {
       return notes;
     }
 
+    closeActiveNoteMenu();
     listElement.innerHTML = '';
 
     if (countElement) {
@@ -1313,13 +1365,54 @@ const initMobileNotes = () => {
       actionBtn.dataset.role = 'note-menu';
       actionBtn.className = 'note-row-overflow note-list-overflow note-options-button note-card-action';
       actionBtn.setAttribute('aria-label', 'Note actions');
+      actionBtn.setAttribute('aria-expanded', 'false');
       actionBtn.tabIndex = 0;
       actionBtn.setAttribute('aria-haspopup', 'true');
-      actionBtn.textContent = '⋯';
+      actionBtn.textContent = '⋮';
 
-      titleRow.appendChild(actionBtn);
+      const actionMenu = document.createElement('div');
+      actionMenu.className = 'note-card-menu';
+      actionMenu.setAttribute('role', 'menu');
 
+      const moveMenuItem = document.createElement('button');
+      moveMenuItem.type = 'button';
+      moveMenuItem.className = 'note-card-menu-item';
+      moveMenuItem.textContent = 'Move to Folder';
+      moveMenuItem.setAttribute('role', 'menuitem');
+      moveMenuItem.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        closeActiveNoteMenu();
+        openFolderSelectorForNote(note.id, {
+          initialFolderId: folderId,
+          triggerEl: actionBtn,
+        });
+      });
+
+      const deleteMenuItem = document.createElement('button');
+      deleteMenuItem.type = 'button';
+      deleteMenuItem.className = 'note-card-menu-item note-card-menu-danger';
+      deleteMenuItem.textContent = 'Delete';
+      deleteMenuItem.setAttribute('role', 'menuitem');
+      deleteMenuItem.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        closeActiveNoteMenu();
+        handleDeleteNote(note.id);
+      });
+
+      actionBtn.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        openNoteCardMenu(actionMenu, actionBtn);
+      });
+
+      actionMenu.appendChild(moveMenuItem);
+      actionMenu.appendChild(deleteMenuItem);
+
+      noteCard.appendChild(actionBtn);
       noteCard.appendChild(cardMain);
+      noteCard.appendChild(actionMenu);
       listItem.appendChild(noteCard);
       listElement.appendChild(listItem);
     });

--- a/styles/index.css
+++ b/styles/index.css
@@ -56,6 +56,7 @@ html {
   margin-bottom: 8px;
   font-size: 1rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
+  position: relative;
 }
 
 .saved-notes-list .note-card-header {
@@ -64,6 +65,7 @@ html {
   justify-content: space-between;
   gap: 0.5rem;
   min-width: 0;
+  padding-right: 40px;
 }
 
 .saved-notes-list .note-card-title {
@@ -91,11 +93,55 @@ html {
   font-size: 1.1rem;
   line-height: 1;
   color: var(--text-secondary, #cbd5e1);
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 2;
 }
 
 .saved-notes-list .note-card-action:hover,
 .saved-notes-list .note-card-action:focus-visible {
   background: rgba(255, 255, 255, 0.08);
+}
+
+.saved-notes-list .note-card-menu {
+  position: absolute;
+  top: 46px;
+  right: 10px;
+  min-width: 160px;
+  padding: 8px;
+  border-radius: 12px;
+  background: rgba(12, 12, 16, 0.96);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+  display: none;
+  flex-direction: column;
+  gap: 4px;
+  z-index: 3;
+}
+
+.saved-notes-list .note-card-menu.open {
+  display: flex;
+}
+
+.saved-notes-list .note-card-menu-item {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  color: var(--text-primary, #e5e7eb);
+  padding: 10px 12px;
+  border-radius: 10px;
+  font-size: 0.95rem;
+}
+
+.saved-notes-list .note-card-menu-item:hover,
+.saved-notes-list .note-card-menu-item:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.saved-notes-list .note-card-menu-danger {
+  color: #fca5a5;
 }
 
 .saved-notes-list .note-card-meta {


### PR DESCRIPTION
## Summary
- add a top-right overflow button to each note card that opens a contextual menu
- provide move-to-folder and delete actions in the popup menu and wire them to existing handlers
- style the note card action button and menu for the saved notes list

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a66ebe2508324841000499edcd10b)