### PR TITLE
Enhance AI capture with priority, actionDate, and follow-up intelligence

### DIFF
--- a/api/capture.js
+++ b/api/capture.js
@@ -72,6 +72,10 @@ module.exports = async function handler(req, res) {
                   'Classify into practical types such as: task, reminder, lesson-idea, lesson-reflection, footy-drill, coaching-note, meeting-note, personal-note, resource.',
                   'Generate 0 to 5 short lowercase tags.',
                   'Choose a simple folder name like: Teaching, Coaching, Personal, Admin, Ideas.',
+                  'Set priority as low, medium, or high based on urgency/importance.',
+                  'Set actionDate to null unless the user clearly implies timing; if implied, return a short ISO-like string the app can store (for example: tomorrow morning, monday, before training, next lesson).',
+                  'Set followUpQuestion to an empty string unless one short clarifying question would materially improve the entry later.',
+                  'Lean into teacher/coach workflows by correctly routing school/lesson notes to Teaching and training/footy notes to Coaching when appropriate.',
                   'If uncertain, still return the best structure and lower the confidence score.',
                   'Never return markdown.',
                   'Never return extra keys.'
@@ -106,9 +110,27 @@ module.exports = async function handler(req, res) {
                   items: { type: 'string' }
                 },
                 folder: { type: 'string' },
+                priority: {
+                  type: 'string',
+                  enum: ['low', 'medium', 'high']
+                },
+                actionDate: {
+                  type: ['string', 'null']
+                },
+                followUpQuestion: { type: 'string' },
                 confidence: { type: 'number' }
               },
-              required: ['type', 'title', 'body', 'tags', 'folder', 'confidence']
+              required: [
+                'type',
+                'title',
+                'body',
+                'tags',
+                'folder',
+                'priority',
+                'actionDate',
+                'followUpQuestion',
+                'confidence'
+              ]
             }
           }
         }
@@ -148,6 +170,13 @@ module.exports = async function handler(req, res) {
         body: result.body,
         tags: Array.isArray(result.tags) ? result.tags : [],
         folder: result.folder,
+        priority:
+          result.priority === 'high' || result.priority === 'medium' || result.priority === 'low'
+            ? result.priority
+            : 'low',
+        actionDate: typeof result.actionDate === 'string' ? result.actionDate : null,
+        followUpQuestion:
+          typeof result.followUpQuestion === 'string' ? result.followUpQuestion : '',
         confidence: typeof result.confidence === 'number' ? result.confidence : 0
       }
     });


### PR DESCRIPTION
### Motivation
- Improve the AI capture endpoint so it extracts teacher/coach-focused intent from a brain-dump and returns richer, actionable metadata for workflows like teaching and coaching.
- Keep the original request shape and Prompt 1 behavior intact while enabling the frontend to receive additional fields it can opt into using over time.

### Description
- Updated the system prompt in `api/capture.js` to ask the model to infer `priority`, `actionDate`, and `followUpQuestion`, and to route school/training notes toward `Teaching`/`Coaching` folders where appropriate.
- Extended the OpenAI JSON schema (strict `json_schema` output) to include new required properties `priority` (enum: `low|medium|high`), `actionDate` (`string|null`), and `followUpQuestion` (`string`).
- Returned all new fields inside the response `entry` while preserving the existing response shape, and added safe fallbacks: `priority` defaults to `low`, `actionDate` defaults to `null`, and `followUpQuestion` defaults to `""`.
- Maintained existing keys (`type`, `title`, `body`, `tags`, `folder`, `confidence`) and ensured backward compatibility with current frontend consumers.

### Testing
- Ran `npm test -- --runInBand` as the automated test run.
- Result: test run showed most suites passing but 2 test suites failed (`js/__tests__/mobile.new-folder.test.js` and `service-worker.test.js`), with 3 failing tests in total; these failures are unrelated to the `api/capture.js` changes and are preexisting in the test environment.
- The new schema and response mapping are confined to `api/capture.js` and do not change the HTTP request shape consumed by the frontend.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acb63aae9c832499afca9a1478c3d7)