### PR TITLE
Refine Reminders mobile header styling for modern iOS feel

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2063,13 +2063,15 @@ body, main, section, div, p, span, li {
     /* New Header Styles */
     .mobile-header {
       background: var(--cauliflower-blue);
-      padding: 8px 16px;
+      padding: 10px 16px;
       position: sticky;
       top: 0;
       z-index: 1000;
       display: flex;
       flex-direction: column;
       gap: 6px;
+      background: rgba(255,255,255,0.85);
+      backdrop-filter: blur(10px);
     }
 
     #view-reminders h1,
@@ -2091,8 +2093,10 @@ body, main, section, div, p, span, li {
     }
 
     .header-title {
-      font-size: 1.5rem;
-      font-weight: 700;
+      font-size: 18px;
+      font-weight: 600;
+      letter-spacing: -0.2px;
+      margin: 0;
     }
 
     .header-actions {
@@ -2103,6 +2107,7 @@ body, main, section, div, p, span, li {
     .header-quick-add,
     .header-search {
       width: 100%;
+      margin: 0;
     }
 
     .mobile-header {
@@ -2157,10 +2162,10 @@ body, main, section, div, p, span, li {
     .control-input {
       flex: 1;
       border: var(--control-border);
-      border-radius: var(--control-radius);
+      border-radius: 16px;
       font-size: var(--control-font-size);
       background: transparent;
-      padding: var(--space-1) var(--space-2);
+      padding: 8px 14px;
       color: var(--control-text-color);
       line-height: 1.3;
     }
@@ -2195,8 +2200,8 @@ body, main, section, div, p, span, li {
     .inbox-search-input {
       width: 100%;
       border: var(--control-border);
-      border-radius: var(--control-radius);
-      padding: var(--space-1) calc(var(--space-3) + var(--space-1)) var(--space-1) var(--space-2);
+      border-radius: 16px;
+      padding: 8px 14px;
       font-size: var(--control-font-size);
       line-height: 1.3;
       color: var(--control-text-color);


### PR DESCRIPTION
### Motivation
- Make the Reminders mobile header feel cleaner, more compact, and softer to match modern iOS aesthetics while preserving existing layout and behavior.

### Description
- Update `.mobile-header` to `padding: 10px 16px`, keep `gap: 6px`, and add a subtle translucent surface using `background: rgba(255,255,255,0.85)` with `backdrop-filter: blur(10px)`.
- Tweak the title (`.header-title`) to `font-size: 18px`, `font-weight: 600`, `letter-spacing: -0.2px`, and remove extra margins with `margin: 0`.
- Normalize Quick Add and Search inputs by setting shared input rules to `padding: 8px 14px` and `border-radius: 16px` for ` .control-input` and `.inbox-search-input`.
- Remove extra spacing between Quick Add and Search by ensuring `.header-quick-add` and `.header-search` have `margin: 0` and leave structure/layout unchanged.

### Testing
- Ran a local static server with `python3 -m http.server 4173` and loaded `mobile.html` to verify the page renders without errors, which succeeded.
- Captured a mobile viewport screenshot using a Playwright script to visually validate the updated header, which completed successfully and produced an artifact.
- Verified the CSS changes with `git diff -- mobile.html` and committed the single-file update to the branch, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a40d8609f08324a243996ef7ebc5f4)