### PR TITLE
Add floating quick capture

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -251,6 +251,57 @@
       margin-bottom: 0.12rem;
     }
 
+    #quickCaptureButton {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      width: 52px;
+      height: 52px;
+      border-radius: 999px;
+      border: none;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.85rem;
+      line-height: 1;
+      color: #ffffff;
+      background: #111111;
+      box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+      z-index: 1000;
+      cursor: pointer;
+    }
+
+    #quickCaptureModal {
+      position: fixed;
+      inset: 0;
+      z-index: 70;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1rem;
+      background: rgba(0, 0, 0, 0.45);
+    }
+
+    #quickCaptureModal.hidden {
+      display: none;
+    }
+
+    .quick-capture-panel {
+      width: min(460px, 100%);
+      background: var(--surface-main);
+      border: 1px solid var(--border-subtle);
+      border-radius: 0.9rem;
+      box-shadow: 0 14px 30px rgba(0, 0, 0, 0.22);
+      padding: 1rem;
+    }
+
+    .quick-capture-actions {
+      margin-top: 0.75rem;
+      display: flex;
+      justify-content: flex-end;
+      gap: 0.5rem;
+    }
+
     .reminders-quick-actions .icon-btn,
     .mobile-footer-nav button,
     .mobile-footer-nav .footer-button,
@@ -5738,6 +5789,20 @@ body, main, section, div, p, span, li {
         </svg>
         <span>Assistant</span>
       </button>
+    </div>
+  </div>
+
+  <div id="quickCaptureButton" role="button" tabindex="0" aria-label="Open quick capture">+</div>
+
+  <div id="quickCaptureModal" class="hidden" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="quickCaptureTitle">
+    <div class="quick-capture-panel">
+      <h2 id="quickCaptureTitle" class="text-base font-semibold mb-3">Capture anything…</h2>
+      <label for="quickCaptureInput" class="sr-only">Capture anything</label>
+      <input id="quickCaptureInput" class="input input-sm w-full" type="text" autocomplete="off" placeholder="Capture anything…" />
+      <div class="quick-capture-actions">
+        <button id="quickCaptureCancel" type="button" class="btn btn-ghost btn-sm">Cancel</button>
+        <button id="quickCaptureSave" type="button" class="btn btn-primary btn-sm">Save</button>
+      </div>
     </div>
   </div>
   <script>

--- a/mobile.js
+++ b/mobile.js
@@ -55,6 +55,11 @@ initViewportHeight();
     const thinkingBarInput = document.getElementById('thinkingBarInput');
     const thinkingBarStatus = document.getElementById('thinkingBarStatus');
     const thinkingBarResults = document.getElementById('thinkingBarResults');
+    const quickCaptureButton = document.getElementById('quickCaptureButton');
+    const quickCaptureModal = document.getElementById('quickCaptureModal');
+    const quickCaptureInput = document.getElementById('quickCaptureInput');
+    const quickCaptureSave = document.getElementById('quickCaptureSave');
+    const quickCaptureCancel = document.getElementById('quickCaptureCancel');
     let isAssistantSending = false;
     let latestThinkingSearchRequest = 0;
 
@@ -333,19 +338,16 @@ initViewportHeight();
       ]);
     };
 
-    const sendAssistantMessage = async (event) => {
-      if (event) {
-        event.preventDefault();
-      }
+    const processThinkingBarMessage = async (rawMessage, options = {}) => {
       if (isAssistantSending) {
-        return;
+        return false;
       }
 
-      const message = thinkingBarInput.value || '';
+      const message = typeof rawMessage === 'string' ? rawMessage : '';
       const trimmedMessage = message.trim();
 
       if (!trimmedMessage) {
-        return;
+        return false;
       }
 
       const isAssistantMode = trimmedMessage.endsWith('?');
@@ -365,8 +367,12 @@ initViewportHeight();
       clearThinkingBarResults();
       appendAssistantMessage(message);
 
-      thinkingBarInput.value = '';
-      thinkingBarInput.focus();
+      if (options.clearThinkingBarInput !== false) {
+        thinkingBarInput.value = '';
+      }
+      if (options.focusThinkingBarInput !== false) {
+        thinkingBarInput.focus();
+      }
 
       if (isSearchMode) {
         if (assistantLoading instanceof HTMLElement) {
@@ -374,7 +380,7 @@ initViewportHeight();
         }
         isAssistantSending = false;
         await renderSearchResults(trimmedMessage);
-        return;
+        return true;
       }
 
       try {
@@ -473,6 +479,19 @@ initViewportHeight();
           assistantLoading.classList.add('hidden');
         }
       }
+
+      return true;
+    };
+
+    const sendAssistantMessage = async (event) => {
+      if (event) {
+        event.preventDefault();
+      }
+
+      await processThinkingBarMessage(thinkingBarInput.value || '', {
+        clearThinkingBarInput: true,
+        focusThinkingBarInput: true,
+      });
     };
 
     assistantForm.addEventListener('submit', sendAssistantMessage);
