### PR TITLE
Quick-add: support prefix routing for footy drills, tasks, and reflections

### DIFF
--- a/js/__tests__/reminders.quick-add.test.js
+++ b/js/__tests__/reminders.quick-add.test.js
@@ -94,6 +94,57 @@ afterEach(() => {
   document.body.innerHTML = '';
 });
 
+test('quick add routes footy drill prefix to Footy – Drills category', async () => {
+  const quickInput = document.getElementById('quickAddInput');
+  quickInput.value = 'footy drill: cone sprint ladders';
+
+  await window.memoryCueQuickAddNow();
+
+  const items = controller.__testing.getItems();
+  expect(items).toHaveLength(1);
+  expect(items[0].title).toBe('cone sprint ladders');
+  expect(items[0].category).toBe('Footy – Drills');
+  expect(Number.isFinite(items[0].createdAt)).toBe(true);
+  expect(Number.isFinite(items[0].updatedAt)).toBe(true);
+});
+
+test('quick add routes task prefix to Tasks category', async () => {
+  const quickInput = document.getElementById('quickAddInput');
+  quickInput.value = 'TASK: mark lesson plans';
+
+  await window.memoryCueQuickAddNow();
+
+  const items = controller.__testing.getItems();
+  expect(items).toHaveLength(1);
+  expect(items[0].title).toBe('mark lesson plans');
+  expect(items[0].category).toBe('Tasks');
+  expect(Number.isFinite(items[0].createdAt)).toBe(true);
+  expect(Number.isFinite(items[0].updatedAt)).toBe(true);
+});
+
+test('quick add routes reflection prefix to Lesson – Reflections notes folder', async () => {
+  const quickInput = document.getElementById('quickAddInput');
+  quickInput.value = 'Reflection: Year 8 class responded better to shorter instructions';
+
+  const note = await window.memoryCueQuickAddNow();
+
+  const items = controller.__testing.getItems();
+  expect(items).toHaveLength(0);
+  expect(note).toBeTruthy();
+
+  const folders = JSON.parse(localStorage.getItem('memoryCueFolders') || '[]');
+  const reflectionFolder = folders.find((folder) => folder?.name === 'Lesson – Reflections');
+  expect(reflectionFolder).toBeTruthy();
+
+  const notes = JSON.parse(localStorage.getItem('memoryCueNotes') || '[]');
+  expect(Array.isArray(notes)).toBe(true);
+  expect(notes).toHaveLength(1);
+  expect(notes[0].title).toBe('Year 8 class responded better to shorter instructions');
+  expect(notes[0].folderId).toBe(reflectionFolder.id);
+  expect(typeof notes[0].updatedAt).toBe('string');
+  expect(Number.isNaN(Date.parse(notes[0].updatedAt))).toBe(false);
+});
+
 test('quick add parses natural language time into due date', async () => {
   const quickInput = document.getElementById('quickAddInput');
   quickInput.value = 'Call parents tomorrow 1pm';


### PR DESCRIPTION
### Motivation
- Provide shortcut prefixes in the quick-add input to route entries into specific categories or notes to speed capture. 
- Allow educators to quickly save reflections as notes instead of reminders and ensure those notes land in a dedicated reflections folder.

### Description
- Added prefix parsing via `parseQuickAddPrefixRoute` to detect `footy drill:`, `task:` and `reflection:` prefixes and strip the prefix from the captured text. 
- Implemented note-saving helpers `readJsonArrayStorage`, `ensureReflectionFolder`, and `saveReflectionQuickNote` that persist notes under `memoryCueNotes` and ensure a `Lesson – Reflections` folder in `memoryCueFolders` with safe localStorage fallbacks. 
- Extended `quickAddNow` to route `footy-drill` to category `Footy – Drills`, `task` to category `Tasks`, and to create a note and return it when the `reflection` prefix is used, clearing the quick input after success. 
- Added constants `NOTES_STORAGE_KEY`, `FOLDERS_STORAGE_KEY`, and `REFLECTION_FOLDER_NAME` and preserved existing due-date parsing behavior.

### Testing
- Added three new Jest tests in `js/__tests__/reminders.quick-add.test.js` that assert routing for `footy drill:`, `TASK:`, and `Reflection:` inputs and verify resulting reminder or note data. 
- Ran the quick-add test file with the test suite and the new tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1fca44f548324a3d0ac31b5c55e6b)