### PR TITLE
Enable assistant recall from memory index

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -149,22 +149,30 @@ initViewportHeight();
       return value.trim().slice(0, maxChars);
     };
 
-    const buildAssistantEntries = async (question) => {
-      let searchFn = null;
+    const searchMemoryIndex = async (question) => {
       try {
         const activityIndexModule = await import('./js/modules/activity-index.js');
+        if (activityIndexModule && typeof activityIndexModule.searchMemoryIndex === 'function') {
+          return activityIndexModule.searchMemoryIndex(question);
+        }
         if (activityIndexModule && typeof activityIndexModule.searchActivityIndex === 'function') {
-          searchFn = activityIndexModule.searchActivityIndex;
+          return activityIndexModule.searchActivityIndex(question);
         }
       } catch (error) {
         console.warn('[assistant] failed to load activity index search module', error);
       }
 
-      const sourceEntries = searchFn
-        ? searchFn(question).slice(0, 10)
-        : [];
+      return [];
+    };
+
+    const buildAssistantEntries = async (question) => {
+      const sourceEntries = (await searchMemoryIndex(question)).slice(0, 10);
+
+      // Keep assistant payloads lightweight while still sending top memory matches.
+      const maxEntries = 10;
 
       return sourceEntries
+        .slice(0, maxEntries)
         .map((entry) => {
           const body = toAssistantEntryText(entry?.body, 1000);
           const title = toAssistantEntryText(entry?.title, 300);
@@ -425,7 +433,7 @@ initViewportHeight();
             body: JSON.stringify({
               schemaVersion: 2,
               question: trimmedMessage,
-              contextText,
+              contextText: '',
               entries,
             }),
           });


### PR DESCRIPTION
### Motivation

- Enable the assistant to include the users saved notes in queries by querying the local memory index before calling the backend assistant API.

### Description

- Add a `searchMemoryIndex(question)` wrapper in `mobile.js` that imports `./js/modules/activity-index.js` and prefers `searchMemoryIndex`, falling back to `searchActivityIndex` if needed.
- Use the memory index results to build assistant `entries`, trimming fields and limiting the payload to the top 10 matches via `buildAssistantEntries`.
- Send the assistant request to `/api/assistant` with the required payload shape `{ schemaVersion: 2, question, contextText: "", entries }` and do not change the backend API.
- Keep entry shaping (id, title, body, type, tags, createdAt) and field-length trimming to avoid exceeding payload limits.

### Testing

- Ran `npm test -- --runInBand js/__tests__/mobile.auth.test.js` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad6c2f1b8083249464bb66884c96ca)