### PR TITLE
Fix assistant API compatibility with mobile frontend

### DIFF
--- a/api/assistant.js
+++ b/api/assistant.js
@@ -54,9 +54,14 @@ module.exports = async function handler(req, res) {
   }
 
   const payload = req.body && typeof req.body === 'object' ? req.body : {};
-  const question = typeof payload.question === 'string' ? payload.question.trim() : '';
+  const question =
+    typeof payload.question === 'string'
+      ? payload.question.trim()
+      : typeof payload.message === 'string'
+      ? payload.message.trim()
+      : '';
   const contextText = typeof payload.contextText === 'string' ? payload.contextText : '';
-  const schemaVersion = payload.schemaVersion;
+  const schemaVersion = payload.schemaVersion == null ? 2 : payload.schemaVersion;
   const rawEntries = Array.isArray(payload.entries) ? payload.entries : [];
 
   if (schemaVersion !== 2) {
@@ -159,7 +164,14 @@ module.exports = async function handler(req, res) {
       return res.status(502).json({ error: 'Assistant returned no output.' });
     }
 
-    return res.status(200).json(JSON.parse(outputText));
+    const result = JSON.parse(outputText);
+
+    return res.status(200).json({
+      answer: result.answer,
+      reply: result.answer,
+      cited_entry_ids: Array.isArray(result.cited_entry_ids) ? result.cited_entry_ids : [],
+      followups: Array.isArray(result.followups) ? result.followups : []
+    });
   } catch (_error) {
     return res.status(500).json({ error: 'Assistant failed.' });
   }


### PR DESCRIPTION
### Motivation
- The mobile frontend sends `{ message: "..." }` and expects `{ reply: "..." }`, while `api/assistant.js` required a different payload and response shape, causing the mobile assistant to fail.
- The goal is to make the API backwards compatible so the mobile app can call `/api/assistant` without frontend changes.

### Description
- Parse both request shapes by reading `payload.question` first and falling back to legacy `payload.message`, trimming the string where present.
- Default `schemaVersion` to `2` when omitted to accept legacy requests without breaking current validation.
- Preserve the existing OpenAI call (`model: "gpt-4o-mini"` and the JSON schema output contract) and map the parsed OpenAI output into a response that includes both `answer` and the legacy `reply` plus `cited_entry_ids` and `followups` with safe array fallbacks.
- Preserve existing CORS allowlist and existing JSON error responses so error handling remains consistent.

### Testing
- Ran the test suite with `npm test -- --runInBand`, which executed 23 test suites with 20 passing and 3 failing due to pre-existing unrelated failures in mobile and service-worker tests, and overall showed 73 passed and 4 failed tests.
- The changes are limited to `api/assistant.js` and do not affect the OpenAI integration or other app logic, and automated tests completed (failures are unrelated to this API compatibility change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac1291227c8324ae405fee82923f04)