### PR TITLE
Add fallback `textureUrl` helper to runtime env shim

### DIFF
--- a/js/runtime-env-shim.js
+++ b/js/runtime-env-shim.js
@@ -1,1 +1,10 @@
 window.__ENV = window.__ENV || {};
+window.textureUrl =
+  window.textureUrl ||
+  ((filename) => {
+    if (typeof filename !== 'string') {
+      return '';
+    }
+
+    return filename;
+  });


### PR DESCRIPTION
### Motivation
- A runtime error occurred (`ReferenceError: textureUrl is not defined`) when code referenced `textureUrl` but the helper was not present in the environment.
- Provide a small, safe shim so pages that expect `textureUrl` don't crash at runtime.

### Description
- Added a fallback in `js/runtime-env-shim.js` that sets `window.textureUrl` when it is not already defined.
- The fallback is a simple function that returns the given filename when it is a string and returns an empty string for non-string inputs.
- The change prevents uncaught reference errors from missing texture helper functions in environments where they are not provided.
- The file `js/runtime-env-shim.js` was updated and committed.

### Testing
- No automated tests were run as part of this change.
- Manual verification expected by loading pages that previously threw the `textureUrl` error to ensure they no longer crash.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694faffc17fc8327baa28916c776d2fa)