### PR TITLE
Add dashboard data engine

### DIFF
--- a/js/modules/dashboard-data.js
+++ b/js/modules/dashboard-data.js
@@ -1,0 +1,61 @@
+import { buildActivityIndex, getRecentActivity } from './activity-index.js';
+import {
+  getCoachingItems,
+  getTeachingItems,
+  getThisWeekActions,
+  getTodayActions,
+} from './action-planner.js';
+
+const INBOX_FOLDER_NAME = 'inbox';
+
+const normalizePriority = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim().toLowerCase();
+  return trimmed.length ? trimmed : null;
+};
+
+const toDashboardItem = (item, activityById) => {
+  const activityEntry = item?.id ? activityById.get(item.id) : null;
+
+  return {
+    id: typeof item?.id === 'string' ? item.id : '',
+    title: typeof item?.title === 'string' && item.title.trim() ? item.title.trim() : 'Untitled note',
+    type:
+      (typeof item?.type === 'string' && item.type.trim()) ||
+      (typeof activityEntry?.type === 'string' && activityEntry.type.trim()) ||
+      'note',
+    folder:
+      (typeof item?.folder === 'string' && item.folder.trim()) ||
+      (typeof activityEntry?.folder === 'string' && activityEntry.folder.trim()) ||
+      'Unsorted',
+    priority: normalizePriority(item?.priority ?? activityEntry?.aiPriority),
+    createdAt: activityEntry?.createdAt ?? 0,
+  };
+};
+
+const mapActionItems = (items, activityById) => items.map((item) => toDashboardItem(item, activityById));
+
+const buildInboxItems = (activityEntries, activityById) => {
+  return mapActionItems(
+    activityEntries.filter(
+      (entry) => typeof entry.folder === 'string' && entry.folder.trim().toLowerCase() === INBOX_FOLDER_NAME,
+    ),
+    activityById,
+  );
+};
+
+export const buildDashboardData = () => {
+  const activityEntries = buildActivityIndex();
+  const activityById = new Map(activityEntries.map((entry) => [entry.id, entry]));
+
+  return {
+    today: mapActionItems(getTodayActions(), activityById),
+    thisWeek: mapActionItems(getThisWeekActions(), activityById),
+    coaching: mapActionItems(getCoachingItems(), activityById),
+    teaching: mapActionItems(getTeachingItems(), activityById),
+    recent: mapActionItems(getRecentActivity(10), activityById),
+    inbox: buildInboxItems(activityEntries, activityById),
+  };
+};


### PR DESCRIPTION
### Motivation
- Provide a single, fast dashboard data provider that aggregates useful sections from the activity index and action planner into one canonical shape for the UI.

### Description
- Added a new module `js/modules/dashboard-data.js` exporting `buildDashboardData()` which returns `{ today, thisWeek, coaching, teaching, recent, inbox }`.
- The module reuses `buildActivityIndex()` and `getRecentActivity(10)` plus `getTodayActions()`, `getThisWeekActions()`, `getCoachingItems()`, and `getTeachingItems()` from the action planner to populate the sections.
- Each returned item is normalized to include `id`, `title`, `type`, `folder`, `priority`, and `createdAt` with safe fallbacks, and `inbox` is derived by filtering activity index entries whose folder name is `Inbox` (case-insensitive).
- Implementation uses a lookup `Map` for the activity index to keep transformations fast and avoid mutating notes.

### Testing
- Ran the test suite with `npm test -- --runInBand` which produced: `Test Suites: 2 failed, 21 passed, 23 total` and `Tests: 3 failed, 74 passed, 77 total`.
- The failing tests were `js/__tests__/mobile.new-folder.test.js` and `service-worker.test.js`, and failures appear to be pre-existing and unrelated to the new `dashboard-data` module.
- The new module file `js/modules/dashboard-data.js` was lint-compatible with the project files and did not introduce runtime test errors specific to its functionality.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad6553745c83249d64c3fad19deec0)