### PR TITLE
Restyle formatting toolbar

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5936,45 +5936,55 @@ body, main, section, div, p, span, li {
 
               <div
                 id="scratchNotesToolbar"
-                class="note-editor-toolbar"
+                class="formatting-toolbar"
                 role="toolbar"
                 aria-label="Formatting options"
               >
-                <button class="rte-btn" data-cmd="bold" type="button">
-                  <span class="rte-icon">B</span>
+                <button class="rte-btn" data-cmd="bold" type="button" title="Bold">
+                  <b>B</b>
                 </button>
-                <button class="rte-btn" data-cmd="italic" type="button">
-                  <span class="rte-icon">I</span>
+                <button class="rte-btn" data-cmd="italic" type="button" title="Italic">
+                  <i>I</i>
                 </button>
-                <button class="rte-btn" data-cmd="underline" type="button">
-                  <span class="rte-icon">U</span>
-                </button>
-
-                <div class="rte-divider"></div>
-
-                <button class="rte-btn" data-cmd="insertUnorderedList" type="button">
-                  <span class="rte-icon">•</span>
-                </button>
-                <button class="rte-btn" data-cmd="insertOrderedList" type="button">
-                  <span class="rte-icon">1.</span>
+                <button class="rte-btn" data-cmd="underline" type="button" title="Underline">
+                  <u>U</u>
                 </button>
 
-                <div class="rte-divider"></div>
+                <div class="rte-divider" aria-hidden="true"></div>
 
-                <button class="rte-btn" data-cmd="indent" type="button">
-                  <span class="rte-icon">→</span>
+                <button
+                  class="rte-btn"
+                  data-cmd="insertUnorderedList"
+                  type="button"
+                  title="Bulleted list"
+                >
+                  •
                 </button>
-                <button class="rte-btn" data-cmd="outdent" type="button">
-                  <span class="rte-icon">←</span>
+                <button
+                  class="rte-btn"
+                  data-cmd="insertOrderedList"
+                  type="button"
+                  title="Numbered list"
+                >
+                  1.
                 </button>
 
-                <div class="rte-divider"></div>
+                <div class="rte-divider" aria-hidden="true"></div>
 
-                <button class="rte-btn" data-cmd="undo" type="button">
-                  <span class="rte-icon">↺</span>
+                <button class="rte-btn" data-cmd="indent" type="button" title="Indent">
+                  →
                 </button>
-                <button class="rte-btn" data-cmd="redo" type="button">
-                  <span class="rte-icon">↻</span>
+                <button class="rte-btn" data-cmd="outdent" type="button" title="Outdent">
+                  ←
+                </button>
+
+                <div class="rte-divider" aria-hidden="true"></div>
+
+                <button class="rte-btn" data-cmd="undo" type="button" title="Undo">
+                  ↺
+                </button>
+                <button class="rte-btn" data-cmd="redo" type="button" title="Redo">
+                  ↻
                 </button>
               </div>
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -5164,6 +5164,38 @@ body {
   height: 18px;
 }
 
+.formatting-toolbar {
+  display: flex;
+  justify-content: start;
+  gap: 8px;
+  padding: 8px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  margin-bottom: 12px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.formatting-toolbar button {
+  background: none;
+  border: none;
+  padding: 4px 6px;
+  font-size: 18px;
+  color: rgba(255, 255, 255, 0.7);
+  border-radius: 6px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s ease;
+}
+
+.formatting-toolbar button:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.formatting-toolbar button.active {
+  color: white;
+  background: rgba(255, 255, 255, 0.12);
+}
+
 .note-editor-card {
   border-radius: 1rem;
   background: var(--surface-soft, #fff);


### PR DESCRIPTION
## Summary
- add compact formatting toolbar styles for the formatting strip
- update the mobile notebook toolbar markup to use the new compact layout with icon-only buttons

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a947040ac8324a9de34bb7e882aac)