### PR TITLE
feat: add semantic embedding infrastructure (stubbed)

### DIFF
--- a/js/modules/notes-storage.js
+++ b/js/modules/notes-storage.js
@@ -4,6 +4,16 @@ const LEGACY_NOTE_KEYS = ['mobileNotes', 'memory-cue-notes'];
 
 const hasLocalStorage = () => typeof localStorage !== 'undefined';
 
+const normalizeSemanticEmbedding = (value) => {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const vector = value
+    .map((entry) => Number(entry))
+    .filter((entry) => Number.isFinite(entry));
+  return vector.length ? vector : null;
+};
+
 let remoteSyncHandler = null;
 
 export const setRemoteSyncHandler = (handler) => {
@@ -108,6 +118,7 @@ export const createNote = (title, bodyHtml, overrides = {}) => {
         ? overrides.updatedAt
         : new Date().toISOString(),
     folderId: overrides.folderId && typeof overrides.folderId === 'string' ? overrides.folderId : null,
+    semanticEmbedding: normalizeSemanticEmbedding(overrides.semanticEmbedding),
   };
 };
 
@@ -143,6 +154,7 @@ const normalizeNotes = (value) => {
           bodyHtml: body,
           bodyText,
           pinned,
+          semanticEmbedding: normalizeSemanticEmbedding(note.semanticEmbedding),
         });
       })
       .filter(Boolean);
@@ -172,6 +184,7 @@ const normalizeNotes = (value) => {
         bodyHtml: body,
         bodyText,
         pinned,
+        semanticEmbedding: normalizeSemanticEmbedding(value.semanticEmbedding),
       }),
     ];
   }
@@ -255,6 +268,7 @@ export const saveAllNotes = (notes, options = {}) => {
     if (out) {
       out.folderId = typeof note.folderId === 'string' && note.folderId ? note.folderId : out.folderId || null;
       out.pinned = typeof note.pinned === 'boolean' ? note.pinned : Boolean(out.pinned);
+      out.semanticEmbedding = normalizeSemanticEmbedding(note.semanticEmbedding);
     }
     return out;
   }).filter(Boolean);


### PR DESCRIPTION
### Motivation
- Prepare the reminders and notes storage for semantic search by adding a place to store embedding vectors and helper utilities without changing UI or existing search behavior.
- Provide a small, safe scaffold for future embeddings API integration while ensuring persisted data shapes are consistent and validated.

### Description
- Add embedding helpers to `js/reminders.js`: `normalizeSemanticEmbedding`, `generateEmbedding(text)` (async stub returning `null` with a TODO for API integration), `cosineSimilarity(vecA, vecB)`, and `ensureEmbeddingForItem(item)` to normalize or backfill an item's embedding if available. 
- Add `ensureAllEmbeddings()` which iterates offline reminders and notes at init to backfill missing embeddings (uses the stub so no network calls are made). This is invoked during reminders initialization but will not change runtime behavior while the stub returns `null`.
- Extend localStorage shapes to persist an optional `semanticEmbedding` field (array of numbers) under the same storage keys: offline reminders (`memoryCue:offlineReminders`), scheduled reminders (`scheduledReminders`), new reminder payloads, quick-reflection notes, and notes in `memoryCueNotes` via `js/modules/notes-storage.js` normalization/persistence. The embedding is stored under the key `semanticEmbedding` and normalized to `number[] | null` before saving/consuming.
- Files changed: `js/reminders.js` (helpers + wiring + storage shape updates) and `js/modules/notes-storage.js` (note normalization and persistence of `semanticEmbedding`). Diff summary: 2 files changed, 119 insertions, 0 deletions.

### Testing
- Ran the repository test suite with `npm test -- --runInBand`; the run shows pre-existing unrelated failures (two failing suites: `mobile.new-folder.test.js` and `service-worker.test.js`) and is therefore not fully green but failures are unrelated to embedding additions. 
- Ran targeted tests `npx jest js/tests/notes-storage.folders.test.js reminders.categories.test.js --runInBand`; both passed.
- Manual verification: confirmed new helpers and fields are present and that the code path which would generate embeddings calls the stub (no external network activity).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a269f53a8883248562a3dbaa7e6481)