### PR TITLE
Add vercel.json for static deployment and API rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "version": 2,
+  "framework": null,
+  "buildCommand": null,
+  "cleanUrls": true,
+  "rewrites": [
+    {
+      "source": "/api/(.*)",
+      "destination": "/api/$1"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide a Vercel configuration that disables framework/build steps and routes `/api/*` requests to serverless functions so the project can be deployed as static assets with working API routes.

### Description
- Add root `vercel.json` with `"$schema"`, `"version": 2`, `"framework": null`, `"buildCommand": null`, `"cleanUrls": true`, and a rewrite from `/api/(.*)` to `/api/$1`; no `builds` section is included.

### Testing
- Verified the file contents using `cat vercel.json` and `nl -ba vercel.json`, confirming the configuration matches the requested JSON.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2b7baa0e88324b2b0c1eb7a2d2d39)