### PR TITLE
Exclude /api routes from SPA rewrite in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,11 @@
   "outputDirectory": "dist",
   "rewrites": [
     {
-      "source": "/((?!.*\\.).*)",
+      "source": "/api/(.*)",
+      "destination": "/api/$1"
+    },
+    {
+      "source": "/((?!api/)(?!.*\\.).*)",
       "destination": "/index.html"
     }
   ]


### PR DESCRIPTION
### Motivation
- The SPA fallback rewrite was matching `/api/*` (e.g. `/api/assistant`) and returning `index.html`, causing API endpoints to behave like static pages and POST requests to return 405. 

### Description
- Added an explicit rewrite `"source": "/api/(.*)", "destination": "/api/$1"` so any route starting with `/api` is routed to the API instead of the SPA entrypoint. 
- Updated the SPA fallback rewrite to `"/((?!api/)(?!.*\\.).*)"` so only non-API, extension-less routes are rewritten to `/index.html`.
- Preserved the existing `outputDirectory` setting (`"dist"`) and made no build-setting changes.

### Testing
- Verified `vercel.json` is valid JSON with `node -e "JSON.parse(require('fs').readFileSync('vercel.json','utf8'))"` which succeeded. 
- Inspected the file contents with `cat vercel.json` to confirm the two rewrite rules are present and in the correct order.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3d7d6c7288324a3f0ee792ab9007e)