### PR TITLE
Emit firebase-config.js at dist root and keep extension-safe Vercel rewrite

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -112,17 +112,18 @@ async function buildScripts() {
 
 async function copyStatic() {
   const filesToCopy = [
-    'manifest.webmanifest',
-    'service-worker.js',
-    '404.html',
-    'index.html',
-    'mobile.html',
-    'js/firebase-config.js',
+    { source: 'manifest.webmanifest' },
+    { source: 'service-worker.js' },
+    { source: '404.html' },
+    { source: 'index.html' },
+    { source: 'mobile.html' },
+    { source: 'js/firebase-config.js' },
+    { source: 'js/firebase-config.js', destination: 'firebase-config.js' },
   ];
 
   for (const file of filesToCopy) {
-    const source = path.join(rootDir, file);
-    const destination = path.join(distDir, file);
+    const source = path.join(rootDir, file.source);
+    const destination = path.join(distDir, file.destination ?? file.source);
     try {
       await fs.mkdir(path.dirname(destination), { recursive: true });
       await fs.copyFile(source, destination);


### PR DESCRIPTION
### Motivation
- Fix runtime error `Uncaught SyntaxError: Unexpected token '<'` caused when Vercel served `index.html` for the `firebase-config.js` request because the file was not available at the requested static path.

### Description
- Update `scripts/build.mjs` `copyStatic()` to copy `js/firebase-config.js` to both `dist/js/firebase-config.js` and `dist/firebase-config.js` so the config is available at the root static path.
- Leave `vercel.json` unchanged since it already uses the extension-safe rewrite `"source": "/((?!.*\\.).*)"` which rewrites only extension-less routes to `/index.html`.

### Testing
- Ran `npm run build` which completed successfully without errors.
- Verified presence of both files with `test -f dist/firebase-config.js` and `test -f dist/js/firebase-config.js`, both checks passed (`root-ok` and `js-ok`).
- Confirmed `vercel.json` contains the extension-safe rewrite rule that prevents `.js` requests from being rewritten to HTML.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3cb943acc8324ab8119e280470079)