### PR TITLE
Add aria labels to resource inputs

### DIFF
--- a/app.js
+++ b/app.js
@@ -2897,6 +2897,7 @@ function renderPlannerLessons(plan) {
                     type="text"
                     class="input input-bordered input-sm w-full"
                     placeholder="Label (e.g. Slides)"
+                    aria-label="Resource label"
                     data-resource-label="true"
                     data-lesson-id="${lessonId}"
                   />
@@ -2904,6 +2905,7 @@ function renderPlannerLessons(plan) {
                     type="url"
                     class="input input-bordered input-sm w-full"
                     placeholder="URL"
+                    aria-label="Resource URL"
                     data-resource-url="true"
                     data-lesson-id="${lessonId}"
                   />


### PR DESCRIPTION
### Motivation
- Improve accessibility for the planner resource inputs by providing explicit labels for assistive technologies.
- Target the resource inputs created in the lesson card template which are identified by `data-resource-label` and `data-resource-url`.

### Description
- Added `aria-label="Resource label"` to the label input in the `renderPlannerLessonCards()` template in `app.js`.
- Added `aria-label="Resource URL"` to the URL input in the same template in `app.js`.
- Kept existing `placeholder` text and input `class` attributes intact and did not introduce any new CSS.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694fba6aaab0832784a80886afec3483)