### PR TITLE
Simplify mobile UI: single universal input bar, fixed bottom nav, and 8px spacing grid

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -1,0 +1,97 @@
+:root {
+  --space-1: 8px;
+  --space-2: 16px;
+  --space-3: 24px;
+  --mobile-bottom-nav-height: 88px;
+  --mobile-input-bar-height: 64px;
+}
+
+body {
+  overflow: hidden;
+}
+
+#main {
+  height: 100vh;
+  overflow-y: auto;
+  padding-bottom: calc(var(--mobile-bottom-nav-height) + var(--mobile-input-bar-height) + var(--space-3)) !important;
+}
+
+.mobile-header {
+  padding: var(--space-2);
+}
+
+.header-main-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-1);
+}
+
+#smartInputBar {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: calc(var(--mobile-bottom-nav-height) + var(--space-1));
+  z-index: 55;
+  padding: 0 var(--space-2);
+}
+
+.smart-input-form {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  background: #fff;
+  border: 1px solid var(--border-subtle, #e3d9f4);
+  border-radius: 999px;
+  padding: var(--space-1);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
+}
+
+.smart-input-form .quick-add-input {
+  flex: 1;
+  border: 0;
+  background: transparent;
+  min-width: 0;
+  padding: 0 var(--space-1);
+}
+
+.smart-send-button {
+  border: 0;
+  border-radius: 999px;
+  padding: 8px 16px;
+  font-weight: 600;
+  background: var(--accent-color, #512663);
+  color: #fff;
+}
+
+#mobile-nav-shell {
+  position: fixed !important;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 0 var(--space-2) var(--space-1);
+  pointer-events: none;
+}
+
+#mobile-nav-shell .floating-footer {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-1);
+  pointer-events: auto;
+}
+
+#mobile-nav-shell .floating-footer .floating-card {
+  flex: 1 1 25%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  min-height: 72px;
+}
+
+#mobile-nav-shell .floating-footer .floating-card span {
+  font-size: 12px;
+}

--- a/mobile.html
+++ b/mobile.html
@@ -10,6 +10,7 @@
   <!-- === /SUPABASE CONFIG === -->
   <!-- Production CSS: compiled via Tailwind/PostCSS; build rewrites this to a hashed asset -->
   <link rel="stylesheet" href="./styles/index.css" />
