### PR TITLE
Add Thinking Bar unified input system

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -209,6 +209,44 @@
       background-color: rgba(0, 0, 0, 0.04);
     }
 
+    #thinkingBarContainer {
+      position: sticky;
+      top: 0;
+      z-index: 2;
+      padding: 0.75rem 0;
+      background: var(--surface-main);
+    }
+
+    #thinkingBarInput {
+      width: 100%;
+    }
+
+    #thinkingBarStatus {
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      margin-top: 0.35rem;
+    }
+
+    #thinkingBarResults {
+      margin-top: 0.4rem;
+      display: grid;
+      gap: 0.45rem;
+    }
+
+    .thinking-result-item {
+      background: var(--surface-elevated);
+      border: 1px solid var(--border-subtle);
+      border-radius: 0.65rem;
+      padding: 0.55rem 0.65rem;
+      font-size: 0.84rem;
+    }
+
+    .thinking-result-title {
+      font-weight: 600;
+      margin-bottom: 0.12rem;
+    }
+
     .reminders-quick-actions .icon-btn,
     .mobile-footer-nav button,
     .mobile-footer-nav .footer-button,
@@ -5586,8 +5624,13 @@ body, main, section, div, p, span, li {
             </div>
     <section data-view="assistant" id="view-assistant" class="view-panel hidden" aria-hidden="true">
       <div class="assistant-panel">
+        <div id="thinkingBarContainer">
+          <input id="thinkingBarInput" class="input input-sm w-full" placeholder="Capture, search, or ask…" autocomplete="off" />
+        </div>
+        <div id="thinkingBarStatus" class="hidden" aria-live="polite"></div>
+        <div id="thinkingBarResults" aria-live="polite"></div>
         <div id="assistantThread" aria-live="polite" aria-label="Assistant conversation"></div>
-        <form id="assistantForm">
+        <form id="assistantForm" class="hidden">
           <input
             id="assistantInput"
             type="text"

--- a/mobile.js
+++ b/mobile.js
@@ -51,11 +51,15 @@ initViewportHeight();
     const assistantThread = document.getElementById('assistantThread');
     const assistantSendBtn = document.getElementById('assistantSendBtn');
     const assistantLoading = document.getElementById('assistantLoading');
+    const thinkingBarInput = document.getElementById('thinkingBarInput');
+    const thinkingBarStatus = document.getElementById('thinkingBarStatus');
+    const thinkingBarResults = document.getElementById('thinkingBarResults');
     let isAssistantSending = false;
 
     if (
       !isFormElement(assistantForm) ||
       !isInputElement(assistantInput) ||
+      !isInputElement(thinkingBarInput) ||
       !(assistantThread instanceof HTMLElement)
     ) {
       return;
@@ -71,6 +75,71 @@ initViewportHeight();
       message.textContent = text;
       assistantThread.appendChild(message);
       assistantThread.scrollTop = assistantThread.scrollHeight;
+    };
+
+    const setThinkingBarStatus = (label) => {
+      if (!(thinkingBarStatus instanceof HTMLElement)) {
+        return;
+      }
+      if (typeof label === 'string' && label.trim()) {
+        thinkingBarStatus.textContent = label;
+        thinkingBarStatus.classList.remove('hidden');
+      } else {
+        thinkingBarStatus.textContent = '';
+        thinkingBarStatus.classList.add('hidden');
+      }
+    };
+
+    const clearThinkingBarResults = () => {
+      if (thinkingBarResults instanceof HTMLElement) {
+        thinkingBarResults.innerHTML = '';
+      }
+    };
+
+    const renderSearchResults = async (query) => {
+      clearThinkingBarResults();
+      setThinkingBarStatus('Search results');
+
+      let searchResults = [];
+      try {
+        const activityIndexModule = await import('./js/modules/activity-index.js');
+        if (activityIndexModule && typeof activityIndexModule.searchActivityIndex === 'function') {
+          searchResults = activityIndexModule.searchActivityIndex(query);
+        }
+      } catch (error) {
+        console.warn('[thinking-bar] failed to load activity index search module', error);
+      }
+
+      if (!(thinkingBarResults instanceof HTMLElement)) {
+        return;
+      }
+
+      if (!Array.isArray(searchResults) || !searchResults.length) {
+        const empty = document.createElement('div');
+        empty.className = 'thinking-result-item';
+        empty.textContent = 'No local matches found.';
+        thinkingBarResults.appendChild(empty);
+        return;
+      }
+
+      searchResults.slice(0, 8).forEach((entry) => {
+        const row = document.createElement('div');
+        row.className = 'thinking-result-item';
+
+        const title = document.createElement('div');
+        title.className = 'thinking-result-title';
+        title.textContent = typeof entry?.title === 'string' && entry.title.trim()
+          ? entry.title.trim()
+          : 'Untitled note';
+
+        const body = document.createElement('div');
+        const entryBody = typeof entry?.body === 'string' ? entry.body.trim() : '';
+        body.textContent = entryBody ? entryBody.slice(0, 120) : 'No preview available.';
+
+        row.appendChild(title);
+        row.appendChild(body);
+        thinkingBarResults.appendChild(row);
+      });
     };
 
     const toAssistantEntryText = (value, maxChars = 1000) => {
@@ -254,30 +323,45 @@ initViewportHeight();
         return;
       }
 
-      const message = assistantInput.value || '';
+      const message = thinkingBarInput.value || '';
       const trimmedMessage = message.trim();
 
       if (!trimmedMessage) {
         return;
       }
 
-      const isCaptureMode = trimmedMessage.startsWith('+');
+      const isAssistantMode = trimmedMessage.endsWith('?');
+      const isSearchMode = !isAssistantMode && trimmedMessage.length < 40 && !trimmedMessage.startsWith('+');
+      const isCaptureMode = trimmedMessage.startsWith('+') || (!isAssistantMode && !isSearchMode);
 
-      console.log('[assistant] send handler executed', { textLength: trimmedMessage.length, isCaptureMode });
+      console.log('[assistant] send handler executed', {
+        textLength: trimmedMessage.length,
+        mode: isCaptureMode ? 'capture' : isSearchMode ? 'search' : 'assistant',
+      });
       isAssistantSending = true;
 
       if (assistantLoading instanceof HTMLElement) {
         assistantLoading.classList.remove('hidden');
       }
 
+      clearThinkingBarResults();
       appendAssistantMessage(message);
 
-      assistantInput.value = '';
-      assistantInput.focus();
+      thinkingBarInput.value = '';
+      thinkingBarInput.focus();
+
+      if (isSearchMode) {
+        if (assistantLoading instanceof HTMLElement) {
+          assistantLoading.classList.add('hidden');
+        }
+        isAssistantSending = false;
+        await renderSearchResults(trimmedMessage);
+        return;
+      }
 
       try {
         if (isCaptureMode) {
-          const captureInput = trimmedMessage.slice(1).trim();
+          const captureInput = trimmedMessage.startsWith('+') ? trimmedMessage.slice(1).trim() : trimmedMessage;
           const response = await fetch('/api/capture', {
             method: 'POST',
             headers: {
@@ -323,6 +407,7 @@ initViewportHeight();
           } else {
             appendAssistantMessage(`Saved to ${targetFolderName}: ${title}`, 'assistant-message assistant-message--reply');
           }
+          setThinkingBarStatus('Saved entry');
 
           if (typeof entry.followUpQuestion === 'string' && entry.followUpQuestion.trim()) {
             appendAssistantMessage(
@@ -354,6 +439,7 @@ initViewportHeight();
             ? payload.reply
             : 'I could not read an assistant response.';
           appendAssistantMessage(replyText, 'assistant-message assistant-message--reply');
+          setThinkingBarStatus('Assistant answer');
         }
       } catch (error) {
         if (isCaptureMode) {
@@ -372,6 +458,12 @@ initViewportHeight();
     };
 
     assistantForm.addEventListener('submit', sendAssistantMessage);
+
+    thinkingBarInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        sendAssistantMessage(event);
+      }
+    });
 
     assistantInput.addEventListener('keydown', (event) => {
       if (event.key === 'Enter' && !event.shiftKey) {


### PR DESCRIPTION
### Motivation
- Provide a single minimal input for capturing ideas, searching notes, or asking the assistant from one place (`Thinking Bar`).
- Route input to existing capture and assistant pipelines rather than removing them, preserving current functionality behind new unified logic.
- Keep UI lightweight and immediate: local searches should return instant results without calling the AI.

### Description
- Added a sticky Thinking Bar UI in the assistant panel with `#thinkingBarContainer`, `#thinkingBarInput`, `#thinkingBarStatus`, and `#thinkingBarResults` and minimal styles in `mobile.html`.
- Wired the Thinking Bar in `mobile.js` and implemented input classification rules on ENTER: `+...` => capture, ends with `?` => assistant, length < 40 & not `?` => search via `searchActivityIndex(query)`, otherwise capture; the old `assistantForm`/`assistantInput` is preserved and hidden.
- Implemented local search rendering under the bar using `./js/modules/activity-index.js` and added compact status labels `Search results`, `Assistant answer`, and `Saved entry`.
- Kept existing capture/assistant flows intact and adjusted capture extraction so non-`+` capture uses the full input when appropriate.

### Testing
- Ran automated tests with `npm test -- --runInBand`; outcome: `23` test suites total, `21` suites passed and `2` suites failed; `77` tests total, `74` passed and `3` failed; failures are in `js/__tests__/mobile.new-folder.test.js` and `service-worker.test.js` (these are unrelated to the Thinking Bar changes).
- Manually validated in a browser container by serving the app and exercising the bar with Playwright; captured a screenshot at `artifacts/thinking-bar-mobile.png` showing search results rendered below the bar.
- No changes were made to existing assistant or capture endpoints; behavior remains routed through `/api/capture` and `/api/assistant` as before.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad6a5c3ac48324b55b77f9bf806c9a)