### PR TITLE
Quick-add: route prefixed entries (footy/task/reflection) and ensure reflections folder

### DIFF
--- a/js/__tests__/reminders.quick-add.test.js
+++ b/js/__tests__/reminders.quick-add.test.js
@@ -94,6 +94,57 @@ afterEach(() => {
   document.body.innerHTML = '';
 });
 
+test('quick add routes footy drill prefix to Footy – Drills category', async () => {
+  const quickInput = document.getElementById('quickAddInput');
+  quickInput.value = 'footy drill: cone sprint ladders';
+
+  await window.memoryCueQuickAddNow();
+
+  const items = controller.__testing.getItems();
+  expect(items).toHaveLength(1);
+  expect(items[0].title).toBe('cone sprint ladders');
+  expect(items[0].category).toBe('Footy – Drills');
+  expect(Number.isFinite(items[0].createdAt)).toBe(true);
+  expect(Number.isFinite(items[0].updatedAt)).toBe(true);
+});
+
+test('quick add routes task prefix to Tasks category', async () => {
+  const quickInput = document.getElementById('quickAddInput');
+  quickInput.value = 'TASK: mark lesson plans';
+
+  await window.memoryCueQuickAddNow();
+
+  const items = controller.__testing.getItems();
+  expect(items).toHaveLength(1);
+  expect(items[0].title).toBe('mark lesson plans');
+  expect(items[0].category).toBe('Tasks');
+  expect(Number.isFinite(items[0].createdAt)).toBe(true);
+  expect(Number.isFinite(items[0].updatedAt)).toBe(true);
+});
+
+test('quick add routes reflection prefix to Lesson – Reflections notes folder', async () => {
+  const quickInput = document.getElementById('quickAddInput');
+  quickInput.value = 'Reflection: Year 8 class responded better to shorter instructions';
+
+  const note = await window.memoryCueQuickAddNow();
+
+  const items = controller.__testing.getItems();
+  expect(items).toHaveLength(0);
+  expect(note).toBeTruthy();
+
+  const folders = JSON.parse(localStorage.getItem('memoryCueFolders') || '[]');
+  const reflectionFolder = folders.find((folder) => folder?.name === 'Lesson – Reflections');
+  expect(reflectionFolder).toBeTruthy();
+
+  const notes = JSON.parse(localStorage.getItem('memoryCueNotes') || '[]');
+  expect(Array.isArray(notes)).toBe(true);
+  expect(notes).toHaveLength(1);
+  expect(notes[0].title).toBe('Year 8 class responded better to shorter instructions');
+  expect(notes[0].folderId).toBe(reflectionFolder.id);
+  expect(typeof notes[0].updatedAt).toBe('string');
+  expect(Number.isNaN(Date.parse(notes[0].updatedAt))).toBe(false);
+});
+
 test('quick add parses natural language time into due date', async () => {
   const quickInput = document.getElementById('quickAddInput');
   quickInput.value = 'Call parents tomorrow 1pm';

--- a/js/tests/notes-storage.folders.test.js
+++ b/js/tests/notes-storage.folders.test.js
@@ -1,0 +1,58 @@
+/** @jest-environment jsdom */
+
+const { beforeEach, expect, test } = require('@jest/globals');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadNotesStorageModule() {
+  const filePath = path.resolve(__dirname, '../modules/notes-storage.js');
+  let source = fs.readFileSync(filePath, 'utf8');
+  source = source
+    .replace(/export\s+const/g, 'const')
+    .replace(/export\s+\{\s*NOTES_STORAGE_KEY\s*\};/g, '')
+    .replace(/export\s+\{\s*NOTES_STORAGE_KEY\s*\}/g, '')
+    .replace(/export\s+\{[^}]*\};?/g, '');
+  source += '\nmodule.exports = { getFolders, saveFolders };\n';
+
+  const module = { exports: {} };
+  const sandbox = {
+    module,
+    exports: module.exports,
+    require,
+    console,
+    localStorage,
+    document,
+    window,
+    crypto: window.crypto,
+    Date,
+    setTimeout,
+    clearTimeout,
+  };
+
+  vm.runInNewContext(source, sandbox, { filename: filePath });
+  return module.exports;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test('getFolders always includes Lesson – Reflections', () => {
+  const { getFolders } = loadNotesStorageModule();
+
+  const folders = getFolders();
+
+  expect(Array.isArray(folders)).toBe(true);
+  expect(folders.some((folder) => folder?.name === 'Lesson – Reflections')).toBe(true);
+});
+
+test('saveFolders keeps Lesson – Reflections in storage', () => {
+  const { saveFolders, getFolders } = loadNotesStorageModule();
+
+  const saved = saveFolders([{ id: 'unsorted', name: 'Unsorted', order: 0 }]);
+
+  expect(saved).toBe(true);
+  const folders = getFolders();
+  expect(folders.some((folder) => folder?.name === 'Lesson – Reflections')).toBe(true);
+});


### PR DESCRIPTION
### Motivation

- Allow users to quickly route short prefixed quick-add text into specific categories or notes so that `footy drill:`, `task:` and `reflection:` inputs behave intuitively. 
- Persist and surface a dedicated `Lesson – Reflections` notes folder so reflection quick-adds are stored in a consistent location. 

### Description

- Added quick-add prefix parsing with `parseQuickAddPrefixRoute` and routing in `quickAddNow` to map `footy drill` => category `Footy – Drills`, `task` => category `Tasks`, and `reflection` => create a note instead of a reminder. 
- Implemented note creation helpers `saveReflectionQuickNote`, `ensureReflectionFolder`, and `readJsonArrayStorage` in `reminders.js` to create or reuse a `Lesson – Reflections` folder and persist notes to `localStorage` (`memoryCueNotes`/`memoryCueFolders`). 
- Updated `notes-storage.js` to introduce `ensureRequiredFolders` which normalizes folders, enforces `Unsorted` and `Lesson – Reflections` presence, stabilizes `id` and `order`, and wired it into `getFolders` and `saveFolders`. 
- Added unit tests: new `js/tests/notes-storage.folders.test.js` and expanded `js/__tests__/reminders.quick-add.test.js` to cover `footy drill`, `task`, and `reflection` quick-add behaviors. 

### Testing

- Ran the updated Jest unit tests for quick-add: `js/__tests__/reminders.quick-add.test.js`, which cover category routing and natural-language due parsing, and the new `js/tests/notes-storage.folders.test.js`; these tests passed. 
- Confirmed `getFolders`/`saveFolders` behavior via unit tests that ensure `Lesson – Reflections` is always present and persisted; tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1fca44f548324a3d0ac31b5c55e6b)