### PR TITLE
Add SPA rewrite for /mobile route

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Ensure Vercel serves the SPA entry (`index.html`) for all routes (including `/mobile`) so client-side routing works in this frontend-only repo.

### Description
- Add `vercel.json` at the project root with the exact rewrite rule: 
```
{
  "rewrites": [
    { "source": "/(.*)", "destination": "/" }
  ]
}
```

### Testing
- Verified the file contents with `cat vercel.json` which matched the expected JSON and succeeded.
- Committed the change with `git commit -m "Add SPA rewrite for /mobile route"` which succeeded.
- Attempted to push with `git push origin HEAD:main` which failed due to no `origin` remote configured in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a36b70a94c832486abfd8ce59e40dd)