### PR TITLE
Add RichTextWidget and Quill CDN for Teacher-Screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,8 +29,8 @@
     http-equiv="Content-Security-Policy"
     content="default-src 'self';
              connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.open-meteo.com https://api.bigdatacloud.net https://hn.algolia.com https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://www.googleapis.com https://cdn.jsdelivr.net;
-             script-src 'self' https://cdn.jsdelivr.net https://esm.sh https://www.gstatic.com https://apis.google.com;
-             style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com;
+             script-src 'self' https://cdn.jsdelivr.net https://cdn.quilljs.com https://esm.sh https://www.gstatic.com https://apis.google.com;
+             style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.quilljs.com https://fonts.googleapis.com;
              img-src 'self' data:;
              font-src 'self' data: https://fonts.gstatic.com https://fonts.googleapis.com;
              worker-src 'self';
@@ -65,6 +65,8 @@
   <link rel="stylesheet" href="./styles/tokens.css" />
   <link rel="stylesheet" href="./styles/a11y.css" />
   <link rel="stylesheet" href="./assets/styles-b0e8fdf5.css" />
+  <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
+  <script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
   <style>
     :root {
       --vh: 1vh;

--- a/js/classroom-widgets.js
+++ b/js/classroom-widgets.js
@@ -1,3 +1,5 @@
+import { RichTextWidget } from './widgets/rich-text-widget.js';
+
 const WIDGETS = [
   {
     id: 'timer',
@@ -35,9 +37,30 @@ const WIDGETS = [
     description: 'Pin reminders and expectations for the current activity.',
     categories: ['Awareness', 'Classroom Climate'],
   },
+  {
+    id: 'rich-text-board',
+    name: 'Rich Text Board',
+    type: 'RichTextWidget',
+    icon: 'fa-pen',
+    description: 'Professional rich text editor for classroom notes.',
+    categories: ['Collaboration', 'Visual'],
+  },
 ];
 
 const PRESET_STORAGE_KEY = 'widgetPresets';
+
+const WIDGET_SIZE_RULES = {
+  RichTextWidget: { minW: 4, minH: 3 },
+};
+
+function createWidgetFromType(type) {
+  switch (type) {
+    case 'RichTextWidget':
+      return new RichTextWidget();
+    default:
+      return null;
+  }
+}
 
 function safeReadPresets() {
   try {

--- a/js/widgets/rich-text-widget.js
+++ b/js/widgets/rich-text-widget.js
@@ -1,0 +1,53 @@
+class RichTextWidget {
+  constructor() {
+    this.element = document.createElement('div');
+    this.element.className = 'rich-text-widget-inner';
+
+    this.editorContainer = document.createElement('div');
+    this.editorContainer.style.height = '100%';
+
+    this.element.appendChild(this.editorContainer);
+
+    setTimeout(() => {
+      this.quill = new Quill(this.editorContainer, {
+        theme: 'snow',
+        modules: {
+          toolbar: [
+            [{ header: [1, 2, 3, false] }],
+            ['bold', 'italic', 'underline'],
+            [{ list: 'ordered' }, { list: 'bullet' }],
+            ['clean']
+          ]
+        }
+      });
+
+      this.load();
+      this.quill.on('text-change', () => this.save());
+    }, 0);
+  }
+
+  serialize() {
+    return {
+      content: this.quill ? this.quill.root.innerHTML : ''
+    };
+  }
+
+  deserialize(data) {
+    if (this.quill && data?.content) {
+      this.quill.root.innerHTML = data.content;
+    }
+  }
+
+  save() {
+    localStorage.setItem('richTextWidgetContent', this.quill.root.innerHTML);
+  }
+
+  load() {
+    const saved = localStorage.getItem('richTextWidgetContent');
+    if (saved && this.quill) {
+      this.quill.root.innerHTML = saved;
+    }
+  }
+}
+
+export { RichTextWidget };


### PR DESCRIPTION
### Motivation
- Provide a professional rich text editor for the Teacher-Screen widget catalog by integrating Quill and exposing a new widget implementation. 
- Keep the change minimal and focused: add Quill assets, a single new widget module, and register the widget in the existing classroom widget manager without touching the main toolbar.

### Description
- Added Quill CDN stylesheet and script tags to `index.html` and updated the CSP `script-src` / `style-src` directives to allow loading Quill from `https://cdn.quilljs.com`.
- Created a new module `js/widgets/rich-text-widget.js` implementing `RichTextWidget` using Quill with the requested toolbar, plus `serialize`, `deserialize`, and localStorage `save`/`load` support.
- Updated `js/classroom-widgets.js` to import `RichTextWidget`, add a catalog entry for "Rich Text Board" (`type: "RichTextWidget"`, `icon: "fa-pen"`), add `WIDGET_SIZE_RULES` for `RichTextWidget`, and register a `createWidgetFromType()` factory with a `RichTextWidget` case.
- All changes were kept minimal and consistent with existing patterns: no changes to main toolbar and no refactors of unrelated code.

### Testing
- Ran the repository test suite with `npm test -- --runInBand`, which completed with many passing tests but overall reported `Test Suites: 3 failed, 20 passed, 23 total` and `Tests: 4 failed, 73 passed, 77 total` (the failing suites were `mobile.new-folder`, `mobile.sheet`, and `service-worker`); these failures are pre-existing and unrelated to the RichTextWidget additions.
- No new automated test failures attributable to the added `RichTextWidget` were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3dc8ba36c8324b82e47679ac65fb1)