### PR TITLE
Fix mobile quick-add, reminder rendering stability, and date/time picker handling

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -221,6 +221,38 @@
       color: #111111;
     }
 
+
+    .reminder-field-with-icon {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    .reminder-picker-trigger {
+      border: 1px solid var(--border-subtle);
+      background: var(--surface-elevated);
+      border-radius: 0.5rem;
+      padding: 0.3rem 0.45rem;
+      line-height: 1;
+      font-size: 0.95rem;
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+
+    #remindersListMobile,
+    #reminderListSection,
+    #remindersWrapper,
+    #reminderList {
+      position: relative;
+      z-index: 1;
+    }
+
+    #reminderList {
+      display: flex !important;
+      flex-direction: column;
+      gap: 0.5rem;
+      overflow: visible;
+    }
     @media (max-width: 380px) {
       .reminders-top-row {
         gap: 0.35rem;
@@ -4894,10 +4926,13 @@ body, main, section, div, p, span, li {
       </div>
     </div>
     <div class="header-quick-add">
-      <form id="quickAddForm" class="quick-add-form" onsubmit="return false;">
-        <span class="material-symbols-rounded">add</span>
+      <form id="quickAddForm" class="quick-add-form">
+        <button id="quickAddSubmit" type="submit" class="icon-button quick-add-submit" aria-label="Add reminder">
+          <span class="material-symbols-rounded">add</span>
+        </button>
         <input id="quickAddInput" class="control-input quick-add-input" type="text" placeholder="Quick reminder..." autocomplete="off" />
         <span id="quickAddParsingIndicator" class="text-xs text-base-content/70" hidden>Parsing…</span>
+        <span id="quickAddSuccessIndicator" class="text-xs text-success" role="status" aria-live="polite" hidden>Saved ✓</span>
         <div class="quick-add-tabs">
           <button type="button" class="filter-toggle reminder-tab reminders-tab-active" data-reminders-tab="all" data-filter="all" aria-pressed="true">All</button>
           <button type="button" class="filter-toggle reminder-tab" data-reminders-tab="today" data-filter="today" aria-pressed="false">Today</button>
@@ -6301,11 +6336,17 @@ body, main, section, div, p, span, li {
                 <div class="reminder-field-group reminder-datetime-grid">
                   <div class="reminder-field">
                     <label class="reminder-field-label" for="reminderDate">Date</label>
-                    <input id="reminderDate" type="date" class="reminder-field-input input input-bordered input-sm w-full text-sm text-base-content" />
+                    <div class="reminder-field-with-icon">
+                      <input id="reminderDate" type="date" class="reminder-field-input input input-bordered input-sm w-full text-sm text-base-content" />
+                      <button type="button" id="reminderDatePickerBtn" class="reminder-picker-trigger" aria-label="Open date picker">📅</button>
+                    </div>
                   </div>
                   <div class="reminder-field">
                     <label class="reminder-field-label" for="reminderTime">Time</label>
-                    <input id="reminderTime" type="time" class="reminder-field-input input input-bordered input-sm w-full text-sm text-base-content" />
+                    <div class="reminder-field-with-icon">
+                      <input id="reminderTime" type="time" class="reminder-field-input input input-bordered input-sm w-full text-sm text-base-content" />
+                      <button type="button" id="reminderTimePickerBtn" class="reminder-picker-trigger" aria-label="Open time picker">🕒</button>
+                    </div>
                   </div>
                 </div>
                 <div id="dateFeedback" class="text-xs text-info"></div>
@@ -7151,6 +7192,8 @@ body, main, section, div, p, span, li {
     })();
 
     (function () {
+      // Keep full reminder list mounted to avoid items disappearing during scroll.
+      return;
       const list = document.getElementById('reminderList');
       if (!list) return;
 


### PR DESCRIPTION
### Motivation

- Restore quick reminder capture so pressing Enter or tapping the “+” control creates a reminder and gives immediate confirmation. 
- Prevent reminder cards from disappearing or being hidden behind UI layers by stabilising the mobile list/container layout and stacking.
- Make date/time inputs reliable: native picker triggers should open on tap and manually-typed ISO values must be parsed and saved.

### Description

- Wire the quick-add control to the existing quick-add flow by converting the header icon into an actual submit button (`#quickAddSubmit`), removing the earlier inline `onsubmit=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a39a5f26a08324b1c0145f955897e2)