### PR TITLE
🎨 Palette: Accessible theme toggle labels

### DIFF
--- a/404.html
+++ b/404.html
@@ -126,13 +126,15 @@
       <div class="navbar-end">
         <div class="flex flex-col items-end gap-2">
           <div class="flex flex-wrap items-center justify-end gap-2">
-            <button
-              id="theme-toggle"
-              type="button"
-              class="btn btn-sm btn-ghost text-base-content"
-              data-icon-dark="🌙"
-              data-icon-light="☀️"
-            ></button>
+              <button
+                id="theme-toggle"
+                type="button"
+                class="btn btn-sm btn-ghost text-base-content"
+                data-icon-dark="🌙"
+                data-icon-light="☀️"
+                aria-label="Toggle theme"
+                aria-pressed="false"
+              ></button>
             <div class="dropdown dropdown-end">
               <button
                 type="button"

--- a/docs/404.html
+++ b/docs/404.html
@@ -126,13 +126,15 @@
       <div class="navbar-end">
         <div class="flex flex-col items-end gap-2">
           <div class="flex flex-wrap items-center justify-end gap-2">
-            <button
-              id="theme-toggle"
-              type="button"
-              class="btn btn-sm btn-ghost text-base-content"
-              data-icon-dark="🌙"
-              data-icon-light="☀️"
-            ></button>
+              <button
+                id="theme-toggle"
+                type="button"
+                class="btn btn-sm btn-ghost text-base-content"
+                data-icon-dark="🌙"
+                data-icon-light="☀️"
+                aria-label="Toggle theme"
+                aria-pressed="false"
+              ></button>
             <div class="dropdown dropdown-end">
               <button
                 type="button"

--- a/index.html
+++ b/index.html
@@ -454,6 +454,8 @@
             class="btn btn-sm btn-ghost text-base-content"
             data-icon-dark="🌙"
             data-icon-light="☀️"
+            aria-label="Toggle theme"
+            aria-pressed="false"
           ></button>
           <div
             class="desktop-account-controls w-full sm:w-auto"


### PR DESCRIPTION
## 💡 What
- Added default accessible labels and state to the theme toggle buttons so they expose a clear name even before JavaScript initializes.
- Updated 404 variants to keep the experience consistent across error and docs pages.

## 🎯 Why
- The icon-only theme toggle had no accessible name on first paint, making it unclear for screen reader users until scripts executed.

## 📸 Before/After
- No visual changes; accessibility-only improvement.

## ♿ Accessibility
- Added `aria-label` and `aria-pressed` defaults to provide an immediate accessible name and state for the toggle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69456463c2f883278a52410f285d0400)