### PR TITLE
Fix mobile reminders list rendering under quick add bar

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2266,6 +2266,7 @@ body, main, section, div, p, span, li {
     #remindersListMobile {
       position: relative;
       margin-top: 0;
+      padding-top: var(--quickbar-height);
       display: flex;
       flex-direction: column;
       gap: var(--space-1);
@@ -3545,6 +3546,7 @@ body, main, section, div, p, span, li {
   <style id="mobile-header-compact" aria-hidden="true">
   :root {
     --mobile-header-height: 112px;
+    --quickbar-height: var(--mobile-header-height, 112px);
   }
 
   /* Make header visually compact while preserving touch targets and accessibility */


### PR DESCRIPTION
### Motivation
- New reminder cards were being rendered underneath the sticky Quick Add/header area on mobile because the reminders list had no top spacing to account for the fixed/sticky quick-add bar height.

### Description
- Added a reusable CSS variable `--quickbar-height` (derived from `--mobile-header-height`) in `mobile.html` and applied `padding-top: var(--quickbar-height)` to `#remindersListMobile` so list content begins below the Quick Add/header without changing sticky behavior or layout; change is limited to `mobile.html`.

Final CSS snippet added:

```css
:root {
  --mobile-header-height: 112px;
  --quickbar-height: var(--mobile-header-height, 112px);
}

#remindersListMobile {
  position: relative;
  margin-top: 0;
  padding-top: var(--quickbar-height);
  display: flex;
  flex-direction: column;
  gap: var(--space-1);
}
```

### Testing
- Ran the unit test suite with `npm test -- --runInBand`, which revealed unrelated pre-existing failures in `js/__tests__/mobile.new-folder.test.js`, `js/__tests__/mobile.sheet.test.js`, and `service-worker.test.js` (tests did not all pass). 
- Performed a visual/functional check by serving the app (`npx serve . -l 4173`) and capturing a mobile viewport screenshot with Playwright, which showed the reminders list starting below the quick add/header (screenshot artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3b479a53483249b4ff55c4304b70b)