### PR TITLE
Wire mobile assistant UI to /api/assistant endpoint

### DIFF
--- a/js/assistant.js
+++ b/js/assistant.js
@@ -1,0 +1,71 @@
+(function () {
+  const assistantForm = document.getElementById('assistantForm');
+  const assistantInput = document.getElementById('assistantInput');
+  const assistantThread = document.getElementById('assistantThread');
+  const assistantLoading = document.getElementById('assistantLoading');
+
+  if (!assistantForm || !assistantInput || !assistantThread) {
+    return;
+  }
+
+  assistantForm.classList.remove('hidden');
+
+  function appendMessage(text) {
+    const messageEl = document.createElement('div');
+    messageEl.className = 'assistant-message';
+    messageEl.textContent = text;
+    assistantThread.appendChild(messageEl);
+    assistantThread.scrollTop = assistantThread.scrollHeight;
+    return messageEl;
+  }
+
+  async function sendAssistantMessage(message) {
+    const response = await fetch('/api/assistant', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ message })
+    });
+
+    if (!response.ok) {
+      throw new Error('Assistant request failed');
+    }
+
+    const data = await response.json();
+    if (!data || typeof data.reply !== 'string') {
+      throw new Error('Assistant response invalid');
+    }
+
+    return data.reply;
+  }
+
+  assistantForm.addEventListener('submit', async function (event) {
+    event.preventDefault();
+
+    const message = assistantInput.value.trim();
+    if (!message) {
+      return;
+    }
+
+    appendMessage(message);
+    assistantInput.value = '';
+
+    const thinkingMessage = appendMessage('Thinking…');
+    if (assistantLoading) {
+      assistantLoading.classList.remove('hidden');
+    }
+
+    try {
+      const reply = await sendAssistantMessage(message);
+      thinkingMessage.textContent = reply;
+    } catch (error) {
+      console.error('Assistant unavailable', error);
+      thinkingMessage.textContent = 'Assistant is unavailable.';
+    } finally {
+      if (assistantLoading) {
+        assistantLoading.classList.add('hidden');
+      }
+    }
+  });
+})();

--- a/mobile.html
+++ b/mobile.html
@@ -10,6 +10,7 @@
   <script type="module" src="./js/init-env.js" defer></script>
   <script type="module" src="./js/config-supabase.js" defer></script>
   <script defer src="./js/firebase-config.js"></script>
+  <script defer src="./js/assistant.js"></script>
   <!-- === /SUPABASE CONFIG === -->
   <!-- Production CSS: compiled via Tailwind/PostCSS; build rewrites this to a hashed asset -->
   <link rel="stylesheet" href="./styles/index.css" />


### PR DESCRIPTION
### Motivation
- Enable the built-in mobile assistant UI so user messages are forwarded to the backend `POST /api/assistant` endpoint and responses are shown in the chat thread.

### Description
- Added a new client script `js/assistant.js` that unhides the assistant form and wires submission handling. 
- The script appends the user message into `#assistantThread`, posts `{ "message": "..." }` to `/api/assistant`, and expects `{ "reply": "..." }` from the server. 
- While awaiting the response it appends a `Thinking…` placeholder and replaces it with the AI `reply` or with `Assistant is unavailable.` on error. 
- Imported `./js/assistant.js` in `mobile.html` without changing existing UI styling.

### Testing
- Ran automated test command `npm test -- --runInBand`; test run completed but several pre-existing unrelated suites failed (not caused by these changes) including `mobile.new-folder`, `mobile.auth`, `mobile.open-sheet`, `mobile.sheet`, and `service-worker` tests. 
- Started the app with `npm start` and manually exercised the mobile assistant flow in a browser using a Playwright script that opened `mobile.html`, sent a message, and captured a screenshot; the flow worked and the screenshot was produced. 
- No new unit tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adff0fcdb08324977503c7268fd6d5)