### PR TITLE
Ensure header stays sticky while scrolling

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -1755,6 +1755,9 @@ input.notebook-notes-search::placeholder {
 
  .desktop-shell .desktop-header {
   grid-area: header;
+  position: sticky;
+  top: calc(env(safe-area-inset-top, 0) + 0.5rem);
+  z-index: 50;
  }
 
  .desktop-shell .desktop-header.desktop-header-bar {


### PR DESCRIPTION
## Summary
- make the desktop header element sticky within the layout grid
- pin the header to the top with a higher z-index so it stays visible while scrolling

## Testing
- not run (CSS-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a91bed9048324a22b3608cbc7e646)