### PR TITLE
Provide dashboard context to assistant queries

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -140,6 +140,81 @@ initViewportHeight();
         .filter(Boolean);
     };
 
+    const buildAssistantContextText = () => {
+      const maxContextItems = 15;
+      const notes = Array.isArray(loadAllNotes()) ? loadAllNotes() : [];
+      const now = new Date();
+      const today = new Date(now);
+      today.setHours(0, 0, 0, 0);
+      const thisWeekEnd = new Date(today);
+      thisWeekEnd.setDate(thisWeekEnd.getDate() + 7);
+
+      const toTimestamp = (value) => {
+        if (typeof value !== 'string') {
+          return 0;
+        }
+        const parsed = Date.parse(value);
+        return Number.isNaN(parsed) ? 0 : parsed;
+      };
+
+      const normalizeTitle = (value) => (typeof value === 'string' ? value.trim() : '');
+      const parseActionDate = (value) => {
+        const timestamp = toTimestamp(value);
+        if (!timestamp) {
+          return null;
+        }
+        const date = new Date(timestamp);
+        if (Number.isNaN(date.getTime())) {
+          return null;
+        }
+        date.setHours(0, 0, 0, 0);
+        return date;
+      };
+
+      const noteRows = notes
+        .map((note) => {
+          const metadata = note && typeof note.metadata === 'object' && note.metadata ? note.metadata : {};
+          return {
+            title: normalizeTitle(note?.title),
+            updatedAt: toTimestamp(note?.updatedAt) || toTimestamp(note?.createdAt),
+            actionDate: parseActionDate(metadata.aiActionDate),
+          };
+        })
+        .filter((entry) => entry.title);
+
+      const todayTitles = noteRows
+        .filter((entry) => entry.actionDate && entry.actionDate.getTime() === today.getTime())
+        .map((entry) => entry.title);
+
+      const thisWeekTitles = noteRows
+        .filter((entry) => entry.actionDate && entry.actionDate >= today && entry.actionDate <= thisWeekEnd)
+        .map((entry) => entry.title);
+
+      const recentNoteTitles = [...noteRows]
+        .sort((a, b) => b.updatedAt - a.updatedAt)
+        .slice(0, maxContextItems)
+        .map((entry) => entry.title);
+
+      const takeWithinLimit = (items, usedCount) => items.slice(0, Math.max(0, maxContextItems - usedCount));
+
+      const selectedToday = takeWithinLimit(todayTitles, 0);
+      const selectedWeek = takeWithinLimit(thisWeekTitles, selectedToday.length);
+      const selectedRecent = takeWithinLimit(recentNoteTitles, selectedToday.length + selectedWeek.length);
+
+      const toListText = (items) => (items.length ? items.map((title) => `- ${title}`).join('\n') : '- None');
+
+      return [
+        'Today actions:',
+        toListText(selectedToday),
+        '',
+        'This week actions:',
+        toListText(selectedWeek),
+        '',
+        'Recent notes:',
+        toListText(selectedRecent),
+      ].join('\n');
+    };
+
     const saveCapturedEntryAsNote = async (entry) => {
       const aiCaptureSave = await aiCaptureSaveModulePromise;
       const saveCaptureFn =
@@ -278,6 +353,7 @@ initViewportHeight();
           }
         } else {
           const entries = buildAssistantEntries(trimmedMessage);
+          const contextText = buildAssistantContextText();
           const response = await fetch('/api/assistant', {
             method: 'POST',
             headers: {
@@ -286,7 +362,7 @@ initViewportHeight();
             body: JSON.stringify({
               schemaVersion: 2,
               question: trimmedMessage,
-              contextText: '',
+              contextText,
               entries,
             }),
           });


### PR DESCRIPTION
### Motivation
- Enable the assistant to reason about recent dashboard activity so users can ask planning questions like “What do I need to do today?” or “What drills have I saved?”.
- Keep the assistant payload small and avoid sending full note bodies to protect size and privacy. 
- Preserve the existing backend API schema while adding richer context to assistant requests.

### Description
- Added `buildAssistantContextText()` to `mobile.js` which gathers note titles and `metadata.aiActionDate` from `loadAllNotes()` and composes a compact `contextText` with `Today actions:`, `This week actions:`, and `Recent notes:` sections. 
- The helper prioritizes today and week action titles, uses titles only (no bodies), and enforces a maximum of 15 listed items across sections to limit payload size. 
- The `/api/assistant` POST payload was updated to include the generated `contextText` while keeping `schemaVersion`, `question`, and `entries` unchanged. 
- Changes are confined to `mobile.js` and follow existing note-loading utilities rather than introducing new backend schema or dependencies.

### Testing
- Ran targeted mobile tests with `npx jest js/__tests__/mobile.auth.test.js js/__tests__/mobile.open-sheet.test.js js/__tests__/mobile.sheet.test.js --runInBand` and they passed. 
- Ran full test suite with `npm test -- --runInBand` and observed pre-existing unrelated failures (not introduced by this change) in `mobile.new-folder` and `service-worker` suites. 
- Verified the new `contextText` is produced and attached to `/api/assistant` requests in `mobile.js` during the assistant flow via unit test runs and local validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad6772eb248324b00a8bf5130e5f1e)