### PR TITLE
Adjust mobile reminder list padding

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -4047,17 +4047,11 @@ body, main, section, div, p, span, li {
   <style id="mobile-reminder-card-refresh">
     .mobile-shell #reminderList,
     .mobile-shell .reminder-list {
-      padding: 0;
       margin-top: 0.8rem;
+      margin-inline: auto;
       width: 100%;
       box-sizing: border-box;
-    }
-
-    @media (min-width: 640px) {
-      .mobile-shell #reminderList,
-      .mobile-shell .reminder-list {
-        padding: 0 0.8rem;
-      }
+      padding-inline: 0.5rem;
     }
 
     .mobile-shell #reminderList {


### PR DESCRIPTION
## Summary
- ensure the mobile reminder list keeps centered padding consistent with the theme by removing zeroed padding overrides
- add margin centering to the reminder list containers to maintain alignment

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693fa7b66448832790246b2ac59da60f)