### PR TITLE
Add reminders list sorting dropdown (Newest / Oldest / Category)

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -402,6 +402,7 @@ export async function initReminders(sel = {}) {
   const details = $(sel.detailsSel);
   const priority = $(sel.prioritySel);
   const categoryInput = $(sel.categorySel);
+  const sortSelect = $(sel.sortSel);
   const saveBtn = $(sel.saveBtnSel);
   const cancelEditBtn = $(sel.cancelEditBtnSel);
   const list = $(sel.listSel);
@@ -615,6 +616,46 @@ export async function initReminders(sel = {}) {
   let mobileRemindersFilterMode = 'all';
   let mobileRemindersCache = [];
   let mobileRemindersTemperatureLabel = '';
+  const REMINDER_SORT_OPTIONS = Object.freeze({
+    newest: 'newest',
+    oldest: 'oldest',
+    category: 'category',
+  });
+  let reminderSortMode = REMINDER_SORT_OPTIONS.newest;
+
+  function getReminderSortTimestamp(reminder) {
+    const createdAt = Number(reminder?.createdAt);
+    if (Number.isFinite(createdAt) && createdAt > 0) {
+      return createdAt;
+    }
+    const updatedAt = Number(reminder?.updatedAt);
+    if (Number.isFinite(updatedAt) && updatedAt > 0) {
+      return updatedAt;
+    }
+    return 0;
+  }
+
+  function sortReminderRows(rows = []) {
+    const sorted = Array.isArray(rows) ? rows.slice() : [];
+    if (reminderSortMode === REMINDER_SORT_OPTIONS.oldest) {
+      sorted.sort((a, b) => getReminderSortTimestamp(a) - getReminderSortTimestamp(b));
+      return sorted;
+    }
+    if (reminderSortMode === REMINDER_SORT_OPTIONS.category) {
+      sorted.sort((a, b) => {
+        const categoryDiff = normalizeCategory(a?.category).localeCompare(normalizeCategory(b?.category), undefined, {
+          sensitivity: 'base',
+        });
+        if (categoryDiff !== 0) {
+          return categoryDiff;
+        }
+        return getReminderSortTimestamp(b) - getReminderSortTimestamp(a);
+      });
+      return sorted;
+    }
+    sorted.sort((a, b) => getReminderSortTimestamp(b) - getReminderSortTimestamp(a));
+    return sorted;
+  }
 
   // Returns a short, user-facing label for "today", e.g. "Tue 18 Nov"
   function getTodayLabelForHeader() {
@@ -4954,6 +4995,32 @@ ${query}`;
     updateMobileRemindersHeaderSubtitle();
   }
 
+  function setupReminderSortControl() {
+    if (typeof HTMLSelectElement === 'undefined' || !(sortSelect instanceof HTMLSelectElement)) {
+      return;
+    }
+
+    const allowedModes = new Set(Object.values(REMINDER_SORT_OPTIONS));
+    const initialMode = String(sortSelect.value || '').trim().toLowerCase();
+    reminderSortMode = allowedModes.has(initialMode) ? initialMode : REMINDER_SORT_OPTIONS.newest;
+    sortSelect.value = reminderSortMode;
+
+    if (setupReminderSortControl._wired) {
+      return;
+    }
+
+    sortSelect.addEventListener('change', () => {
+      const nextMode = String(sortSelect.value || '').trim().toLowerCase();
+      if (!allowedModes.has(nextMode) || nextMode === reminderSortMode) {
+        return;
+      }
+      reminderSortMode = nextMode;
+      render();
+    });
+
+    setupReminderSortControl._wired = true;
+  }
+
   function setupMobileReminderTabs() {
     if (variant !== 'mobile' || typeof document === 'undefined') {
       return;
@@ -4977,6 +5044,7 @@ ${query}`;
   }
 
   function render(){
+    setupReminderSortControl();
     const now = new Date();
     const localNow = new Date(now);
     const t0 = new Date(localNow); t0.setHours(0,0,0,0);
@@ -5040,9 +5108,7 @@ ${query}`;
       }
     }
 
-    let rows = items.slice();
-
-    sortItemsByOrder(rows);
+    let rows = sortReminderRows(items);
 
     if (variant === 'mobile') {
       mobileRemindersCache = rows.slice();

--- a/mobile.html
+++ b/mobile.html
@@ -5327,6 +5327,14 @@ body, main, section, div, p, span, li {
             id="reminderListSection"
             class="w-full relative memory-glass-card-soft"
           >
+            <div class="mb-2 flex items-center justify-end gap-2 px-1">
+              <label for="reminderSort" class="text-xs font-semibold uppercase tracking-wide text-base-content/70">Sort by:</label>
+              <select id="reminderSort" class="select select-bordered select-xs max-w-[10rem]" aria-label="Sort reminders">
+                <option value="newest">Newest</option>
+                <option value="oldest">Oldest</option>
+                <option value="category">Category</option>
+              </select>
+            </div>
             <div class="w-full" id="remindersWrapper">
               <div id="emptyState" class="hidden text-center text-base-content/60 py-8 sm:px-4"></div>
               <p id="reminderReorderHint" class="sr-only">

--- a/mobile.js
+++ b/mobile.js
@@ -933,6 +933,7 @@ const bootstrapReminders = () => {
     detailsSel: '#reminderDetails',
     prioritySel: '#priority',
     categorySel: '#category',
+    sortSel: '#reminderSort',
     saveBtnSel: '#saveReminder',
     cancelEditBtnSel: '#cancelEditBtn',
     listSel: '#reminderList',


### PR DESCRIPTION
### Motivation
- Provide users an easy way to reorder the reminders/entries list by common criteria so lists can be viewed by recency or grouped by category.

### Description
- Add a `Sort by` dropdown in `mobile.html` with options `Newest`, `Oldest`, and `Category` and an `id` of `reminderSort`.
- Wire the dropdown into the reminders controller by passing `sortSel: '#reminderSort'` from the mobile bootstrap in `mobile.js`.
- Add sorting state and logic in `js/reminders.js`: introduce `REMINDER_SORT_OPTIONS`, `getReminderSortTimestamp()`, and `sortReminderRows()` to handle `newest`, `oldest`, and `category` modes.
- Add `setupReminderSortControl()` to attach a `change` listener to the select that updates `reminderSortMode` and calls `render()` so the list updates immediately, and apply `sortReminderRows(items)` inside `render()` before existing filtering.

### Testing
- Ran the targeted Jest suites with `npx jest reminders.categories.test.js js/__tests__/reminders.dom-sync.test.js` and all tests passed (2 suites, 4 tests). 
- Launched a dev server with `npx serve . -l 4173` and captured a Playwright screenshot to validate the rendered mobile UI and dropdown placement, which loaded successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae077738488324a7f7a64c68052a7d)