### PR TITLE
Update vercel.json to serve static files and API functions

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,15 @@
 {
-  "rewrites": [
+  "routes": [
     {
-      "source": "/api/(.*)",
-      "destination": "/api/$1"
+      "src": "/api/(.*)",
+      "dest": "/api/$1"
     },
     {
-      "source": "/(.*)",
-      "destination": "/mobile.html"
+      "handle": "filesystem"
+    },
+    {
+      "src": "/",
+      "dest": "/mobile.html"
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Replace the previous catch-all rewrite to `mobile.html` so static assets and the service worker can load correctly while keeping `/api/*` as serverless functions.

### Description
- Replace `rewrites` with ordered `routes` in `vercel.json`, add an explicit `/api/(.*)` route, insert `{"handle": "filesystem"}` to let filesystem assets (including service worker files) be served first, and map `/` to `/mobile.html` without forcing a build output directory.

### Testing
- Validated the updated file structure with `jq . vercel.json`, which succeeded and confirmed the new `routes` JSON was well-formed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aeac893ed0832489d6878838eec59e)