### PR TITLE
Add Assistant UI init and send handler to mobile.js

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -916,6 +916,77 @@ function openEditor() {
     setupSheet();
   }
 })();
+
+// =============================
+// Assistant UI
+// =============================
+
+function initAssistant() {
+  const sendBtn = document.getElementById('assistantSend');
+  const input = document.getElementById('assistantInput');
+  const output = document.getElementById('assistantOutput');
+
+  if (!sendBtn || !input) {
+    console.warn('Assistant UI not found');
+    return;
+  }
+
+  sendBtn.addEventListener('click', async () => {
+    const question = input.value.trim();
+    if (!question) return;
+
+    // show loading
+    if (output) {
+      output.innerHTML += `<div class="assistant-user">${question}</div>`;
+      output.innerHTML += '<div class="assistant-loading">Thinking...</div>';
+    }
+
+    try {
+      const response = await fetch('/api/assistant', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          schemaVersion: 2,
+          question,
+          contextText: '',
+          entries: [],
+        }),
+      });
+
+      const data = await response.json();
+
+      if (output) {
+        const loading = output.querySelector('.assistant-loading');
+        if (loading) loading.remove();
+
+        output.innerHTML += `
+          <div class="assistant-ai">
+            ${data.answer || 'No response'}
+          </div>
+        `;
+      }
+    } catch (err) {
+      console.error('Assistant error:', err);
+
+      if (output) {
+        output.innerHTML += `
+          <div class="assistant-error">
+            Assistant failed to respond
+          </div>
+        `;
+      }
+    }
+
+    input.value = '';
+  });
+}
+
+// ensure DOM loaded before attaching listeners
+document.addEventListener('DOMContentLoaded', () => {
+  initAssistant();
+});
 /* END GPT CHANGE */
 
 const bootstrapReminders = () => {


### PR DESCRIPTION
### Motivation
- Wire a simple Assistant UI into the mobile client so the app can post a user question to the backend and display the assistant's reply in the existing mobile bundle.

### Description
- Added an `initAssistant()` function that looks up `#assistantSend`, `#assistantInput`, and `#assistantOutput` and safely exits when elements are missing.
- Wires a click handler on the send button that appends the user's prompt and a loading indicator, posts a JSON payload to `/api/assistant` (`{ schemaVersion: 2, question, contextText: '', entries: [] }`), and renders the returned `answer` or a fallback.
- Handles network/response errors by logging to console and appending an inline error message to the output, and clears the input after send.
- Calls `initAssistant()` on `DOMContentLoaded` to ensure listeners are attached after the DOM is ready.

### Testing
- Ran the repository test suite with `npm test -- --runInBand` to validate changes against existing tests.
- Test run completed but several pre-existing test failures remain (Test Suites: 5 failed, 18 passed, 23 total; Tests: 8 failed, 69 passed), including failures in `js/__tests__/mobile.new-folder.test.js`, `js/__tests__/mobile.auth.test.js`, `js/__tests__/mobile.open-sheet.test.js`, `js/__tests__/mobile.sheet.test.js`, and `service-worker.test.js`, which are unrelated to this focused UI wiring change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aeb622c5148324a330dbc9fff40a7f)