### PR TITLE
Bypass service worker interception for /api requests

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -93,6 +93,10 @@ self.addEventListener('fetch', (event) => {
   const req = event.request;
   const url = new URL(req.url);
 
+  if (url.pathname.startsWith('/api/')) {
+    return;
+  }
+
   // Only handle http(s)
   if (url.protocol !== 'http:' && url.protocol !== 'https:') return;
 


### PR DESCRIPTION
### Motivation
- Fix POST requests like `POST /api/assistant` returning `405 Method Not Allowed` by ensuring API requests are not intercepted by the service worker.

### Description
- Add an early-bail check at the top of the `fetch` event listener that returns immediately when `url.pathname.startsWith('/api/')`, ensuring API requests go directly to the network and that this runs before static asset caching logic.

### Testing
- Ran the test suite with `npm test -- --runInBand`; the run completed but there are existing unrelated test failures in the repository (summary: `Test Suites: 3 failed, 20 passed, 23 total` and `Tests: 4 failed, 73 passed, 77 total`), and the change was applied as a minimal targeted fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3d64ff32c8324a7af63a4b7278ffe)