### PR TITLE
Fix assistant mobile layout so input stays visible

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1933,6 +1933,8 @@ html, body {
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   color: #111111;
+  height: 100%;
+  overflow: hidden;
 }
 
 /* Ensure controls inherit the same typography */
@@ -2829,6 +2831,10 @@ body, main, section, div, p, span, li {
 
     #view-assistant {
       align-content: start;
+      display: flex;
+      flex-direction: column;
+      height: 100dvh;
+      overflow: hidden;
     }
 
     .assistant-panel {
@@ -2837,18 +2843,22 @@ body, main, section, div, p, span, li {
       border-radius: 1rem;
       box-shadow: 0 8px 20px rgba(81, 38, 99, 0.08);
       padding: 0.75rem;
-      display: grid;
+      display: flex;
+      flex-direction: column;
       gap: 0.75rem;
-      min-height: 60vh;
+      flex: 1;
+      min-height: 0;
     }
 
-    #assistantThread {
+    #assistantThread,
+    .assistant-messages {
       display: grid;
       gap: 0.5rem;
       align-content: start;
+      flex: 1;
       overflow-y: auto;
       padding-right: 0.25rem;
-      min-height: 40vh;
+      min-height: 0;
     }
 
     .assistant-message {


### PR DESCRIPTION
### Motivation
- Mobile assistant input was being pushed out of view on small/dynamic viewports due to fixed viewport-height assumptions and grid/absolute positioning in the assistant container.
- The goal is to make the assistant pane fill the mobile viewport, let the message area scroll, and keep the input bar pinned to the bottom using normal flex flow rather than absolute positioning or height hacks.

### Description
- Updated `mobile.html` to set `html, body { height: 100%; overflow: hidden; }` to stabilise mobile viewport calculations.
- Converted `#view-assistant` to a vertical flex container with `height: 100dvh; display: flex; flex-direction: column; overflow: hidden;` so it respects the dynamic viewport height.
- Replaced `.assistant-panel` grid layout with `display: flex; flex-direction: column; flex: 1; min-height: 0;` so content and input naturally stack and the panel grows to available space.
- Made the messages region (`#assistantThread` and a new `.assistant-messages` selector) flex-grow with `flex: 1; overflow-y: auto; padding-right: 0.25rem; min-height: 0;` and removed previous fixed `min-height` values so the message area scrolls internally while the input remains visible.

### Testing
- Ran the unit test `npm test -- --runInBand sample.test.js` which passed.
- Started the local server with `npm run start -- --listen 4173` and executed a Playwright script to open the mobile assistant view and capture a screenshot of the layout, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a40017ce308324b3bccf0cf37f1d21)