### PR TITLE
Configure Vercel runtime for root API functions

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,18 +1,7 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "version": 2,
-  "framework": null,
-  "buildCommand": "npm run build",
-  "outputDirectory": "dist",
-  "cleanUrls": true,
-  "rewrites": [
-    {
-      "source": "/",
-      "destination": "/mobile"
-    },
-    {
-      "source": "/api/(.*)",
-      "destination": "/api/$1"
+  "functions": {
+    "api/*.js": {
+      "runtime": "nodejs18.x"
     }
-  ]
+  }
 }


### PR DESCRIPTION
### Motivation
- Ensure Vercel recognises `/api/*.js` as Node.js serverless functions so the existing endpoint `/api/parse-entry` can be deployed and respond.

### Description
- Replace `vercel.json` with a minimal functions runtime config that sets `"functions": { "api/*.js": { "runtime": "nodejs18.x" } }`.
- Keep `api/parse-entry.js` at the repository root under `/api` and do not modify Firebase auth or frontend code.

### Testing
- Verified `vercel.json` content with `cat vercel.json` and confirmed it matches the required functions configuration (success).
- Confirmed `api/parse-entry.js` exists at the repository root using `test -f api/parse-entry.js` and `find` output (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a358a135808324b7d08670ce8ed106)