### PR TITLE
Redesign mobile UI with a universal capture input

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -13,7 +13,7 @@ body {
 #main {
   height: 100vh;
   overflow-y: auto;
-  padding-bottom: calc(var(--mobile-bottom-nav-height) + var(--mobile-input-bar-height) + var(--space-3)) !important;
+  padding-bottom: calc(var(--mobile-bottom-nav-height) + var(--mobile-input-bar-height) + var(--space-2)) !important;
 }
 
 .mobile-header {
@@ -94,4 +94,29 @@ body {
 
 #mobile-nav-shell .floating-footer .floating-card span {
   font-size: 12px;
+}
+
+
+#view-reminders,
+#view-notebook,
+#view-inbox,
+#view-assistant {
+  padding: 0 var(--space-2);
+}
+
+#reminderList [data-reminder-item],
+#reminderList .reminder-card,
+#assistantThread .assistant-message {
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(31, 26, 36, 0.08);
+  padding: 12px;
+  background: #fff;
+}
+
+.smart-input-form .quick-add-input::placeholder {
+  color: var(--text-muted, #9a8bb0);
+}
+
+#mobile-nav-shell .floating-footer .floating-card {
+  border-radius: 14px;
 }

--- a/mobile.html
+++ b/mobile.html
@@ -4514,18 +4514,9 @@ body, main, section, div, p, span, li {
         <button id="openSavedNotesGlobal" type="button" class="icon-button control-icon-button" aria-label="Open saved notes">
           <span class="material-symbols-rounded">search</span>
         </button>
-        <button id="startVoiceCaptureGlobal" type="button" class="icon-button control-icon-button" aria-label="Start voice capture">
-          <span class="material-symbols-rounded">mic</span>
-        </button>
         <button id="overflowMenuBtn" type="button" class="icon-button control-icon-button" aria-haspopup="true" aria-expanded="false" aria-controls="overflowMenu" aria-label="More options">
           <span class="material-symbols-rounded">more_vert</span>
         </button>
-      </div>
-    </div>
-    <div id="inboxSearchContainer" class="inbox-search-container hidden" role="search" aria-label="Inbox search">
-      <div class="inbox-search-input-wrap">
-        <input id="inboxSearchInput" class="control-input inbox-search-input" type="search" placeholder="Search reminders, notes, drills…" autocomplete="off" />
-        <button id="inboxSearchClear" type="button" class="inbox-search-clear control-icon-button" aria-label="Clear inbox search" hidden>&times;</button>
       </div>
     </div>
     <div id="overflowMenu" class="overflow-menu quick-actions-panel hidden" role="menu" aria-hidden="true">

--- a/mobile.js
+++ b/mobile.js
@@ -41,18 +41,11 @@ function initAssistant() {
       typeof HTMLInputElement !== 'undefined'
         ? value instanceof HTMLInputElement
         : value && value.tagName === 'INPUT';
-    const isButtonElement = (value) =>
-      typeof HTMLButtonElement !== 'undefined'
-        ? value instanceof HTMLButtonElement
-        : value && value.tagName === 'BUTTON';
-
     const assistantThread = document.getElementById('assistantThread');
-    const assistantSendBtn = document.getElementById('assistantSend');
     const assistantLoading = document.getElementById('assistantLoading');
     const thinkingBarInput = document.getElementById('thinkingBarInput') || document.getElementById('quickAddInput');
     const universalInput = document.getElementById('quickAddInput') || thinkingBarInput;
     const quickAddForm = document.getElementById('quickAddForm');
-    const inboxSearchInput = document.getElementById('inboxSearchInput');
     const thinkingBarStatus = document.getElementById('thinkingBarStatus');
     const thinkingBarResults = document.getElementById('thinkingBarResults');
     let isAssistantSending = false;
@@ -60,10 +53,6 @@ function initAssistant() {
 
     if (!isInputElement(thinkingBarInput) || !(assistantThread instanceof HTMLElement)) {
       return;
-    }
-
-    if (assistantSendBtn && !isButtonElement(assistantSendBtn)) {
-      console.warn('[assistant] Send button not found; click listener was not attached.');
     }
 
     const appendAssistantMessage = (text, className = 'assistant-message') => {
@@ -332,11 +321,12 @@ function initAssistant() {
     const getActiveView = () => document.body?.getAttribute('data-active-view') || '';
 
     const syncInboxSearchInput = () => {
-      if (!isInputElement(universalInput) || !isInputElement(inboxSearchInput)) {
+      if (!isInputElement(universalInput)) {
         return;
       }
-      inboxSearchInput.value = universalInput.value;
-      inboxSearchInput.dispatchEvent(new Event('input', { bubbles: true }));
+      document.dispatchEvent(new CustomEvent('memoryCue:universalSearch', {
+        detail: { query: universalInput.value },
+      }));
     };
 
     const sendAssistantMessage = async (event) => {
@@ -354,13 +344,13 @@ function initAssistant() {
         return;
       }
 
-      const isAssistantMode = trimmedMessage.endsWith('?');
-      const isSearchMode = !isAssistantMode && trimmedMessage.length < 40 && !trimmedMessage.startsWith('+');
-      const isCaptureMode = trimmedMessage.startsWith('+') || (!isAssistantMode && !isSearchMode);
+      const isReminderMode = /\bremind\b/i.test(trimmedMessage);
+      const isAssistantMode = /[?]$/.test(trimmedMessage);
+      const isCaptureMode = !isReminderMode && !isAssistantMode;
 
       console.log('[assistant] send handler executed', {
         textLength: trimmedMessage.length,
-        mode: isCaptureMode ? 'capture' : isSearchMode ? 'search' : 'assistant',
+        mode: isReminderMode ? 'reminder' : isCaptureMode ? 'capture' : 'assistant',
       });
       isAssistantSending = true;
 
@@ -374,17 +364,24 @@ function initAssistant() {
       thinkingBarInput.value = '';
       thinkingBarInput.focus();
 
-      if (isSearchMode) {
-        if (assistantLoading instanceof HTMLElement) {
-          assistantLoading.classList.add('hidden');
-        }
-        isAssistantSending = false;
-        await renderSearchResults(trimmedMessage);
-        return;
-      }
-
       try {
-        if (isCaptureMode) {
+        if (isReminderMode) {
+          const reminderOpenEvent = new CustomEvent('cue:open', { detail: { trigger: 'universal-input' } });
+          document.dispatchEvent(reminderOpenEvent);
+
+          const reminderTitleInput = document.getElementById('reminderText');
+          if (isInputElement(reminderTitleInput)) {
+            reminderTitleInput.value = trimmedMessage;
+            reminderTitleInput.dispatchEvent(new Event('input', { bubbles: true }));
+          }
+
+          const reminderSaveEvent = new CustomEvent('reminder:save', {
+            detail: { trigger: document.getElementById('saveReminder') },
+          });
+          document.dispatchEvent(reminderSaveEvent);
+          appendAssistantMessage('Reminder created.', 'assistant-message assistant-message--reply');
+          setThinkingBarStatus('Reminder saved');
+        } else if (isCaptureMode) {
           const captureText = trimmedMessage.startsWith('+') ? trimmedMessage.slice(1).trim() : trimmedMessage;
           const response = await fetch('/api/capture', {
             method: 'POST',
@@ -466,7 +463,10 @@ function initAssistant() {
           setThinkingBarStatus('Assistant answer');
         }
       } catch (error) {
-        if (isCaptureMode) {
+        if (isReminderMode) {
+          console.error('[assistant] failed to create reminder from universal input', error);
+          appendAssistantMessage('Sorry, I couldn\'t create that reminder.', 'assistant-message assistant-message--error');
+        } else if (isCaptureMode) {
           console.error('[assistant] request failed while calling /api/capture', error);
           appendAssistantMessage('Sorry, I couldn\'t save that brain dump.', 'assistant-message assistant-message--error');
         } else {


### PR DESCRIPTION
### Motivation
- Replace multiple stacked mobile input fields with a single Universal Capture bar to reduce clutter and improve capture/search/assistant workflows.
- Follow the requested mobile layout: minimal header, scrollable content, fixed smart input above the bottom nav, and card-based item presentation.

### Description
- Removed the header voice capture button and the inbox search input row and kept a single universal input form (`#quickAddForm` / `#quickAddInput`) fixed above the bottom navigation, with placeholder `Capture, search, or ask...` (updated `mobile.html`).
- Implemented classification in the universal input send handler so inputs containing the word `remind` open the reminder sheet and trigger a save, inputs ending in `?` route to the assistant API, and all other text uses the existing capture flow to save notes (updated `mobile.js`).
- Replaced inbox-sync behavior with an event-driven universal search dispatch (`memoryCue:universalSearch`) so the universal input can feed search without duplicating inputs (updated `mobile.js`).
- Tightened mobile spacing, adjusted bottom padding, added rounded card styling and subtle shadows for reminder/assistant items, and ensured the smart input bar and bottom nav spacing follow the 8px grid (updated `mobile.css`).

### Testing
- Ran `npm run verify` which passed successfully.
- Ran `npm test -- --runInBand`; test run shows existing unrelated failures in `mobile.auth`, `mobile.sheet`, and `service-worker` suites that pre-existed these UI changes and are not caused by the universal input changes.
- Started the dev server with `npm start` and captured a Playwright screenshot of `/mobile.html` for visual verification (screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aebd7d6a10832497241b473ac765a0)