### PR TITLE
Harmonize mobile reminder list spacing

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -114,12 +114,12 @@ body.mobile-shell #mobile-shell #reminderList,
 .mobile-shell #reminderList {
   width: 100%;
   max-width: 100%;
-  margin: 0.8rem auto 0;
+  margin: 0 auto;
   padding-inline: 0.75rem;
   padding-top: 0;
   box-sizing: border-box;
   overflow-x: hidden;
-  gap: 0.9rem;
+  gap: 0.75rem;
 }
 
 @media (min-width: 640px) {

--- a/mobile.html
+++ b/mobile.html
@@ -1903,17 +1903,6 @@ body[data-active-view="notebook"] #view-notebook .card-body {
   cursor: pointer;
 }
 
-/* Remove gap between header bar and first reminder */
-#reminderList {
-  margin-top: 0;
-  padding-top: 0;
-}
-
-.reminders-list-container,
-.mobile-view-inner .reminders-content-shell {
-  padding-top: 0 !important;
-  margin-top: 0 !important;
-}
     /* Global crisp, confident text */
 body {
   color: #111 !important;            /* deep, neutral black */
@@ -3317,11 +3306,8 @@ body, main, section, div, p, span, li {
     /* Responsive reminder grid - default grid layout */
     #reminderList {
       list-style: none;
-      margin: 0 auto;
-      padding: 0;
       display: flex;
       flex-direction: column;
-      gap: 0.4rem;
       align-content: start;
       width: 100%;
     }
@@ -3330,7 +3316,6 @@ body, main, section, div, p, span, li {
     #reminderList.space-y-3 {
       display: flex;
       flex-direction: column;
-      gap: 0.4rem;
     }
 
     /* Horizontal single-row layout */


### PR DESCRIPTION
## Summary
- consolidate mobile reminder list spacing into the shared mobile theme stylesheet
- remove inline duplicate spacing overrides from mobile.html to rely on one source
- align list layout rules to inherit unified padding and gap values

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693faae2b1f48327a9c3a34e581cfe59)