### PR TITLE
Add serverless assistant integration with structured outputs and offline fallback

### DIFF
--- a/api/assistant.js
+++ b/api/assistant.js
@@ -1,35 +1,166 @@
-import OpenAI from "openai";
+const ALLOWED_ORIGINS = [
+  'https://dmaher42.github.io',
+  'https://memory-cue.vercel.app',
+  'http://localhost:3000',
+  'http://localhost:5173'
+];
 
-export default async function handler(req, res) {
-  if (req.method !== "POST") {
-    return res.status(405).json({ error: "Method not allowed" });
+const MAX_QUESTION_CHARS = 1000;
+const MAX_CONTEXT_CHARS = 12000;
+const MAX_ENTRIES = 50;
+const MAX_ENTRY_CHARS = 1200;
+
+function applyCors(req, res) {
+  const origin = req.headers.origin;
+  if (origin && ALLOWED_ORIGINS.includes(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Vary', 'Origin');
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  }
+}
+
+function trimEntry(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+
+  const id = typeof entry.id === 'string' ? entry.id.slice(0, 128) : '';
+  const type = typeof entry.type === 'string' ? entry.type.slice(0, 40) : 'note';
+  const title = typeof entry.title === 'string' ? entry.title.slice(0, MAX_ENTRY_CHARS) : '';
+  const body = typeof entry.body === 'string' ? entry.body.slice(0, MAX_ENTRY_CHARS) : '';
+  const createdAt = typeof entry.createdAt === 'string' ? entry.createdAt.slice(0, 64) : null;
+
+  if (!title && !body) {
+    return null;
+  }
+
+  return { id, type, title, body, createdAt };
+}
+
+module.exports = async function handler(req, res) {
+  applyCors(req, res);
+
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end();
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    return res.status(500).json({ error: 'Server misconfiguration: missing OpenAI API key.' });
+  }
+
+  const payload = req.body && typeof req.body === 'object' ? req.body : {};
+  const question = typeof payload.question === 'string' ? payload.question.trim() : '';
+  const contextText = typeof payload.contextText === 'string' ? payload.contextText : '';
+  const schemaVersion = payload.schemaVersion;
+  const rawEntries = Array.isArray(payload.entries) ? payload.entries : [];
+
+  if (schemaVersion !== 2) {
+    return res.status(400).json({ error: 'Invalid schemaVersion.' });
+  }
+
+  if (!question || question.length > MAX_QUESTION_CHARS) {
+    return res.status(400).json({ error: 'Invalid question length.' });
+  }
+
+  if (contextText.length > MAX_CONTEXT_CHARS) {
+    return res.status(400).json({ error: 'contextText too large.' });
+  }
+
+  if (rawEntries.length > MAX_ENTRIES) {
+    return res.status(400).json({ error: 'Too many entries.' });
+  }
+
+  const entries = rawEntries.map(trimEntry).filter(Boolean);
+
+  let response;
+  try {
+    response = await fetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        max_output_tokens: 400,
+        store: false,
+        input: [
+          {
+            role: 'system',
+            content: [
+              {
+                type: 'input_text',
+                text: 'You are the Memory Cue assistant. Use only supplied entries/context. If answer is unknown, say so briefly.'
+              }
+            ]
+          },
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'input_text',
+                text: `Question:\n${question}\n\nContext:\n${contextText}\n\nEntries JSON:\n${JSON.stringify(entries)}`
+              }
+            ]
+          }
+        ],
+        text: {
+          format: {
+            type: 'json_schema',
+            name: 'memory_cue_answer',
+            strict: true,
+            schema: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                answer: { type: 'string' },
+                cited_entry_ids: {
+                  type: 'array',
+                  items: { type: 'string' }
+                },
+                followups: {
+                  type: 'array',
+                  items: { type: 'string' }
+                }
+              },
+              required: ['answer', 'cited_entry_ids', 'followups']
+            }
+          }
+        }
+      })
+    });
+  } catch (_error) {
+    return res.status(500).json({ error: 'Assistant failed.' });
+  }
+
+  if (!response.ok) {
+    return res.status(response.status === 429 ? 429 : 500).json({
+      error: response.status === 429 ? 'Rate limit exceeded.' : 'Assistant failed.'
+    });
   }
 
   try {
-    const { message } = req.body;
+    const data = await response.json();
+    const outputText =
+      data.output_text ||
+      (data.output &&
+        data.output[0] &&
+        data.output[0].content &&
+        data.output[0].content[0] &&
+        data.output[0].content[0].text) ||
+      null;
 
-    if (!process.env.OPENAI_API_KEY) {
-      console.error("Assistant misconfiguration: OPENAI_API_KEY is not set");
-      return res.status(500).json({ error: "Server misconfiguration: missing OpenAI API key." });
+    if (!outputText) {
+      return res.status(502).json({ error: 'Assistant returned no output.' });
     }
 
-    const openai = new OpenAI({
-      apiKey: process.env.OPENAI_API_KEY
-    });
-
-    const completion = await openai.chat.completions.create({
-      model: "gpt-4o-mini",
-      messages: [
-        { role: "system", content: "You are the Memory Cue assistant." },
-        { role: "user", content: message }
-      ]
-    });
-
-    const reply = completion.choices[0].message.content;
-
-    return res.status(200).json({ reply });
-  } catch (error) {
-    console.error("Assistant error:", error);
-    return res.status(500).json({ error: "Assistant failed" });
+    return res.status(200).json(JSON.parse(outputText));
+  } catch (_error) {
+    return res.status(500).json({ error: 'Assistant failed.' });
   }
-}
+};

