### PR TITLE
Add Timeline tab with date-based entry grouping

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,6 +31,7 @@
   const searchInput = document.getElementById('searchInput');
   const typeFilters = document.getElementById('typeFilters');
   const entriesList = document.getElementById('entriesList');
+  const timelineList = document.getElementById('timelineList');
   const assistantInput = document.getElementById('assistantInput');
   const askButton = document.getElementById('askButton');
   const assistantResponses = document.getElementById('assistantResponses');
@@ -216,6 +217,10 @@
     if (tabId === 'tab-entries') {
       renderEntries();
     }
+
+    if (tabId === 'tab-timeline') {
+      renderTimeline();
+    }
   }
 
   function moveTabFocus(currentIndex, key) {
@@ -258,6 +263,106 @@
       });
   }
 
+  function getStartOfDay(date) {
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  }
+
+  function getStartOfWeek(date) {
+    const start = getStartOfDay(date);
+    const day = start.getDay();
+    const offset = day === 0 ? 6 : day - 1;
+    start.setDate(start.getDate() - offset);
+    return start;
+  }
+
+  function getTimelineGroup(entryDate, now) {
+    const todayStart = getStartOfDay(now);
+    const entryStart = getStartOfDay(entryDate);
+    const diffDays = Math.floor((todayStart.getTime() - entryStart.getTime()) / 86400000);
+
+    if (diffDays === 0) {
+      return 'Today';
+    }
+
+    if (diffDays === 1) {
+      return 'Yesterday';
+    }
+
+    if (entryStart >= getStartOfWeek(now)) {
+      return 'Earlier this week';
+    }
+
+    return 'Older';
+  }
+
+  function renderTimeline() {
+    if (!timelineList) {
+      return;
+    }
+
+    const grouped = {
+      Today: [],
+      Yesterday: [],
+      'Earlier this week': [],
+      Older: []
+    };
+
+    const orderedEntries = filteredEntries();
+    const now = new Date();
+
+    orderedEntries.forEach(function (entry) {
+      const createdDate = new Date(entry.createdAt);
+      const group = getTimelineGroup(createdDate, now);
+      grouped[group].push(entry);
+    });
+
+    timelineList.innerHTML = '';
+
+    if (!orderedEntries.length) {
+      const empty = document.createElement('p');
+      empty.className = 'empty';
+      empty.textContent = 'No entries in your timeline yet.';
+      timelineList.appendChild(empty);
+      return;
+    }
+
+    ['Today', 'Yesterday', 'Earlier this week', 'Older'].forEach(function (groupName) {
+      const entries = grouped[groupName];
+      if (!entries.length) {
+        return;
+      }
+
+      const section = document.createElement('section');
+      section.className = 'timeline-group';
+
+      const heading = document.createElement('h3');
+      heading.className = 'timeline-heading';
+      heading.textContent = groupName;
+      section.appendChild(heading);
+
+      entries.forEach(function (entry) {
+        const item = document.createElement('article');
+        item.className = 'timeline-entry';
+        item.setAttribute('role', 'listitem');
+
+        const text = document.createElement('p');
+        text.className = 'timeline-text';
+        text.textContent = entry.body || entry.title || '(Untitled)';
+
+        const meta = document.createElement('p');
+        meta.className = 'timeline-meta';
+        const timeCreated = new Date(entry.createdAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+        meta.textContent = `Category: ${entry.type} • Created: ${timeCreated}`;
+
+        item.appendChild(text);
+        item.appendChild(meta);
+        section.appendChild(item);
+      });
+
+      timelineList.appendChild(section);
+    });
+  }
+
   function renderTypeFilters() {
     typeFilters.innerHTML = '';
     TYPE_LABELS.forEach(function (label) {
@@ -276,6 +381,7 @@
         activeTypeFilter = label;
         renderTypeFilters();
         renderEntries();
+        renderTimeline();
       });
       typeFilters.appendChild(button);
     });
@@ -369,6 +475,7 @@
           entry.updatedAt = new Date().toISOString();
           saveDB(db);
           renderEntries();
+          renderTimeline();
           showToast('Task marked done.');
         });
         actions.appendChild(doneBtn);
@@ -384,6 +491,7 @@
         pendingDelete = entry.id;
         saveDB(db);
         renderEntries();
