### PR TITLE
Add AI capture save helper and optional metadata support in notes storage

### DIFF
--- a/js/modules/ai-capture-save.js
+++ b/js/modules/ai-capture-save.js
@@ -1,0 +1,102 @@
+import {
+  createNote,
+  getFolders,
+  loadAllNotes,
+  saveAllNotes,
+  saveFolders,
+} from './notes-storage.js';
+
+const normalizeString = (value) => (typeof value === 'string' ? value.trim() : '');
+
+export const htmlFromPlainText = (text) => {
+  if (typeof text !== 'string' || !text.length) {
+    return '';
+  }
+
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/\r\n|\r|\n/g, '<br>');
+};
+
+export const textFromPlainText = (text) => {
+  if (typeof text !== 'string') {
+    return '';
+  }
+  return text.trim();
+};
+
+export const ensureFolderExistsByName = (folderName) => {
+  const requestedName = normalizeString(folderName);
+  const fallbackId = 'unsorted';
+
+  if (!requestedName) {
+    return fallbackId;
+  }
+
+  const folders = Array.isArray(getFolders()) ? getFolders() : [];
+  const existing = folders.find(
+    (folder) => folder && typeof folder.name === 'string' && folder.name.trim().toLowerCase() === requestedName.toLowerCase(),
+  );
+
+  if (existing && typeof existing.id === 'string' && existing.id.trim()) {
+    return existing.id;
+  }
+
+  const newFolderId = `folder-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  const createdFolder = {
+    id: newFolderId,
+    name: requestedName,
+    order: folders.length,
+  };
+
+  const saved = saveFolders([...folders, createdFolder]);
+  return saved ? newFolderId : fallbackId;
+};
+
+export const saveCapturedEntry = (entry, options = {}) => {
+  if (!entry || typeof entry !== 'object') {
+    throw new Error('Unable to save captured entry: entry must be an object.');
+  }
+
+  const title = normalizeString(entry.title) || 'Untitled note';
+  const plainTextBody = typeof entry.body === 'string' ? entry.body : '';
+  const bodyHtml = htmlFromPlainText(plainTextBody);
+  const bodyText = textFromPlainText(plainTextBody);
+
+  const nowIso = new Date().toISOString();
+  const folderId = ensureFolderExistsByName(entry.folder);
+  const confidenceValue = Number(entry.confidence);
+  const tags = Array.isArray(entry.tags)
+    ? entry.tags
+        .map((tag) => normalizeString(tag))
+        .filter((tag, index, list) => tag.length && list.indexOf(tag) === index)
+    : [];
+
+  const note = createNote(title, bodyHtml, {
+    bodyHtml,
+    bodyText,
+    createdAt: nowIso,
+    updatedAt: nowIso,
+    folderId,
+    metadata: {
+      type: normalizeString(entry.type) || undefined,
+      tags,
+      aiCaptured: true,
+      aiConfidence: Number.isFinite(confidenceValue) ? confidenceValue : undefined,
+    },
+  });
+
+  const existingNotes = loadAllNotes();
+  const shouldSkipRemoteSync = options && options.skipRemoteSync === true;
+  const saved = saveAllNotes([note, ...existingNotes], { skipRemoteSync: shouldSkipRemoteSync });
+
+  if (!saved) {
+    throw new Error('Unable to save captured entry: failed to persist note to storage.');
+  }
+
+  return note;
+};

--- a/js/modules/notes-storage.js
+++ b/js/modules/notes-storage.js
@@ -96,6 +96,43 @@ const isValidDateString = (value) => {
   return !Number.isNaN(time);
 };
 
+const sanitizeTags = (value) => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((tag) => (typeof tag === 'string' ? tag.trim() : ''))
+    .filter((tag, index, list) => tag.length && list.indexOf(tag) === index);
+};
+
+const sanitizeMetadata = (value) => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const metadata = {};
+
+  if (typeof value.type === 'string' && value.type.trim()) {
+    metadata.type = value.type.trim();
+  }
+
+  const tags = sanitizeTags(value.tags);
+  if (tags.length) {
+    metadata.tags = tags;
+  }
+
+  if (value.aiCaptured === true) {
+    metadata.aiCaptured = true;
+  }
+
+  const aiConfidence = Number(value.aiConfidence);
+  if (Number.isFinite(aiConfidence)) {
+    metadata.aiConfidence = aiConfidence;
+  }
+
+  return Object.keys(metadata).length ? metadata : null;
+};
+
 export const createNote = (title, bodyHtml, overrides = {}) => {
   const trimmedTitle = typeof title === 'string' ? title.trim() : '';
   const rawBodyHtml =
@@ -113,12 +150,17 @@ export const createNote = (title, bodyHtml, overrides = {}) => {
     bodyHtml: normalizedBodyHtml,
     bodyText: normalizedBodyText,
     pinned: typeof overrides.pinned === 'boolean' ? overrides.pinned : false,
+    createdAt:
+      overrides.createdAt && isValidDateString(overrides.createdAt)
+        ? overrides.createdAt
+        : new Date().toISOString(),
     updatedAt:
       overrides.updatedAt && isValidDateString(overrides.updatedAt)
         ? overrides.updatedAt
         : new Date().toISOString(),
     folderId: overrides.folderId && typeof overrides.folderId === 'string' ? overrides.folderId : null,
     semanticEmbedding: normalizeSemanticEmbedding(overrides.semanticEmbedding),
+    metadata: sanitizeMetadata(overrides.metadata),
   };
 };
 
@@ -149,12 +191,14 @@ const normalizeNotes = (value) => {
         }
         return createNote(title || 'Untitled note', body, {
           id,
+          createdAt: isValidDateString(note.createdAt) ? note.createdAt : updatedAt,
           updatedAt,
           folderId: typeof note.folderId === 'string' && note.folderId ? note.folderId : null,
           bodyHtml: body,
           bodyText,
           pinned,
           semanticEmbedding: normalizeSemanticEmbedding(note.semanticEmbedding),
+          metadata: sanitizeMetadata(note.metadata),
         });
       })
       .filter(Boolean);
@@ -179,12 +223,14 @@ const normalizeNotes = (value) => {
     return [
       createNote(title, body, {
         id: typeof value.id === 'string' ? value.id : undefined,
+        createdAt: isValidDateString(value.createdAt) ? value.createdAt : undefined,
         updatedAt: typeof value.updatedAt === 'string' ? value.updatedAt : undefined,
         folderId: typeof value.folderId === 'string' ? value.folderId : undefined,
         bodyHtml: body,
         bodyText,
         pinned,
         semanticEmbedding: normalizeSemanticEmbedding(value.semanticEmbedding),
+        metadata: sanitizeMetadata(value.metadata),
       }),
     ];
   }
@@ -268,7 +314,9 @@ export const saveAllNotes = (notes, options = {}) => {
     if (out) {
       out.folderId = typeof note.folderId === 'string' && note.folderId ? note.folderId : out.folderId || null;
       out.pinned = typeof note.pinned === 'boolean' ? note.pinned : Boolean(out.pinned);
+      out.createdAt = isValidDateString(note.createdAt) ? note.createdAt : out.createdAt;
       out.semanticEmbedding = normalizeSemanticEmbedding(note.semanticEmbedding);
+      out.metadata = sanitizeMetadata(note.metadata);
     }
     return out;
   }).filter(Boolean);


### PR DESCRIPTION
### Motivation
- Enable saving structured AI-captured entries as normal Memory Cue notes while preserving backward compatibility with existing notes and UI.
- Provide a small, reusable helper that creates folders as needed and stores AI metadata safely without refactoring the existing notes system.

### Description
- Add new module `js/modules/ai-capture-save.js` exporting `saveCapturedEntry(entry, options = {})` and helpers `ensureFolderExistsByName`, `htmlFromPlainText`, and `textFromPlainText`; the function converts a capture payload into a normal note, attaches sanitized metadata, ensures or creates the requested folder (falls back to `unsorted`), persists the note via existing storage helpers, and returns the saved note or throws on failure.
- Extend `js/modules/notes-storage.js` with `sanitizeTags` and `sanitizeMetadata`, and wire optional `createdAt` and `metadata` through `createNote`, `normalizeNotes`, and `saveAllNotes` so metadata fields (`type`, `tags`, `aiCaptured`, `aiConfidence`) are stored safely and non-breaking for older consumers.
- Keep existing note schema and rendering untouched by placing AI-specific fields inside a non-required `metadata` object and by preserving legacy normalization behavior.

### Testing
- Ran `npm test -- --runInBand js/tests/notes-storage.folders.test.js`, which passed all tests (2 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acb14b5bfc8324b4765172c81229ed)