### PR TITLE
Fix mobile reminders tab switching

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -3722,9 +3722,6 @@ export async function initReminders(sel = {}) {
     tabButtons.forEach((button) => {
       button.addEventListener('click', () => {
         const mode = button.getAttribute('data-reminders-tab');
-        if (!applyMobileRemindersFilter(mode)) {
-          return;
-        }
         setMobileRemindersFilter(mode);
       });
     });


### PR DESCRIPTION
## Summary
- ensure mobile reminder tab clicks invoke filter application so All/Today toggles respond

## Testing
- npm test -- --runInBand (fails: mobile.new-folder wiring, service-worker cache expectations)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693fd7e59744832786300fefef9bdc9b)