### PR TITLE
Disable auto-focus when opening notebook

### DIFF
--- a/js/__tests__/mobile.footer-nav.test.js
+++ b/js/__tests__/mobile.footer-nav.test.js
@@ -112,7 +112,7 @@ describe('mobile footer navigation', () => {
     window.addEventListener('app:navigate', (ev) => events.push(ev.detail));
 
     // Attach a navFooter handler (simulate inline script; just to ensure closers get called
-    // and focus moves to the notebook editor when the notebook nav button is clicked)
+    // when the notebook nav button is clicked)
     navFooter.addEventListener('click', (event) => {
       const button = event.target instanceof Element ? event.target.closest('[data-nav-target]') : null;
       if (!button) return;
@@ -128,14 +128,13 @@ describe('mobile footer navigation', () => {
       if (!view) return;
       // Simulate the actual mobile nav behavior for the notebook button
       if (view === 'notebook') {
-        try { document.getElementById('noteTitleMobile')?.focus(); } catch (e) {}
         window.dispatchEvent(new CustomEvent('app:navigate', { detail: { view } }));
         return;
       }
       window.dispatchEvent(new CustomEvent('app:navigate', { detail: { view } }));
     });
 
-    // add a fake notebook input to assert focus behavior
+    // add a fake notebook input to assert focus behavior does not trigger automatically
     const fakeNoteInput = document.createElement('input');
     fakeNoteInput.setAttribute('id', 'noteTitleMobile');
     fakeNoteInput.focus = jest.fn();
@@ -149,7 +148,7 @@ describe('mobile footer navigation', () => {
     expect(closeAddSheetSpy).toHaveBeenCalled();
     expect(events.length).toBe(1);
     expect(events[0]).toEqual({ view: 'notebook' });
-    expect(fakeNoteInput.focus).toHaveBeenCalled();
+    expect(fakeNoteInput.focus).not.toHaveBeenCalled();
     expect(window.focusNotebookInputs).toHaveBeenCalled();
     expect(cueCloseSpy).toHaveBeenCalled();
   });

--- a/mobile.html
+++ b/mobile.html
@@ -6447,24 +6447,7 @@ body, main, section, div, p, span, li {
       }
 
       const focusNotebookInputs = () => {
-        const focusField = () => {
-          const titleInput = document.getElementById('noteTitleMobile');
-          if (titleInput) {
-            titleInput.focus();
-            return;
-          }
-
-          const noteEditor = document.getElementById('notebook-editor-body');
-          if (noteEditor) {
-            noteEditor.focus();
-          }
-        };
-
-        if (typeof queueMicrotask === 'function') {
-          queueMicrotask(focusField);
-        } else {
-          setTimeout(focusField, 0);
-        }
+        // Do not auto-focus notebook fields on navigation to avoid opening mobile keyboards.
       };
 
       const closeSavedNotesSheet = () => {

--- a/mobile.js
+++ b/mobile.js
@@ -24,7 +24,6 @@ function openEditor() {
   editorSheet.classList.remove('hidden');
 
   setTimeout(() => {
-    editorSheet.querySelector('.note-title')?.focus();
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }, 50);
 }
@@ -2585,21 +2584,6 @@ const initMobileNotes = () => {
     const labelElNew = document.getElementById('note-folder-label');
     if (labelElNew) {
       labelElNew.textContent = getFolderNameById(currentEditingNoteFolderId);
-    }
-    const shouldFocusBody = isMobileViewport();
-    if (shouldFocusBody) {
-      try {
-        if (scratchNotesEditor && typeof scratchNotesEditor.focus === 'function') {
-          scratchNotesEditor.focus();
-        } else if (
-          scratchNotesEditorElement &&
-          typeof scratchNotesEditorElement.focus === 'function'
-        ) {
-          scratchNotesEditorElement.focus();
-        }
-      } catch {}
-    } else if (typeof titleInput.focus === 'function') {
-      try { titleInput.focus(); } catch {}
     }
   };
 


### PR DESCRIPTION
## Summary
- prevent automatic focus on notebook title/body when opening the editor or navigating to the notebook view
- keep the notebook focus helper non-focusing to avoid opening the mobile keyboard while preserving navigation behavior
- update the footer navigation test to reflect the new focus behavior

## Testing
- npm test -- js/__tests__/mobile.footer-nav.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ce49a89508324b2c83d9d27ab5cc3)