### PR TITLE
Guard non-GET requests in service worker staleWhileRevalidate

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -163,6 +163,10 @@ function isStaticAsset(pathname) {
 }
 
 async function staleWhileRevalidate(req) {
+  if (req.method !== 'GET') {
+    return fetch(req);
+  }
+
   const cache = await caches.open(RUNTIME_CACHE);
   const cached = await cache.match(req);
   const fetchPromise = fetch(req)


### PR DESCRIPTION
### Motivation
- The service worker attempted to `cache.put` non-GET requests (e.g. `HEAD`) which the Cache API doesn't support, causing runtime `TypeError` errors.

### Description
- Add an early-return to `staleWhileRevalidate(req)` so that if `req.method !== 'GET'` the function simply `return fetch(req);`, preserving the existing stale-while-revalidate behavior for GET requests and keeping all other logic unchanged.

### Testing
- There are no repository unit tests for the service worker; performed a quick smoke verification by printing the modified function lines with `nl -ba service-worker.js | sed -n '150,210p'` and committed the change (`git commit`), both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3ca79babc832483813c6da3635fe7)