### PR TITLE
refactor: normalize mobile UI single-column layout

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2059,6 +2059,27 @@ body, main, section, div, p, span, li {
       width: 100%;
     }
 
+    .header-quick-add {
+      border-top: 1px solid var(--border-subtle);
+      padding-top: var(--space-2);
+    }
+
+    .header-search {
+      border-top: 1px solid var(--border-subtle);
+      padding-top: var(--space-2);
+    }
+
+    .reminders-mobile-flow {
+      display: block;
+      width: 100%;
+      padding: var(--space-2) var(--space-4) var(--space-4);
+      background: var(--mobile-quick-surface);
+    }
+
+    .reminders-mobile-flow > * + * {
+      margin-top: var(--space-2);
+    }
+
     .quick-add-form {
       display: flex;
       align-items: center;
@@ -2146,7 +2167,7 @@ body, main, section, div, p, span, li {
       z-index: 21;
       max-height: 12rem;
       overflow-y: auto;
-      margin-top: var(--space-1);
+      margin: 0;
       display: flex;
       flex-direction: column;
       gap: calc(var(--space-1) / 2);
@@ -2155,7 +2176,7 @@ body, main, section, div, p, span, li {
     #remindersListMobile {
       position: relative;
       z-index: 0;
-      margin-top: var(--space-2);
+      margin-top: 0;
       display: flex;
       flex-direction: column;
       gap: var(--space-1);
@@ -4126,18 +4147,16 @@ body, main, section, div, p, span, li {
       }
     }
 
-    /* Keep reminders content below the fixed mobile header + search area */
+    /* Keep reminders content in a single vertical flow under the sticky header */
     #view-reminders {
-      padding-top: calc(var(--mobile-header-height, 112px) + 0.5rem) !important;
+      padding-top: 0 !important;
     }
 
     .reminders-content-shell {
       background-color: transparent;
       border-radius: 1.25rem;
-      /* remove top padding so content sits flush under the sticky header */
-      padding: 0 1rem 1rem;
-      padding-top: 0 !important;
-      margin-top: 0 !important;
+      padding: 0;
+      margin-top: 0;
       width: 100%;
     }
 
@@ -4780,7 +4799,6 @@ body, main, section, div, p, span, li {
           <input id="inboxSearchInput" type="search" placeholder="Search reminders, notes, drills…" autocomplete="off" />
           <button id="inboxSearchClear" type="button" class="inbox-search-clear" aria-label="Clear inbox search" hidden>&times;</button>
         </div>
-        <ul id="inboxSearchResults"></ul>
       </div>
     </div>
     <div id="overflowMenu" class="overflow-menu quick-actions-panel hidden" role="menu" aria-hidden="true">
@@ -4972,25 +4990,23 @@ body, main, section, div, p, span, li {
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: reminders view -->
     <section data-view="reminders" id="view-reminders" class="view-panel">
-      <div class="mobile-view-inner mx-auto w-full px-4 pt-2 pb-4 space-y-2" style="background: var(--mobile-quick-surface);">
-        <!-- header removed to keep view minimal -->
-        <div class="reminders-content-shell space-y-2">
+      <div class="reminders-mobile-flow reminders-content-shell">
+        <div id="inboxSearchResults"></div>
 
-          <div id="remindersListMobile">
-            <section
-              id="reminderListSection"
-              class="w-full relative memory-glass-card-soft"
-            >
-              <div class="w-full" id="remindersWrapper">
-                <div id="emptyState" class="hidden text-center text-base-content/60 py-8 sm:px-4"></div>
-                <p id="reminderReorderHint" class="sr-only">
-                  Press, hold, and drag a reminder card to reorder your list. Screen reader users can double-tap and hold, then drag to move a reminder.
-                </p>
-                <ul id="reminderList" class="grid grid-cols-2 gap-1 w-full overflow-x-hidden reminder-list reminders-list" aria-describedby="reminderReorderHint"></ul>
-              </div>
-            </section>
-          </div>
-        </div>
+        <section id="remindersListMobile">
+          <section
+            id="reminderListSection"
+            class="w-full relative memory-glass-card-soft"
+          >
+            <div class="w-full" id="remindersWrapper">
+              <div id="emptyState" class="hidden text-center text-base-content/60 py-8 sm:px-4"></div>
+              <p id="reminderReorderHint" class="sr-only">
+                Press, hold, and drag a reminder card to reorder your list. Screen reader users can double-tap and hold, then drag to move a reminder.
+              </p>
+              <ul id="reminderList" class="grid grid-cols-2 gap-1 w-full overflow-x-hidden reminder-list reminders-list" aria-describedby="reminderReorderHint"></ul>
+            </div>
+          </section>
+        </section>
       </div>
     </section>
     <!-- END GPT CHANGE -->


### PR DESCRIPTION
### Motivation
- Make the mobile reminders UI deterministic and readable by enforcing a single-column vertical flow: header → quick add → search bar → search results → reminders list.  
- Remove nested/competing layout containers and unpredictable flex/grid rules that caused overlapping spacing and flattened structure.  
- Ensure functional pieces like quick add and search have clear separators/padding while relying on the repo spacing scale (`var(--space-*)`).

### Description
- Added a single-column container `.reminders-mobile-flow` and applied consistent spacing rules so children flow vertically and use the spacing scale.  
- Moved `#inboxSearchResults` out of the header search wrapper and into the reminders content flow above `#remindersListMobile` to guarantee the requested order.  
- Introduced light separators/padding for header functional blocks by updating `.header-quick-add` and `.header-search` (border-top + `padding-top`) to avoid overlap with the header.  
- Normalized margins/padding that previously forced offsets by setting `#view-reminders { padding-top: 0 }`, zeroing `#remindersListMobile` top margin, and resetting `#inboxSearchResults` margin to rely on the new flow.  
- All edits are confined to a single file: `mobile.html` (net +44 / -28 lines); markup reordering and CSS adjustments are the main changes.

### Testing
- Ran unit tests with `npm test -- --runInBand`; most suites passed but there are pre-existing unrelated failures: `js/__tests__/mobile.new-folder.test.js` and `service-worker.test.js`, which did not appear to be caused by this layout change.  
- Performed a visual smoke test by serving the app (`npm run start`) and capturing a mobile viewport screenshot via Playwright to confirm the single-column flow renders as intended.  
- No new automated tests were added or modified as part of this refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a254c2b7f48324b61ff737e99bd972)