### PR TITLE
Simplify build pipeline to bundle only mobile app modules

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -58,18 +58,10 @@ function buildEntryMap(metafile) {
 
 async function buildScripts() {
   const moduleEntries = {
-    './js/main.js': 'main',
+    './mobile.js': 'mobile',
     './js/config-supabase.js': 'config-supabase',
     './js/init-env.js': 'init-env',
     './js/mobile-theme-toggle.js': 'mobile-theme-toggle',
-    './mobile.js': 'mobile',
-  };
-
-  const legacyEntries = {
-    './js/runtime-env-shim.js': 'runtime-env-shim',
-    './js/update-footer-year.js': 'update-footer-year',
-    './js/register-service-worker.js': 'register-service-worker',
-    './js/router.js': 'router',
   };
 
   const moduleResult = await build({
@@ -88,25 +80,7 @@ async function buildScripts() {
     logLevel: 'info',
   });
 
-  const legacyResult = await build({
-    entryPoints: Object.keys(legacyEntries),
-    outdir: distDir,
-    bundle: true,
-    splitting: false,
-    format: 'iife',
-    minify: true,
-    sourcemap: false,
-    target: ['es2017'],
-    metafile: true,
-    entryNames: 'assets/[name]-[hash]',
-    assetNames: 'assets/[name]-[hash]',
-    logLevel: 'info',
-  });
-
-  return new Map([
-    ...buildEntryMap(moduleResult.metafile),
-    ...buildEntryMap(legacyResult.metafile),
-  ]);
+  return buildEntryMap(moduleResult.metafile);
 }
 
 async function copyStatic() {


### PR DESCRIPTION
### Motivation
- Reduce build complexity so the Memory Cue PWA deploys reliably on Vercel by only producing the JS needed for the mobile app.
- Avoid bundling the service worker and legacy/desktop scripts so `service-worker.js` remains a static root file.
- Keep built JS assets grouped under `/assets` and preserve the ability to run the app directly from source without a build step.

### Description
- Updated `scripts/build.mjs` so `buildScripts()` only bundles the mobile module entry points (`./mobile.js`, `./js/config-supabase.js`, `./js/init-env.js`, `./js/mobile-theme-toggle.js`) and removed the legacy/IIFE bundling pass.
- Kept esbuild output naming (`entryNames`, `chunkNames`, `assetNames`) so compiled JS files are emitted to `dist/assets` (e.g. `dist/assets/mobile-<hash>.js`).
- Left `service-worker.js`, `mobile.html`, `manifest.webmanifest`, and `icons/` as static copies via the existing `copyStatic()` step so they remain at the repository root in `dist/` after the build.
- Continued using the existing `rewriteHtml()` step to update `dist` HTML files (including `mobile.html`) to reference the hashed JS outputs under `./assets/`, while preserving the original source `mobile.html` and `js/` files so the app still runs without a build.

### Testing
- Ran `npm run build` successfully and esbuild emitted hashed JS files under `dist/assets` (build completed without errors).
- Verified required root files exist in the build output with `test -f dist/mobile.html && test -f dist/service-worker.js && test -f dist/manifest.webmanifest && test -d dist/icons` which succeeded.
- Verified `dist/mobile.html` references the hashed JS assets under `./assets/*` using `rg -n "assets/" dist/mobile.html`, confirming `rewriteHtml()` updated script tags correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aeabcd9cbc832480bb70791b318520)