### PR TITLE
Enable quick note editor launch from FAB

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5901,7 +5901,7 @@ body, main, section, div, p, span, li {
         <div class="mobile-view-inner mx-auto w-full px-0 pt-2 pb-2 space-y-0" style="padding: 0 !important; max-width: 100%;">
         <!-- notebook view header removed to keep UI minimal -->
         <!-- Enhanced Notebook Card -->
-        <div class="note-sheet-wrapper scratch-notes-wrapper">
+        <div id="noteEditorSheet" class="note-sheet-wrapper scratch-notes-wrapper sheet hidden">
          <div id="scratch-notes-card" class="writing-panel scratch-notes-card p-0 space-y-3 pb-3 bg-white rounded-none shadow-none" style="background:white; border-radius:0; box-shadow:none; padding: 0 !important; width: 100vw; margin: 0 -1rem;">
             <!-- Top-right Saved notes pill in notebook view -->
             <div class="note-actions-top">
@@ -5919,7 +5919,7 @@ body, main, section, div, p, span, li {
                 <input
                   id="noteTitleMobile"
                   type="text"
-                  class="input input-sm w-full bg-base-100 border border-base-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-[color-mix(in_srgb,var(--accent-color,_#512663)_65%,#ffffff_35%)]"
+                  class="input input-sm w-full bg-base-100 border border-base-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-[color-mix(in_srgb,var(--accent-color,_#512663)_65%,#ffffff_35%)] note-title"
                   placeholder="Note title"
                   autocomplete="off"
                 />

--- a/mobile.js
+++ b/mobile.js
@@ -15,6 +15,20 @@ import { saveFolders } from './js/modules/notes-storage.js';
 
 initViewportHeight();
 
+document.querySelector('.fab-button')?.addEventListener('click', () => {
+  openEditor();
+});
+
+function openEditor() {
+  const editorSheet = document.querySelector('#noteEditorSheet');
+  editorSheet.classList.remove('hidden');
+
+  setTimeout(() => {
+    editorSheet.querySelector('.note-title')?.focus();
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, 50);
+}
+
 /* BEGIN GPT CHANGE: bottom sheet open/close */
 (function () {
   const setupSheet = () => {

--- a/styles/index.css
+++ b/styles/index.css
@@ -5213,6 +5213,15 @@ body {
   line-height: 1.5;
 }
 
+.sheet {
+  transition: transform 0.2s ease-out, opacity 0.2s ease-out;
+}
+
+.sheet.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
 /* Move-to-folder bottom sheet */
 .sheet-backdrop {
   position: fixed;


### PR DESCRIPTION
## Summary
- hook the floating action button to open the note editor sheet and focus the title field
- ensure the note editor sheet starts hidden and the title input can be targeted for focus
- add sheet transition styles for smooth visibility changes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a92c7b074832495324176f358d51a)