### PR TITLE
Ensure /api/assistant exports a valid POST serverless handler

### DIFF
--- a/api/assistant.js
+++ b/api/assistant.js
@@ -1,5 +1,3 @@
-import OpenAI from "openai";
-
 export default async function handler(req, res) {
   if (req.method !== "POST") {
     return res.status(405).json({ error: "Method not allowed" });
@@ -8,23 +6,13 @@ export default async function handler(req, res) {
   try {
     const { message } = req.body;
 
-    const openai = new OpenAI({
-      apiKey: process.env.OPENAI_API_KEY
-    });
+    if (!message) {
+      return res.status(400).json({ error: "Message required" });
+    }
 
-    const completion = await openai.chat.completions.create({
-      model: "gpt-4o-mini",
-      messages: [
-        { role: "system", content: "You are the Memory Cue assistant." },
-        { role: "user", content: message }
-      ]
-    });
-
-    const reply = completion.choices[0].message.content;
-
-    return res.status(200).json({ reply });
-  } catch (error) {
-    console.error("Assistant error:", error);
-    return res.status(500).json({ error: "Assistant failed" });
+    // Temporary test response to confirm routing works
+    return res.status(200).json({ reply: `Echo: ${message}` });
+  } catch (err) {
+    return res.status(500).json({ error: "Server error" });
   }
 }


### PR DESCRIPTION
### Motivation
- Verify that the Assistant API route at `api/assistant.js` is present and exported as a default serverless handler that responds to `POST` requests.
- Provide a minimal, safe scaffold that validates input and confirms routing without calling external services or relying on runtime overrides.

### Description
- Replaced the previous OpenAI integration in `api/assistant.js` with a minimal default `export default async function handler(req, res)` that only accepts `POST` requests and returns `405` for others.
- Added request validation to return `400` when `message` is missing and return a temporary echo response `200` (`{ reply: `Echo: ${message}` }`) to confirm routing.
- Removed the `OpenAI` import and all OpenAI call logic to avoid external dependencies in the default scaffold, and standardized error handling to return `500` on server errors.
- Verified `vercel.json` contains only rewrites and no custom function `runtime` entries or invalid runtime config.

### Testing
- Ran `rg 'runtime' vercel.json api -n` to confirm no invalid `runtime` entries were present, which returned no matches.
- Ran the repository test suite with `npm test -- --runInBand`; the test run completed but several unrelated pre-existing tests failed: `js/__tests__/mobile.new-folder.test.js`, `js/__tests__/mobile.sheet.test.js`, and `service-worker.test.js` (3 suites failing, 20 passing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3f404117483249c8745f9df6ce7c2)