### PR TITLE
Remove legacy ./app.js from esbuild entry points

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -58,7 +58,6 @@ function buildEntryMap(metafile) {
 
 async function buildScripts() {
   const moduleEntries = {
-    './app.js': 'app',
     './js/main.js': 'main',
     './js/config-supabase.js': 'config-supabase',
     './js/init-env.js': 'init-env',


### PR DESCRIPTION
### Motivation
- The build referenced a removed legacy entry (`./app.js`) in the esbuild configuration causing the build to fail, while the mobile entry should remain `./mobile.js`.

### Description
- Updated `scripts/build.mjs` to remove the `./app.js` entry from the `moduleEntries` map and left `./mobile.js` and other entries unchanged.

### Testing
- Ran `npm run build` which completed successfully and produced the mobile bundle (e.g. `dist/assets/mobile-*.js`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aea991f0f083248ac51cd3f9015d50)