### PR TITLE
Improve Quick Add focus visual and prevent double submissions

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -6130,6 +6130,20 @@ body, main, section, div, p, span, li {
       outline: none;
     }
 
+    /* Quick Add: visible focus treatment without layout shift */
+    .reminders-quick-bar:focus-within {
+      border-color: color-mix(in srgb, var(--accent-color) 36%, rgba(81, 38, 99, 0.08));
+      background: color-mix(in srgb, var(--accent-color) 8%, #f8f6ff);
+      box-shadow:
+        0 0 0 1px color-mix(in srgb, var(--accent-color) 24%, transparent),
+        0 4px 10px rgba(15, 10, 41, 0.08);
+    }
+
+    #quickAddInput:focus,
+    #quickAddInput:focus-visible {
+      background: color-mix(in srgb, var(--accent-color) 7%, transparent);
+    }
+
     .reminder-tabs {
       display: inline-flex;
       align-items: center;


### PR DESCRIPTION
### Motivation
- Improve Quick Add UX by adding a clear visual focus state and ensuring single-submit behaviour without changing layout, routing, storage, or global design tokens. 
- Prevent accidental duplicate reminders from rapid Enter presses and avoid Quick Add interfering with the Inbox Search input.

### Description
- Add CSS focus styling for the Quick Add control so focus is visually clear using existing theme variables and without layout shift (`mobile.html` changes). 
- Add a simple in-flight guard `isQuickAddSubmitting` and disable the quick add button while processing to prevent double submissions (`js/reminders.js`).
- On successful add (reminder or reflection note) the input is cleared immediately and focus is restored to the input using `focus({ preventScroll: true })` with a fallback, keeping the cursor ready for the next entry (`js/reminders.js`).
- Stop event propagation for the Quick Add Enter key and form submit handlers to avoid bubbling into the Inbox Search handlers and ensure Quick Add only uses `#quickAddInput` (`js/reminders.js`).

### Testing
- Ran the Quick Add unit suite: `npm test -- --runInBand js/__tests__/reminders.quick-add.test.js` and all tests in that file passed. 
- Ran full test suite: `npm test -- --runInBand` and Quick Add changes did not introduce regressions, but unrelated pre-existing failures remain in `js/__tests__/mobile.new-folder.test.js` and `service-worker.test.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a3ec83708324ba9216b8dab3b04f)