### PR TITLE
Enable semantic recall for assistant queries

### DIFF
--- a/api/assistant.js
+++ b/api/assistant.js
@@ -30,12 +30,18 @@ function trimEntry(entry) {
   const title = typeof entry.title === 'string' ? entry.title.slice(0, MAX_ENTRY_CHARS) : '';
   const body = typeof entry.body === 'string' ? entry.body.slice(0, MAX_ENTRY_CHARS) : '';
   const createdAt = typeof entry.createdAt === 'string' ? entry.createdAt.slice(0, 64) : null;
+  const tags = Array.isArray(entry.tags)
+    ? entry.tags
+        .map((tag) => (typeof tag === 'string' ? tag.slice(0, 64) : ''))
+        .filter((tag, index, list) => tag && list.indexOf(tag) === index)
+        .slice(0, 20)
+    : [];
 
   if (!title && !body) {
     return null;
   }
 
-  return { id, type, title, body, createdAt };
+  return { id, type, title, body, tags, createdAt };
 }
 
 module.exports = async function handler(req, res) {

--- a/js/modules/activity-index.js
+++ b/js/modules/activity-index.js
@@ -2,6 +2,17 @@ import { getFolderNameById, loadAllNotes } from './notes-storage.js';
 
 const MAX_SEARCH_RESULTS = 20;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const WEEKDAY_NAMES = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+const TOKEN_SYNONYMS = Object.freeze({
+  footy: ['football'],
+  football: ['footy'],
+  drill: ['drills', 'practice', 'training'],
+  drills: ['drill', 'practice', 'training'],
+  reflection: ['reflections', 'reflect'],
+  reflections: ['reflection', 'reflect'],
+  reminder: ['reminders'],
+  reminders: ['reminder'],
+});
 
 let cachedIndex = null;
 let hasBoundNotesUpdatedListener = false;
@@ -53,6 +64,23 @@ const buildIndexEntry = (note) => {
 
 const sortByRecency = (a, b) => b.updatedAt - a.updatedAt;
 
+const tokenizeQuery = (query) => {
+  const rawTokens = normalizeString(query)
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+
+  const expanded = new Set(rawTokens);
+  rawTokens.forEach((token) => {
+    const synonyms = TOKEN_SYNONYMS[token] || [];
+    synonyms.forEach((synonym) => expanded.add(synonym));
+  });
+
+  return Array.from(expanded);
+};
+
+const getWeekdayFromQuery = (queryTokens) => queryTokens.find((token) => WEEKDAY_NAMES.includes(token)) || null;
+
 const ensureNotesUpdatedListener = () => {
   if (hasBoundNotesUpdatedListener || typeof document === 'undefined') {
     return;
@@ -65,7 +93,7 @@ const ensureNotesUpdatedListener = () => {
   hasBoundNotesUpdatedListener = true;
 };
 
-const scoreEntryForQuery = (entry, queryTokens) => {
+const scoreEntryForQuery = (entry, normalizedQuery, queryTokens, weekdayToken) => {
   const titleLower = entry.title.toLowerCase();
   const bodyLower = entry.body.toLowerCase();
   const typeLower = entry.type.toLowerCase();
@@ -74,6 +102,11 @@ const scoreEntryForQuery = (entry, queryTokens) => {
   let score = 0;
   let matched = false;
 
+  if (normalizedQuery.length > 2 && titleLower.includes(normalizedQuery)) {
+    score += 18;
+    matched = true;
+  }
+
   queryTokens.forEach((token) => {
     const inTitle = titleLower.includes(token);
     const inTags = tagsLower.some((tag) => tag.includes(token));
@@ -81,11 +114,11 @@ const scoreEntryForQuery = (entry, queryTokens) => {
     const inBody = bodyLower.includes(token);
 
     if (inTitle) {
-      score += 10;
+      score += 12;
       matched = true;
     }
     if (inTags) {
-      score += 7;
+      score += 10;
       matched = true;
     }
     if (inType) {
@@ -93,13 +126,21 @@ const scoreEntryForQuery = (entry, queryTokens) => {
       matched = true;
     }
     if (inBody) {
-      score += 3;
+      score += 2;
       matched = true;
     }
   });
 
+  if (weekdayToken && Number.isFinite(entry.createdAt) && entry.createdAt > 0) {
+    const entryWeekday = WEEKDAY_NAMES[new Date(entry.createdAt).getDay()];
+    if (entryWeekday === weekdayToken) {
+      score += 8;
+      matched = true;
+    }
+  }
+
   const recencyDays = Math.max(0, (Date.now() - entry.updatedAt) / MS_PER_DAY);
-  const recencyWeight = Math.max(0, 2 - recencyDays / 30);
+  const recencyWeight = Math.max(0, 3 - recencyDays / 20);
 
   return {
     entry,
@@ -126,10 +167,11 @@ export const searchActivityIndex = (query) => {
     return getRecentActivity(MAX_SEARCH_RESULTS);
   }
 
-  const queryTokens = normalizedQuery.split(/\s+/).filter(Boolean);
+  const queryTokens = tokenizeQuery(normalizedQuery);
+  const weekdayToken = getWeekdayFromQuery(queryTokens);
 
-  return buildActivityIndex()
-    .map((entry) => scoreEntryForQuery(entry, queryTokens))
+  const ranked = buildActivityIndex()
+    .map((entry) => scoreEntryForQuery(entry, normalizedQuery, queryTokens, weekdayToken))
     .filter((result) => result.matched)
     .sort((a, b) => {
       if (b.score !== a.score) {
@@ -139,6 +181,13 @@ export const searchActivityIndex = (query) => {
     })
     .slice(0, MAX_SEARCH_RESULTS)
     .map((result) => result.entry);
+
+  if (ranked.length) {
+    return ranked;
+  }
+
+  // Keep assistant search lightweight by falling back to recent notes.
+  return getRecentActivity(MAX_SEARCH_RESULTS);
 };
 
 export const getRecentActivity = (limit = MAX_SEARCH_RESULTS) => {

--- a/mobile.js
+++ b/mobile.js
@@ -80,61 +80,40 @@ initViewportHeight();
       return value.trim().slice(0, maxChars);
     };
 
-    const buildAssistantEntries = (question) => {
-      const notes = Array.isArray(loadAllNotes()) ? loadAllNotes() : [];
-      if (!notes.length) {
-        return [];
+    const buildAssistantEntries = async (question) => {
+      let searchFn = null;
+      try {
+        const activityIndexModule = await import('./js/modules/activity-index.js');
+        if (activityIndexModule && typeof activityIndexModule.searchActivityIndex === 'function') {
+          searchFn = activityIndexModule.searchActivityIndex;
+        }
+      } catch (error) {
+        console.warn('[assistant] failed to load activity index search module', error);
       }
 
-      const keywords = Array.from(
-        new Set(
-          String(question || '')
-            .toLowerCase()
-            .split(/[^a-z0-9]+/)
-            .map((token) => token.trim())
-            .filter((token) => token.length >= 3),
-        ),
-      );
+      const sourceEntries = searchFn
+        ? searchFn(question).slice(0, 10)
+        : [];
 
-      const sortedByRecent = [...notes].sort((a, b) => {
-        const aTime = Date.parse(a?.createdAt || '') || 0;
-        const bTime = Date.parse(b?.createdAt || '') || 0;
-        return bTime - aTime;
-      });
-
-      const recentWindow = sortedByRecent.slice(0, 60);
-      const matchesQuestion = (note) => {
-        if (!keywords.length) {
-          return false;
-        }
-        const haystack = `${note?.title || ''} ${note?.bodyText || ''} ${note?.body || ''}`.toLowerCase();
-        return keywords.some((token) => haystack.includes(token));
-      };
-
-      const matchingNotes = recentWindow.filter(matchesQuestion);
-      const fallbackRecent = recentWindow.filter((note) => !matchesQuestion(note));
-      const selected = [...matchingNotes, ...fallbackRecent].slice(0, 20);
-
-      return selected
-        .map((note) => {
-          const bodyText = toAssistantEntryText(note?.bodyText, 1000);
-          const body = toAssistantEntryText(bodyText || note?.body, 1000);
-          const title = toAssistantEntryText(note?.title, 300);
-
+      return sourceEntries
+        .map((entry) => {
+          const body = toAssistantEntryText(entry?.body, 1000);
+          const title = toAssistantEntryText(entry?.title, 300);
           if (!title && !body) {
             return null;
           }
 
           return {
-            id: typeof note?.id === 'string' ? note.id : '',
-            type: typeof note?.type === 'string'
-              ? note.type
-              : typeof note?.metadata?.type === 'string'
-                ? note.metadata.type
-                : 'note',
+            id: typeof entry?.id === 'string' ? entry.id : '',
             title,
             body,
-            createdAt: typeof note?.createdAt === 'string' ? note.createdAt : null,
+            type: typeof entry?.type === 'string' ? entry.type : 'note',
+            tags: Array.isArray(entry?.tags)
+              ? entry.tags.map((tag) => toAssistantEntryText(tag, 64)).filter(Boolean).slice(0, 12)
+              : [],
+            createdAt: Number.isFinite(entry?.createdAt) && entry.createdAt > 0
+              ? new Date(entry.createdAt).toISOString()
+              : null,
           };
         })
         .filter(Boolean);
@@ -277,7 +256,7 @@ initViewportHeight();
             );
           }
         } else {
-          const entries = buildAssistantEntries(trimmedMessage);
+          const entries = await buildAssistantEntries(trimmedMessage);
           const response = await fetch('/api/assistant', {
             method: 'POST',
             headers: {


### PR DESCRIPTION
### Motivation
- Provide lightweight semantic recall so assistant-mode questions retrieve relevant notes by meaning rather than exact matches, while keeping search cheap and focused. 
- When the assistant is asked a question, return the top entries (max 10) containing `id`, `title`, `body`, `type`, `tags`, and `createdAt` so the server-side `/api/assistant` can use them as context.

### Description
- Enhanced `searchActivityIndex()` in `js/modules/activity-index.js` to support semantic-friendly heuristics: tokenization with a small synonym map, weekday-intent boosting (e.g. “Monday”), stronger title/tag weighting, and increased recency weight; the function falls back to recent activity when there are no matches.
- Updated the mobile assistant flow in `mobile.js` to call `searchActivityIndex(question)`, take the top 10 results, and map each entry to the required shape (`id`, `title`, `body`, `type`, `tags`, `createdAt`) before sending them to `/api/assistant`; the local retrieval is loaded dynamically via `import()` and `buildAssistantEntries` is now `async`.
- Extended server-side entry sanitization in `api/assistant.js` so `trimEntry()` accepts and forwards `tags` safely with length and uniqueness limits.

### Testing
- Ran targeted mobile tests: `npx jest js/__tests__/mobile.auth.test.js --runInBand` (passed).
- Ran UI assistant tests: `npx jest js/__tests__/mobile.open-sheet.test.js js/__tests__/mobile.sheet.test.js --runInBand` (passed).
- Ran the full test suite with `npm test -- --runInBand`; the run completed but there are unrelated failing suites in this environment (not caused by these changes), notably `js/__tests__/mobile.new-folder.test.js` and `service-worker.test.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad68706b908324b036dbe6198879ec)