### PR TITLE
Add inbox search clear button and refine mobile reminders header layout/styles

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -1057,6 +1057,7 @@ export async function initReminders(sel = {}) {
   function setupInboxSearch() {
     const inboxSearchInput = typeof document !== 'undefined' ? document.getElementById('inboxSearchInput') : null;
     const inboxSearchResults = typeof document !== 'undefined' ? document.getElementById('inboxSearchResults') : null;
+    const inboxSearchClear = typeof document !== 'undefined' ? document.getElementById('inboxSearchClear') : null;
     if (!inboxSearchInput || !inboxSearchResults) {
       return;
     }
@@ -1115,6 +1116,9 @@ export async function initReminders(sel = {}) {
     const runSearch = () => {
       const query = inboxSearchInput.value || '';
       const trimmed = query.trim();
+      if (inboxSearchClear) {
+        inboxSearchClear.hidden = !trimmed;
+      }
       if (!trimmed) {
         inboxSearchResults.innerHTML = '';
         return;
@@ -1165,6 +1169,16 @@ export async function initReminders(sel = {}) {
     };
 
     inboxSearchInput.addEventListener('input', runSearch);
+
+    if (inboxSearchClear) {
+      inboxSearchClear.addEventListener('click', () => {
+        inboxSearchInput.value = '';
+        inboxSearchResults.innerHTML = '';
+        inboxSearchClear.hidden = true;
+        inboxSearchInput.focus();
+      });
+    }
+
     document.addEventListener('memoryCue:remindersUpdated', runSearch);
   }
 

--- a/mobile.html
+++ b/mobile.html
@@ -2029,7 +2029,7 @@ body, main, section, div, p, span, li {
       padding: 1rem;
       position: sticky;
       top: 0;
-      z-index: 10;
+      z-index: 40;
       display: flex;
       flex-direction: column;
       gap: 1rem;
@@ -2051,19 +2051,35 @@ body, main, section, div, p, span, li {
       gap: 0.5rem;
     }
 
+    .header-quick-add,
+    .header-search {
+      width: 100%;
+    }
+
     .quick-add-form {
       display: flex;
       align-items: center;
       background: white;
+      border: 1px solid var(--border-subtle);
       border-radius: 999px;
-      padding: 0.5rem;
+      padding: 0.5rem 0.65rem;
+      gap: 0.35rem;
     }
 
     .quick-add-form input {
       flex: 1;
-      border: none;
+      border: 1px solid var(--border-subtle);
+      border-radius: 999px;
+      font-size: 0.95rem;
       background: transparent;
-      padding: 0 0.5rem;
+      padding: 0.42rem 0.75rem;
+      color: var(--text-main);
+      line-height: 1.3;
+    }
+
+    .quick-add-form input::placeholder,
+    #inboxSearchInput::placeholder {
+      color: var(--text-placeholder);
     }
 
     .quick-add-tabs {
@@ -2079,14 +2095,52 @@ body, main, section, div, p, span, li {
 
 
     .inbox-search-container {
-      margin-top: 0.5rem;
-      margin-bottom: 0.9rem;
       position: relative;
-      z-index: 1;
+      z-index: 20;
       display: block;
     }
 
+    .inbox-search-input-wrap {
+      position: relative;
+    }
+
+    #inboxSearchInput {
+      width: 100%;
+      border: 1px solid var(--border-subtle);
+      border-radius: 999px;
+      padding: 0.42rem 2.15rem 0.42rem 0.75rem;
+      font-size: 0.95rem;
+      line-height: 1.3;
+      color: var(--text-main);
+      background: #fff;
+    }
+
+    .inbox-search-clear {
+      position: absolute;
+      top: 50%;
+      right: 0.4rem;
+      transform: translateY(-50%);
+      border: none;
+      border-radius: 999px;
+      width: 1.55rem;
+      height: 1.55rem;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: color-mix(in srgb, var(--card-border) 55%, #ffffff);
+      color: var(--text-secondary);
+      font-size: 1rem;
+      line-height: 1;
+      cursor: pointer;
+    }
+
+    .inbox-search-clear[hidden] {
+      display: none;
+    }
+
     #inboxSearchResults {
+      position: relative;
+      z-index: 21;
       max-height: 12rem;
       overflow-y: auto;
     }
@@ -2094,6 +2148,7 @@ body, main, section, div, p, span, li {
     #remindersListMobile {
       position: relative;
       z-index: 0;
+      margin-top: 0.85rem;
     }
 
     /* Accessibility helper */
@@ -4061,9 +4116,9 @@ body, main, section, div, p, span, li {
       }
     }
 
-    /* Adjust main content to account for sticky header */
+    /* Keep reminders content below the fixed mobile header + search area */
     #view-reminders {
-      padding-top: 0 !important;
+      padding-top: calc(var(--mobile-header-height, 112px) + 0.5rem) !important;
     }
 
     .reminders-content-shell {
@@ -4708,8 +4763,13 @@ body, main, section, div, p, span, li {
           <button type="button" class="filter-toggle reminder-tab" data-reminders-tab="today" data-filter="today" aria-pressed="false">Today</button>
         </div>
       </form>
+    </div>
+    <div class="header-search">
       <div id="inboxSearchContainer" class="inbox-search-container" role="search" aria-label="Inbox search">
-        <input id="inboxSearchInput" type="search" class="input input-sm w-full" placeholder="Inbox search (keywords, today, Monday 4pm)" autocomplete="off" />
+        <div class="inbox-search-input-wrap">
+          <input id="inboxSearchInput" type="search" placeholder="Search reminders, notes, drills…" autocomplete="off" />
+          <button id="inboxSearchClear" type="button" class="inbox-search-clear" aria-label="Clear inbox search" hidden>&times;</button>
+        </div>
         <ul id="inboxSearchResults" class="mt-2 space-y-1"></ul>
       </div>
     </div>
@@ -4906,7 +4966,7 @@ body, main, section, div, p, span, li {
         <!-- header removed to keep view minimal -->
         <div class="reminders-content-shell space-y-2">
 
-          <div id="remindersListMobile" class="space-y-2 mt-2">
+          <div id="remindersListMobile" class="space-y-2">
             <section
               id="reminderListSection"
               class="w-full relative memory-glass-card-soft"


### PR DESCRIPTION
### Motivation
- Improve the mobile Reminders header by integrating the quick-add/search UI, adding a clear affordance for inbox search, and ensuring reminders content sits correctly under the sticky header.
- Make the inbox search experience more discoverable and accessible by showing a clear button while typing and restoring focus when cleared.

### Description
- Wire up a new `inboxSearchClear` element in `initReminders` and toggle its `hidden` state on input while adding a click handler that clears the input, clears results, hides the button, and focuses the input.
- Update `mobile.html` to move the quick-add into the header, add a search input wrapper and the `inboxSearchClear` button markup, and reorganize header sections for the compact mobile layout.
- Add and adjust CSS rules for the mobile header and search: increase header `z-index`, style `.quick-add-form`, `#inboxSearchInput`, `.inbox-search-clear`, and other header/search layout refinements, plus update `#view-reminders` top padding to account for the sticky header.
- Tweak list/container spacing and z-indexes so the search results and reminders list render correctly beneath the new header layout.

### Testing
- Ran the project's linter with `npm run lint` and the build with `npm run build`, both completed successfully.
- Executed the automated test suite with `npm test` and all tests passed.
- No new automated tests were added for this UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a24ae15b188324888d6bab7579a8e1)