### PR TITLE
Ensure notebook view keeps mobile footer visible

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -338,7 +338,7 @@
   body[data-active-view="notebook"] #main {
     max-width: none;
     margin: 0;
-    padding-bottom: 0;
+    padding-bottom: calc(var(--mobile-bottom-nav-height, 80px) + 8px);
   }
 
   /* Ensure notebook content hugs the header with a micro-gap */
@@ -6366,6 +6366,29 @@ body, main, section, div, p, span, li {
     (function() {
       const navFooter = document.querySelector('#mobile-nav-shell .floating-footer');
       if (!navFooter) return;
+
+      const updateBottomNavHeight = () => {
+        const footerRect = navFooter.getBoundingClientRect();
+        const styles = getComputedStyle(navFooter);
+        const marginBottom = parseFloat(styles.marginBottom) || 0;
+        const totalHeight = footerRect.height + marginBottom;
+
+        if (totalHeight > 0) {
+          document.documentElement.style.setProperty(
+            '--mobile-bottom-nav-height',
+            `${Math.ceil(totalHeight)}px`
+          );
+        }
+      };
+
+      updateBottomNavHeight();
+
+      if (typeof ResizeObserver === 'function') {
+        const observer = new ResizeObserver(updateBottomNavHeight);
+        observer.observe(navFooter);
+      } else {
+        window.addEventListener('resize', updateBottomNavHeight, { passive: true });
+      }
 
       const focusNotebookInputs = () => {
         const focusField = () => {


### PR DESCRIPTION
## Summary
- add padding to the notebook main container so mobile footer remains visible
- calculate the bottom navigation height from the floating footer element to keep spacing accurate

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aa549ebf08324a1ae9f3ac04589c3)