### PR TITLE
Wire reminders assistant query through backend API

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -1466,7 +1466,35 @@ ${context}
 USER QUESTION:
 ${query}`;
     console.log('[RAG assistant] Prompt:\n', prompt);
-    return 'Assistant response placeholder.';
+    try {
+      const response = await fetch('/api/assistant', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ query: prompt }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Assistant request failed (${response.status})`);
+      }
+
+      const payload = await response.json();
+      const reply = typeof payload?.reply === 'string'
+        ? payload.reply
+        : typeof payload?.text === 'string'
+          ? payload.text
+          : typeof payload?.message === 'string'
+            ? payload.message
+            : '';
+      return reply || 'I could not read an assistant response.';
+    } catch (error) {
+      console.error('[RAG assistant] request failed while calling /api/assistant', {
+        error,
+        query,
+      });
+      return 'Sorry, something went wrong while contacting the assistant.';
+    }
   }
 
   function setupInboxSearch() {


### PR DESCRIPTION
### Motivation

- Replace the placeholder assistant reply with a real backend call so the RAG assistant can use a deployed assistant service to answer queries.

### Description

- Updated `askAssistant(query)` in `js/reminders.js` to POST the composed RAG `prompt` to the backend endpoint `/api/assistant` as JSON (`body: JSON.stringify({ query: prompt })`).
- Parse the JSON response and return the assistant text from `payload.reply` with fallbacks to `payload.text` and `payload.message`, and return a safe fallback string when no usable text is present.
- Preserve graceful failure behavior by catching fetch or API errors, logging contextual debug information (`error` and `query`), and returning a user-facing fallback message.

### Testing

- Ran the test suite with `npm test -- --runInBand` which executed the repository tests; the run completed but had pre-existing unrelated failures (3 test suites failed: `js/__tests__/mobile.new-folder.test.js`, `js/__tests__/mobile.sheet.test.js`, and `service-worker.test.js`) and overall results were 20 passed / 3 failed test suites; no new failures attributable to the `askAssistant` change were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6b0988680832491e5cab67ee5bbdc)