### PR TITLE
Ensure mobile toolbar retains note editor class

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5936,7 +5936,7 @@ body, main, section, div, p, span, li {
 
               <div
                 id="scratchNotesToolbar"
-                class="formatting-toolbar"
+                class="note-editor-toolbar formatting-toolbar"
                 role="toolbar"
                 aria-label="Formatting options"
               >


### PR DESCRIPTION
## Summary
- add note-editor-toolbar class back to the mobile scratch notes toolbar so formatting styles and selectors both apply

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a9696dcb483248fc5d615bec87f61)