### PR TITLE
refactor: stabilize header and search layering for consistent dropdown behavior

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2032,7 +2032,7 @@ body, main, section, div, p, span, li {
       padding: var(--space-2);
       position: sticky;
       top: 0;
-      z-index: 40;
+      z-index: 1000;
       display: flex;
       flex-direction: column;
       gap: var(--space-2);
@@ -2131,7 +2131,6 @@ body, main, section, div, p, span, li {
 
     .inbox-search-container {
       position: relative;
-      z-index: 20;
       display: block;
     }
 
@@ -2190,8 +2189,11 @@ body, main, section, div, p, span, li {
     }
 
     #inboxSearchResults {
-      position: relative;
-      z-index: 21;
+      position: absolute;
+      top: calc(100% + var(--space-1));
+      left: 0;
+      right: 0;
+      z-index: 1001;
       max-height: 12rem;
       overflow-y: auto;
       margin: 0;
@@ -2202,7 +2204,6 @@ body, main, section, div, p, span, li {
 
     #remindersListMobile {
       position: relative;
-      z-index: 0;
       margin-top: 0;
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
### Motivation
- Ensure the sticky mobile header always sits above page content so it never gets visually overlapped.
- Make the inbox/search results dropdown reliably render on top of reminder list items.
- Remove per-list-item stacking overrides that could compete with the search dropdown.

### Description
- Set `.mobile-header` to `z-index: 1000` in `mobile.html` to establish a high global header stacking level.
- Make `#inboxSearchResults` an absolutely positioned overlay with `top: calc(100% + var(--space-1))`, `left: 0`, `right: 0` and `z-index: 1001` so results sit above list items.
- Removed the explicit `z-index` from `#remindersListMobile` so reminder list items no longer compete with the dropdown stacking order.
- Kept `.inbox-search-container` as the positioned parent (`position: relative`) to provide the correct positioning context for the absolute results element.

### Testing
- Verified the file diff with `git diff -- mobile.html` and committed the change with the requested message, which succeeded.
- Confirmed CSS changes are present using ripgrep (`rg -n "mobile-header|inbox-search-container|inboxSearchResults|remindersListMobile|z-index" mobile.html`), which returned the updated selectors.
- Attempted automated visual verification by launching a local server and capturing a screenshot with Playwright, but the environment failed to serve the page (`ERR_EMPTY_RESPONSE`), so the screenshot step could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a256d81af08324a4b9b610eaf4bba7)