+  <link rel="stylesheet" href="./mobile.css" />
   <style>
     :root {
       --card-bg: color-mix(in srgb, #ffffff 92%, #f8f4ec 8%); /* off-white card surface */
@@ -4508,11 +4509,10 @@ body, main, section, div, p, span, li {
   <!-- Unified Mobile Header -->
   <header id="reminders-slim-header" class="mobile-header" role="banner">
     <div class="header-main-row">
-      <h1 class="header-title">Reminders</h1>
+      <h1 class="header-title">Memory Cue</h1>
       <div class="header-actions">
-        <!-- The existing icon buttons can be moved here -->
         <button id="openSavedNotesGlobal" type="button" class="icon-button control-icon-button" aria-label="Open saved notes">
-          <span class="material-symbols-rounded">bookmark</span>
+          <span class="material-symbols-rounded">search</span>
         </button>
         <button id="startVoiceCaptureGlobal" type="button" class="icon-button control-icon-button" aria-label="Start voice capture">
           <span class="material-symbols-rounded">mic</span>
@@ -4522,26 +4522,10 @@ body, main, section, div, p, span, li {
         </button>
       </div>
     </div>
-    <div class="header-quick-add">
-      <form id="quickAddForm" class="quick-add-form">
-        <button id="quickAddSubmit" type="submit" class="icon-button quick-add-submit" aria-label="Add reminder">
-          <span class="material-symbols-rounded">add</span>
-        </button>
-        <input id="quickAddInput" class="control-input quick-add-input" type="text" placeholder="Quick reminder..." autocomplete="off" />
-        <span id="quickAddParsingIndicator" class="text-xs text-base-content/70" hidden>Parsing…</span>
-        <span id="quickAddSuccessIndicator" class="text-xs text-success" role="status" aria-live="polite" hidden>Saved ✓</span>
-        <div class="quick-add-tabs">
-          <button type="button" class="filter-toggle reminder-tab reminders-tab-active" data-reminders-tab="all" data-filter="all" aria-pressed="true">All</button>
-          <button type="button" class="filter-toggle reminder-tab" data-reminders-tab="today" data-filter="today" aria-pressed="false">Today</button>
-        </div>
-      </form>
-    </div>
-    <div class="header-search">
-      <div id="inboxSearchContainer" class="inbox-search-container" role="search" aria-label="Inbox search">
-        <div class="inbox-search-input-wrap">
-          <input id="inboxSearchInput" class="control-input inbox-search-input" type="search" placeholder="Search reminders, notes, drills…" autocomplete="off" />
-          <button id="inboxSearchClear" type="button" class="inbox-search-clear control-icon-button" aria-label="Clear inbox search" hidden>&times;</button>
-        </div>
+    <div id="inboxSearchContainer" class="inbox-search-container hidden" role="search" aria-label="Inbox search">
+      <div class="inbox-search-input-wrap">
+        <input id="inboxSearchInput" class="control-input inbox-search-input" type="search" placeholder="Search reminders, notes, drills…" autocomplete="off" />
+        <button id="inboxSearchClear" type="button" class="inbox-search-clear control-icon-button" aria-label="Clear inbox search" hidden>&times;</button>
       </div>
     </div>
     <div id="overflowMenu" class="overflow-menu quick-actions-panel hidden" role="menu" aria-hidden="true">
@@ -5099,22 +5083,9 @@ body, main, section, div, p, span, li {
             </div>
     <section data-view="assistant" id="view-assistant" class="view-panel hidden" aria-hidden="true">
       <div class="assistant-panel">
-        <div id="thinkingBarContainer">
-          <input id="thinkingBarInput" class="input input-sm w-full" placeholder="Capture, search, or ask…" autocomplete="off" />
-        </div>
         <div id="thinkingBarStatus" class="hidden" aria-live="polite"></div>
         <div id="thinkingBarResults" aria-live="polite"></div>
         <div id="assistantThread" aria-live="polite" aria-label="Assistant conversation"></div>
-        <form id="assistantForm" class="hidden">
-          <input
-            id="assistantInput"
-            type="text"
-            class="input input-sm w-full"
-            placeholder="Ask Memory Cue assistant..."
-            autocomplete="off"
-          />
-          <button id="assistantSend" type="submit" class="btn btn-sm btn-primary">Send</button>
-        </form>
         <div id="assistantLoading" class="hidden" aria-live="polite">Assistant is thinking…</div>
       </div>
     </section>
@@ -5130,6 +5101,15 @@ body, main, section, div, p, span, li {
         <!-- populated dynamically -->
       </ul>
     </div>
+  </div>
+
+  <div id="smartInputBar" class="smart-input-bar">
+    <form id="quickAddForm" class="smart-input-form">
+      <input id="quickAddInput" class="control-input quick-add-input" type="text" placeholder="Capture, search, or ask..." autocomplete="off" />
+      <button id="quickAddSubmit" type="submit" class="smart-send-button" aria-label="Send">Send</button>
+      <span id="quickAddParsingIndicator" class="text-xs text-base-content/70" hidden>Parsing…</span>
+      <span id="quickAddSuccessIndicator" class="text-xs text-success" role="status" aria-live="polite" hidden>Saved ✓</span>
+    </form>
   </div>
 
   <div id="mobile-nav-shell" class="sticky inset-x-0 bottom-0 z-50 flex justify-center pointer-events-none px-2 pb-3">
@@ -5156,6 +5136,7 @@ body, main, section, div, p, span, li {
           <circle cx="12" cy="12" r="7" />
           <path d="M12 9v3.5l2 1.5" />
         </svg>
+        <span>Reminders</span>
       </button>
 
       <button
@@ -5182,6 +5163,7 @@ body, main, section, div, p, span, li {
           <path d="M10 8h4" />
           <path d="M10 11.5h4" />
         </svg>
+        <span>Notes</span>
       </button>
 
       <button

--- a/mobile.js
+++ b/mobile.js
@@ -46,24 +46,24 @@ function initAssistant() {
         ? value instanceof HTMLButtonElement
         : value && value.tagName === 'BUTTON';
 
-    const assistantForm = document.getElementById('assistantForm');
-    const assistantInput = document.getElementById('assistantInput');
     const assistantThread = document.getElementById('assistantThread');
     const assistantSendBtn = document.getElementById('assistantSend');
     const assistantLoading = document.getElementById('assistantLoading');
-    const thinkingBarInput = document.getElementById('thinkingBarInput');
+    const thinkingBarInput = document.getElementById('thinkingBarInput') || document.getElementById('quickAddInput');
+    const universalInput = document.getElementById('quickAddInput') || thinkingBarInput;
+    const quickAddForm = document.getElementById('quickAddForm');
+    const inboxSearchInput = document.getElementById('inboxSearchInput');
     const thinkingBarStatus = document.getElementById('thinkingBarStatus');
     const thinkingBarResults = document.getElementById('thinkingBarResults');
     let isAssistantSending = false;
     let latestThinkingSearchRequest = 0;
 
-    if (!isFormElement(assistantForm) || !isInputElement(thinkingBarInput) || !(assistantThread instanceof HTMLElement)) {
+    if (!isInputElement(thinkingBarInput) || !(assistantThread instanceof HTMLElement)) {
       return;
     }
 
-    if (!isInputElement(assistantInput) || !isButtonElement(assistantSendBtn)) {
+    if (assistantSendBtn && !isButtonElement(assistantSendBtn)) {
       console.warn('[assistant] Send button not found; click listener was not attached.');
-      return;
     }
 
     const appendAssistantMessage = (text, className = 'assistant-message') => {
@@ -328,6 +328,17 @@ function initAssistant() {
       ]);
     };
 
+
+    const getActiveView = () => document.body?.getAttribute('data-active-view') || '';
+
+    const syncInboxSearchInput = () => {
+      if (!isInputElement(universalInput) || !isInputElement(inboxSearchInput)) {
+        return;
+      }
+      inboxSearchInput.value = universalInput.value;
+      inboxSearchInput.dispatchEvent(new Event('input', { bubbles: true }));
+    };
+
     const sendAssistantMessage = async (event) => {
       if (event) {
         event.preventDefault();
@@ -479,6 +490,11 @@ function initAssistant() {
     thinkingBarInput.addEventListener('input', () => {
       const query = typeof thinkingBarInput.value === 'string' ? thinkingBarInput.value.trim() : '';
 
+      if (getActiveView() === 'inbox') {
+        syncInboxSearchInput();
+        return;
+      }
+
       if (query.length <= 2) {
         latestThinkingSearchRequest += 1;
         clearThinkingBarResults();
@@ -488,6 +504,20 @@ function initAssistant() {
 
       renderSearchResults(query);
     });
+
+    if (isFormElement(quickAddForm) && isInputElement(universalInput)) {
+      quickAddForm.addEventListener('submit', (event) => {
+        const activeView = getActiveView();
+        if (activeView === 'assistant') {
+          sendAssistantMessage(event);
+          return;
+        }
+        if (activeView === 'inbox') {
+          event.preventDefault();
+          syncInboxSearchInput();
+        }
+      });
+    }
 
     // The legacy assistant form is handled by js/assistant.js via a submit listener.
     // Avoid binding a separate click/keydown handler here, because preventing default


### PR DESCRIPTION
### Motivation
- Reduce clutter by replacing multiple stacked inputs (quick reminder, duplicate search, assistant input) with a single universal input bar on mobile. 
- Preserve existing reminder and assistant functionality while making the interface mobile-first and easier to scan.
- Enforce consistent spacing using an 8px spacing grid and keep input/navigation fixed while content scrolls.

### Description
- Added `mobile.css` and linked it from `mobile.html` to provide mobile-first layout overrides, spacing variables (`--space-1: 8px`), fixed smart input bar sizing, and fixed bottom navigation sizing.
- Simplified the header in `mobile.html` to a title row and compact icon actions, removed the visible quick-reminder and assistant input fields from the header/assistant panel, and hid the duplicate inbox search in the header.
- Introduced a single universal smart input bar in `mobile.html` with placeholder `"Capture, search, or ask..."` and a `Send` button positioned fixed above the bottom nav, and added labels to bottom nav items so icons are equally spaced and labeled (Reminders, Notes, Inbox, Assistant).
- Updated `mobile.js` to use the universal input as a fallback (`thinkingBarInput || quickAddInput`), route form submissions based on the active view (assistant/inbox/reminders), and synchronize the universal input to the inbox search when the Inbox view is active, preserving existing capture/assistant behaviour.

### Testing
- Ran targeted unit tests with `npm test -- --runInBand js/__tests__/mobile.header.test.js js/__tests__/mobile.footer-nav.test.js`, both test suites passed.
- Served the site with `npm start` and validated the mobile page visually by capturing a Playwright screenshot of `mobile.html` at a mobile viewport to confirm layout (screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aebbe53e7c832487a096ad2ea9c6cc)