### PR TITLE
Reduce mobile header padding and gap for tighter header layout

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2063,13 +2063,13 @@ body, main, section, div, p, span, li {
     /* New Header Styles */
     .mobile-header {
       background: var(--cauliflower-blue);
-      padding: 12px 16px;
+      padding: 8px 16px;
       position: sticky;
       top: 0;
       z-index: 1000;
       display: flex;
       flex-direction: column;
-      gap: 8px;
+      gap: 6px;
     }
 
     #view-reminders h1,
@@ -4278,7 +4278,7 @@ body, main, section, div, p, span, li {
       top: 0;
       z-index: 999;
       width: 100%;
-      padding: 12px 16px;
+      padding: 8px 16px;
       background: rgba(255, 255, 255, 0.75);
       backdrop-filter: blur(14px);
       -webkit-backdrop-filter: blur(14px);


### PR DESCRIPTION
### Motivation
- Tighten header spacing on mobile to reduce vertical footprint and improve visual balance on small viewports.

### Description
- Reduced `.mobile-header` padding from `12px 16px` to `8px 16px` and gap from `8px` to `6px`, and reduced `#reminders-slim-header` padding from `12px 16px` to `8px 16px` in `mobile.html`.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4075195f883249588a08ef0d7a47a)