### PR TITLE
Fix mobile reminders list being hidden under quick-add header

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -4637,7 +4637,9 @@ body, main, section, div, p, span, li {
             // If the variable is "112px", we want "calc(112px + 18px)"
             main.style.setProperty('padding-top', `calc(${heightVal} + 18px)`, 'important');
           } else {
-            main.style.removeProperty('padding-top');
+            const headerHeight = getComputedStyle(document.documentElement).getPropertyValue('--mobile-header-height').trim();
+            const heightVal = headerHeight ? headerHeight : '112px';
+            main.style.setProperty('padding-top', heightVal, 'important');
           }
         }
         if (document.body) document.body.setAttribute('data-active-view', name);


### PR DESCRIPTION
### Motivation
- The first reminder in the mobile reminders view was rendering underneath the fixed quick-add header bar because `main` top padding was removed when switching views.

### Description
- Update `showViewFor` in `mobile.html` to set `main` top padding to the measured `--mobile-header-height` for non-notebook views instead of removing the padding. 
- Preserve the notebook-specific behavior by keeping the existing `calc(${headerHeight} + 18px)` padding when `name === 'notebook'`.

### Testing
- Ran `npm test -- --runInBand`, which completed but failed overall due to existing unrelated test failures in `js/__tests__/mobile.new-folder.test.js` and `service-worker.test.js`.
- Ran `npx jest js/__tests__/mobile.header.test.js --runInBand`, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a202012ea88324be4b159a34ebcfe4)