### PR TITLE
Add /api/assistant POST endpoint for mobile assistant

### DIFF
--- a/api/assistant.js
+++ b/api/assistant.js
@@ -1,0 +1,30 @@
+import OpenAI from "openai";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const { message } = req.body;
+
+    const openai = new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY
+    });
+
+    const completion = await openai.chat.completions.create({
+      model: "gpt-4o-mini",
+      messages: [
+        { role: "system", content: "You are the Memory Cue assistant." },
+        { role: "user", content: message }
+      ]
+    });
+
+    const reply = completion.choices[0].message.content;
+
+    return res.status(200).json({ reply });
+  } catch (error) {
+    console.error("Assistant error:", error);
+    return res.status(500).json({ error: "Assistant failed" });
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a simple server endpoint for the mobile assistant tab that accepts a user message and returns an AI-generated reply.

### Description
- Add `api/assistant.js` which exports an async `handler(req, res)`, rejects non-`POST` with `405`, reads `message` from `req.body.message`, calls OpenAI using `process.env.OPENAI_API_KEY` via the `openai` client, and returns `{ reply }` on success or a `500` error on failure.

### Testing
- Ran `npm test -- --runInBand`; the test run completed but there are unrelated failing suites (`js/__tests__/mobile.new-folder.test.js`, `js/__tests__/mobile.sheet.test.js`, and `service-worker.test.js`) that pre-existed and are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3db93a790832498e473a61c1a5836)