### PR TITLE
Reduce mobile reminder card height

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -1205,11 +1205,11 @@ html[data-theme="professional"] {
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  padding: 0.4rem 0.85rem;
+  padding: 0.3rem 0.75rem;
   border-radius: 0.9rem;
   background: var(--surface-soft, rgba(255, 255, 255, 0.7));
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.02);
-  gap: 0.45rem;
+  gap: 0.35rem;
 }
 
 .reminder-row * {
@@ -1234,7 +1234,7 @@ html[data-theme="professional"] {
 }
 
 .reminder-row-title {
-  font-size: 0.9rem;
+  font-size: 0.88rem;
   font-weight: 500;
   color: var(--text-primary);
   white-space: nowrap;
@@ -1243,8 +1243,8 @@ html[data-theme="professional"] {
 }
 
 .reminder-row-meta {
-  margin-top: 0.1rem;
-  font-size: 0.75rem;
+  margin-top: 0.05rem;
+  font-size: 0.73rem;
   color: var(--text-muted);
 }
 


### PR DESCRIPTION
## Summary
- reduce padding and spacing on mobile reminder rows to shrink their visual height
- slightly adjust title and meta typography for a more compact list

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693fdb911f048327985204441e82ee16)