### PR TITLE
Remove floating add button menu from mobile navigation

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5285,50 +5285,6 @@ body, main, section, div, p, span, li {
   </div>
 
   <div id="mobile-nav-shell" class="sticky inset-x-0 bottom-0 z-50 flex justify-center pointer-events-none px-2 pb-3">
-    <div class="fab-container" id="mobile-fab-container">
-      <button
-        type="button"
-        class="fab-button"
-        id="mobile-fab-button"
-        aria-label="Create new item"
-        aria-expanded="false"
-        aria-controls="mobile-fab-menu"
-      >
-        <svg
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-          focusable="false"
-        >
-          <path d="M12 5v14" />
-          <path d="M5 12h14" />
-        </svg>
-      </button>
-
-      <div class="fab-menu" id="mobile-fab-menu" role="menu" aria-hidden="true" hidden>
-        <button
-          type="button"
-          class="fab-menu-item"
-          id="mobile-footer-new-reminder"
-          data-fab-action="new-reminder"
-          data-open-add-task
-          aria-label="New reminder"
-          role="menuitem"
-        >
-          New reminder
-        </button>
-        <button
-          type="button"
-          class="fab-menu-item"
-          id="mobile-fab-new-note"
-          data-fab-action="new-note"
-          aria-label="New note"
-          role="menuitem"
-        >
-          New note
-        </button>
-      </div>
-    </div>
-
     <div class="floating-footer">
       <button
         type="button"


### PR DESCRIPTION
### Motivation
- The floating FAB (+) menu on mobile was causing an unwanted floating add button UI; the intent is to remove that floating add control while keeping the bottom navigation intact.

### Description
- Removed the `fab-container` block (the floating add button and its menu items `New reminder` and `New note`) from `mobile.html` under `#mobile-nav-shell`.
- Preserved the existing `floating-footer` navigation buttons and surrounding markup and scripts.
- No other files or JS logic were modified in this change, so any code that referenced the removed FAB IDs remains unchanged.

### Testing
- Ran the focused Jest test with `npm test -- --runTestsByPath js/__tests__/mobile.footer-nav.test.js` and it passed.
- Started the app with `npm start` and captured a mobile viewport screenshot using Playwright to visually confirm the FAB is no longer present, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1fac699648324a28bd328785cfeb3)