### PR TITLE
Send recent saved notes as context for assistant answers

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -73,6 +73,73 @@ initViewportHeight();
       assistantThread.scrollTop = assistantThread.scrollHeight;
     };
 
+    const toAssistantEntryText = (value, maxChars = 1000) => {
+      if (typeof value !== 'string') {
+        return '';
+      }
+      return value.trim().slice(0, maxChars);
+    };
+
+    const buildAssistantEntries = (question) => {
+      const notes = Array.isArray(loadAllNotes()) ? loadAllNotes() : [];
+      if (!notes.length) {
+        return [];
+      }
+
+      const keywords = Array.from(
+        new Set(
+          String(question || '')
+            .toLowerCase()
+            .split(/[^a-z0-9]+/)
+            .map((token) => token.trim())
+            .filter((token) => token.length >= 3),
+        ),
+      );
+
+      const sortedByRecent = [...notes].sort((a, b) => {
+        const aTime = Date.parse(a?.createdAt || '') || 0;
+        const bTime = Date.parse(b?.createdAt || '') || 0;
+        return bTime - aTime;
+      });
+
+      const recentWindow = sortedByRecent.slice(0, 60);
+      const matchesQuestion = (note) => {
+        if (!keywords.length) {
+          return false;
+        }
+        const haystack = `${note?.title || ''} ${note?.bodyText || ''} ${note?.body || ''}`.toLowerCase();
+        return keywords.some((token) => haystack.includes(token));
+      };
+
+      const matchingNotes = recentWindow.filter(matchesQuestion);
+      const fallbackRecent = recentWindow.filter((note) => !matchesQuestion(note));
+      const selected = [...matchingNotes, ...fallbackRecent].slice(0, 20);
+
+      return selected
+        .map((note) => {
+          const bodyText = toAssistantEntryText(note?.bodyText, 1000);
+          const body = toAssistantEntryText(bodyText || note?.body, 1000);
+          const title = toAssistantEntryText(note?.title, 300);
+
+          if (!title && !body) {
+            return null;
+          }
+
+          return {
+            id: typeof note?.id === 'string' ? note.id : '',
+            type: typeof note?.type === 'string'
+              ? note.type
+              : typeof note?.metadata?.type === 'string'
+                ? note.metadata.type
+                : 'note',
+            title,
+            body,
+            createdAt: typeof note?.createdAt === 'string' ? note.createdAt : null,
+          };
+        })
+        .filter(Boolean);
+    };
+
     const saveCapturedEntryAsNote = async (entry) => {
       const aiCaptureSave = await aiCaptureSaveModulePromise;
       const saveCaptureFn =
@@ -210,6 +277,7 @@ initViewportHeight();
             );
           }
         } else {
+          const entries = buildAssistantEntries(trimmedMessage);
           const response = await fetch('/api/assistant', {
             method: 'POST',
             headers: {
@@ -219,7 +287,7 @@ initViewportHeight();
               schemaVersion: 2,
               question: trimmedMessage,
               contextText: '',
-              entries: [],
+              entries,
             }),
           });
 


### PR DESCRIPTION
### Motivation
- Improve assistant responses by automatically supplying recent, relevant saved notes as context for normal (non-capture) chat messages. 
- Keep the existing assistant contract and capture-mode behaviour unchanged while staying within backend size limits. 

### Description
- Added `buildAssistantEntries(question)` and `toAssistantEntryText()` in `mobile.js` to load notes from the existing storage (`loadAllNotes`) and produce a bounded `entries` array. 
- Selection picks the most recent notes (sorted by `createdAt`), prefers notes with keywords from the question, and caps the final list at 20 entries. 
- Each entry includes only `id`, `type`, `title`, `body`, and `createdAt`, with per-field truncation to avoid oversized payloads and to respect backend limits. 
- Normal assistant POST to `/api/assistant` now sends the generated `entries`; capture-mode (`+` prefix) flow is left intact. 

### Testing
- Ran the full test suite with `npm test -- --runInBand`. 
- Most test suites passed, but the overall run failed due to unrelated existing test failures in `js/__tests__/mobile.new-folder.test.js` and `service-worker.test.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad612f701c832494528ee1f7b760eb)