### PR TITLE
Connect mobile smart capture to external API service

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -1059,7 +1059,7 @@ export async function initReminders(sel = {}) {
     const timeoutId = controller ? setTimeout(() => controller.abort(), 8000) : null;
 
     try {
-      const response = await fetch('/api/parse-entry', {
+      const response = await fetch('https://memory-cue-api.vercel.app/api/parse-entry', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text }),


### PR DESCRIPTION
### Motivation
- Route AI Smart Capture requests to the externally hosted parsing service instead of the local `/api/parse-entry` route.

### Description
- Replaced the `fetch('/api/parse-entry', ...)` call with `fetch('https://memory-cue-api.vercel.app/api/parse-entry', ...)` in `parseSmartEntryWithAI` inside `js/reminders.js`, preserving loading state, error handling, and the fallback classifier.

### Testing
- No unit test suite was modified; validated the change by running `rg -n "parse-entry" js/reminders.js` to confirm the URL update and committing the change successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3780bbfa483248c21671f1863b4cd)