### PR TITLE
Center mobile reminders list and card corners

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -63,6 +63,7 @@ body.mobile-shell #mobile-shell #main {
 }
 
 /* Reminders layout (mobile) */
+
 .mobile-shell #view-reminders,
 .mobile-shell #view-reminders .mobile-view-inner,
 .mobile-shell #view-reminders .reminders-content-shell,
@@ -70,7 +71,7 @@ body.mobile-shell #mobile-shell #main {
 .mobile-shell #remindersWrapper {
   width: 100%;
   max-width: 100vw;
-  margin: -2px;
+  margin: 0 auto;
   box-sizing: border-box;
 }
 
@@ -99,6 +100,7 @@ body.mobile-shell #mobile-shell #main {
 
 .mobile-shell #remindersWrapper {
   overflow-x: hidden;
+  padding-inline: 0.5rem;
 }
 
 .mobile-shell #view-reminders .reminder-tabs {
@@ -111,8 +113,9 @@ body.mobile-shell #mobile-shell #main {
 body.mobile-shell #mobile-shell #reminderList {
   width: 100%;
   max-width: 100%;
-  margin: 21px;
-  padding: 34px 0px 0px 0px;
+  margin-inline: auto;
+  padding-inline: 0.5rem;
+  padding-top: 0;
   box-sizing: border-box;
   overflow-x: hidden;
 }
@@ -262,6 +265,14 @@ body.mobile-theme .reminder-card {
   border-left: 3px solid color-mix(in srgb, var(--accent-color, #5080BF) 55%, transparent);
   margin: 0 0 8px;
   text-align: left !important;
+}
+
+/* Ensure reminder cards stay rounded on all corners */
+.task-item,
+.cue-task-card,
+.reminder-card {
+  border-radius: 0.75rem;
+  overflow: hidden;
 }
 
 .reminder-card-main {

--- a/memory/memory.css
+++ b/memory/memory.css
@@ -87,7 +87,7 @@
   position: absolute;
   inset: 0 auto 0 0;
   width: 4px;
-  border-radius: 0 20px 20px 0;
+  border-radius: 0 0.75rem 0.75rem 0;
   background: linear-gradient(180deg, #38bdf8, #0ea5e9);
   opacity: 0.9;
   pointer-events: none;

--- a/mobile.html
+++ b/mobile.html
@@ -1402,8 +1402,8 @@ body[data-active-view="notebook"] #view-notebook .card-body {
   /* Main reminders list container */
   #reminderList {
     list-style: none;
-    margin: 0;
-    padding: 0;
+    margin: 0 auto;
+    padding: 0 0.5rem;
     display: flex;
     flex-direction: column;
     gap: 0;


### PR DESCRIPTION
## Summary
- balance mobile reminders list padding to center the grid
- ensure reminder/task cards keep rounded corners with hidden overflow
- align reminder accent pseudo-element radius with card corners

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693f8b1c588c8327a51becc1f90a3304)