### PR TITLE
Add brain-dump quick capture persistence and prefix-based auto-categorization

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -1823,6 +1823,48 @@ ${query}`;
         : (quickInput.value || '').trim();
     const t = typeof text === 'string' ? text.trim() : '';
     if (!t) return null;
+
+    const resolveBrainDumpCategory = (rawText) => {
+      const normalized = String(rawText || '').trim().toLowerCase();
+      if (normalized.startsWith('footy')) return 'coaching';
+      if (normalized.startsWith('lesson')) return 'teaching';
+      if (normalized.startsWith('task')) return 'tasks';
+      if (normalized.startsWith('idea')) return 'ideas';
+      return 'inbox';
+    };
+
+    const saveBrainDumpEntry = (sourceText, reminderEntry) => {
+      if (typeof localStorage === 'undefined') {
+        return;
+      }
+      const cleanText = String(sourceText || '').trim();
+      if (!cleanText) {
+        return;
+      }
+
+      const payload = {
+        id:
+          reminderEntry && reminderEntry.id
+            ? reminderEntry.id
+            : `entry-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+        text: cleanText,
+        category: resolveBrainDumpCategory(cleanText),
+        createdAt:
+          reminderEntry && reminderEntry.createdAt
+            ? new Date(reminderEntry.createdAt).toISOString()
+            : new Date().toISOString(),
+      };
+
+      try {
+        const existing = JSON.parse(localStorage.getItem('memoryCueEntries') || '[]');
+        const entries = Array.isArray(existing) ? existing : [];
+        entries.unshift(payload);
+        localStorage.setItem('memoryCueEntries', JSON.stringify(entries));
+      } catch (error) {
+        console.warn('Failed to persist memoryCueEntries', error);
+      }
+    };
+
     isQuickAddSubmitting = true;
     if (quickInput && typeof quickInput.disabled !== 'undefined') {
       quickInput.disabled = true;
@@ -1954,6 +1996,7 @@ ${query}`;
       }
 
       if (entry && typeof document !== 'undefined') {
+        saveBrainDumpEntry(t, entry);
         quickInput.value = '';
         try {
           quickInput.focus({ preventScroll: true });


### PR DESCRIPTION
### Motivation
- Provide a lightweight "brain dump" capture for quick entries that auto-categorizes by a simple prefix and persists captures for offline access.

### Description
- Updated the quick capture flow in `js/reminders.js` by enhancing `quickAddNow` to add two helpers: `resolveBrainDumpCategory` (maps prefixes to categories) and `saveBrainDumpEntry` (persists captures).
- The prefix rules implemented are: `footy` → `coaching`, `lesson` → `teaching`, `task` → `tasks`, `idea` → `ideas`, otherwise `inbox`.
- Captures are stored in `localStorage` under the key `memoryCueEntries` as an array of objects shaped like `{ id, text, category, createdAt }` and new entries are unshifted to the front of the array.
- The existing reminder creation/render pipeline is preserved (entries continue to be added via `addItem`), and after save the quick input is cleared, refocused, and the normal success indicator dispatched.

### Testing
- Ran the targeted quick-add unit tests with `npm test -- --runInBand js/__tests__/reminders.quick-add.test.js` and the suite passed.
- Ran the full test suite with `npm test -- --runInBand` and observed unrelated existing failures in other suites (`mobile.auth`, `mobile.sheet`, `service-worker`), so the change was validated against the quick-add tests but did not resolve pre-existing unrelated test failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae014ca6bc8324aacf6f113d48f31d)