### PR TITLE
Wire empty-state "Create reminder" button to existing reminder sheet flow

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -3803,6 +3803,20 @@ ${query}`;
     window.openEditReminderSheet = openEditReminderSheet;
   }
 
+  if (emptyStateEl instanceof HTMLElement) {
+    emptyStateEl.addEventListener('click', (event) => {
+      const trigger = event.target instanceof Element
+        ? event.target.closest('#emptyStateCreateBtn')
+        : null;
+      if (!(trigger instanceof HTMLElement)) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      openNewReminderSheet(trigger);
+    });
+  }
+
   function createReminderFromPayload(payload = {}, options = {}) {
     const {
       closeSheet = true,
@@ -4657,7 +4671,7 @@ ${query}`;
             description,
             action: hasAny
               ? undefined
-              : `<button type="button" class="${sharedEmptyStateCtaClasses}" data-trigger="open-cue">Create reminder</button>`
+              : `<button id="emptyStateCreateBtn" type="button" class="${sharedEmptyStateCtaClasses}">Create reminder</button>`
           });
         } else {
           emptyStateEl.textContent = description;


### PR DESCRIPTION
### Motivation
- Make the Empty State "Create reminder" CTA functional so it opens the same reminder creation UI as other add controls.
- Reuse the existing Quick Add / sheet opener logic and avoid duplicating reminder creation code.
- Keep empty-state rendering and layout unchanged and only wire the click target.

### Description
- Added a stable `id="emptyStateCreateBtn"` to the empty-state CTA markup so the button target is explicit in the DOM.
- Added a delegated click listener on `emptyStateEl` that detects clicks on `#emptyStateCreateBtn` and calls the existing `openNewReminderSheet(trigger)` function.
- All changes were made in `js/reminders.js` and only wire up the button to the existing flow without introducing new reminder logic.

### Testing
- Ran `npm test -- --runInBand js/__tests__/reminders.quick-add.test.js js/__tests__/mobile.sheet.test.js` and both test suites passed.
- Tests produced existing console warnings about missing Firebase configuration in the test environment, which are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a92f20f483249436c55a42462185)