### PR TITLE
Add verify script to validate required build files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
   "name": "memory-cue",
   "version": "1.0.0",
-  "description": "Memory Cue – a PWA for reminders, notes, and study aids",
+  "description": "Memory Cue \u2013 a PWA for reminders, notes, and study aids",
   "main": "service-worker.js",
   "scripts": {
     "start": "serve .",
     "test": "jest",
     "deploy": "npm run build && gh-pages -d dist",
     "dev": "tailwindcss -i src/input.css -o styles/tailwind.css --watch",
-    "build": "node scripts/build.mjs"
+    "build": "node scripts/build.mjs",
+    "verify": "node scripts/verify-build.mjs"
   },
   "keywords": [],
   "author": "Daniel Maher",

--- a/scripts/verify-build.mjs
+++ b/scripts/verify-build.mjs
@@ -1,0 +1,23 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+const rootDir = process.cwd();
+
+const requiredPaths = [
+  { path: 'mobile.js', type: 'file' },
+  { path: 'mobile.html', type: 'file' },
+  { path: 'service-worker.js', type: 'file' },
+  { path: 'api', type: 'directory' },
+];
+
+const missing = requiredPaths.filter((entry) => !existsSync(path.join(rootDir, entry.path)));
+
+if (missing.length > 0) {
+  const details = missing
+    .map((entry) => `- Missing ${entry.type}: ${entry.path}`)
+    .join('\n');
+  console.error(`Build verification failed:\n${details}`);
+  process.exit(1);
+}
+
+console.log('Build verification passed.');


### PR DESCRIPTION
### Motivation
- Provide a fast pre-deploy check to catch missing build inputs and fail early for missing files or folders like `mobile.js`, `mobile.html`, `service-worker.js`, or `api/`.

### Description
- Add `scripts/verify-build.mjs` which verifies existence of `mobile.js`, `mobile.html`, `service-worker.js`, and the `api` directory and exits with an error listing any missing items, and add a `verify` npm script in `package.json` as `node scripts/verify-build.mjs`.

### Testing
- Ran `node scripts/verify-build.mjs` (and the combined check `[ -d api ] && echo api_yes || echo api_no; node scripts/verify-build.mjs`) and observed `Build verification passed.` indicating the script succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aead6448d483249142faa37092235e)