### PR TITLE
Center notebook folder pill in mobile notebook header

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -356,6 +356,19 @@
     padding-top: 0rem;
   }
 
+  /* Center the notebook folder pill */
+  #noteFolderPillMobile {
+    display: inline-flex;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .scratch-notes-header-block {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
   /* Hide notebook action buttons: top "Saved notes" pill and bottom New/Save bar */
   #view-notebook .note-actions-top,
   #view-notebook .note-actions.fixed-bottom,


### PR DESCRIPTION
## Summary
- add CSS to center the notebook folder pill within the mobile notebook header
- adjust the header container layout to stack items and align them centrally

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cc65be2ec83249634ed04a7d76980)