### PR TITLE
Enable browser speech recognition for quick add voice capture

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5210,6 +5210,50 @@ body, main, section, div, p, span, li {
       const init = () => {
         const quickForm = document.getElementById('quickAddForm');
         const quickInput = document.getElementById('quickAddInput');
+        const voiceButton = document.getElementById('startVoiceCaptureGlobal');
+
+        const startVoiceCapture = () => {
+          if (!(quickInput instanceof HTMLInputElement)) {
+            return;
+          }
+
+          const SpeechRecognition =
+            window.SpeechRecognition || window.webkitSpeechRecognition;
+
+          if (typeof SpeechRecognition !== 'function') {
+            window.alert('Voice capture not supported on this device.');
+            return;
+          }
+
+          const recognition = new SpeechRecognition();
+          recognition.lang = document.documentElement.lang || 'en-US';
+          recognition.continuous = false;
+          recognition.interimResults = false;
+
+          recognition.onresult = (event) => {
+            const transcript = event?.results?.[0]?.[0]?.transcript;
+            if (typeof transcript !== 'string') {
+              return;
+            }
+
+            quickInput.value = transcript.trim();
+            quickInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+            try {
+              quickInput.focus({ preventScroll: true });
+            } catch (error) {
+              quickInput.focus();
+            }
+          };
+
+          recognition.onerror = (event) => {
+            if (event?.error === 'not-allowed' || event?.error === 'service-not-allowed') {
+              window.alert('Voice capture not supported on this device.');
+            }
+          };
+
+          recognition.start();
+        };
 
         document.addEventListener('click', (event) => {
           const trigger = event.target instanceof Element
@@ -5222,7 +5266,14 @@ body, main, section, div, p, span, li {
         });
 
         if (!(quickForm instanceof HTMLFormElement) || !(quickInput instanceof HTMLInputElement)) {
+          if (voiceButton instanceof HTMLElement) {
+            voiceButton.addEventListener('click', startVoiceCapture);
+          }
           return;
+        }
+
+        if (voiceButton instanceof HTMLElement) {
+          voiceButton.addEventListener('click', startVoiceCapture);
         }
 
         if (typeof window.memoryCueQuickAddNow !== 'function') {


### PR DESCRIPTION
### Motivation
- Enable quick voice capture when the header microphone button is pressed so users can dictate quick reminders.  
- Support Chrome mobile via `webkitSpeechRecognition` and fail gracefully on platforms where the API is unavailable.

### Description
- Wire the header microphone button (`#startVoiceCaptureGlobal`) to a `startVoiceCapture` handler inside the quick-add initializer in `mobile.html`.  
- Detect `window.SpeechRecognition || window.webkitSpeechRecognition`, start recognition, and set `recognition.lang`, `continuous`, and `interimResults` for predictable behavior.  
- On successful `onresult` insert the transcript into `#quickAddInput`, dispatch an `input` event, and focus the input; show `alert("Voice capture not supported on this device.")` when unsupported or blocked.

### Testing
- Ran the repository test suite with `npm test -- --runInBand`; the run completed with multiple passing suites but had existing unrelated failures (total: 69 passed, 8 failed).  
- The failing tests were in pre-existing suites (`mobile.new-folder`, `mobile.auth`, `mobile.open-sheet`, `mobile.sheet`, and `service-worker`) and are not caused by the small DOM wiring for voice capture, which does not alter module imports or service-worker logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae068aa2948324bae0feb900cc7731)