--- a/api/parse-entry.js
+++ b/api/parse-entry.js
@@ -25,18 +25,23 @@ const PARSED_ENTRY_SCHEMA = {
   required: ['type', 'title', 'tags', 'reminderDate']
 };
 
+const ALLOWED_ORIGINS = [
+  'https://memory-cue.vercel.app',
+  'https://dmaher42.github.io',
+  'http://localhost:3000',
+  'http://localhost:5173'
+];
+
+const MAX_TEXT_LENGTH = 4000;
+
 module.exports = async function handler(req, res) {
   const origin = req.headers.origin;
-  const allowedOrigins = [
-    'https://memory-cue.vercel.app',
-    'http://localhost:3000',
-    'http://localhost:5173'
-  ];
 
-  if (origin && allowedOrigins.includes(origin)) {
+  if (origin && ALLOWED_ORIGINS.includes(origin)) {
     res.setHeader('Access-Control-Allow-Origin', origin);
     res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    res.setHeader('Vary', 'Origin');
   }
 
   if (req.method === 'OPTIONS') {
@@ -47,26 +52,29 @@ module.exports = async function handler(req, res) {
     return res.status(405).send('Method not allowed');
   }
 
-  const text = typeof req.body === 'string' ? (() => {
+  const body = typeof req.body === 'string' ? (() => {
     try {
-      const parsed = JSON.parse(req.body);
-      return parsed && parsed.text;
+      return JSON.parse(req.body);
     } catch (_error) {
-      return undefined;
+      return {};
     }
-  })() : req.body && req.body.text;
+  })() : (req.body || {});
 
-  if (typeof text !== 'string' || !text.trim()) {
+  const text = typeof body.text === 'string' ? body.text.trim() : '';
+
+  if (!text) {
     return res.status(400).json({ error: 'Invalid input: text must be a non-empty string.' });
   }
 
+  if (text.length > MAX_TEXT_LENGTH) {
+    return res.status(400).json({ error: 'Input too large.' });
+  }
+
   if (!process.env.OPENAI_API_KEY) {
-    console.error('Parse entry misconfiguration: OPENAI_API_KEY is not set');
     return res.status(500).json({ error: 'Server misconfiguration: missing OpenAI API key.' });
   }
 
   let response;
-
   try {
     response = await fetch('https://api.openai.com/v1/responses', {
       method: 'POST',
@@ -75,7 +83,8 @@ module.exports = async function handler(req, res) {
         Authorization: `Bearer ${process.env.OPENAI_API_KEY}`
       },
       body: JSON.stringify({
-        model: 'gpt-5.2',
+        model: 'gpt-4o-mini',
+        max_output_tokens: 250,
         store: false,
         input: [
           {
@@ -83,7 +92,7 @@ module.exports = async function handler(req, res) {
             content: [
               {
                 type: 'input_text',
-                text: `You are a structured data parser.\n\nReturn ONLY valid JSON.\n\nExtract from the user's input:\n- type (footy_drill, netball_note, reflection, reminder, teaching_note, general_note)\n- title (short clean summary under 60 characters)\n- tags (array of lowercase keywords)\n- reminderDate (ISO string if date/time mentioned, otherwise null)\n\nIf unsure, use general_note.`
+                text: `Return ONLY JSON matching schema.\nExtract:\n- type (footy_drill, netball_note, reflection, reminder, teaching_note, general_note)\n- title (short summary under 60 chars)\n- tags (lowercase keywords)\n- reminderDate (ISO string if date/time mentioned, else null)\nIf unsure, use general_note.`
               }
             ]
           },
@@ -108,37 +117,31 @@ module.exports = async function handler(req, res) {
       })
     });
   } catch (error) {
-    console.error('AI request failed:', error);
-    return res.status(500).json({
-      error: 'AI request failed',
-      message: error.message
-    });
+    return res.status(500).json({ error: 'AI request failed', message: error.message });
+  }
+
+  if (!response.ok) {
+    const details = await response.text();
+    return res.status(response.status === 429 ? 429 : 500).json({ error: 'Failed to parse entry.', details });
   }
 
   try {
-    if (!response.ok) {
-      const errorText = await response.text();
-      console.error('OpenAI API error:', response.status, errorText);
-      return res.status(500).json({ error: 'Failed to parse entry.' });
-    }
-
     const data = await response.json();
-    const outputText = data.output_text
-      || (data.output && data.output[0] && data.output[0].content && data.output[0].content[0] && data.output[0].content[0].text)
-      || null;
+    const outputText =
+      data.output_text ||
+      (data.output &&
+        data.output[0] &&
+        data.output[0].content &&
+        data.output[0].content[0] &&
+        data.output[0].content[0].text) ||
+      null;
 
     if (!outputText) {
-      console.error('OpenAI response missing output text:', data);
       return res.status(500).json({ error: 'Failed to parse entry.' });
     }
 
-    const parsedResult = JSON.parse(outputText);
-    return res.status(200).json(parsedResult);
+    return res.status(200).json(JSON.parse(outputText));
   } catch (error) {
-    console.error('AI request failed:', error);
-    return res.status(500).json({
-      error: 'AI request failed',
-      message: error.message
-    });
+    return res.status(500).json({ error: 'AI parse error', message: error.message });
   }
 };

--- a/app.js
+++ b/app.js
@@ -493,8 +493,13 @@
     appendAssistantBubble('Thinking...', 'assistant');
 
     try {
-      const answer = await window.MemoryCueAssistant.askMemoryCue(question);
-      assistantResponses.firstChild.textContent = answer;
+      const result = await window.MemoryCueAssistant.askMemoryCue(question);
+      const answerText = result && typeof result.answer === 'string' ? result.answer : String(result || 'No answer returned.');
+      const usedOfflineFallback = !!(result && result.offline_fallback);
+      assistantResponses.firstChild.textContent = usedOfflineFallback
+        ? `Offline fallback:
+${answerText}`
+        : answerText;
     } catch (error) {
       console.error(error);
       assistantResponses.firstChild.textContent = 'Sorry, the assistant is unavailable right now.';

--- a/assistant.js
+++ b/assistant.js
@@ -1,71 +1,224 @@
 (function () {
-  const STORAGE_KEY = 'memoryCueEntries';
-  const MAX_CONTEXT_ENTRIES = 50;
+  const DB_KEY = 'memoryCueDB';
+  const SCHEMA_VERSION = 2;
+  const DEFAULT_MAX_ENTRIES = 50;
+  const DEFAULT_MAX_CHARS = 12000;
 
-  function loadStoredEntries() {
+  function normalizeEntry(entry) {
+    if (!entry || typeof entry !== 'object') {
+      return null;
+    }
+
+    const body = typeof entry.body === 'string' ? entry.body.trim() : '';
+    const title = typeof entry.title === 'string' ? entry.title.trim() : '';
+    const type = typeof entry.type === 'string' ? entry.type : 'note';
+    const createdAt = entry.createdAt || entry.updatedAt || null;
+
+    if (!body && !title) {
+      return null;
+    }
+
+    return {
+      id: String(entry.id || ''),
+      type,
+      title,
+      body,
+      createdAt
+    };
+  }
+
+  function sortNewestFirst(entries) {
+    return entries.slice().sort(function (a, b) {
+      const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return bTime - aTime;
+    });
+  }
+
+  function loadEntriesFromDB() {
     try {
-      const raw = localStorage.getItem(STORAGE_KEY);
-      const parsed = raw ? JSON.parse(raw) : [];
-      return Array.isArray(parsed) ? parsed : [];
+      const raw = window.localStorage.getItem(DB_KEY);
+      if (!raw) {
+        return { settings: {}, entries: [] };
+      }
+
+      const parsed = JSON.parse(raw);
+      if (!parsed || parsed.schemaVersion !== SCHEMA_VERSION || !Array.isArray(parsed.entries)) {
+        return { settings: {}, entries: [] };
+      }
+
+      return {
+        settings: parsed.settings && typeof parsed.settings === 'object' ? parsed.settings : {},
+        entries: parsed.entries.map(normalizeEntry).filter(Boolean)
+      };
     } catch (error) {
-      console.error('Unable to load Memory Cue entries.', error);
-      return [];
+      console.error('Unable to load Memory Cue DB.', error);
+      return { settings: {}, entries: [] };
     }
   }
 
-  function buildSearchContext(entries) {
-    return entries
-      .slice()
-      .sort((a, b) => b.timestamp - a.timestamp)
-      .slice(0, MAX_CONTEXT_ENTRIES)
-      .map((entry) => {
-        return `Entry:\nCategory: ${entry.category || 'notes'}\nContent: ${entry.content || ''}\nDate: ${entry.date || ''}`;
+  function selectEntries(entries, maxEntries, maxChars) {
+    const sorted = sortNewestFirst(entries);
+    const selected = [];
+    let usedChars = 0;
+
+    for (let i = 0; i < sorted.length; i += 1) {
+      if (selected.length >= maxEntries || usedChars >= maxChars) {
+        break;
+      }
+
+      const entry = sorted[i];
+      const line = `[${entry.id || 'no-id'}] (${entry.type}) ${entry.title || ''} ${entry.body || ''}`.trim();
+      if (!line) {
+        continue;
+      }
+
+      const lineSize = line.length + 1;
+      if (selected.length > 0 && usedChars + lineSize > maxChars) {
+        break;
+      }
+
+      selected.push(entry);
+      usedChars += lineSize;
+    }
+
+    return selected;
+  }
+
+  function buildContext(entries, maxEntries, maxChars) {
+    const safeMaxEntries = Number.isFinite(maxEntries) ? Math.max(1, Math.floor(maxEntries)) : DEFAULT_MAX_ENTRIES;
+    const safeMaxChars = Number.isFinite(maxChars) ? Math.max(200, Math.floor(maxChars)) : DEFAULT_MAX_CHARS;
+    const selected = selectEntries(entries.map(normalizeEntry).filter(Boolean), safeMaxEntries, safeMaxChars);
+
+    return selected
+      .map(function (entry) {
+        const createdLabel = entry.createdAt ? ` | ${entry.createdAt}` : '';
+        return `[${entry.id || 'no-id'}] ${entry.type}${createdLabel}\nTitle: ${entry.title || '(untitled)'}\nBody: ${entry.body || ''}`;
       })
       .join('\n\n');
   }
 
-  async function askMemoryCue(question) {
-    const entries = loadStoredEntries();
-    if (entries.length === 0) {
-      return 'You have no saved notes yet. Save a few entries, then ask again.';
-    }
+  function keywordFallback(question, entries, reason) {
+    const tokens = String(question || '')
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(function (token) {
+        return token.length >= 3;
+      });
 
-    const apiKey = window.MEMORY_CUE_OPENAI_API_KEY || localStorage.getItem('memoryCueOpenAIKey');
-    if (!apiKey) {
-      return 'Missing OpenAI API key. Set window.MEMORY_CUE_OPENAI_API_KEY or localStorage key memoryCueOpenAIKey.';
-    }
-
-    const context = buildSearchContext(entries);
-    const prompt = `You are an assistant that helps a teacher and sports coach retrieve notes.\n\nHere are stored notes:\n\n${context}\n\nAnswer the user's question using only these notes.\n\nUser question:\n${question}`;
-
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`
-      },
-      body: JSON.stringify({
-        model: 'gpt-4.1-mini',
-        messages: [
-          {
-            role: 'user',
-            content: prompt
+    const scored = entries
+      .map(function (entry) {
+        const haystack = `${entry.title} ${entry.body} ${entry.type}`.toLowerCase();
+        let score = 0;
+        tokens.forEach(function (token) {
+          if (haystack.includes(token)) {
+            score += 1;
           }
-        ]
+        });
+        return { entry, score };
       })
+      .filter(function (item) {
+        return item.score > 0;
+      })
+      .sort(function (a, b) {
+        if (b.score !== a.score) {
+          return b.score - a.score;
+        }
+        const aTime = a.entry.createdAt ? new Date(a.entry.createdAt).getTime() : 0;
+        const bTime = b.entry.createdAt ? new Date(b.entry.createdAt).getTime() : 0;
+        return bTime - aTime;
+      })
+      .slice(0, 5);
+
+    if (!scored.length) {
+      return {
+        answer: `Offline fallback: I couldn't find matching entries for "${question}".`,
+        cited_entry_ids: [],
+        followups: ['Try a different keyword from your note text.'],
+        offline_fallback: true,
+        reason
+      };
+    }
+
+    const lines = scored.map(function (item) {
+      const text = item.entry.body || item.entry.title;
+      const preview = text.length > 160 ? `${text.slice(0, 157)}...` : text;
+      return `• ${preview}`;
     });
 
+    return {
+      answer: `Offline fallback results:\n${lines.join('\n')}`,
+      cited_entry_ids: scored.map(function (item) {
+        return item.entry.id;
+      }),
+      followups: ['Ask again when online for a fuller AI answer.'],
+      offline_fallback: true,
+      reason
+    };
+  }
+
+  async function askMemoryCue(question, options) {
+    const safeQuestion = typeof question === 'string' ? question.trim() : '';
+    if (!safeQuestion) {
+      throw new Error('Question is required.');
+    }
+
+    const opts = options && typeof options === 'object' ? options : {};
+    const maxEntries = Number.isFinite(opts.maxEntries) ? opts.maxEntries : DEFAULT_MAX_ENTRIES;
+    const maxChars = Number.isFinite(opts.maxChars) ? opts.maxChars : DEFAULT_MAX_CHARS;
+    const loaded = loadEntriesFromDB();
+    const selectedEntries = selectEntries(loaded.entries, maxEntries, maxChars);
+    const contextText = buildContext(selectedEntries, maxEntries, maxChars);
+
+    if (!navigator.onLine) {
+      return keywordFallback(safeQuestion, selectedEntries, 'offline');
+    }
+
+    const endpointUrl =
+      (loaded.settings && loaded.settings.assistant && loaded.settings.assistant.endpointUrl) ||
+      '/api/assistant';
+
+    let response;
+    try {
+      response = await fetch(endpointUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          question: safeQuestion,
+          entries: selectedEntries,
+          contextText,
+          schemaVersion: SCHEMA_VERSION
+        })
+      });
+    } catch (error) {
+      console.error('Assistant request failed. Using offline fallback.', error);
+      return keywordFallback(safeQuestion, selectedEntries, 'network_error');
+    }
+
+    if (response.status === 429) {
+      return keywordFallback(safeQuestion, selectedEntries, 'rate_limited');
+    }
+
     if (!response.ok) {
-      throw new Error(`OpenAI request failed (${response.status}).`);
+      return keywordFallback(safeQuestion, selectedEntries, `http_${response.status}`);
     }
 
     const data = await response.json();
-    return data.choices?.[0]?.message?.content?.trim() || 'No answer returned.';
+    if (!data || typeof data.answer !== 'string') {
+      return keywordFallback(safeQuestion, selectedEntries, 'invalid_response');
+    }
+
+    return {
+      answer: data.answer,
+      cited_entry_ids: Array.isArray(data.cited_entry_ids) ? data.cited_entry_ids : [],
+      followups: Array.isArray(data.followups) ? data.followups : []
+    };
   }
 
   window.MemoryCueAssistant = {
-    loadStoredEntries,
-    buildSearchContext,
+    buildContext,
     askMemoryCue
   };
 })();


### PR DESCRIPTION
### Motivation
- Provide an Assistant integration that does not expose OpenAI API keys in the browser by routing requests to a serverless endpoint.
- Build a bounded, local context from the user's `memoryCueDB` (schema version 2) to limit what is sent to the model and control size.
- Make the assistant resilient: return useful offline/rate-limit/network fallbacks using a local keyword search when the AI endpoint is unavailable.

### Description
- Added `assistant.js` which exposes `window.MemoryCueAssistant` with `buildContext(entries, maxEntries=50, maxChars=12000)` and `askMemoryCue(question, options)` that loads `memoryCueDB` (schemaVersion 2), selects newest entries up to the char/entry limits, posts `{ question, entries, contextText, schemaVersion: 2 }` to a configurable endpoint (`settings.assistant.endpointUrl` or `/api/assistant`), and returns structured `{ answer, cited_entry_ids, followups }` or an offline keyword-fallback object.
- Updated `app.js` assistant flow to call `window.MemoryCueAssistant.askMemoryCue`, render structured responses, and label/display offline fallback results when returned.
- Reworked `api/assistant.js` to call the OpenAI Responses API (`POST /v1/responses`) with a `json_schema` `strict: true` structure so the model returns `{ answer, cited_entry_ids, followups }`, and added CORS allowlist support, input-size validation, max output token caps, and trimming of entry content before sending; server uses `OPENAI_API_KEY` from environment only and does not log entry contents.
- Updated `api/parse-entry.js` to use a supported model and structured outputs with `json_schema` validation, CORS allowlist, input length checks, and safer response parsing.

### Testing
- Ran syntax checks with `node --check` on `assistant.js`, `app.js`, `api/assistant.js`, and `api/parse-entry.js`, which completed successfully.
- Executed unit tests with `npm test -- --runInBand`; many suites passed, but several existing UI/service-worker tests failed (three test suites failed: `mobile.new-folder`, `mobile.sheet`, and `service-worker`), which appear unrelated to these assistant-specific changes.
- Manually verified the assistant UI flow in the app by invoking the assistant tab code paths and confirming the offline fallback path and structured parsing flows are exercised.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a959c8412c83248ca4cb204515c3a4)