### PR TITLE
Implement Smart Capture Mode for quick input entries

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -2879,6 +2879,15 @@ const initMobileNotes = () => {
       }
     });
 
+    document.addEventListener('memoryCue:notesUpdated', () => {
+      try {
+        lastSerializedNotes = readStoredSnapshot();
+        refreshFromStorage({ preserveDraft: true });
+      } catch (error) {
+        console.error('Failed to refresh notes after smart capture update', error);
+      }
+    });
+
     if (!window.__memoryCueNotesWatcher) {
       window.__memoryCueNotesWatcher = window.setInterval(() => {
         const snapshot = readStoredSnapshot();


### PR DESCRIPTION
### Motivation
- Provide a Smart Capture flow for the quick input so freeform natural-language entries are automatically classified, given a short title, tagged, persisted as a structured object, and rendered immediately without manual category selection.

### Description
- Added a small Smart Capture API in `js/reminders.js` including `classifyInput(text)`, `extractTitle(text)`, `extractTags(text)`, and `createSmartEntry(text)` to build the required structured entry and persist it using the existing `memoryCueNotes` localStorage pattern.
- Introduced `SMART_TAG_KEYWORDS` (case-insensitive) and tag extraction that returns unique lowercase matches from the required keyword list.
- Rewired the quick-add Enter/save flow (`quickAddNow`) to call `createSmartEntry`, clear the input, and dispatch the existing `reminder:quick-add:complete` event so UI consumers receive the saved entry immediately; preserved previous safety/guard checks and added `console.error` logging on save/dispatch failures.
- Added a `memoryCue:notesUpdated` listener in `mobile.js` so the mobile notebook refresh mechanism picks up smart-captured notes immediately.
- Did not modify Firebase configuration or remove any existing storage paths; structured entries include `id` (uses `Date.now().toString()`), `type`, `title`, `content`, `tags`, and `dateCreated` plus fields required by the existing notes model for compatibility.

### Testing
- Ran `npm run build` which completed successfully and produced the distribution artifacts (build passed).
- Ran the repository test `npm test -- --runInBand js/__tests__/reminders.quick-add.test.js` and observed failures: tests expect the legacy prefix-based quick-add routing and time-parsing behavior that this Smart Capture flow replaces; test results were `4 failed, 3 passed` (7 total), with failing specs including "quick add routes footy drill prefix to Footy – Drills category", "quick add routes task prefix to Tasks category", "quick add routes reflection prefix to Lesson – Reflections notes folder", and "quick add parses natural language time into due date".
- Manual smoke validation: new smart entries are persisted to `localStorage` under the existing `memoryCueNotes` key and a `memoryCue:notesUpdated` event is emitted so the notebook UI refreshes (mobile refresh hook added).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a34ee035e88324ba86885181f000df)