### PR TITLE
Add icon utility and update mobile header icons

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -3753,22 +3753,20 @@
     style="position: fixed; padding-top: calc(env(safe-area-inset-top, 0px) + 1rem)"
   >
     <div class="mb-6 flex items-center justify-between">
-           <button
+      <button
         type="button"
         class="rounded-xl p-2 text-neutral-500 hover:bg-neutral-100 hover:text-neutral-900 dark:text-neutral-400 dark:hover:bg-neutral-800"
         aria-label="Close menu"
         data-close-drawer
       >
         <svg
-          width="20"
-          height="20"
+          class="icon"
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"
           stroke-width="1.75"
           stroke-linecap="round"
           stroke-linejoin="round"
-          class="size-5"
         >
           <path d="M6 6l12 12M6 18 18 6" />
         </svg>
@@ -4203,9 +4201,7 @@
       <!-- Notebook opener + Save (check) button moved into header for quick access -->
       <button id="openSavedNotesSheet" type="button" class="header-btn header-btn-icon" aria-label="Open Notebook" title="Open Notebook">
         <svg
-          class="w-5 h-5"
-          width="20"
-          height="20"
+          class="icon"
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"
@@ -4222,9 +4218,7 @@
       <!-- Save (check) button moved into header for quick access -->
       <button id="noteSaveMobile" type="button" class="header-btn header-btn-icon" aria-label="Save note">
         <svg
-          class="w-5 h-5"
-          width="20"
-          height="20"
+          class="icon"
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"
@@ -4316,8 +4310,7 @@
                     aria-label="Open saved notes"
                   >
                     <svg
-                      width="20"
-                      height="20"
+                      class="icon"
                       viewBox="0 0 24 24"
                       fill="none"
                       stroke="currentColor"
@@ -4336,8 +4329,7 @@
                     aria-label="Start voice capture"
                   >
                     <svg
-                      width="20"
-                      height="20"
+                      class="icon"
                       viewBox="0 0 24 24"
                       fill="none"
                       stroke="currentColor"
@@ -4359,8 +4351,7 @@
                     aria-label="Add reminder"
                   >
                     <svg
-                      width="20"
-                      height="20"
+                      class="icon"
                       viewBox="0 0 24 24"
                       fill="none"
                       stroke="currentColor"
@@ -4384,8 +4375,7 @@
                     aria-label="More options"
                   >
                     <svg
-                      width="20"
-                      height="20"
+                      class="icon"
                       viewBox="0 0 24 24"
                       fill="none"
                       stroke="currentColor"

--- a/mobile.html
+++ b/mobile.html
@@ -4981,22 +4981,20 @@ body, main, section, div, p, span, li {
     style="position: fixed; padding-top: calc(env(safe-area-inset-top, 0px) + 1rem)"
   >
     <div class="mb-6 flex items-center justify-between">
-           <button
+      <button
         type="button"
         class="rounded-xl p-2 text-neutral-500 hover:bg-neutral-100 hover:text-neutral-900 dark:text-neutral-400 dark:hover:bg-neutral-800"
         aria-label="Close menu"
         data-close-drawer
       >
         <svg
-          width="20"
-          height="20"
+          class="icon"
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"
           stroke-width="1.75"
           stroke-linecap="round"
           stroke-linejoin="round"
-          class="size-5"
         >
           <path d="M6 6l12 12M6 18 18 6" />
         </svg>
@@ -5593,8 +5591,7 @@ body, main, section, div, p, span, li {
               aria-label="Open saved notes"
             >
               <svg
-                width="20"
-                height="20"
+                class="icon"
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
@@ -5613,8 +5610,7 @@ body, main, section, div, p, span, li {
               aria-label="Start voice capture"
             >
               <svg
-                width="20"
-                height="20"
+                class="icon"
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
@@ -5636,8 +5632,7 @@ body, main, section, div, p, span, li {
               aria-label="Add reminder"
             >
               <svg
-                width="20"
-                height="20"
+                class="icon"
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
@@ -5661,8 +5656,7 @@ body, main, section, div, p, span, li {
               aria-label="More options"
             >
               <svg
-                width="20"
-                height="20"
+                class="icon"
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"

--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,18 @@ html {
   scroll-behavior: smooth;
 }
 
+.icon {
+  width: 24px;
+  height: 24px;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.icon svg {
+  width: 100%;
+  height: 100%;
+}
+
 .saved-notes-container {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add a shared .icon utility class to standardize icon sizing
- apply the icon utility to mobile header buttons and quick-action icons
- update the drawer close control to use the shared icon sizing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a806f57cc8324a33130ad58a4f798)