### PR TITLE
Remove outputDirectory from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-  "outputDirectory": "dist",
   "rewrites": [
     {
       "source": "/api/(.*)",


### PR DESCRIPTION
### Motivation
- Vercel projects should manage the build output directory via the Dashboard rather than `vercel.json`, and modern Vercel deployments do not require `builds` config in `vercel.json`.

### Description
- Removed the `outputDirectory` key from `vercel.json` and left only the two rewrite rules for API routing and SPA fallback, with no `builds` configuration.

### Testing
- Validated `vercel.json` parses as JSON using `node -e "JSON.parse(require('fs').readFileSync('vercel.json','utf8'))"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3e84c858083249e68f6607c55eab5)