### PR TITLE
Make reminder rows more compact

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -1205,11 +1205,11 @@ html[data-theme="professional"] {
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  padding: 0.55rem 0.9rem;
+  padding: 0.4rem 0.85rem;
   border-radius: 0.9rem;
   background: var(--surface-soft, rgba(255, 255, 255, 0.7));
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.02);
-  gap: 0.6rem;
+  gap: 0.45rem;
 }
 
 .reminder-row * {
@@ -1234,7 +1234,7 @@ html[data-theme="professional"] {
 }
 
 .reminder-row-title {
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   font-weight: 500;
   color: var(--text-primary);
   white-space: nowrap;
@@ -1244,7 +1244,7 @@ html[data-theme="professional"] {
 
 .reminder-row-meta {
   margin-top: 0.1rem;
-  font-size: 0.78rem;
+  font-size: 0.75rem;
   color: var(--text-muted);
 }
 


### PR DESCRIPTION
## Summary
- reduce padding and spacing on reminder rows to shrink their height
- decrease reminder title and meta font sizes for a tighter layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693fda3108ac8327b1930755e581812a)