### PR TITLE
Add instant search to Thinking Bar

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -240,6 +240,10 @@
       border-radius: 0.65rem;
       padding: 0.55rem 0.65rem;
       font-size: 0.84rem;
+      width: 100%;
+      text-align: left;
+      cursor: pointer;
+      color: inherit;
     }
 
     .thinking-result-title {

--- a/mobile.js
+++ b/mobile.js
@@ -55,6 +55,7 @@ initViewportHeight();
     const thinkingBarStatus = document.getElementById('thinkingBarStatus');
     const thinkingBarResults = document.getElementById('thinkingBarResults');
     let isAssistantSending = false;
+    let latestThinkingSearchRequest = 0;
 
     if (
       !isFormElement(assistantForm) ||
@@ -97,17 +98,14 @@ initViewportHeight();
     };
 
     const renderSearchResults = async (query) => {
+      const requestId = ++latestThinkingSearchRequest;
       clearThinkingBarResults();
       setThinkingBarStatus('Search results');
 
-      let searchResults = [];
-      try {
-        const activityIndexModule = await import('./js/modules/activity-index.js');
-        if (activityIndexModule && typeof activityIndexModule.searchActivityIndex === 'function') {
-          searchResults = activityIndexModule.searchActivityIndex(query);
-        }
-      } catch (error) {
-        console.warn('[thinking-bar] failed to load activity index search module', error);
+      const searchResults = (await searchMemoryIndex(query)).slice(0, 10);
+
+      if (requestId !== latestThinkingSearchRequest) {
+        return;
       }
 
       if (!(thinkingBarResults instanceof HTMLElement)) {
@@ -122,9 +120,11 @@ initViewportHeight();
         return;
       }
 
-      searchResults.slice(0, 8).forEach((entry) => {
-        const row = document.createElement('div');
+      searchResults.forEach((entry) => {
+        const row = document.createElement('button');
+        row.type = 'button';
         row.className = 'thinking-result-item';
+        row.setAttribute('aria-label', `Open note ${entry?.title || 'Untitled note'}`);
 
         const title = document.createElement('div');
         title.className = 'thinking-result-title';
@@ -132,12 +132,21 @@ initViewportHeight();
           ? entry.title.trim()
           : 'Untitled note';
 
-        const body = document.createElement('div');
-        const entryBody = typeof entry?.body === 'string' ? entry.body.trim() : '';
-        body.textContent = entryBody ? entryBody.slice(0, 120) : 'No preview available.';
+        const details = document.createElement('div');
+        const entryType = typeof entry?.type === 'string' && entry.type.trim() ? entry.type.trim() : 'Note';
+        const entryFolder = typeof entry?.folder === 'string' && entry.folder.trim() ? entry.folder.trim() : 'Unsorted';
+        details.textContent = `${entryType} • ${entryFolder}`;
+
+        row.addEventListener('click', () => {
+          const noteId = typeof entry?.id === 'string' ? entry.id : '';
+          if (!noteId) {
+            return;
+          }
+          document.dispatchEvent(new CustomEvent('thinkingBar:openNote', { detail: { noteId } }));
+        });
 
         row.appendChild(title);
-        row.appendChild(body);
+        row.appendChild(details);
         thinkingBarResults.appendChild(row);
       });
     };
@@ -471,6 +480,19 @@ initViewportHeight();
       if (event.key === 'Enter' && !event.shiftKey) {
         sendAssistantMessage(event);
       }
+    });
+
+    thinkingBarInput.addEventListener('input', () => {
+      const query = typeof thinkingBarInput.value === 'string' ? thinkingBarInput.value.trim() : '';
+
+      if (query.length <= 2) {
+        latestThinkingSearchRequest += 1;
+        clearThinkingBarResults();
+        setThinkingBarStatus('');
+        return;
+      }
+
+      renderSearchResults(query);
     });
 
     assistantInput.addEventListener('keydown', (event) => {
@@ -1561,6 +1583,14 @@ const initMobileNotes = () => {
 
     document.dispatchEvent(new CustomEvent('app:navigate', { detail: { view: 'notebook' } }));
   };
+
+  document.addEventListener('thinkingBar:openNote', (event) => {
+    const noteId = event?.detail?.noteId;
+    if (!noteId) {
+      return;
+    }
+    openNoteFromDashboard(noteId);
+  });
 
   const renderDashboardPanel = () => {
     const dashboardPanel = document.getElementById('dashboardPanel');


### PR DESCRIPTION
### Motivation
- Provide immediate, local search feedback in the Thinking Bar as the user types (for queries longer than 2 characters) without calling the assistant API.
- Surface relevant notes quickly to improve discovery and editing workflow from the assistant view.
- Keep results local, lightweight, and limited to reduce UI clutter and avoid sending unnecessary payloads to external services.

### Description
- Added live input handling to the Thinking Bar that calls `searchMemoryIndex(query)` when the typed query length is > 2 and calls `renderSearchResults` to update results as the user types.
- Implemented result rendering that limits displayed results to 10, shows each item as a clickable card with `Title` and `Type • Folder`, and dispatches a `thinkingBar:openNote` event when a card is clicked to open the note editor.
- Added request-tracking (`latestThinkingSearchRequest`) to avoid race conditions where older async searches overwrite newer results.
- Updated styles in `mobile.html` so result cards are full-width, left-aligned, and visually clickable, and wired an event listener in `mobile.js` to handle `thinkingBar:openNote` and open the corresponding note via existing `openNoteFromDashboard` flow.

### Testing
- Ran the test suite with `npm test -- --runInBand`, which mostly passed but surfaced unrelated existing failures: 2 failing test suites (`js/__tests__/mobile.new-folder.test.js` and `service-worker.test.js`), with 3 individual tests failing and 74 passing; the failures are pre-existing and unrelated to the thinking-bar changes.
- Attempted a headless browser check to visually validate the instant search UI, but the Playwright run timed out / crashed in this environment so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ade18a8e4c8324abe0a6eb7a3f9272)