### PR TITLE
Add dashboard panel to mobile interface

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5194,6 +5194,7 @@ body, main, section, div, p, span, li {
     <section data-view="reminders" id="view-reminders" class="view-panel">
       <div class="reminders-mobile-flow reminders-content-shell">
         <div id="inboxSearchResults"></div>
+        <div id="dashboardPanel"></div>
 
         <section id="remindersListMobile">
           <section

--- a/mobile.js
+++ b/mobile.js
@@ -1334,6 +1334,127 @@ const initMobileNotes = () => {
     return extractPlainText(source);
   };
 
+  const getDashboardItemLabel = (note) => {
+    const title = typeof note?.title === 'string' ? note.title.trim() : '';
+    if (title) {
+      return title;
+    }
+    const body = getNoteBodyText(note).trim();
+    return body || 'Untitled note';
+  };
+
+  const getDashboardSectionItems = (notes, matcher, maxItems = 3) => {
+    if (!Array.isArray(notes)) {
+      return [];
+    }
+    const items = notes.filter((note) => matcher(note));
+    return items.slice(0, maxItems);
+  };
+
+  const buildDashboardData = () => {
+    const sourceNotes = sortNotesForDisplay(allNotes || []);
+    const now = new Date();
+    const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+    const startOfWeek = startOfToday - (now.getDay() * 24 * 60 * 60 * 1000);
+
+    const hasKeyword = (note, keywords = []) => {
+      const haystack = `${note?.title || ''} ${getNoteBodyText(note)}`.toLowerCase();
+      return keywords.some((keyword) => haystack.includes(keyword));
+    };
+
+    return [
+      {
+        title: 'Today',
+        items: getDashboardSectionItems(sourceNotes, (note) => getNoteTimestamp(note) >= startOfToday),
+      },
+      {
+        title: 'This Week',
+        items: getDashboardSectionItems(sourceNotes, (note) => getNoteTimestamp(note) >= startOfWeek),
+      },
+      {
+        title: 'Coaching',
+        items: getDashboardSectionItems(sourceNotes, (note) => hasKeyword(note, ['coaching', 'drill', 'training'])),
+      },
+      {
+        title: 'Teaching',
+        items: getDashboardSectionItems(sourceNotes, (note) => hasKeyword(note, ['teaching', 'lesson', 'class', 'worksheet'])),
+      },
+      {
+        title: 'Recent',
+        items: sourceNotes.slice(0, 3),
+      },
+      {
+        title: 'Inbox',
+        items: getDashboardSectionItems(sourceNotes, (note) => normalizeFolderId(note?.folderId) === 'inbox'),
+      },
+    ];
+  };
+
+  const openNoteFromDashboard = (noteId) => {
+    if (!noteId) {
+      return;
+    }
+    const note = allNotes.find((item) => item?.id === noteId);
+    if (!note) {
+      return;
+    }
+
+    setEditorValues(note);
+    updateListSelection();
+    if (isSavedNotesSheetOpen()) {
+      hideSavedNotesSheet();
+    }
+
+    document.dispatchEvent(new CustomEvent('app:navigate', { detail: { view: 'notebook' } }));
+  };
+
+  const renderDashboardPanel = () => {
+    const dashboardPanel = document.getElementById('dashboardPanel');
+    if (!(dashboardPanel instanceof HTMLElement)) {
+      return;
+    }
+
+    const sections = buildDashboardData();
+    dashboardPanel.innerHTML = '';
+
+    sections.forEach((section) => {
+      const sectionEl = document.createElement('section');
+      sectionEl.className = 'memory-glass-card-soft p-3 mb-2';
+
+      const titleEl = document.createElement('h3');
+      titleEl.className = 'text-sm font-semibold mb-1';
+      titleEl.textContent = section.title;
+      sectionEl.appendChild(titleEl);
+
+      const listEl = document.createElement('ul');
+      listEl.className = 'space-y-1';
+
+      if (!Array.isArray(section.items) || section.items.length === 0) {
+        const emptyEl = document.createElement('li');
+        emptyEl.className = 'text-xs text-base-content/60';
+        emptyEl.textContent = 'No notes yet';
+        listEl.appendChild(emptyEl);
+      } else {
+        section.items.forEach((note) => {
+          const itemEl = document.createElement('li');
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.className = 'text-left w-full text-sm';
+          button.dataset.noteId = note.id;
+          button.textContent = `• ${getDashboardItemLabel(note)}`;
+          button.addEventListener('click', () => {
+            openNoteFromDashboard(note.id);
+          });
+          itemEl.appendChild(button);
+          listEl.appendChild(itemEl);
+        });
+      }
+
+      sectionEl.appendChild(listEl);
+      dashboardPanel.appendChild(sectionEl);
+    });
+  };
+
   const updateListSelection = () => {
     if (!listElement) {
       return;
@@ -1463,6 +1584,7 @@ const initMobileNotes = () => {
     const visibleNotes = getVisibleNotes();
 
     renderNotesList(visibleNotes);
+    renderDashboardPanel();
 
     if (!hasAnyNotes) {
       if (!shouldPreserveEditor) {
@@ -3138,6 +3260,7 @@ const initMobileNotes = () => {
   updateToolbarState();
   applyInitialSelection();
   buildFolderFilterSelect();
+  renderDashboardPanel();
 
   if (typeof window !== 'undefined') {
     window.addEventListener('storage', (event) => {


### PR DESCRIPTION
### Motivation
- Provide a small, focused mobile dashboard that surfaces the most useful notes without redesigning the UI.
- Surface six lightweight sections (`Today`, `This Week`, `Coaching`, `Teaching`, `Recent`, `Inbox`) so users can quickly open recent or relevant notes.
- Keep UI minimal and reuse existing styling and navigation patterns so the assistant and notebook flows are not disrupted.

### Description
- Add a dashboard mount point `<div id="dashboardPanel"></div>` into the reminders mobile flow in `mobile.html` under `#inboxSearchResults`.
- Implement `buildDashboardData()` and helper functions (`getDashboardItemLabel`, `getDashboardSectionItems`) in `mobile.js` to pick notes for each section using existing note utilities (timestamps, folder IDs, plain text extraction, and keyword matching).
- Implement `renderDashboardPanel()` to render each section as a simple bullet list using existing CSS utility classes and wire each item to `openNoteFromDashboard()` which opens the note via `setEditorValues()` and navigates to the notebook view.
- Wire dashboard rendering into the notes lifecycle by calling `renderDashboardPanel()` after `renderNotesList()` and during initial setup so the panel updates when notes are loaded or storage changes.

### Testing
- Ran the existing test suite with `npm test -- --runInBand`, which completed with `21` passing suites and `2` failing suites; failing tests are existing, unrelated assertions in `js/__tests__/mobile.new-folder.test.js` and `service-worker.test.js` and are not caused by the dashboard changes.
- Manually launched the dev server and captured a mobile screenshot of the dashboard using Playwright to validate the UI rendering (artifact: `artifacts/dashboard-mobile.png`).
- Verified that dashboard items are clickable and open the notebook editor in the running app during manual validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad6643e36483248f6b9a95c6855d4b)