### PR TITLE
Improve mobile note title styling

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5919,7 +5919,7 @@ body, main, section, div, p, span, li {
                 <input
                   id="noteTitleMobile"
                   type="text"
-                  class="input input-sm w-full bg-base-100 border border-base-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-[color-mix(in_srgb,var(--accent-color,_#512663)_65%,#ffffff_35%)]"
+                  class="note-title input input-sm w-full bg-base-100 border border-base-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-[color-mix(in_srgb,var(--accent-color,_#512663)_65%,#ffffff_35%)]"
                   placeholder="Note title"
                   autocomplete="off"
                 />

--- a/styles/index.css
+++ b/styles/index.css
@@ -5201,6 +5201,23 @@ body {
   outline-offset: 1px;
 }
 
+.note-title {
+  width: 100%;
+  font-size: 1.25rem;
+  font-weight: 600;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 12px 0;
+  margin-bottom: 8px;
+  color: inherit;
+}
+
+.note-title:focus {
+  outline: none;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.4);
+}
+
 .note-editor-content,
 .note-editor-card .note-editor-area {
   min-height: 220px;


### PR DESCRIPTION
## Summary
- add dedicated styling for the note title input with larger typography and subtle focus state
- apply the note-title class to the mobile note title field to use the new styling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a939bb8e083249766b6b2e274cd47)