### PR TITLE
Return best-matching stored entry from assistant note search

### DIFF
--- a/api/assistant.js
+++ b/api/assistant.js
@@ -87,6 +87,11 @@ module.exports = async function handler(req, res) {
   }
 
   const entries = rawEntries.map(trimEntry).filter(Boolean);
+  const entryById = new Map(
+    entries
+      .filter((entry) => entry.id)
+      .map((entry) => [entry.id, entry])
+  );
 
   let response;
   try {
@@ -106,7 +111,8 @@ module.exports = async function handler(req, res) {
             content: [
               {
                 type: 'input_text',
-                text: 'You are the Memory Cue assistant. Use only supplied entries/context. If answer is unknown, say so briefly.'
+                text:
+                  'You are the Memory Cue assistant. Search the supplied notes to answer the question. Use only supplied entries/context, pick the best matching entry, and if answer is unknown say so briefly.'
               }
             ]
           },
@@ -115,7 +121,7 @@ module.exports = async function handler(req, res) {
             content: [
               {
                 type: 'input_text',
-                text: `Question:\n${question}\n\nContext:\n${contextText}\n\nEntries JSON:\n${JSON.stringify(entries)}`
+                text: `Search these notes and answer the question.\n\nQuestion:\n${question}\n\nContext:\n${contextText}\n\nEntries JSON:\n${JSON.stringify(entries)}`
               }
             ]
           }
@@ -137,9 +143,12 @@ module.exports = async function handler(req, res) {
                 followups: {
                   type: 'array',
                   items: { type: 'string' }
+                },
+                best_entry_id: {
+                  type: 'string'
                 }
               },
-              required: ['answer', 'cited_entry_ids', 'followups']
+              required: ['answer', 'cited_entry_ids', 'followups', 'best_entry_id']
             }
           }
         }
@@ -176,7 +185,12 @@ module.exports = async function handler(req, res) {
       answer: result.answer,
       reply: result.answer,
       cited_entry_ids: Array.isArray(result.cited_entry_ids) ? result.cited_entry_ids : [],
-      followups: Array.isArray(result.followups) ? result.followups : []
+      followups: Array.isArray(result.followups) ? result.followups : [],
+      best_entry_id: typeof result.best_entry_id === 'string' ? result.best_entry_id : '',
+      best_entry:
+        typeof result.best_entry_id === 'string' && entryById.has(result.best_entry_id)
+          ? entryById.get(result.best_entry_id)
+          : null
     });
   } catch (_error) {
     return res.status(500).json({ error: 'Assistant failed.' });

--- a/assistant.js
+++ b/assistant.js
@@ -213,7 +213,9 @@
     return {
       answer: data.answer,
       cited_entry_ids: Array.isArray(data.cited_entry_ids) ? data.cited_entry_ids : [],
-      followups: Array.isArray(data.followups) ? data.followups : []
+      followups: Array.isArray(data.followups) ? data.followups : [],
+      best_entry_id: typeof data.best_entry_id === 'string' ? data.best_entry_id : '',
+      best_entry: data.best_entry && typeof data.best_entry === 'object' ? data.best_entry : null
     };
   }
 


### PR DESCRIPTION
### Motivation
- Enable the assistant to search the stored notes and identify the single best matching entry so the UI can surface a direct note result alongside the AI answer.
- Make the server-side prompt and schema explicit so the model returns a stable identifier for the chosen entry.

### Description
- Update `api/assistant.js` prompt to instruct the model to "Search the supplied notes and answer the question" and to choose the best matching entry from the provided entries.
- Add an `entryById` lookup map and extend the assistant JSON schema to require a `best_entry_id` property, then resolve and return a `best_entry` object when available.
- Propagate the new fields on the client side by returning `best_entry_id` and `best_entry` from `askMemoryCue()` in `assistant.js`.

### Testing
- Ran the test suite with `npm test -- --runInBand` which executed the repository tests.
- Test run completed but the repository has pre-existing unrelated failures: 5 test suites failed and 18 passed (summary: `mobile.*` import-mode related failures and `service-worker.test.js` expectation mismatches), so CI is not green after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae9c00bc4c832497bc6f4da38bcf2a)