### PR TITLE
Fix Vercel SPA rewrites and include firebase-config.js in dist

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -117,12 +117,15 @@ async function copyStatic() {
     '404.html',
     'index.html',
     'mobile.html',
+    'js/firebase-config.js',
   ];
 
   for (const file of filesToCopy) {
     const source = path.join(rootDir, file);
+    const destination = path.join(distDir, file);
     try {
-      await fs.copyFile(source, path.join(distDir, file));
+      await fs.mkdir(path.dirname(destination), { recursive: true });
+      await fs.copyFile(source, destination);
     } catch (error) {
       if (error.code !== 'ENOENT') throw error;
     }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,9 @@
 {
+  "outputDirectory": "dist",
   "rewrites": [
-    { "source": "/(.*)", "destination": "/" }
+    {
+      "source": "/((?!.*\\.).*)",
+      "destination": "/index.html"
+    }
   ]
 }


### PR DESCRIPTION
### Motivation
- Prevent `js/firebase-config.js` requests from being rewritten to HTML (which caused `Unexpected token '<'`) by ensuring the file is present in the final build and that Vercel serves static files directly. 
- Make Vercel use the actual build output by setting the `outputDirectory` to `dist`. 
- Preserve the SPA fallback behavior while ensuring direct routes like `mobile.html` continue to be served intact.

### Description
- Added `js/firebase-config.js` to the static `filesToCopy` list in `scripts/build.mjs` so the file is emitted to `dist/js/firebase-config.js`. 
- Changed the copy logic in `scripts/build.mjs` to create parent directories before copying by calling `fs.mkdir(path.dirname(destination), { recursive: true })`. 
- Updated `vercel.json` to include `"outputDirectory": "dist"` and replaced the catch-all rewrite with an extension-aware SPA fallback using the rule `"source": "/((?!.*\\.).*)", "destination": "/index.html"`. 
- These changes keep static assets (JS/CSS/HTML files) served directly while still rewriting only extension-less routes to `index.html`.

### Testing
- Ran `npm run build` and the build completed successfully. 
- Verified the artifact `dist/js/firebase-config.js` exists after the build. 
- Verified `vercel.json` contains `outputDirectory: "dist"` and the extension-aware rewrite rule. 
- No existing automated test suites were modified; only build verification was executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3ba0e524883248b75cfb56820ece3)