### PR TITLE
Add inline new folder prompt

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -986,6 +986,27 @@
     min-width: 160px;
   }
 
+  .folder-filter-action-row {
+    margin: -2px 0 12px;
+  }
+
+  .folder-filter-new-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 0;
+    font-size: 0.85rem;
+    color: var(--accent-color, #512663);
+    background: transparent;
+    border: none;
+    text-decoration: none;
+  }
+
+  .folder-filter-new-btn:hover,
+  .folder-filter-new-btn:focus-visible {
+    text-decoration: underline;
+  }
+
   /* Scrollable area inside the sidebar */
   .saved-notes-list-shell {
     flex: 1 1 auto;
@@ -6062,6 +6083,12 @@ body, main, section, div, p, span, li {
                       <option value="school">School</option>
                       <option value="shopping">Shopping</option>
                     </select>
+                  </div>
+                  <div class="folder-filter-action-row">
+                    <button id="folderFilterNewFolder" class="folder-filter-new-btn" type="button">
+                      <span aria-hidden="true">+</span>
+                      <span>New Folder</span>
+                    </button>
                   </div>
                   <div class="saved-notes-list">
                     <ul

--- a/mobile.js
+++ b/mobile.js
@@ -443,6 +443,7 @@ const initMobileNotes = () => {
   const countElement = document.getElementById('notesCountMobile');
   const filterInput = document.getElementById('notebook-search-input');
   const folderFilterSelect = document.getElementById('folderFilterSelect');
+  const folderFilterNewButton = document.getElementById('folderFilterNewFolder');
   const savedNotesSheet = document.getElementById('savedNotesSheet');
   const openSavedNotesButton =
     document.getElementById('openSavedNotesGlobal') ||
@@ -1579,10 +1580,17 @@ const initMobileNotes = () => {
     newFolderModalController.show();
   };
 
-    // Expose helper globally for other scripts or tests that expect a window-level API
-    if (typeof window !== 'undefined' && typeof window.openNewFolderDialog === 'undefined') {
-      window.openNewFolderDialog = openNewFolderDialog;
-    }
+  // Expose helper globally for other scripts or tests that expect a window-level API
+  if (typeof window !== 'undefined' && typeof window.openNewFolderDialog === 'undefined') {
+    window.openNewFolderDialog = openNewFolderDialog;
+  }
+
+  if (folderFilterNewButton) {
+    folderFilterNewButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      openNewFolderDialog();
+    });
+  }
 
   const createNewFolder = () => {
     if (!newFolderNameInput) return;
@@ -1625,6 +1633,11 @@ const initMobileNotes = () => {
       buildFolderChips();
     } catch (e) {
       console.warn('[notebook] rebuild folder chips failed', e);
+    }
+    try {
+      buildFolderFilterSelect();
+    } catch (e) {
+      console.warn('[notebook] rebuild folder filter failed', e);
     }
     if (typeof afterFolderCreated === 'function') {
       try {


### PR DESCRIPTION
## Summary
- add an inline “+ New Folder” control beneath the mobile folder filter dropdown
- wire the button to the existing new-folder dialog and reuse link-style styling
- rebuild folder filter options after creating a folder so the dropdown updates immediately

## Testing
- `npm test -- --runInBand` *(fails: existing mobile auth, mobile new-folder, and service-worker tests as noted in output)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a68353c44832496a9f8092216e3b0)