### PR TITLE
Ensure mobile header sticks on mobile

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5545,7 +5545,7 @@ body, main, section, div, p, span, li {
   <!-- Mobile header matching screenshot -->
     <header
     id="reminders-slim-header"
-    class="w-full px-4 pt-3 pb-3 mobile-header pt-safe-top"
+    class="w-full px-4 pt-3 pb-3 mobile-header pt-safe-top sticky"
     role="banner"
   >
     <div class="max-w-3xl mx-auto">


### PR DESCRIPTION
## Summary
- add the sticky class to the mobile reminders header so its sticky styles apply

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aa7dffa3c832489480a87d9e29491)