### PR TITLE
feat: add RAG assistant reasoning layer (stubbed)

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -1235,6 +1235,21 @@ export async function initReminders(sel = {}) {
     return formatRagContext(topMatches);
   }
 
+  async function askAssistant(query) {
+    const context = await buildRagContext(query);
+    const prompt = `You are an assistant that must answer ONLY using the provided MEMORY CONTEXT.
+Do not invent new information.
+If answer not in context, say: "I do not have enough information."
+
+MEMORY CONTEXT:
+${context}
+
+USER QUESTION:
+${query}`;
+    console.log('[RAG assistant] Prompt:\n', prompt);
+    return 'Assistant response placeholder.';
+  }
+
   function setupInboxSearch() {
     const inboxSearchInput = typeof document !== 'undefined' ? document.getElementById('inboxSearchInput') : null;
     const inboxSearchResults = typeof document !== 'undefined' ? document.getElementById('inboxSearchResults') : null;
@@ -5259,6 +5274,7 @@ export async function initReminders(sel = {}) {
     getActiveNotifications: () => activeNotifications,
     addNoteToReminder,
     buildRagContext,
+    askAssistant,
     __testing: {
       setItems(listItems = []) {
         items = Array.isArray(listItems)
@@ -5272,6 +5288,7 @@ export async function initReminders(sel = {}) {
       getItems: () => items.map(item => ({ ...item })),
       parseInboxTimeQuery,
       buildRagContext,
+      askAssistant,
     },
   };
 }


### PR DESCRIPTION
### Motivation
- Add a small RAG reasoning layer to generate a MEMORY-CONSTRAINED assistant prompt from existing local reminders/notes so the app can later invoke an LLM without changing current search behavior.

### Description
- Added an async `askAssistant(query)` function in `js/reminders.js` that calls `buildRagContext(query)`, constructs the requested prompt (including the exact "You are an assistant that must answer ONLY using the provided MEMORY CONTEXT..." template), logs the final prompt to the console for inspection, returns a placeholder response string (no external API calls), and exposes `askAssistant` on the controller return object and in `__testing` without altering existing search or ranking logic.

### Testing
- Ran the targeted automated test: `npm test -- --runInBand reminders.categories.test.js`, and the suite passed (3 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a28be6b43883248d0374bf67dbc2b6)