### PR TITLE
Fix mobile reminders tab binding for unified top bar

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -3628,7 +3628,9 @@ export async function initReminders(sel = {}) {
     if (setupMobileReminderTabs._wired) {
       return;
     }
-    const tabButtons = document.querySelectorAll('#view-reminders [data-reminders-tab]');
+    const tabButtons = document.querySelectorAll(
+      '#reminders-slim-header [data-reminders-tab], #view-reminders [data-reminders-tab]'
+    );
     if (!tabButtons.length) {
       return;
     }


### PR DESCRIPTION
## Summary
- widen the reminder tab query to include the new top bar container so mobile filter buttons are wired up

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6941313dbf3c8327966efdf39772a5fd)