### PR TITLE
fix: improve mobile UI layout and spacing

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -1057,6 +1057,7 @@ export async function initReminders(sel = {}) {
   function setupInboxSearch() {
     const inboxSearchInput = typeof document !== 'undefined' ? document.getElementById('inboxSearchInput') : null;
     const inboxSearchResults = typeof document !== 'undefined' ? document.getElementById('inboxSearchResults') : null;
+    const inboxSearchClear = typeof document !== 'undefined' ? document.getElementById('inboxSearchClear') : null;
     if (!inboxSearchInput || !inboxSearchResults) {
       return;
     }
@@ -1115,6 +1116,9 @@ export async function initReminders(sel = {}) {
     const runSearch = () => {
       const query = inboxSearchInput.value || '';
       const trimmed = query.trim();
+      if (inboxSearchClear) {
+        inboxSearchClear.hidden = !trimmed;
+      }
       if (!trimmed) {
         inboxSearchResults.innerHTML = '';
         return;
@@ -1165,6 +1169,16 @@ export async function initReminders(sel = {}) {
     };
 
     inboxSearchInput.addEventListener('input', runSearch);
+
+    if (inboxSearchClear) {
+      inboxSearchClear.addEventListener('click', () => {
+        inboxSearchInput.value = '';
+        inboxSearchResults.innerHTML = '';
+        inboxSearchClear.hidden = true;
+        inboxSearchInput.focus();
+      });
+    }
+
     document.addEventListener('memoryCue:remindersUpdated', runSearch);
   }
 

--- a/mobile.html
+++ b/mobile.html
@@ -2051,19 +2051,35 @@ body, main, section, div, p, span, li {
       gap: 0.5rem;
     }
 
+    .header-quick-add,
+    .header-search {
+      width: 100%;
+    }
+
     .quick-add-form {
       display: flex;
       align-items: center;
       background: white;
+      border: 1px solid var(--border-subtle);
       border-radius: 999px;
-      padding: 0.5rem;
+      padding: 0.5rem 0.65rem;
+      gap: 0.35rem;
     }
 
     .quick-add-form input {
       flex: 1;
-      border: none;
+      border: 1px solid var(--border-subtle);
+      border-radius: 999px;
+      font-size: 0.95rem;
       background: transparent;
-      padding: 0 0.5rem;
+      padding: 0.42rem 0.75rem;
+      color: var(--text-main);
+      line-height: 1.3;
+    }
+
+    .quick-add-form input::placeholder,
+    #inboxSearchInput::placeholder {
+      color: var(--text-placeholder);
     }
 
     .quick-add-tabs {
@@ -2079,11 +2095,49 @@ body, main, section, div, p, span, li {
 
 
     .inbox-search-container {
-      margin-top: 0.5rem;
-      margin-bottom: 0.9rem;
+      margin-top: 0.75rem;
+      margin-bottom: 0;
       position: relative;
       z-index: 1;
       display: block;
+    }
+
+    .inbox-search-input-wrap {
+      position: relative;
+    }
+
+    #inboxSearchInput {
+      width: 100%;
+      border: 1px solid var(--border-subtle);
+      border-radius: 999px;
+      padding: 0.42rem 2.15rem 0.42rem 0.75rem;
+      font-size: 0.95rem;
+      line-height: 1.3;
+      color: var(--text-main);
+      background: #fff;
+    }
+
+    .inbox-search-clear {
+      position: absolute;
+      top: 50%;
+      right: 0.4rem;
+      transform: translateY(-50%);
+      border: none;
+      border-radius: 999px;
+      width: 1.55rem;
+      height: 1.55rem;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: color-mix(in srgb, var(--card-border) 55%, #ffffff);
+      color: var(--text-secondary);
+      font-size: 1rem;
+      line-height: 1;
+      cursor: pointer;
+    }
+
+    .inbox-search-clear[hidden] {
+      display: none;
     }
 
     #inboxSearchResults {
@@ -2094,6 +2148,11 @@ body, main, section, div, p, span, li {
     #remindersListMobile {
       position: relative;
       z-index: 0;
+      margin-top: 0.85rem;
+    }
+
+    #reminderList {
+      margin-top: 0.35rem;
     }
 
     /* Accessibility helper */
@@ -4708,8 +4767,13 @@ body, main, section, div, p, span, li {
           <button type="button" class="filter-toggle reminder-tab" data-reminders-tab="today" data-filter="today" aria-pressed="false">Today</button>
         </div>
       </form>
+    </div>
+    <div class="header-search">
       <div id="inboxSearchContainer" class="inbox-search-container" role="search" aria-label="Inbox search">
-        <input id="inboxSearchInput" type="search" class="input input-sm w-full" placeholder="Inbox search (keywords, today, Monday 4pm)" autocomplete="off" />
+        <div class="inbox-search-input-wrap">
+          <input id="inboxSearchInput" type="search" class="input input-sm w-full" placeholder="Search reminders, notes, drills…" autocomplete="off" />
+          <button id="inboxSearchClear" type="button" class="inbox-search-clear" aria-label="Clear inbox search" hidden>&times;</button>
+        </div>
         <ul id="inboxSearchResults" class="mt-2 space-y-1"></ul>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Improve mobile reminders UX so the inbox search no longer overlaps the first reminder and the header inputs look consistent.
- Move the search into its own container below the quick-add bar and provide a single-tap clear control for faster query clearing.
- Keep all existing reminder logic and quick-add routing intact while only changing structure, styles, and minimal supporting JS.

### Description
- Moved the inbox search markup into a dedicated header-search container directly below the quick-add form in `mobile.html` while preserving `#inboxSearchInput` and `#inboxSearchResults` IDs.
- Updated CSS in `mobile.html` to unify input styling (borders, padding, font-size, placeholder color) for quick-add and search, and added vertical spacing so `#remindersListMobile` / `#reminderList` are pushed below the search container.
- Added an inline clear button (`#inboxSearchClear`) inside the search input and styling for the control (hidden by default).
- Wired a small, non-invasive handler in `js/reminders.js` (`setupInboxSearch`) to toggle visibility of the clear button and to clear the input and results when tapped; no reminder logic or routes were changed.
- Files changed: `mobile.html`, `js/reminders.js` (84 insertions, 6 deletions total).

### Testing
- Ran unit tests with `npm test -- --runInBand`; the run completed with most suites passing but there are 2 pre-existing failing suites unrelated to this UI change: `js/__tests__/mobile.new-folder.test.js` and `service-worker.test.js`, so overall test summary was `23 total` suites with `21 passed, 2 failed`.
- Verified the updated mobile layout by launching the local dev server and capturing a mobile viewport screenshot with Playwright to confirm spacing and search clear control render correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a24ae15b188324888d6bab7579a8e1)