+        renderTimeline();
         showToast('Entry deleted.', {
           undo: function () {
             const target = db.entries.find(function (item) {
@@ -394,6 +502,7 @@
               target.updatedAt = new Date().toISOString();
               saveDB(db);
               renderEntries();
+              renderTimeline();
               showToast('Delete undone.');
             }
           },
@@ -467,6 +576,7 @@
     captureInput.value = '';
     showToast(count === 1 ? 'Saved 1 entry.' : `Saved ${count} entries.`);
     renderEntries();
+    renderTimeline();
   }
 
   function appendAssistantBubble(text, type) {
@@ -527,9 +637,15 @@ ${answerText}`
         return;
       }
 
-      if (key === '1' || key === '2' || key === '3') {
+      if (key === '1' || key === '2' || key === '3' || key === '4') {
         event.preventDefault();
-        const targetId = key === '1' ? 'tab-capture' : key === '2' ? 'tab-entries' : 'tab-assistant';
+        const targetId = key === '1'
+          ? 'tab-capture'
+          : key === '2'
+            ? 'tab-entries'
+            : key === '3'
+              ? 'tab-assistant'
+              : 'tab-timeline';
         setTab(targetId, true);
         return;
       }
@@ -575,6 +691,7 @@ ${answerText}`
 
     updateBrainDumpUI();
     renderEntries();
+    renderTimeline();
     setTab('tab-capture');
 
     captureButton.addEventListener('click', saveCapture);
@@ -590,6 +707,7 @@ ${answerText}`
     searchInput.addEventListener('input', function () {
       activeSearch = searchInput.value.trim().toLowerCase();
       renderEntries();
+      renderTimeline();
     });
 
     assistantInput.addEventListener('keydown', function (event) {

--- a/index.html
+++ b/index.html
@@ -51,6 +51,18 @@
           >
             Assistant
           </button>
+          <button
+            id="tab-timeline"
+            class="tab-btn"
+            role="tab"
+            type="button"
+            aria-selected="false"
+            aria-controls="panel-timeline"
+            tabindex="-1"
+            data-panel="panel-timeline"
+          >
+            Timeline
+          </button>
         </div>
       </div>
 
@@ -98,6 +110,19 @@
             <div id="typeFilters" class="filters" aria-label="Type filters"></div>
           </div>
           <div id="entriesList" class="entries-list" role="list"></div>
+        </div>
+      </section>
+
+      <section
+        id="panel-timeline"
+        class="panel"
+        role="tabpanel"
+        tabindex="0"
+        aria-labelledby="tab-timeline"
+        hidden
+      >
+        <div class="card timeline-card">
+          <div id="timelineList" class="timeline-list" role="list"></div>
         </div>
       </section>
 

--- a/styles.css
+++ b/styles.css
@@ -50,7 +50,7 @@ body {
 
 .tabs {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0.45rem;
 }
 
@@ -242,6 +242,41 @@ input[type='search'] {
 .empty {
   color: var(--muted);
   margin: 0.5rem 0;
+}
+
+
+.timeline-list {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.timeline-group {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.timeline-heading {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--accent-2);
+}
+
+.timeline-entry {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: #0a1426;
+  padding: 0.6rem;
+}
+
+.timeline-text {
+  margin: 0 0 0.35rem;
+  white-space: pre-wrap;
+}
+
+.timeline-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.8rem;
 }
 
 .assistant-card h2 {


### PR DESCRIPTION
### Motivation
- Provide a dedicated Timeline view to browse saved entries grouped by recency buckets so users can scan entries by date context.
- Keep the new UI consistent with existing tabs and reuse existing entry/filter/search state to avoid duplicating data flows.

### Description
- Added a new `Timeline` navigation button and panel (`#tab-timeline` / `#panel-timeline`) and a container `#timelineList` in `index.html` to host grouped entries.
- Implemented timeline grouping and rendering in `app.js` by adding `getStartOfDay`, `getStartOfWeek`, and `getTimelineGroup` helpers and a `renderTimeline()` function that groups entries into `Today`, `Yesterday`, `Earlier this week`, and `Older` and renders each item showing the entry text, `entry.type` (category), and created time.
- Wired timeline rendering to the app lifecycle so `renderTimeline()` is called from `setTab`, after saves/deletes/status-changes, and when filters or search input change, reusing `filteredEntries()` ordering for chronological display.
- Updated UI layout and styles in `styles.css` to support a 4-tab layout and added styles for timeline groups and entries to match the existing visual language.

### Testing
- Ran `npm run build` successfully to ensure the production bundle compiles (`build` succeeded).
- Ran `npm test -- --runInBand` which reported existing unrelated failures in `mobile.*` and `service-worker` test suites; those failures pre-existed and are not caused by the timeline changes (test run: many suites passed, some unrelated suites failed).
- Performed a manual UI verification by serving the app with `npm start` and exercising the capture + Timeline tab flow (Playwright script used to save entries and capture a screenshot), confirming the Timeline panel displays grouped entries as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae0ce27c008324bca117b8ae1a50e1)