### PR TITLE
Refresh notebook immediately after AI capture save

### DIFF
--- a/js/modules/ai-capture-save.js
+++ b/js/modules/ai-capture-save.js
@@ -98,5 +98,13 @@ export const saveCapturedEntry = (entry, options = {}) => {
     throw new Error('Unable to save captured entry: failed to persist note to storage.');
   }
 
+  try {
+    if (typeof document !== 'undefined' && typeof CustomEvent === 'function') {
+      document.dispatchEvent(new CustomEvent('memoryCue:notesUpdated', { detail: { note } }));
+    }
+  } catch (error) {
+    console.error('Unable to dispatch notes update event after AI capture save.', error);
+  }
+
   return note;
 };


### PR DESCRIPTION
### Motivation
- Ensure a note created via AI capture appears in the notebook immediately after `saveCapturedEntry(...)` completes so the user does not need to refresh the UI.

### Description
- After successful save in `saveCapturedEntry` (file `js/modules/ai-capture-save.js`), dispatch `memoryCue:notesUpdated` with the saved note in the event `detail` so existing listeners can react.
- Reuses the existing notebook refresh listener in `mobile.js` which handles `memoryCue:notesUpdated` and calls `refreshFromStorage({ preserveDraft: true })`, preserving editor/draft state and avoiding duplicate writes.

### Testing
- Ran `npm test -- --runInBand`; test run completed but there are pre-existing unrelated failures in `js/__tests__/mobile.new-folder.test.js`, `js/__tests__/mobile.sheet.test.js`, and `service-worker.test.js`, and no new failures attributable to the `ai-capture-save` change were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acb55edeb08324b0329bafc9065939)