### PR TITLE
Add AI capture API route for structured brain dumps

### DIFF
--- a/api/capture.js
+++ b/api/capture.js
@@ -1,0 +1,157 @@
+const ALLOWED_ORIGINS = [
+  'https://dmaher42.github.io',
+  'https://memory-cue.vercel.app',
+  'http://localhost:3000',
+  'http://localhost:5173'
+];
+
+const MAX_INPUT_CHARS = 6000;
+
+function applyCors(req, res) {
+  const origin = req.headers.origin;
+  if (origin && ALLOWED_ORIGINS.includes(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Vary', 'Origin');
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  }
+}
+
+module.exports = async function handler(req, res) {
+  applyCors(req, res);
+
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end();
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    return res.status(500).json({ error: 'Server misconfiguration: missing OpenAI API key.' });
+  }
+
+  const payload = req.body && typeof req.body === 'object' ? req.body : {};
+  const schemaVersion = payload.schemaVersion;
+  const input = typeof payload.input === 'string' ? payload.input.trim() : '';
+
+  if (schemaVersion !== 1) {
+    return res.status(400).json({ error: 'Invalid schemaVersion.' });
+  }
+
+  if (!input) {
+    return res.status(400).json({ error: 'Missing input.' });
+  }
+
+  if (input.length > MAX_INPUT_CHARS) {
+    return res.status(400).json({ error: 'input too large.' });
+  }
+
+  let response;
+  try {
+    response = await fetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        store: false,
+        input: [
+          {
+            role: 'system',
+            content: [
+              {
+                type: 'input_text',
+                text: [
+                  'Turn the user\'s free-text input into one structured Memory Cue entry.',
+                  'Keep titles short and useful.',
+                  'Preserve the user\'s meaning.',
+                  'Classify into practical types such as: task, reminder, lesson-idea, lesson-reflection, footy-drill, coaching-note, meeting-note, personal-note, resource.',
+                  'Generate 0 to 5 short lowercase tags.',
+                  'Choose a simple folder name like: Teaching, Coaching, Personal, Admin, Ideas.',
+                  'If uncertain, still return the best structure and lower the confidence score.',
+                  'Never return markdown.',
+                  'Never return extra keys.'
+                ].join(' ')
+              }
+            ]
+          },
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'input_text',
+                text: input
+              }
+            ]
+          }
+        ],
+        text: {
+          format: {
+            type: 'json_schema',
+            name: 'memory_cue_capture_entry',
+            strict: true,
+            schema: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                type: { type: 'string' },
+                title: { type: 'string' },
+                body: { type: 'string' },
+                tags: {
+                  type: 'array',
+                  items: { type: 'string' }
+                },
+                folder: { type: 'string' },
+                confidence: { type: 'number' }
+              },
+              required: ['type', 'title', 'body', 'tags', 'folder', 'confidence']
+            }
+          }
+        }
+      })
+    });
+  } catch (_error) {
+    return res.status(500).json({ error: 'Capture failed.' });
+  }
+
+  if (!response.ok) {
+    return res.status(response.status === 429 ? 429 : 500).json({
+      error: response.status === 429 ? 'Rate limit exceeded.' : 'Capture failed.'
+    });
+  }
+
+  try {
+    const data = await response.json();
+    const outputText =
+      data.output_text ||
+      (data.output &&
+        data.output[0] &&
+        data.output[0].content &&
+        data.output[0].content[0] &&
+        data.output[0].content[0].text) ||
+      null;
+
+    if (!outputText) {
+      return res.status(502).json({ error: 'Capture returned no output.' });
+    }
+
+    const result = JSON.parse(outputText);
+
+    return res.status(200).json({
+      entry: {
+        type: result.type,
+        title: result.title,
+        body: result.body,
+        tags: Array.isArray(result.tags) ? result.tags : [],
+        folder: result.folder,
+        confidence: typeof result.confidence === 'number' ? result.confidence : 0
+      }
+    });
+  } catch (_error) {
+    return res.status(500).json({ error: 'Capture failed.' });
+  }
+};


### PR DESCRIPTION
### Motivation

- Provide a dedicated Vercel API route to convert free-text brain dumps into a single structured Memory Cue entry for later UI integration and automated capture workflows.

### Description

- Add a new route at `api/capture.js` that mirrors the CORS origin list used by `api/assistant.js`, handles `OPTIONS`, and accepts only `POST` requests.
- Validate request payloads enforcing `schemaVersion: 1` and a non-empty `input` (with a max length), and return errors consistently as `{ "error": "..." }`.
- Call the OpenAI Responses API with `model: "gpt-4o-mini"` and `store: false`, providing a system prompt that converts free text into a strict JSON schema requiring `type`, `title`, `body`, `tags`, `folder`, and `confidence` with `additionalProperties: false`.
- Return successful responses exactly as `{ "entry": { type, title, body, tags, folder, confidence } }` and require `process.env.OPENAI_API_KEY` to be set.

### Testing

- Ran `npm test -- --runInBand`; test runner completed with mostly passing suites but some pre-existing unrelated failures occurred in UI/service-worker tests.
- Test summary: `3` failing test suites and `20` passing suites (failures in `js/__tests__/mobile.new-folder.test.js`, `js/__tests__/mobile.sheet.test.js`, and `service-worker.test.js`), which are unrelated to this backend route change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac92f3d844832487e63840d8c25a14)