@@ -504,6 +523,78 @@ initViewportHeight();
 
     if (isButtonElement(assistantSendBtn)) {
       assistantSendBtn.addEventListener('click', sendAssistantMessage);
+    }
+
+    const openQuickCaptureModal = () => {
+      if (!(quickCaptureModal instanceof HTMLElement) || !isInputElement(quickCaptureInput)) {
+        return;
+      }
+      quickCaptureModal.classList.remove('hidden');
+      quickCaptureModal.setAttribute('aria-hidden', 'false');
+      quickCaptureInput.value = '';
+      quickCaptureInput.focus();
+    };
+
+    const closeQuickCaptureModal = () => {
+      if (!(quickCaptureModal instanceof HTMLElement) || !isInputElement(quickCaptureInput)) {
+        return;
+      }
+      quickCaptureModal.classList.add('hidden');
+      quickCaptureModal.setAttribute('aria-hidden', 'true');
+      quickCaptureInput.value = '';
+    };
+
+    const saveQuickCapture = async () => {
+      if (!isInputElement(quickCaptureInput)) {
+        return;
+      }
+      const didSend = await processThinkingBarMessage(quickCaptureInput.value || '', {
+        clearThinkingBarInput: false,
+        focusThinkingBarInput: true,
+      });
+      if (didSend) {
+        closeQuickCaptureModal();
+      }
+    };
+
+    if (quickCaptureButton instanceof HTMLElement) {
+      quickCaptureButton.addEventListener('click', openQuickCaptureModal);
+      quickCaptureButton.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          openQuickCaptureModal();
+        }
+      });
+    }
+
+    if (quickCaptureCancel instanceof HTMLElement) {
+      quickCaptureCancel.addEventListener('click', closeQuickCaptureModal);
+    }
+
+    if (quickCaptureSave instanceof HTMLElement) {
+      quickCaptureSave.addEventListener('click', saveQuickCapture);
+    }
+
+    if (isInputElement(quickCaptureInput)) {
+      quickCaptureInput.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' && !event.shiftKey) {
+          event.preventDefault();
+          saveQuickCapture();
+        }
+      });
+    }
+
+    if (quickCaptureModal instanceof HTMLElement) {
+      quickCaptureModal.addEventListener('click', (event) => {
+        if (event.target === quickCaptureModal) {
+          closeQuickCaptureModal();
+        }
+      });
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && !quickCaptureModal.classList.contains('hidden')) {
+          closeQuickCaptureModal();
+        }
+      });
     }
   };
 


### PR DESCRIPTION
### Motivation
- Provide a persistent quick-capture trigger available from all screens so users can capture thoughts rapidly.
- Reuse the existing Thinking Bar capture/search/assistant pipeline to avoid duplicating capture logic and ensure consistent behavior.

### Description
- Added a floating button and modal markup/styles to `mobile.html` (`#quickCaptureButton`, `#quickCaptureModal`, input and action buttons) positioned at `bottom: 20px; right: 20px` and styled as a circular FAB.
- Extracted Thinking Bar send behavior into a shared function `processThinkingBarMessage(...)` in `mobile.js` and wired the original `sendAssistantMessage` to call it so the same capture/search/assistant routing and `/api/capture` flow are reused.
- Wired quick-capture interactions in `mobile.js`: open/close modal, Save/Cancel handlers, keyboard accessibility (Enter/Space to open, Enter to save, Escape or backdrop to close), and modal closes on successful submit.
- Minor UI adjustment (z-index) to ensure the floating button is clickable above footer controls.

### Testing
- Ran full test suite with `npm test -- --runInBand`, which completed but failed in pre-existing unrelated suites (`mobile.auth`, `mobile.sheet`, `service-worker`); failures are unrelated to the quick-capture changes.
- Ran focused test `npx jest js/__tests__/mobile.new-folder.test.js --runInBand`, which showed one passing and one failing assertion that appears unrelated to the quick-capture implementation.
- Started the app with `npm start` and used Playwright to verify the button renders and the modal opens; captured screenshots of the quick-capture button and modal for visual validation (manual/CI screenshot artifacts).
- Fixed a temporary string-escaping syntax issue encountered during implementation; no new unit tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ade4deeb5c8324844040910cdcbaa9)