### PR TITLE
Add memory index for fast search and recall

### DIFF
--- a/js/modules/memory-index.js
+++ b/js/modules/memory-index.js
@@ -1,0 +1,155 @@
+import { getFolderNameById, loadAllNotes } from './notes-storage.js';
+
+const MAX_SEARCH_RESULTS = 20;
+const DEFAULT_RECENT_LIMIT = 20;
+const ALLOWED_MEMORY_TYPES = new Set([
+  'task',
+  'lesson-idea',
+  'lesson-reflection',
+  'footy-drill',
+  'coaching-note',
+  'reminder',
+  'resource',
+]);
+
+let cachedIndex = null;
+let hasBoundNotesUpdatedListener = false;
+
+const normalizeString = (value) => (typeof value === 'string' ? value.trim() : '');
+
+const normalizeTags = (value) => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((tag) => normalizeString(tag))
+    .filter((tag, index, list) => tag.length && list.indexOf(tag) === index);
+};
+
+const toTimestamp = (value) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return 0;
+};
+
+const sortByRecency = (a, b) => b.updatedAt - a.updatedAt;
+
+const ensureNotesUpdatedListener = () => {
+  if (hasBoundNotesUpdatedListener || typeof document === 'undefined') {
+    return;
+  }
+
+  document.addEventListener('memoryCue:notesUpdated', () => {
+    cachedIndex = null;
+  });
+
+  hasBoundNotesUpdatedListener = true;
+};
+
+const buildIndexEntry = (note) => {
+  const metadata = note && typeof note.metadata === 'object' && note.metadata ? note.metadata : {};
+  const createdAt = toTimestamp(note.createdAt);
+  const updatedAt = toTimestamp(note.updatedAt) || createdAt;
+  const type = normalizeString(metadata.type).toLowerCase();
+
+  return {
+    id: normalizeString(note.id),
+    title: normalizeString(note.title) || 'Untitled note',
+    body: normalizeString(note.bodyText) || normalizeString(note.body),
+    type,
+    tags: normalizeTags(metadata.tags),
+    folder: getFolderNameById(note.folderId),
+    createdAt,
+    updatedAt,
+  };
+};
+
+const scoreMemoryMatch = (entry, normalizedQuery) => {
+  const lowerTitle = entry.title.toLowerCase();
+  const lowerBody = entry.body.toLowerCase();
+  const lowerTags = entry.tags.map((tag) => tag.toLowerCase());
+
+  let score = 0;
+  let matched = false;
+
+  if (lowerTitle.includes(normalizedQuery)) {
+    score += 1000;
+    matched = true;
+  }
+
+  if (lowerTags.some((tag) => tag.includes(normalizedQuery))) {
+    score += 500;
+    matched = true;
+  }
+
+  if (lowerBody.includes(normalizedQuery)) {
+    score += 100;
+    matched = true;
+  }
+
+  // Recency is the final tie-breaker after relevance rules.
+  const recencyBoost = entry.updatedAt > 0 ? Math.max(0, 50 - (Date.now() - entry.updatedAt) / (24 * 60 * 60 * 1000)) : 0;
+  score += recencyBoost;
+
+  return { entry, matched, score };
+};
+
+export const buildMemoryIndex = () => {
+  ensureNotesUpdatedListener();
+
+  if (cachedIndex) {
+    return cachedIndex;
+  }
+
+  cachedIndex = loadAllNotes()
+    .map((note) => buildIndexEntry(note))
+    .filter((entry) => entry.id)
+    .sort(sortByRecency);
+
+  return cachedIndex;
+};
+
+export const searchMemoryIndex = (query) => {
+  const normalizedQuery = normalizeString(query).toLowerCase();
+  if (!normalizedQuery.length) {
+    return getRecentMemory(MAX_SEARCH_RESULTS);
+  }
+
+  return buildMemoryIndex()
+    .map((entry) => scoreMemoryMatch(entry, normalizedQuery))
+    .filter((result) => result.matched)
+    .sort((a, b) => {
+      if (b.score !== a.score) {
+        return b.score - a.score;
+      }
+      return b.entry.updatedAt - a.entry.updatedAt;
+    })
+    .slice(0, MAX_SEARCH_RESULTS)
+    .map((result) => result.entry);
+};
+
+export const getRecentMemory = (limit = DEFAULT_RECENT_LIMIT) => {
+  const normalizedLimit = Number(limit);
+  const safeLimit = Number.isFinite(normalizedLimit) && normalizedLimit > 0
+    ? Math.floor(normalizedLimit)
+    : DEFAULT_RECENT_LIMIT;
+
+  return buildMemoryIndex().slice(0, safeLimit);
+};
+
+export const getMemoryByType = (type) => {
+  const normalizedType = normalizeString(type).toLowerCase();
+  if (!ALLOWED_MEMORY_TYPES.has(normalizedType)) {
+    return [];
+  }
+
+  return buildMemoryIndex().filter((entry) => entry.type === normalizedType);
+};


### PR DESCRIPTION
### Motivation
- Provide a lightweight memory layer that builds a searchable index of all notes and AI captures to enable fast search and AI recall.
- Keep storage unchanged and only read data from the existing notes storage while providing fast in-memory lookups and rebuilds when notes change.

### Description
- Add new module `js/modules/memory-index.js` that exports `buildMemoryIndex()`, `searchMemoryIndex(query)`, `getRecentMemory(limit)`, and `getMemoryByType(type)`.
- `buildMemoryIndex()` reads notes via `loadAllNotes()` and returns normalized entries with `id`, `title`, `body`, `type`, `tags`, `folder`, `createdAt`, and `updatedAt`.
- `searchMemoryIndex(query)` returns the top 20 matches ranked by title match, tag match, body match, then recency as a tie-breaker, and `getRecentMemory`/`getMemoryByType` provide recent and type-filtered views.
- Cache the index in memory and invalidate the cache when the `memoryCue:notesUpdated` event is dispatched, without modifying how notes are persisted.

### Testing
- Ran `npm test -- --runInBand sample.test.js` and it passed (1 test, 1 suite).
- Ran `npm test -- --runInBand js/tests/notes-storage.folders.test.js` and it passed (2 tests, 1 suite).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad6b9cdfcc83248171a0a8ba249bcd)