### PR TITLE
Upgrade mobile app to frictionless AI capture inbox

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,147 +1,472 @@
 (function () {
-  const STORAGE_KEY = 'memoryCueEntries';
-  const CATEGORY_MAP = {
-    task: 'tasks',
-    idea: 'ideas',
-    drill: 'drills',
-    lesson: 'lessons',
-    reflection: 'reflections',
-    note: 'notes'
+  const DB_KEY = 'memoryCueDB';
+  const LEGACY_KEY = 'memoryCueEntries';
+  const SCHEMA_VERSION = 2;
+
+  const TYPE_LABELS = ['all', 'task', 'idea', 'note', 'reflection', 'lesson', 'drill'];
+  const PREFIX_MAP = {
+    task: 'task',
+    todo: 'task',
+    idea: 'idea',
+    note: 'note',
+    notes: 'note',
+    reflection: 'reflection',
+    lesson: 'lesson',
+    drill: 'drill'
   };
 
-  const screens = Array.from(document.querySelectorAll('.screen'));
-  const bottomTabs = Array.from(document.querySelectorAll('.bottom-tab'));
-  const entryFilters = Array.from(document.querySelectorAll('.filter'));
+  let db = null;
+  let storageAvailable = true;
+  let activeTypeFilter = 'all';
+  let activeSearch = '';
+  let pendingDelete = null;
+  let toastTimer = null;
 
+  const tabs = Array.from(document.querySelectorAll('[role="tab"]'));
+  const panels = Array.from(document.querySelectorAll('[role="tabpanel"]'));
   const captureInput = document.getElementById('captureInput');
   const captureButton = document.getElementById('captureButton');
+  const brainDumpToggle = document.getElementById('brainDumpToggle');
+  const brainDumpHint = document.getElementById('brainDumpHint');
+  const searchInput = document.getElementById('searchInput');
+  const typeFilters = document.getElementById('typeFilters');
   const entriesList = document.getElementById('entriesList');
-
   const assistantInput = document.getElementById('assistantInput');
   const askButton = document.getElementById('askButton');
   const assistantResponses = document.getElementById('assistantResponses');
+  const toastLive = document.getElementById('toastLive');
 
-  let activeFilter = 'all';
-
-  function loadEntries() {
+  function safeStorageCheck() {
     try {
-      const raw = localStorage.getItem(STORAGE_KEY);
-      const parsed = raw ? JSON.parse(raw) : [];
-      return Array.isArray(parsed) ? parsed : [];
+      const testKey = '__memory_cue_test__';
+      window.localStorage.setItem(testKey, '1');
+      window.localStorage.removeItem(testKey);
+      return true;
     } catch (error) {
-      console.error('Could not load entries from localStorage.', error);
-      return [];
+      console.error('localStorage is not available.', error);
+      return false;
     }
   }
 
-  function saveEntries(entries) {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
-  }
-
-  function createId() {
-    if (typeof crypto !== 'undefined' && crypto.randomUUID) {
-      return crypto.randomUUID();
+  function createUUID() {
+    if (window.crypto && window.crypto.randomUUID) {
+      return window.crypto.randomUUID();
     }
-    return `id-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (char) {
+      const random = (Math.random() * 16) | 0;
+      const value = char === 'x' ? random : (random & 0x3) | 0x8;
+      return value.toString(16);
+    });
   }
 
-  function parseCapture(text) {
-    const value = text.trim();
-    const match = value.match(/^([^:\n]+):\s*(.*)$/s);
+  function cleanLine(line) {
+    return line.replace(/^[-•*]\s+/, '').trim();
+  }
 
+  function parseTypeAndContent(text) {
+    const trimmed = text.trim();
+    const match = trimmed.match(/^([a-zA-Z]+)\s*:\s*(.+)$/);
     if (!match) {
-      return { category: 'notes', content: value };
+      return { type: 'note', content: trimmed };
     }
 
-    const prefix = match[1].trim().toLowerCase();
-    const mappedCategory = CATEGORY_MAP[prefix] || 'notes';
-    const content = match[2].trim();
+    const mappedType = PREFIX_MAP[match[1].toLowerCase()];
+    if (!mappedType) {
+      return { type: 'note', content: trimmed };
+    }
+
+    return { type: mappedType, content: match[2].trim() };
+  }
+
+  function makeEntry(rawText) {
+    const parsed = parseTypeAndContent(rawText);
+    const now = new Date().toISOString();
+    const title = parsed.content.length > 80 ? `${parsed.content.slice(0, 77)}...` : parsed.content;
 
     return {
-      category: mappedCategory,
-      content: content || value
+      id: createUUID(),
+      createdAt: now,
+      updatedAt: now,
+      type: parsed.type,
+      status: parsed.type === 'task' ? 'open' : 'active',
+      title,
+      body: parsed.content,
+      tags: [],
+      dueAt: null,
+      source: {
+        channel: 'capture',
+        app: 'memory-cue-mobile'
+      },
+      deletedAt: null
     };
   }
 
-  function renderEntries() {
-    const entries = loadEntries();
-    const filtered =
-      activeFilter === 'all'
-        ? entries
-        : entries.filter((entry) => entry.category === activeFilter);
+  function defaultDB() {
+    return {
+      schemaVersion: SCHEMA_VERSION,
+      settings: {
+        brainDumpMode: false
+      },
+      entries: []
+    };
+  }
 
+  function saveDB(nextDB) {
+    db = nextDB;
+    if (!storageAvailable) {
+      return;
+    }
+    try {
+      window.localStorage.setItem(DB_KEY, JSON.stringify(db));
+    } catch (error) {
+      console.error('Failed to save Memory Cue DB.', error);
+      showToast('Could not save to local storage.');
+    }
+  }
+
+  function migrateLegacyEntries(legacyEntries) {
+    const migratedEntries = legacyEntries
+      .filter(function (item) {
+        return item && (item.content || '').trim();
+      })
+      .map(function (item) {
+        const iso = item.timestamp ? new Date(item.timestamp).toISOString() : new Date().toISOString();
+        const type = item.category ? String(item.category).replace(/s$/, '') : 'note';
+        const body = String(item.content || '').trim();
+        const title = body.length > 80 ? `${body.slice(0, 77)}...` : body;
+
+        return {
+          id: item.id || createUUID(),
+          createdAt: iso,
+          updatedAt: iso,
+          type: TYPE_LABELS.includes(type) ? type : 'note',
+          status: type === 'task' ? 'open' : 'active',
+          title,
+          body,
+          tags: [],
+          dueAt: null,
+          source: {
+            channel: 'legacy-import',
+            app: 'memory-cue-mobile'
+          },
+          deletedAt: null
+        };
+      });
+
+    const migrated = defaultDB();
+    migrated.entries = migratedEntries;
+    return migrated;
+  }
+
+  function loadDB() {
+    if (!storageAvailable) {
+      return defaultDB();
+    }
+
+    try {
+      const raw = window.localStorage.getItem(DB_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (parsed && parsed.schemaVersion === SCHEMA_VERSION && Array.isArray(parsed.entries)) {
+          return {
+            schemaVersion: SCHEMA_VERSION,
+            settings: Object.assign({ brainDumpMode: false }, parsed.settings || {}),
+            entries: parsed.entries
+          };
+        }
+      }
+
+      const legacyRaw = window.localStorage.getItem(LEGACY_KEY);
+      if (legacyRaw) {
+        const legacyParsed = JSON.parse(legacyRaw);
+        if (Array.isArray(legacyParsed)) {
+          const migrated = migrateLegacyEntries(legacyParsed);
+          window.localStorage.setItem(DB_KEY, JSON.stringify(migrated));
+          return migrated;
+        }
+      }
+    } catch (error) {
+      console.error('Failed to load Memory Cue DB.', error);
+      showToast('Could not load your saved entries.');
+    }
+
+    const initial = defaultDB();
+    saveDB(initial);
+    return initial;
+  }
+
+  function setTab(tabId, shouldFocusPanel) {
+    tabs.forEach(function (tab) {
+      const isSelected = tab.id === tabId;
+      tab.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      tab.tabIndex = isSelected ? 0 : -1;
+      tab.classList.toggle('is-active', isSelected);
+    });
+
+    panels.forEach(function (panel) {
+      const controllingTab = panel.getAttribute('aria-labelledby');
+      const isActive = controllingTab === tabId;
+      panel.hidden = !isActive;
+      panel.classList.toggle('is-active', isActive);
+      if (isActive && shouldFocusPanel) {
+        panel.focus();
+      }
+    });
+
+    if (tabId === 'tab-entries') {
+      renderEntries();
+    }
+  }
+
+  function moveTabFocus(currentIndex, key) {
+    let target = currentIndex;
+    if (key === 'ArrowRight') {
+      target = (currentIndex + 1) % tabs.length;
+    }
+    if (key === 'ArrowLeft') {
+      target = (currentIndex - 1 + tabs.length) % tabs.length;
+    }
+    if (key === 'Home') {
+      target = 0;
+    }
+    if (key === 'End') {
+      target = tabs.length - 1;
+    }
+    tabs[target].focus();
+  }
+
+  function currentEntries() {
+    return db.entries.filter(function (entry) {
+      return !entry.deletedAt;
+    });
+  }
+
+  function filteredEntries() {
+    return currentEntries()
+      .filter(function (entry) {
+        return activeTypeFilter === 'all' ? true : entry.type === activeTypeFilter;
+      })
+      .filter(function (entry) {
+        if (!activeSearch) {
+          return true;
+        }
+        const haystack = `${entry.title} ${entry.body} ${(entry.tags || []).join(' ')}`.toLowerCase();
+        return haystack.includes(activeSearch);
+      })
+      .sort(function (a, b) {
+        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+      });
+  }
+
+  function renderTypeFilters() {
+    typeFilters.innerHTML = '';
+    TYPE_LABELS.forEach(function (label) {
+      const count = label === 'all'
+        ? currentEntries().length
+        : currentEntries().filter(function (entry) {
+            return entry.type === label;
+          }).length;
+
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = `filter-pill${activeTypeFilter === label ? ' is-active' : ''}`;
+      button.textContent = `${label} (${count})`;
+      button.setAttribute('aria-pressed', activeTypeFilter === label ? 'true' : 'false');
+      button.addEventListener('click', function () {
+        activeTypeFilter = label;
+        renderTypeFilters();
+        renderEntries();
+      });
+      typeFilters.appendChild(button);
+    });
+  }
+
+  function showToast(message, options) {
+    clearTimeout(toastTimer);
+    toastLive.innerHTML = '';
+
+    const wrap = document.createElement('div');
+    wrap.className = 'toast';
+
+    const text = document.createElement('span');
+    text.textContent = message;
+    wrap.appendChild(text);
+
+    if (options && options.undo) {
+      const undoButton = document.createElement('button');
+      undoButton.type = 'button';
+      undoButton.textContent = 'Undo';
+      undoButton.addEventListener('click', function () {
+        options.undo();
+        toastLive.innerHTML = '';
+      });
+      wrap.appendChild(undoButton);
+    }
+
+    toastLive.appendChild(wrap);
+    toastTimer = setTimeout(function () {
+      toastLive.innerHTML = '';
+    }, options && options.sticky ? 8000 : 2200);
+  }
+
+  function renderEntries() {
+    renderTypeFilters();
+    const list = filteredEntries();
     entriesList.innerHTML = '';
 
-    if (filtered.length === 0) {
+    if (!list.length) {
       const empty = document.createElement('p');
       empty.className = 'empty';
-      empty.textContent = 'No entries yet.';
+      empty.textContent = 'No entries match your filters.';
       entriesList.appendChild(empty);
       return;
     }
 
-    filtered
-      .slice()
-      .sort((a, b) => b.timestamp - a.timestamp)
-      .forEach((entry) => {
-        const card = document.createElement('article');
-        card.className = 'entry-card';
-        card.setAttribute('role', 'listitem');
+    list.forEach(function (entry) {
+      const card = document.createElement('article');
+      card.className = 'entry-card';
+      card.setAttribute('role', 'listitem');
 
-        const badge = document.createElement('span');
-        badge.className = 'badge';
-        badge.textContent = (entry.category || 'notes').toUpperCase();
+      const topRow = document.createElement('div');
+      topRow.className = 'entry-row-top';
 
-        const content = document.createElement('p');
-        content.className = 'entry-content';
-        content.textContent = entry.content;
+      const badge = document.createElement('span');
+      badge.className = 'badge';
+      badge.textContent = entry.type;
 
-        const meta = document.createElement('p');
-        meta.className = 'entry-meta';
-        meta.textContent = `${entry.date || ''}`;
+      const status = document.createElement('span');
+      status.className = 'status';
+      status.textContent = entry.status;
 
-        card.appendChild(badge);
-        card.appendChild(content);
-        card.appendChild(meta);
-        entriesList.appendChild(card);
+      topRow.appendChild(badge);
+      topRow.appendChild(status);
+
+      const title = document.createElement('h3');
+      title.className = 'entry-title';
+      title.textContent = entry.title || '(Untitled)';
+
+      const body = document.createElement('p');
+      body.className = 'entry-body';
+      body.textContent = entry.body;
+
+      const bottomRow = document.createElement('div');
+      bottomRow.className = 'entry-row-bottom';
+
+      const meta = document.createElement('span');
+      meta.className = 'meta';
+      meta.textContent = new Date(entry.createdAt).toLocaleString();
+
+      const actions = document.createElement('div');
+      actions.className = 'entry-actions';
+
+      if (entry.type === 'task' && entry.status !== 'done') {
+        const doneBtn = document.createElement('button');
+        doneBtn.type = 'button';
+        doneBtn.className = 'btn-small success';
+        doneBtn.textContent = 'Mark done';
+        doneBtn.addEventListener('click', function () {
+          entry.status = 'done';
+          entry.updatedAt = new Date().toISOString();
+          saveDB(db);
+          renderEntries();
+          showToast('Task marked done.');
+        });
+        actions.appendChild(doneBtn);
+      }
+
+      const deleteBtn = document.createElement('button');
+      deleteBtn.type = 'button';
+      deleteBtn.className = 'btn-small danger';
+      deleteBtn.textContent = 'Delete';
+      deleteBtn.addEventListener('click', function () {
+        entry.deletedAt = new Date().toISOString();
+        entry.updatedAt = entry.deletedAt;
+        pendingDelete = entry.id;
+        saveDB(db);
+        renderEntries();
+        showToast('Entry deleted.', {
+          undo: function () {
+            const target = db.entries.find(function (item) {
+              return item.id === pendingDelete;
+            });
+            if (target) {
+              target.deletedAt = null;
+              target.updatedAt = new Date().toISOString();
+              saveDB(db);
+              renderEntries();
+              showToast('Delete undone.');
+            }
+          },
+          sticky: true
+        });
       });
+
+      actions.appendChild(deleteBtn);
+      bottomRow.appendChild(meta);
+      bottomRow.appendChild(actions);
+
+      card.appendChild(topRow);
+      card.appendChild(title);
+      card.appendChild(body);
+      card.appendChild(bottomRow);
+      entriesList.appendChild(card);
+    });
   }
 
-  function captureEntry() {
-    const rawText = captureInput.value;
-    if (!rawText.trim()) {
+  function updateBrainDumpUI() {
+    const enabled = !!db.settings.brainDumpMode;
+    brainDumpToggle.checked = enabled;
+    brainDumpHint.textContent = enabled
+      ? 'ON: each non-empty line saves as a separate entry.'
+      : 'OFF: save as one entry.';
+  }
+
+  function addEntriesFromCapture(rawText) {
+    const text = rawText.trim();
+    if (!text) {
+      return 0;
+    }
+
+    const created = [];
+    if (db.settings.brainDumpMode) {
+      const lines = text
+        .split('\n')
+        .map(cleanLine)
+        .filter(function (line) {
+          return line.length > 0;
+        });
+
+      lines.forEach(function (line) {
+        created.push(makeEntry(line));
+      });
+    } else {
+      created.push(makeEntry(text));
+    }
+
+    if (!created.length) {
+      return 0;
+    }
+
+    db.entries = db.entries.concat(created);
+    saveDB(db);
+    return created.length;
+  }
+
+  function saveCapture() {
+    if (!storageAvailable) {
+      showToast('Storage is unavailable. Entries cannot be saved on this device.');
       return;
     }
 
-    const parsed = parseCapture(rawText);
-    const now = Date.now();
-
-    const record = {
-      id: createId(),
-      category: parsed.category,
-      content: parsed.content,
-      timestamp: now,
-      date: new Date(now).toISOString().slice(0, 10)
-    };
-
-    const entries = loadEntries();
-    entries.push(record);
-    saveEntries(entries);
+    const count = addEntriesFromCapture(captureInput.value);
+    if (!count) {
+      showToast('Add some text before saving.');
+      return;
+    }
 
     captureInput.value = '';
+    showToast(count === 1 ? 'Saved 1 entry.' : `Saved ${count} entries.`);
     renderEntries();
-  }
-
-  function showScreen(screenId) {
-    screens.forEach((screen) => {
-      const isActive = screen.id === screenId;
-      screen.classList.toggle('is-active', isActive);
-    });
-
-    bottomTabs.forEach((tab) => {
-      const isActive = tab.dataset.screen === screenId;
-      tab.classList.toggle('active', isActive);
-    });
   }
 
   function appendAssistantBubble(text, type) {
@@ -160,6 +485,11 @@
     appendAssistantBubble(question, 'user');
     assistantInput.value = '';
 
+    if (!window.MemoryCueAssistant || typeof window.MemoryCueAssistant.askMemoryCue !== 'function') {
+      appendAssistantBubble('Assistant integration is unavailable in this build.', 'assistant');
+      return;
+    }
+
     appendAssistantBubble('Thinking...', 'assistant');
 
     try {
@@ -167,41 +497,106 @@
       assistantResponses.firstChild.textContent = answer;
     } catch (error) {
       console.error(error);
-      assistantResponses.firstChild.textContent = 'Sorry, I could not retrieve your notes right now.';
+      assistantResponses.firstChild.textContent = 'Sorry, the assistant is unavailable right now.';
     }
   }
 
-  captureButton.addEventListener('click', captureEntry);
-  askButton.addEventListener('click', askAssistant);
+  function setupKeyboardShortcuts() {
+    document.addEventListener('keydown', function (event) {
+      const isMod = event.ctrlKey || event.metaKey;
+      if (!isMod) {
+        return;
+      }
 
-  captureInput.addEventListener('keydown', (event) => {
-    if (event.key === 'Enter' && !event.shiftKey) {
-      event.preventDefault();
-      captureEntry();
-    }
-  });
+      const key = String(event.key).toLowerCase();
+      if (key === 'enter') {
+        event.preventDefault();
+        saveCapture();
+        return;
+      }
 
-  assistantInput.addEventListener('keydown', (event) => {
-    if (event.key === 'Enter' && !event.shiftKey) {
-      event.preventDefault();
-      askAssistant();
-    }
-  });
+      if (key === 'k') {
+        event.preventDefault();
+        setTab('tab-capture');
+        captureInput.focus();
+        return;
+      }
 
-  bottomTabs.forEach((tab) => {
-    tab.addEventListener('click', () => {
-      showScreen(tab.dataset.screen);
+      if (key === '1' || key === '2' || key === '3') {
+        event.preventDefault();
+        const targetId = key === '1' ? 'tab-capture' : key === '2' ? 'tab-entries' : 'tab-assistant';
+        setTab(targetId, true);
+        return;
+      }
+
+      if (event.shiftKey && key === 'b') {
+        event.preventDefault();
+        db.settings.brainDumpMode = !db.settings.brainDumpMode;
+        saveDB(db);
+        updateBrainDumpUI();
+        showToast(`Brain Dump ${db.settings.brainDumpMode ? 'enabled' : 'disabled'}.`);
+      }
     });
-  });
+  }
 
-  entryFilters.forEach((filter) => {
-    filter.addEventListener('click', () => {
-      activeFilter = filter.dataset.filter || 'all';
-      entryFilters.forEach((node) => node.classList.remove('active'));
-      filter.classList.add('active');
+  function setupTabs() {
+    tabs.forEach(function (tab, index) {
+      tab.addEventListener('click', function () {
+        setTab(tab.id);
+      });
+
+      tab.addEventListener('keydown', function (event) {
+        if (['ArrowRight', 'ArrowLeft', 'Home', 'End'].includes(event.key)) {
+          event.preventDefault();
+          moveTabFocus(index, event.key);
+          return;
+        }
+
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          setTab(tab.id, true);
+        }
+      });
+    });
+  }
+
+  function init() {
+    storageAvailable = safeStorageCheck();
+    db = loadDB();
+
+    if (!storageAvailable) {
+      showToast('Storage is blocked in this browser. Your entries will not persist.', { sticky: true });
+    }
+
+    updateBrainDumpUI();
+    renderEntries();
+    setTab('tab-capture');
+
+    captureButton.addEventListener('click', saveCapture);
+    askButton.addEventListener('click', askAssistant);
+
+    brainDumpToggle.addEventListener('change', function () {
+      db.settings.brainDumpMode = brainDumpToggle.checked;
+      saveDB(db);
+      updateBrainDumpUI();
+      showToast(`Brain Dump ${db.settings.brainDumpMode ? 'enabled' : 'disabled'}.`);
+    });
+
+    searchInput.addEventListener('input', function () {
+      activeSearch = searchInput.value.trim().toLowerCase();
       renderEntries();
     });
-  });
 
-  renderEntries();
+    assistantInput.addEventListener('keydown', function (event) {
+      if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+        event.preventDefault();
+        askAssistant();
+      }
+    });
+
+    setupTabs();
+    setupKeyboardShortcuts();
+  }
+
+  init();
 })();

--- a/index.html
+++ b/index.html
@@ -9,59 +9,118 @@
   <body>
     <main class="app-shell">
       <header class="app-header">
-        <h1>Memory Cue Mobile</h1>
-        <p>Capture and ask your notes.</p>
+        <h1>Memory Cue Inbox</h1>
+        <p>Capture fast. Sort later.</p>
       </header>
 
-      <section id="captureScreen" class="screen is-active" aria-label="Capture">
-        <div class="card">
-          <label for="captureInput" class="sr-only">Capture note</label>
+      <div class="tabs-wrap">
+        <div class="tabs" role="tablist" aria-label="Main tabs">
+          <button
+            id="tab-capture"
+            class="tab-btn is-active"
+            role="tab"
+            type="button"
+            aria-selected="true"
+            aria-controls="panel-capture"
+            tabindex="0"
+            data-panel="panel-capture"
+          >
+            Capture
+          </button>
+          <button
+            id="tab-entries"
+            class="tab-btn"
+            role="tab"
+            type="button"
+            aria-selected="false"
+            aria-controls="panel-entries"
+            tabindex="-1"
+            data-panel="panel-entries"
+          >
+            Entries
+          </button>
+          <button
+            id="tab-assistant"
+            class="tab-btn"
+            role="tab"
+            type="button"
+            aria-selected="false"
+            aria-controls="panel-assistant"
+            tabindex="-1"
+            data-panel="panel-assistant"
+          >
+            Assistant
+          </button>
+        </div>
+      </div>
+
+      <section
+        id="panel-capture"
+        class="panel is-active"
+        role="tabpanel"
+        tabindex="0"
+        aria-labelledby="tab-capture"
+      >
+        <div class="card capture-card">
+          <div class="capture-top-row">
+            <div class="toggle-wrap">
+              <input id="brainDumpToggle" type="checkbox" />
+              <label for="brainDumpToggle">Brain Dump mode</label>
+            </div>
+            <p id="brainDumpHint" class="hint">OFF: save as one entry.</p>
+          </div>
+
+          <label for="captureInput" class="sr-only">Capture text</label>
           <textarea
             id="captureInput"
-            placeholder="What's on your mind?"
-            rows="6"
+            class="capture-input"
+            placeholder="What's on your mind?\n\nTip: use task:, idea:, note:, reflection:, lesson:, drill:"
             autocomplete="off"
             spellcheck="true"
           ></textarea>
-          <button id="captureButton" type="button" class="primary-btn">CAPTURE</button>
+
+          <button id="captureButton" class="primary-btn" type="button">Save</button>
         </div>
       </section>
 
-      <section id="entriesScreen" class="screen" aria-label="Entries">
-        <div class="card">
-          <nav id="entryFilters" class="filters" aria-label="Entry filters">
-            <button class="filter active" data-filter="all" type="button">All</button>
-            <button class="filter" data-filter="tasks" type="button">Tasks</button>
-            <button class="filter" data-filter="drills" type="button">Drills</button>
-            <button class="filter" data-filter="lessons" type="button">Lessons</button>
-            <button class="filter" data-filter="reflections" type="button">Reflections</button>
-            <button class="filter" data-filter="ideas" type="button">Ideas</button>
-            <button class="filter" data-filter="notes" type="button">Notes</button>
-          </nav>
+      <section
+        id="panel-entries"
+        class="panel"
+        role="tabpanel"
+        tabindex="0"
+        aria-labelledby="tab-entries"
+        hidden
+      >
+        <div class="card entries-card">
+          <div class="entries-controls">
+            <label for="searchInput" class="sr-only">Search entries</label>
+            <input id="searchInput" type="search" placeholder="Search entries" />
+            <div id="typeFilters" class="filters" aria-label="Type filters"></div>
+          </div>
           <div id="entriesList" class="entries-list" role="list"></div>
         </div>
       </section>
 
-      <section id="assistantScreen" class="screen" aria-label="Assistant">
-        <div class="card">
-          <h2>Ask Memory Cue</h2>
-          <label for="assistantInput" class="sr-only">Ask anything about your notes</label>
-          <textarea
-            id="assistantInput"
-            placeholder="Ask anything about your notes..."
-            rows="3"
-          ></textarea>
-          <button id="askButton" type="button" class="primary-btn">ASK</button>
+      <section
+        id="panel-assistant"
+        class="panel"
+        role="tabpanel"
+        tabindex="0"
+        aria-labelledby="tab-assistant"
+        hidden
+      >
+        <div class="card assistant-card">
+          <h2>Assistant</h2>
+          <p class="hint">Ask about your saved entries. Works with optional assistant integration.</p>
+          <label for="assistantInput" class="sr-only">Ask anything about your entries</label>
+          <textarea id="assistantInput" rows="4" placeholder="Ask anything about your entries..."></textarea>
+          <button id="askButton" class="primary-btn" type="button">Ask</button>
           <div id="assistantResponses" class="assistant-responses" aria-live="polite"></div>
         </div>
       </section>
     </main>
 
-    <nav class="bottom-tabs" aria-label="Main navigation">
-      <button class="bottom-tab active" data-screen="captureScreen" type="button">Capture</button>
-      <button class="bottom-tab" data-screen="entriesScreen" type="button">Entries</button>
-      <button class="bottom-tab" data-screen="assistantScreen" type="button">Assistant</button>
-    </nav>
+    <div id="toastLive" class="toast-live" aria-live="polite" aria-atomic="true"></div>
 
     <script src="assistant.js"></script>
     <script src="app.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -1,10 +1,14 @@
 :root {
-  --bg: #0f172a;
-  --card: #1e293b;
-  --accent: #38bdf8;
-  --text: #f8fafc;
-  --border: #334155;
-  --muted: #cbd5e1;
+  --bg: #0b1220;
+  --card: #101a2f;
+  --card-2: #0f172a;
+  --text: #e2e8f0;
+  --muted: #9fb1c9;
+  --border: #24334e;
+  --accent: #4cc9f0;
+  --accent-2: #22d3ee;
+  --danger: #ef4444;
+  --success: #22c55e;
 }
 
 * {
@@ -13,172 +17,295 @@
 
 body {
   margin: 0;
-  padding: 0;
   min-height: 100vh;
-  background: var(--bg);
+  background: linear-gradient(180deg, #0a1020, #0b1220);
   color: var(--text);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 }
 
 .app-shell {
-  max-width: 760px;
+  max-width: 860px;
   margin: 0 auto;
-  padding: 1rem 1rem 5.5rem;
+  padding: 0.8rem 0.8rem 1rem;
 }
 
 .app-header h1 {
   margin: 0;
-  font-size: 1.5rem;
+  font-size: 1.35rem;
 }
 
 .app-header p {
-  margin: 0.4rem 0 1rem;
+  margin: 0.3rem 0 0.8rem;
   color: var(--muted);
 }
 
-.screen {
+.tabs-wrap {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(11, 18, 32, 0.92);
+  backdrop-filter: blur(4px);
+  padding-bottom: 0.6rem;
+}
+
+.tabs {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+
+.tab-btn {
+  border: 1px solid var(--border);
+  background: var(--card-2);
+  color: var(--text);
+  border-radius: 12px;
+  padding: 0.7rem 0.5rem;
+  font-size: 0.95rem;
+}
+
+.tab-btn.is-active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.panel {
   display: none;
 }
 
-.screen.is-active {
+.panel.is-active {
   display: block;
 }
 
 .card {
   background: var(--card);
   border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 1rem;
+  border-radius: 16px;
+  padding: 0.8rem;
 }
 
-textarea {
-  width: 100%;
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  background: #0b1220;
-  color: var(--text);
-  padding: 0.85rem;
-  font-size: 1rem;
-}
-
-textarea:focus {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-.primary-btn {
-  width: 100%;
-  margin-top: 0.75rem;
-  border: 0;
-  border-radius: 12px;
-  background: var(--accent);
-  color: #052033;
-  font-weight: 700;
-  font-size: 1rem;
-  padding: 0.95rem 1rem;
-}
-
-.filters {
-  display: flex;
-  gap: 0.45rem;
-  flex-wrap: wrap;
-  margin-bottom: 0.9rem;
-}
-
-.filter {
-  border: 1px solid var(--border);
-  background: #0b1220;
-  color: var(--text);
-  border-radius: 999px;
-  padding: 0.35rem 0.65rem;
-}
-
-.filter.active {
-  border-color: var(--accent);
-  color: var(--accent);
-}
-
-.entries-list {
+.capture-card {
+  min-height: calc(100vh - 180px);
   display: grid;
+  grid-template-rows: auto 1fr auto;
   gap: 0.7rem;
 }
 
-.entry-card {
-  background: #0b1220;
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 0.75rem;
+.capture-top-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
 }
 
-.badge {
-  display: inline-block;
-  margin-bottom: 0.5rem;
-  border-radius: 999px;
-  background: rgba(56, 189, 248, 0.18);
-  color: var(--accent);
-  font-size: 0.72rem;
-  font-weight: 700;
-  padding: 0.2rem 0.5rem;
+.toggle-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
 }
 
-.entry-content {
+.hint {
   margin: 0;
-}
-
-.entry-meta,
-.empty {
   color: var(--muted);
   font-size: 0.86rem;
 }
 
-.assistant-responses {
-  margin-top: 1rem;
+textarea,
+input[type='search'] {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: #0a1426;
+  color: var(--text);
+  padding: 0.8rem;
+  font-size: 1rem;
+}
+
+.capture-input {
+  min-height: 100%;
+  resize: none;
+}
+
+.primary-btn {
+  width: 100%;
+  border: 1px solid #0f2f42;
+  border-radius: 12px;
+  background: var(--accent);
+  color: #04202f;
+  font-weight: 700;
+  font-size: 1rem;
+  padding: 0.9rem 1rem;
+}
+
+.entries-controls {
+  display: grid;
+  gap: 0.6rem;
+  margin-bottom: 0.7rem;
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.filter-pill {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: #0a1426;
+  color: var(--text);
+  padding: 0.35rem 0.7rem;
+  font-size: 0.85rem;
+}
+
+.filter-pill.is-active {
+  border-color: var(--accent-2);
+  color: var(--accent-2);
+}
+
+.entries-list {
   display: grid;
   gap: 0.6rem;
 }
 
+.entry-card {
+  background: #0a1426;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.7rem;
+}
+
+.entry-row-top,
+.entry-row-bottom {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.badge {
+  display: inline-block;
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  background: rgba(76, 201, 240, 0.2);
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+.status {
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
+.entry-title {
+  margin: 0.45rem 0;
+  font-size: 0.98rem;
+}
+
+.entry-body {
+  margin: 0 0 0.6rem;
+  color: var(--text);
+  white-space: pre-wrap;
+}
+
+.meta {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.entry-actions {
+  display: inline-flex;
+  gap: 0.35rem;
+}
+
+.btn-small {
+  border: 1px solid var(--border);
+  background: #0b1a31;
+  color: var(--text);
+  border-radius: 9px;
+  padding: 0.3rem 0.55rem;
+  font-size: 0.8rem;
+}
+
+.btn-small.danger {
+  border-color: #5a2020;
+  color: #fecaca;
+}
+
+.btn-small.success {
+  border-color: #22533a;
+  color: #bbf7d0;
+}
+
+.empty {
+  color: var(--muted);
+  margin: 0.5rem 0;
+}
+
+.assistant-card h2 {
+  margin: 0 0 0.35rem;
+}
+
+.assistant-responses {
+  margin-top: 0.75rem;
+  display: grid;
+  gap: 0.55rem;
+}
+
 .bubble {
   margin: 0;
-  border-radius: 12px;
-  padding: 0.75rem;
+  border-radius: 10px;
+  padding: 0.65rem;
   white-space: pre-wrap;
 }
 
 .bubble-user {
-  background: #0b1220;
   border: 1px solid var(--border);
+  background: #0a1426;
 }
 
 .bubble-assistant {
-  background: rgba(56, 189, 248, 0.15);
-  border: 1px solid rgba(56, 189, 248, 0.4);
+  border: 1px solid #235a6d;
+  background: rgba(34, 211, 238, 0.13);
 }
 
-.bottom-tabs {
+.toast-live {
   position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: var(--card);
-  border-top: 1px solid var(--border);
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 0.4rem;
-  padding: 0.6rem;
-}
-
-.bottom-tab {
-  border: 1px solid var(--border);
-  background: #0b1220;
+  left: 50%;
+  bottom: 1rem;
+  transform: translateX(-50%);
+  min-height: 1.5rem;
+  width: min(92vw, 560px);
+  text-align: center;
   color: var(--text);
-  border-radius: 10px;
-  padding: 0.75rem 0.5rem;
-  font-size: 0.95rem;
+  pointer-events: none;
 }
 
-.bottom-tab.active {
-  border-color: var(--accent);
-  color: var(--accent);
+.toast {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  background: rgba(8, 14, 28, 0.95);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.4rem 0.7rem;
+  pointer-events: auto;
+}
+
+.toast button {
+  border: 1px solid var(--border);
+  background: #0b1a31;
+  color: var(--text);
+  border-radius: 999px;
+  font-size: 0.75rem;
+  padding: 0.15rem 0.45rem;
+}
+
+:focus-visible {
+  outline: 3px solid #fde047;
+  outline-offset: 2px;
 }
 
 .sr-only {


### PR DESCRIPTION
### Motivation
- Replace the minimal capture app with a mobile-first, frictionless inbox focused on fast capture and later organization. 
- Add a Brain Dump mode that converts multi-line input into individual entries and supports prefix→type mapping. 
- Move to a more robust, versioned localStorage model to support migration and richer entry metadata. 
- Improve accessibility, keyboard navigation, and quick workflows for power users on mobile devices.

### Description
- Replaced `index.html`, `styles.css`, and `app.js` with a new mobile-first three-tab UI implementing ARIA `tablist`/`tab`/`tabpanel` semantics and visible focus styles. 
- Implemented schema v2 storage under `memoryCueDB` with `schemaVersion`, `settings`, and `entries[]`, and added migration from legacy `memoryCueEntries`. 
- Added Brain Dump mode (toggleable) that strips bullet prefixes, splits non-empty lines into separate entries, and maps typed prefixes like `task:`/`idea:` to entry `type`; single-save mode still supported. 
- Added entries features: newest-first sorting, search box, type filter pills, task "Mark done", soft-delete with undo via toast, and an assistant UI that degrades gracefully if `window.MemoryCueAssistant` is unavailable. 
- Implemented keyboard behavior and shortcuts: ARROW/HOME/END for tab focus, ENTER/SPACE to activate tabs (manual activation), `Ctrl/Cmd+Enter` to save capture, `Ctrl/Cmd+K` to focus capture, `Ctrl/Cmd+1/2/3` to switch tabs, and `Ctrl/Cmd+Shift+B` to toggle Brain Dump. 
- Added defensive handling when `localStorage` is unavailable (friendly toast) and minimized write churn by batching created entries and performing a single DB save per capture.

### Testing
- Ran `node --check app.js` which completed successfully. 
- Ran `node --check assistant.js` which completed successfully. 
- Performed a visual smoke check by serving the site and capturing a mobile viewport screenshot via Playwright; the page rendered and the screenshot was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9576e9a0483248276241a4465586a)