### PR TITLE
feat: mobile autocomplete dropdown for inbox search

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2200,6 +2200,35 @@ body, main, section, div, p, span, li {
       display: flex;
       flex-direction: column;
       gap: calc(var(--space-1) / 2);
+      border-radius: var(--control-radius);
+      background: var(--card-bg, #fff);
+      border: 1px solid color-mix(in srgb, var(--card-border) 65%, #fff);
+      box-shadow: 0 10px 20px rgba(15, 23, 42, 0.12);
+      padding: calc(var(--space-1) / 2);
+    }
+
+    .inbox-search-result-item {
+      list-style: none;
+      padding: var(--space-1);
+      border-radius: calc(var(--control-radius) - 4px);
+      border-bottom: 1px solid color-mix(in srgb, var(--card-border) 55%, #fff);
+      background: transparent;
+      cursor: pointer;
+    }
+
+    .inbox-search-result-item:last-child {
+      border-bottom: none;
+    }
+
+    .inbox-search-result-item.is-active {
+      background: color-mix(in srgb, var(--accent-color) 12%, #fff);
+    }
+
+    .inbox-search-result-title mark.inbox-search-match {
+      background: color-mix(in srgb, var(--accent-color) 25%, #fff);
+      color: inherit;
+      border-radius: 0.2rem;
+      padding: 0 0.1rem;
     }
 
     #remindersListMobile {


### PR DESCRIPTION
### Motivation
- Provide a mobile-friendly autocomplete for the inbox search that improves quick selection on small screens while preserving all existing search/filter and storage behavior.

### Description
- Added autocomplete logic inside `setupInboxSearch()` including `buildCombinedEntries`, `findAutocompleteResults`, `highlightMatch`, and a 120ms debounce, reusing the existing `items` array and `readNotes()` output.
- Rendered an absolute-positioned dropdown into `#inboxSearchResults` that shows up to 8 case-insensitive matches (title or body), prioritizes entries starting with the query, displays a type badge (Reminder/Note), highlights matched text with `<mark>`, and shows a subtle "No matches" message when empty.
- Made each result clickable so selecting one fills `#inboxSearchInput` and then triggers the existing `runSearch()`; keyboard navigation supports `ArrowDown`/`ArrowUp` to move selection, `Enter` to choose the highlighted result, and `Escape` to close the dropdown while maintaining internal index state and visual `.is-active` highlighting.
- Added compact mobile styles in `mobile.html` for dropdown positioning, elevated `z-index`, max-height scrolling, active-row visuals, and highlighted-match styling without altering layout or sticky header behavior.

### Testing
- Ran `npm test -- --runInBand`; most suites passed but there are pre-existing unrelated failures in `js/__tests__/mobile.new-folder.test.js` and `service-worker.test.js`, otherwise test suites ran successfully.
- Performed a Playwright visual check by loading `mobile.html`, injecting notes into `localStorage`, typing into `#inboxSearchInput`, and capturing a screenshot that shows the autocomplete dropdown working as expected.
- Confirmed that `runSearch()` and reminder/note storage usage were not modified and that autocomplete only augments UI behavior, preserving previous search results and filtering logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a267e379048324b0ed89555854d52a)