### PR TITLE
Store richer AI capture metadata in saved notes

### DIFF
--- a/js/modules/ai-capture-save.js
+++ b/js/modules/ai-capture-save.js
@@ -7,6 +7,32 @@ import {
 } from './notes-storage.js';
 
 const normalizeString = (value) => (typeof value === 'string' ? value.trim() : '');
+const normalizeOptionalString = (value) => {
+  const normalized = normalizeString(value);
+  return normalized || undefined;
+};
+
+const buildMetadataFooter = ({ tags = [], type, aiPriority, aiActionDate, aiFollowUpQuestion }) => {
+  const lines = [];
+
+  if (tags.length) {
+    lines.push(`Tags: ${tags.join(', ')}`);
+  }
+  if (type) {
+    lines.push(`Type: ${type}`);
+  }
+  if (aiPriority) {
+    lines.push(`Priority: ${aiPriority}`);
+  }
+  if (aiActionDate) {
+    lines.push(`Action Date: ${aiActionDate}`);
+  }
+  if (aiFollowUpQuestion) {
+    lines.push(`Follow Up: ${aiFollowUpQuestion}`);
+  }
+
+  return lines.length ? lines.join('\n') : '';
+};
 
 export const htmlFromPlainText = (text) => {
   if (typeof text !== 'string' || !text.length) {
@@ -63,18 +89,33 @@ export const saveCapturedEntry = (entry, options = {}) => {
   }
 
   const title = normalizeString(entry.title) || 'Untitled note';
-  const plainTextBody = typeof entry.body === 'string' ? entry.body : '';
-  const bodyHtml = htmlFromPlainText(plainTextBody);
-  const bodyText = textFromPlainText(plainTextBody);
+  const basePlainTextBody = typeof entry.body === 'string' ? entry.body : '';
 
   const nowIso = new Date().toISOString();
   const folderId = ensureFolderExistsByName(entry.folder);
-  const confidenceValue = Number(entry.confidence);
+  const confidenceRaw = entry.aiConfidence ?? entry.confidence;
+  const confidenceValue = Number(confidenceRaw);
   const tags = Array.isArray(entry.tags)
     ? entry.tags
         .map((tag) => normalizeString(tag))
         .filter((tag, index, list) => tag.length && list.indexOf(tag) === index)
     : [];
+  const type = normalizeOptionalString(entry.type);
+  const aiPriority = normalizeOptionalString(entry.aiPriority);
+  const aiActionDate = normalizeOptionalString(entry.aiActionDate);
+  const aiFollowUpQuestion = normalizeOptionalString(entry.aiFollowUpQuestion);
+  const metadataFooter = buildMetadataFooter({
+    tags,
+    type,
+    aiPriority,
+    aiActionDate,
+    aiFollowUpQuestion,
+  });
+  const plainTextBody = metadataFooter
+    ? `${basePlainTextBody.trimEnd()}${basePlainTextBody.trimEnd() ? '\n\n' : ''}${metadataFooter}`
+    : basePlainTextBody;
+  const bodyHtml = htmlFromPlainText(plainTextBody);
+  const bodyText = textFromPlainText(plainTextBody);
 
   const note = createNote(title, bodyHtml, {
     bodyHtml,
@@ -83,10 +124,13 @@ export const saveCapturedEntry = (entry, options = {}) => {
     updatedAt: nowIso,
     folderId,
     metadata: {
-      type: normalizeString(entry.type) || undefined,
+      type,
       tags,
       aiCaptured: true,
       aiConfidence: Number.isFinite(confidenceValue) ? confidenceValue : undefined,
+      aiPriority,
+      aiActionDate,
+      aiFollowUpQuestion,
     },
   });
 

--- a/js/modules/notes-storage.js
+++ b/js/modules/notes-storage.js
@@ -130,6 +130,18 @@ const sanitizeMetadata = (value) => {
     metadata.aiConfidence = aiConfidence;
   }
 
+  if (typeof value.aiPriority === 'string' && value.aiPriority.trim()) {
+    metadata.aiPriority = value.aiPriority.trim();
+  }
+
+  if (typeof value.aiActionDate === 'string' && value.aiActionDate.trim()) {
+    metadata.aiActionDate = value.aiActionDate.trim();
+  }
+
+  if (typeof value.aiFollowUpQuestion === 'string' && value.aiFollowUpQuestion.trim()) {
+    metadata.aiFollowUpQuestion = value.aiFollowUpQuestion.trim();
+  }
+
   return Object.keys(metadata).length ? metadata : null;
 };
 


### PR DESCRIPTION
### Motivation
- Enable saving optional AI capture fields on notes so downstream features can access `type`, `tags`, `aiCaptured`, `aiConfidence`, `aiPriority`, `aiActionDate`, and `aiFollowUpQuestion` without changing existing UI or title behavior.
- Provide a subtle plain-text footer in note bodies when helpful to improve future AI retrieval while keeping notes editable and readable.

### Description
- Added `normalizeOptionalString` and `buildMetadataFooter` helpers to `js/modules/ai-capture-save.js` to normalize optional fields and build a compact, readable footer only when metadata is present.
- Adjusted `saveCapturedEntry` to prefer `aiConfidence` but fall back to `confidence`, to preserve existing behavior while exposing the richer AI fields; appended the compact footer into `bodyHtml`/`bodyText` only when relevant and kept the note `title` unchanged.
- Extended the `metadata` passed to `createNote` so new fields (`aiPriority`, `aiActionDate`, `aiFollowUpQuestion`) are included alongside existing `type`, `tags`, `aiCaptured`, and `aiConfidence`.
- Updated `js/modules/notes-storage.js` `sanitizeMetadata` to persist the new AI metadata fields through load/save normalization and serialization.

### Testing
- Ran the test suite with `npm test -- --runInBand`.
- Most test suites passed; failures are unrelated pre-existing issues in `js/__tests__/mobile.new-folder.test.js` and `service-worker.test.js` and did not appear to be caused by these changes.
- No new test failures were introduced by the metadata changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acb72c8ec08324ac7c148f138b0543)