### PR TITLE
Guard service-worker staleWhileRevalidate cache.put to GET requests

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -165,9 +165,10 @@ function isStaticAsset(pathname) {
 async function staleWhileRevalidate(req) {
   const cache = await caches.open(RUNTIME_CACHE);
   const cached = await cache.match(req);
+  const shouldCache = req.method === 'GET';
   const fetchPromise = fetch(req)
     .then((res) => {
-      if (res && res.ok) cache.put(req, res.clone());
+      if (shouldCache && res && res.ok) cache.put(req, res.clone());
       return res;
     })
     .catch(() => undefined);


### PR DESCRIPTION
### Motivation
- Prevent runtime errors from attempting to `cache.put()` non-GET requests (e.g. `HEAD`) while preserving existing stale-while-revalidate and offline behavior.

### Description
- Updated only `staleWhileRevalidate(req)` in `service-worker.js` to add `const shouldCache = req.method === 'GET'` and applied that guard before calling `cache.put(req, res.clone())` so cache writes run only for GET requests.

### Testing
- Ran the test suite with `npm test -- --runInBand`; the command executed but the repository test run reported unrelated failing tests in `js/__tests__/mobile.new-folder.test.js`, `js/__tests__/mobile.sheet.test.js`, and `service-worker.test.js` (no new tests were added for this targeted fix).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3b75b37a08324888202429a7ead92)