### PR TITLE
Add OPENAI_API_KEY guards to AI endpoints and document AI setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ Memory Cue expects Supabase credentials to be available at runtime via `window._
 
 Keep your real Supabase URL and anon key out of version control—set them through deployment-specific templating or secrets management rather than committing them to the repository.
 
+
+## AI setup
+
+The serverless AI endpoints require an OpenAI API key at runtime:
+
+- `OPENAI_API_KEY` for `api/assistant.js`
+- `OPENAI_API_KEY` for `api/parse-entry.js`
+
+If this variable is missing, these endpoints return a `500` JSON error indicating server misconfiguration.
+
 ## Privacy & Data
 
 Memory Cue stores notes and reminders in Firebase services (e.g., Firestore or Realtime Database). Review your Firebase security rules to ensure only authorized users can read or write their data, and communicate the data retention policy to your users. As with any Firebase-backed app, do not commit private API keys or service credentials to the repository.

--- a/api/assistant.js
+++ b/api/assistant.js
@@ -8,6 +8,11 @@ export default async function handler(req, res) {
   try {
     const { message } = req.body;
 
+    if (!process.env.OPENAI_API_KEY) {
+      console.error("Assistant misconfiguration: OPENAI_API_KEY is not set");
+      return res.status(500).json({ error: "Server misconfiguration: missing OpenAI API key." });
+    }
+
     const openai = new OpenAI({
       apiKey: process.env.OPENAI_API_KEY
     });

--- a/api/parse-entry.js
+++ b/api/parse-entry.js
@@ -51,6 +51,11 @@ module.exports = async function handler(req, res) {
     return res.status(400).json({ error: 'Invalid input: text must be a non-empty string.' });
   }
 
+  if (!process.env.OPENAI_API_KEY) {
+    console.error('Parse entry misconfiguration: OPENAI_API_KEY is not set');
+    return res.status(500).json({ error: 'Server misconfiguration: missing OpenAI API key.' });
+  }
+
   let response;
 
   try {


### PR DESCRIPTION
### Motivation
- Prevent the serverless AI endpoints from attempting OpenAI requests when the API key is not configured, and surface a clear, non-sensitive server-side error instead of failing or leaking secrets.

### Description
- Added a preflight check in `api/assistant.js` that logs a concise server-side message and returns HTTP 500 JSON if `process.env.OPENAI_API_KEY` is not set.
- Added the same preflight check in `api/parse-entry.js` before making the outbound OpenAI `fetch` call, with the same logging and 500 JSON response behavior.
- Added an `AI setup` section to `README.md` documenting the required `OPENAI_API_KEY` runtime variable and the endpoints' behavior when it is missing.

### Testing
- Ran the test suite with `npm test -- --runInBand`, which executed the repository tests; the run shows pre-existing unrelated test failures in `js/__tests__/mobile.new-folder.test.js`, `js/__tests__/mobile.sheet.test.js`, and `service-worker.test.js` and did not surface new failures attributable to these small API-guard changes.
- Verified basic local inspection of `api/assistant.js` and `api/parse-entry.js` to confirm the guards return `500` JSON responses and log concise misconfiguration messages when `OPENAI_API_KEY` is absent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6b1c059988324ac2ca7bc9ca042f7)