### PR TITLE
Fix assistant request payload to match API schema

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -89,7 +89,12 @@ initViewportHeight();
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify({ message }),
+          body: JSON.stringify({
+            schemaVersion: 2,
+            question: message,
+            contextText: '',
+            entries: [],
+          }),
         });
 
         if (!response.ok) {


### PR DESCRIPTION
### Motivation
- The mobile assistant UI was sending `{ message }` to `POST /api/assistant` while the backend expects a specific schema containing `schemaVersion`, `question`, `contextText`, and `entries`, causing API errors.  

### Description
- Updated `mobile.js` to send the expected payload by replacing `body: JSON.stringify({ message })` with `body: JSON.stringify({ schemaVersion: 2, question: message, contextText: '', entries: [] })` while keeping the `POST` method, `Content-Type` header, and existing response handling unchanged.  

### Testing
- Verified the change via `git diff -- mobile.js`, inspected the modified lines with `nl -ba mobile.js | sed -n '78,110p'`, and created the commit with `git commit -m "Fix assistant request payload to match API schema"`; these commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac15c155288324b772bf573c6c5c3a)