### PR TITLE
Make build entrypoint selection resilient

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -57,12 +57,28 @@ function buildEntryMap(metafile) {
 }
 
 async function buildScripts() {
+  const mobileEntry = './mobile.js';
+  const appEntry = './app.js';
+
+  let primaryEntry;
+  try {
+    await fs.access(path.join(rootDir, mobileEntry));
+    primaryEntry = mobileEntry;
+  } catch {
+    try {
+      await fs.access(path.join(rootDir, appEntry));
+      primaryEntry = appEntry;
+    } catch {
+      throw new Error('No valid entry point found for Memory Cue build.');
+    }
+  }
+
   const moduleEntries = {
     './js/main.js': 'main',
     './js/config-supabase.js': 'config-supabase',
     './js/init-env.js': 'init-env',
     './js/mobile-theme-toggle.js': 'mobile-theme-toggle',
-    './mobile.js': 'mobile',
+    [primaryEntry]: 'mobile',
   };
 
   const legacyEntries = {


### PR DESCRIPTION
### Motivation
- Prevent build failures when the configured mobile entry file changes by selecting an existing entry before invoking esbuild.
- Prefer `./mobile.js`, fall back to `./app.js`, and surface a clear error if neither exists to make build failures actionable.

### Description
- Updated `scripts/build.mjs` to probe for `./mobile.js` and `./app.js` using `fs.access` and set a `primaryEntry` accordingly.
- Replaced the hard-coded mobile entry in `moduleEntries` with a dynamic entry computed as `[primaryEntry]: 'mobile'`.
- Throws the exact error `"No valid entry point found for Memory Cue build."` when neither entry file is present.
- Kept all other build behavior unchanged (esbuild options, CSS hashing, static copying, and HTML rewrites).

### Testing
- Ran `npm run build` and the build completed successfully (generated `dist` assets).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aeab310c7083249a3913c35ceccc42)