### PR TITLE
Add AI Smart Capture: backend parse route and quick-add integration

### DIFF
--- a/api/parse-entry.js
+++ b/api/parse-entry.js
@@ -1,0 +1,142 @@
+const PARSE_SCHEMA = {
+  name: 'memory_cue_parse',
+  strict: true,
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      type: {
+        type: 'string',
+        enum: [
+          'footy_drill',
+          'netball_note',
+          'reflection',
+          'reminder',
+          'teaching_note',
+          'general_note',
+        ],
+      },
+      title: { type: 'string' },
+      tags: { type: 'array', items: { type: 'string' } },
+      reminderDate: { type: ['string', 'null'] },
+    },
+    required: ['type', 'title', 'tags', 'reminderDate'],
+  },
+};
+
+function readStructuredOutput(payload) {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  if (typeof payload.output_text === 'string' && payload.output_text.trim()) {
+    try {
+      return JSON.parse(payload.output_text);
+    } catch {
+      // continue to other extraction paths
+    }
+  }
+
+  if (!Array.isArray(payload.output)) {
+    return null;
+  }
+
+  for (const item of payload.output) {
+    const contentItems = Array.isArray(item?.content) ? item.content : [];
+    for (const content of contentItems) {
+      if (content?.type === 'output_text' && typeof content.text === 'string') {
+        try {
+          return JSON.parse(content.text);
+        } catch {
+          // continue searching
+        }
+      }
+      if (content?.type === 'json_schema' && content?.json && typeof content.json === 'object') {
+        return content.json;
+      }
+    }
+  }
+
+  return null;
+}
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const text = typeof req.body?.text === 'string' ? req.body.text.trim() : '';
+  if (!text) {
+    return res.status(400).json({ error: 'text must be a non-empty string' });
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    // OPENAI_API_KEY must be set in Vercel project environment variables.
+    return res.status(500).json({ error: 'OPENAI_API_KEY is not configured' });
+  }
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-5.2',
+        store: false,
+        input: [
+          {
+            role: 'system',
+            content: [
+              {
+                type: 'input_text',
+                text:
+                  'Return structured data for the user\'s input. Keep title <= 60 chars. tags: 0–8 items, lowercase, unique, no spaces preferred (use hyphens if needed). If a date/time is implied (e.g., “tomorrow 4:30”), set reminderDate as ISO string in the user\'s local timezone Australia/Adelaide. If not present, null. If unsure of type, use general_note. Output must match the schema.',
+              },
+            ],
+          },
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'input_text',
+                text,
+              },
+            ],
+          },
+        ],
+        text: {
+          format: {
+            type: 'json_schema',
+            name: PARSE_SCHEMA.name,
+            strict: PARSE_SCHEMA.strict,
+            schema: PARSE_SCHEMA.schema,
+          },
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(500).json({ error: 'OpenAI request failed', details: errorText.slice(0, 500) });
+    }
+
+    const payload = await response.json();
+    const parsed = readStructuredOutput(payload);
+
+    if (!parsed || typeof parsed !== 'object') {
+      return res.status(500).json({ error: 'Failed to parse structured response' });
+    }
+
+    return res.status(200).json({
+      type: parsed.type,
+      title: parsed.title,
+      tags: parsed.tags,
+      reminderDate: parsed.reminderDate,
+    });
+  } catch (error) {
+    return res.status(500).json({ error: 'Failed to parse entry', details: error?.message || 'unknown error' });
+  }
+};

--- a/mobile.html
+++ b/mobile.html
@@ -4897,6 +4897,7 @@ body, main, section, div, p, span, li {
       <form id="quickAddForm" class="quick-add-form" onsubmit="return false;">
         <span class="material-symbols-rounded">add</span>
         <input id="quickAddInput" class="control-input quick-add-input" type="text" placeholder="Quick reminder..." autocomplete="off" />
+        <span id="quickAddParsingIndicator" class="text-xs text-base-content/70" hidden>Parsing…</span>
         <div class="quick-add-tabs">
           <button type="button" class="filter-toggle reminder-tab reminders-tab-active" data-reminders-tab="all" data-filter="all" aria-pressed="true">All</button>
           <button type="button" class="filter-toggle reminder-tab" data-reminders-tab="today" data-filter="today" aria-pressed="false">Today</button>


### PR DESCRIPTION
### Motivation
- Provide an AI-powered “Smart Capture” that parses natural-language quick-add input into structured entries (type/title/tags/reminderDate) and integrates with the app’s existing storage and UI flows.
- Keep secrets out of the frontend by using a Vercel serverless route that reads `OPENAI_API_KEY` from environment variables.

### Description
- Added a Vercel serverless API route `api/parse-entry.js` that accepts `POST { text }`, validates input, calls the OpenAI Responses API with `store: false` and a strict Structured Outputs `json_schema`, and returns only `{ type, title, tags, reminderDate }` (reads `OPENAI_API_KEY` from env).
- Integrated frontend logic in `js/reminders.js` to call `/api/parse-entry` with an 8s abort timeout, sanitize the AI response, build the final entry object (including `id`, `content`, `dateCreated`, `tags`, `reminderDate`), save using the existing localStorage pattern, and dispatch `memoryCue:notesUpdated` so the UI updates immediately.
- Implemented a robust fallback classifier (`parseSmartEntryWithFallback`) that uses existing rules (`footy` → `footy_drill`, `netball` → `netball_note`, `reflection` → `reflection`, `remind` → `reminder`, `lesson` → `teaching_note`), a simple title extractor (first 6 words, ≤60 chars), tag detection, and `reminderDate: null` when AI fails or times out.
- Small UX change: added a minimal `Parsing…` indicator in `mobile.html` and disabled/reenabled the quick-add input (with `aria-busy`) during parsing to provide immediate feedback.

### Testing
- Ran unit tests: `npm test -- --runInBand sample.test.js` — passed.
- Ran category tests: `npm test -- --runInBand reminders.categories.test.js` — passed (some Firebase init warnings are expected in test environment but tests succeeded).
- Built the project: `npm run build` — succeeded and produced `dist` assets.
- Manual logic checks for requested phrases using the local fallback parser produced the expected classifications for the examples: 
  - "Footy drill chaos hb 4v2 pressure" → `footy_drill` with tags including `footy`, `pressure`, `drill` (passed),
  - "Remind me talk to Maja tomorrow 4:30" → `reminder` and fallback title extraction worked (reminderDate is produced by AI when available in production),
  - "Reflection Year 7 preferential vote was messy but valuable" → `reflection` with tags including `year7`, `preferential`, `voting` (passed).

Note: `OPENAI_API_KEY` must be set in Vercel project environment variables for `api/parse-entry` to function in production.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3521811008324b89c32d5ee8c84ee)