### PR TITLE
Tighten reminder card spacing

### DIFF
--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -42,9 +42,9 @@
       --shadow-sm: 0 1px 3px var(--shadow-color);
       --shadow-md: 0 4px 12px var(--shadow-color);
       --transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-      --reminder-card-padding-y: 0.35rem;
-      --reminder-card-padding-x: 0.6rem;
-      --reminder-card-gap: 0.3rem;
+      --reminder-card-padding-y: 0.23rem;
+      --reminder-card-padding-x: 0.5rem;
+      --reminder-card-gap: 0.22rem;
       --reminder-card-font-size: 0.85rem;
 
       /* Mobile chrome for refreshed indigo shell */
@@ -983,7 +983,7 @@
       margin: 0;
       border: 1px solid var(--card-border);
       font-size: var(--reminder-card-font-size);
-      line-height: 1.4;
+      line-height: 1.0;
       background: var(--card-bg);
       border-radius: 12px;
       box-shadow: 0 1px 3px var(--shadow-color);
@@ -1042,15 +1042,15 @@
         display: grid;
         grid-template-columns: minmax(0, 1fr) auto;
         align-items: start;
-        gap: 0.5rem;
-        padding: 0.6rem 0.8rem;
-        margin-bottom: 0.5rem;
+        gap: var(--reminder-card-gap);
+        padding: var(--reminder-card-padding-y) var(--reminder-card-padding-x);
+        margin-bottom: var(--reminder-card-gap);
         background: var(--card-bg);
         border: 1px solid var(--card-border);
         border-radius: 0.5rem;
         box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
         font-size: var(--reminder-card-font-size);
-        line-height: 1.4;
+        line-height: 1.0;
       }
 
       #reminderList > .reminder-card.priority-high {
@@ -2310,7 +2310,7 @@
       box-shadow: 0 1px 3px var(--shadow-color);
       transition: all 0.2s ease;
       font-size: var(--reminder-card-font-size);
-      line-height: 1.4;
+      line-height: 1.0;
     }
 
     .cue-item:last-child,
@@ -2735,7 +2735,7 @@
       position: relative;
       width: 100%;
       min-height: 48px;
-      line-height: 1.4;
+      line-height: 1.2;
       touch-action: manipulation;
     }
 

--- a/mobile.html
+++ b/mobile.html
@@ -3596,8 +3596,8 @@ body, main, section, div, p, span, li {
       display: flex;
       align-items: center;
       justify-content: flex-start;
-      gap: 0.6rem;
-      padding: -0.45rem 0.9rem;
+      gap: 0.5rem;
+      padding: 0.25rem 0.65rem 0.3rem;
       margin-bottom: 0;
       background: var(--surface-soft, rgba(255, 255, 255, 0.7));
       border: 1px solid rgba(0, 0, 0, 0.02);
@@ -3605,7 +3605,7 @@ body, main, section, div, p, span, li {
       box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.02);
       transition: all 0.2s ease;
       font-size: var(--reminder-card-font-size);
-      line-height: 1.25;
+      line-height: 1.0;
     }
 
     .cue-item:last-child,
@@ -3640,7 +3640,7 @@ body, main, section, div, p, span, li {
       margin: 0;
       color: var(--primary-dark);
       font-weight: 500;
-      line-height: 1.25;
+      line-height: 1.15;
       font-size: 0.95rem;
       min-width: 0;
       overflow: hidden;


### PR DESCRIPTION
## Summary
- reduce reminder item padding, gap, and line height in the mobile view to shrink card height
- align documentation mobile styles with the tighter reminder spacing and typography

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693fd0564a588327a0eddcd4e459b73f)