### PR TITLE
Adjust notebook spacing for mobile footer

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -130,6 +130,7 @@ body.mobile-shell #mobile-shell #reminderList {
 .bottom-nav,
 #mobile-nav-shell {
   flex: 0 0 auto;
+  z-index: 60;
 }
 
 /* Header / Top Bar */
@@ -654,6 +655,11 @@ body.mobile-theme .text-secondary {
 /* Allow the scratch-notes card to use the full vertical space */
 .mobile-shell #view-notebook #scratch-notes-card {
   max-height: none;
+}
+
+/* Ensure notebook content doesn't sit under the floating footer */
+body.mobile-shell[data-active-view="notebook"] #scratch-notes-card {
+  padding-bottom: calc(var(--mobile-bottom-nav-height, 80px) + env(safe-area-inset-bottom, 0px));
 }
 
 .note-editor-content.is-placeholder,


### PR DESCRIPTION
## Summary
- add notebook-specific bottom padding so the notes card clears the floating footer on mobile
- raise the mobile nav shell z-index so the footer stays above the writing panel

## Testing
- npm test -- --runInBand *(fails: known issues in mobile.new-folder.test.js and service-worker.test.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b2b3caeb883248c1edb4bfa9f3150)