### PR TITLE
Use allowlist-based CORS origin handling in parse-entry API

### DIFF
--- a/api/parse-entry.js
+++ b/api/parse-entry.js
@@ -26,9 +26,18 @@ const PARSED_ENTRY_SCHEMA = {
 };
 
 module.exports = async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', 'https://memory-cue.vercel.app');
-  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  const origin = req.headers.origin;
+  const allowedOrigins = [
+    'https://memory-cue.vercel.app',
+    'http://localhost:3000',
+    'http://localhost:5173'
+  ];
+
+  if (origin && allowedOrigins.includes(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  }
 
   if (req.method === 'OPTIONS') {
     return res.status(200).end();


### PR DESCRIPTION
### Motivation
- Replace the single hardcoded `Access-Control-Allow-Origin` in the parse-entry API with origin allowlist logic so CORS is only enabled for known production and local development origins.

### Description
- In `api/parse-entry.js` read `req.headers.origin`, define an `allowedOrigins` array (`'https://memory-cue.vercel.app'`, `'http://localhost:3000'`, `'http://localhost:5173'`), and only set `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods`, and `Access-Control-Allow-Headers` when the origin is allowed while keeping existing preflight handling intact.

### Testing
- Ran the test suite with `npm test -- --runInBand`, observing the repository test summary `Test Suites: 3 failed, 20 passed, 23 total` where failures are pre-existing unrelated tests (`js/__tests__/mobile.new-folder.test.js`, `js/__tests__/mobile.sheet.test.js`, and `service-worker.test.js`), and no new failures were introduced by this focused API change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6b14d419c83248ee95af53a14e6a6)