### PR TITLE
Introduce structured memoryEntries and type-aware assistant retrieval

### DIFF
--- a/api/assistant.js
+++ b/api/assistant.js
@@ -30,6 +30,7 @@ function trimEntry(entry) {
   const title = typeof entry.title === 'string' ? entry.title.slice(0, MAX_ENTRY_CHARS) : '';
   const body = typeof entry.body === 'string' ? entry.body.slice(0, MAX_ENTRY_CHARS) : '';
   const createdAt = typeof entry.createdAt === 'string' ? entry.createdAt.slice(0, 64) : null;
+  const updatedAt = typeof entry.updatedAt === 'string' ? entry.updatedAt.slice(0, 64) : null;
   const tags = Array.isArray(entry.tags)
     ? entry.tags
         .map((tag) => (typeof tag === 'string' ? tag.slice(0, 64) : ''))
@@ -37,12 +38,30 @@ function trimEntry(entry) {
         .slice(0, 20)
     : [];
 
+  const relatedIds = Array.isArray(entry.relatedIds)
+    ? entry.relatedIds
+        .map((relatedId) => (typeof relatedId === 'string' ? relatedId.slice(0, 128) : ''))
+        .filter(Boolean)
+        .slice(0, 30)
+    : [];
+
   if (!title && !body) {
     return null;
   }
 
-  return { id, type, title, body, tags, createdAt };
+  return { id, type, title, body, tags, createdAt, updatedAt, relatedIds };
 }
+
+function inferRelevantType(question) {
+  const normalized = typeof question === 'string' ? question.toLowerCase() : '';
+  if (normalized.includes('drill') || normalized.includes('footy')) return 'drill';
+  if (normalized.includes('remind')) return 'reminder';
+  if (normalized.includes('task') || normalized.includes('todo') || normalized.includes('to do')) return 'task';
+  if (normalized.includes('idea')) return 'idea';
+  if (normalized.includes('note')) return 'note';
+  return null;
+}
+
 
 module.exports = async function handler(req, res) {
   applyCors(req, res);
@@ -87,6 +106,11 @@ module.exports = async function handler(req, res) {
   }
 
   const entries = rawEntries.map(trimEntry).filter(Boolean);
+  const relevantType = inferRelevantType(question);
+  const rankedEntries = relevantType
+    ? entries.filter((entry) => entry.type === relevantType)
+    : entries;
+  const selectedEntries = (rankedEntries.length ? rankedEntries : entries).slice(0, MAX_ENTRIES);
   const entryById = new Map(
     entries
       .filter((entry) => entry.id)
@@ -121,7 +145,7 @@ module.exports = async function handler(req, res) {
             content: [
               {
                 type: 'input_text',
-                text: `Search these notes and answer the question.\n\nQuestion:\n${question}\n\nContext:\n${contextText}\n\nEntries JSON:\n${JSON.stringify(entries)}`
+                text: `Search these notes and answer the question.\n\nQuestion:\n${question}\n\nContext:\n${contextText}\n\nEntries JSON:\n${JSON.stringify(selectedEntries)}`
               }
             ]
           }

--- a/api/capture.js
+++ b/api/capture.js
@@ -36,7 +36,7 @@ module.exports = async function handler(req, res) {
   const schemaVersion = payload.schemaVersion;
   const input = typeof payload.input === 'string' ? payload.input.trim() : '';
 
-  if (schemaVersion !== 1) {
+  if (schemaVersion !== 2) {
     return res.status(400).json({ error: 'Invalid schemaVersion.' });
   }
 
@@ -69,14 +69,8 @@ module.exports = async function handler(req, res) {
                   'Turn the user\'s free-text input into one structured Memory Cue entry.',
                   'Keep titles short and useful.',
                   'Preserve the user\'s meaning.',
-                  'Classify into practical types such as: task, reminder, lesson-idea, lesson-reflection, footy-drill, coaching-note, meeting-note, personal-note, resource.',
+                  'Classify into one type only: note, reminder, drill, idea, or task.',
                   'Generate 0 to 5 short lowercase tags.',
-                  'Choose a simple folder name like: Teaching, Coaching, Personal, Admin, Ideas.',
-                  'Set priority as low, medium, or high based on urgency/importance.',
-                  'Set actionDate to null unless the user clearly implies timing; if implied, return a short ISO-like string the app can store (for example: tomorrow morning, monday, before training, next lesson).',
-                  'Set followUpQuestion to an empty string unless one short clarifying question would materially improve the entry later.',
-                  'Lean into teacher/coach workflows by correctly routing school/lesson notes to Teaching and training/footy notes to Coaching when appropriate.',
-                  'If uncertain, still return the best structure and lower the confidence score.',
                   'Never return markdown.',
                   'Never return extra keys.'
                 ].join(' ')
@@ -102,34 +96,27 @@ module.exports = async function handler(req, res) {
               type: 'object',
               additionalProperties: false,
               properties: {
-                type: { type: 'string' },
+                type: {
+                  type: 'string',
+                  enum: ['note', 'reminder', 'drill', 'idea', 'task']
+                },
                 title: { type: 'string' },
                 body: { type: 'string' },
                 tags: {
                   type: 'array',
                   items: { type: 'string' }
                 },
-                folder: { type: 'string' },
-                priority: {
-                  type: 'string',
-                  enum: ['low', 'medium', 'high']
-                },
-                actionDate: {
-                  type: ['string', 'null']
-                },
-                followUpQuestion: { type: 'string' },
-                confidence: { type: 'number' }
+                relatedIds: {
+                  type: 'array',
+                  items: { type: 'string' }
+                }
               },
               required: [
                 'type',
                 'title',
                 'body',
                 'tags',
-                'folder',
-                'priority',
-                'actionDate',
-                'followUpQuestion',
-                'confidence'
+                'relatedIds'
               ]
             }
           }
@@ -169,15 +156,7 @@ module.exports = async function handler(req, res) {
         title: result.title,
         body: result.body,
         tags: Array.isArray(result.tags) ? result.tags : [],
-        folder: result.folder,
-        priority:
-          result.priority === 'high' || result.priority === 'medium' || result.priority === 'low'
-            ? result.priority
-            : 'low',
-        actionDate: typeof result.actionDate === 'string' ? result.actionDate : null,
-        followUpQuestion:
-          typeof result.followUpQuestion === 'string' ? result.followUpQuestion : '',
-        confidence: typeof result.confidence === 'number' ? result.confidence : 0
+        relatedIds: Array.isArray(result.relatedIds) ? result.relatedIds : []
       }
     });
   } catch (_error) {

--- a/api/parse-entry.js
+++ b/api/parse-entry.js
@@ -5,12 +5,11 @@ const PARSED_ENTRY_SCHEMA = {
     type: {
       type: 'string',
       enum: [
-        'footy_drill',
-        'netball_note',
-        'reflection',
+        'note',
         'reminder',
-        'teaching_note',
-        'general_note'
+        'drill',
+        'idea',
+        'task'
       ]
     },
     title: { type: 'string' },
@@ -92,7 +91,7 @@ module.exports = async function handler(req, res) {
             content: [
               {
                 type: 'input_text',
-                text: `Return ONLY JSON matching schema.\nExtract:\n- type (footy_drill, netball_note, reflection, reminder, teaching_note, general_note)\n- title (short summary under 60 chars)\n- tags (lowercase keywords)\n- reminderDate (ISO string if date/time mentioned, else null)\nIf unsure, use general_note.`
+                text: `Return ONLY JSON matching schema.\nExtract:\n- type (note, reminder, drill, idea, task)\n- title (short summary under 60 chars)\n- tags (lowercase keywords)\n- reminderDate (ISO string if date/time mentioned, else null)\nIf unsure, use note.`
               }
             ]
           },

--- a/js/__tests__/reminders.quick-add.test.js
+++ b/js/__tests__/reminders.quick-add.test.js
@@ -106,6 +106,11 @@ test('quick add routes footy drill prefix to Footy – Drills category', async (
   expect(items[0].category).toBe('Footy – Drills');
   expect(Number.isFinite(items[0].createdAt)).toBe(true);
   expect(Number.isFinite(items[0].updatedAt)).toBe(true);
+
+  const memoryEntries = JSON.parse(localStorage.getItem('memoryEntries') || '[]');
+  expect(memoryEntries).toHaveLength(1);
+  expect(memoryEntries[0].type).toBe('drill');
+  expect(Array.isArray(memoryEntries[0].relatedIds)).toBe(true);
 });
 
 test('quick add routes task prefix to Tasks category', async () => {

--- a/js/entries.js
+++ b/js/entries.js
@@ -134,7 +134,7 @@
 
   const readEntries = () => {
     try {
-      const raw = window.localStorage?.getItem('memoryCueEntries');
+      const raw = window.localStorage?.getItem('memoryEntries');
       if (!raw) return [];
       const parsed = JSON.parse(raw);
       if (Array.isArray(parsed)) return parsed;
@@ -148,7 +148,7 @@
 
   const writeEntries = (entries) => {
     try {
-      window.localStorage?.setItem('memoryCueEntries', JSON.stringify(entries));
+      window.localStorage?.setItem('memoryEntries', JSON.stringify(entries));
       document.dispatchEvent(new CustomEvent('memoryCue:entriesUpdated'));
     } catch (error) {
       console.warn('Unable to update memoryCueEntries in localStorage', error);
@@ -223,6 +223,11 @@
       const meta = document.createElement('div');
       meta.className = 'text-xs opacity-70 flex items-center gap-2 flex-wrap';
 
+      const typeTag = document.createElement('span');
+      typeTag.className = 'badge badge-outline badge-sm';
+      const entryType = typeof entry?.type === 'string' && entry.type.trim() ? entry.type.trim() : 'note';
+      typeTag.textContent = `${entryType.charAt(0).toUpperCase()}${entryType.slice(1)} card`;
+
       const categoryTag = document.createElement('span');
       categoryTag.className = 'badge badge-outline badge-sm';
       categoryTag.textContent = getEntryCategory(entry);
@@ -230,7 +235,7 @@
       const createdAt = document.createElement('span');
       createdAt.textContent = getEntryCreatedDate(entry);
 
-      meta.append(categoryTag, createdAt);
+      meta.append(typeTag, categoryTag, createdAt);
 
       const actions = document.createElement('div');
       actions.className = 'flex items-center gap-2 flex-wrap';
@@ -332,7 +337,7 @@
 
   document.addEventListener('memoryCue:entriesUpdated', renderInboxEntries);
   window.addEventListener('storage', (event) => {
-    if (event.key === 'memoryCueEntries') {
+    if (event.key === 'memoryEntries') {
       renderInboxEntries();
     }
   });
@@ -341,7 +346,7 @@
     const originalSetItem = window.localStorage.setItem.bind(window.localStorage);
     window.localStorage.setItem = function patchedSetItem(key, value) {
       originalSetItem(key, value);
-      if (key === 'memoryCueEntries') {
+      if (key === 'memoryEntries') {
         document.dispatchEvent(new CustomEvent('memoryCue:entriesUpdated'));
       }
     };

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -930,6 +930,7 @@ export async function initReminders(sel = {}) {
   let isQuickAddSubmitting = false;
   let stopQuickAddVoiceListening = null;
   const NOTES_STORAGE_KEY = 'memoryCueNotes';
+  const MEMORY_ENTRIES_STORAGE_KEY = 'memoryEntries';
   const FOLDERS_STORAGE_KEY = 'memoryCueFolders';
   const REFLECTION_FOLDER_NAME = 'Lesson – Reflections';
   const SMART_TAG_KEYWORDS = [
@@ -1052,12 +1053,47 @@ export async function initReminders(sel = {}) {
 
   function classifyInput(text) {
     const normalized = typeof text === 'string' ? text.toLowerCase() : '';
-    if (normalized.includes('footy')) return 'footy_drill';
-    if (normalized.includes('netball')) return 'netball_note';
-    if (normalized.includes('reflection')) return 'reflection';
     if (normalized.includes('remind')) return 'reminder';
-    if (normalized.includes('lesson')) return 'teaching_note';
-    return 'general_note';
+    if (normalized.includes('drill') || normalized.includes('footy')) return 'drill';
+    if (normalized.includes('task') || normalized.includes('todo') || normalized.includes('to do')) return 'task';
+    if (normalized.includes('idea')) return 'idea';
+    return 'note';
+  }
+
+  function normalizeMemoryEntryType(type) {
+    const value = typeof type === 'string' ? type.trim().toLowerCase() : '';
+    if (value === 'note' || value === 'reminder' || value === 'drill' || value === 'idea' || value === 'task') {
+      return value;
+    }
+    return 'note';
+  }
+
+  function inferRelevantEntryType(query) {
+    const normalized = typeof query === 'string' ? query.toLowerCase() : '';
+    if (normalized.includes('remind')) return 'reminder';
+    if (normalized.includes('drill') || normalized.includes('footy')) return 'drill';
+    if (normalized.includes('task') || normalized.includes('todo') || normalized.includes('to do')) return 'task';
+    if (normalized.includes('idea')) return 'idea';
+    if (normalized.includes('note')) return 'note';
+    return null;
+  }
+
+  function readMemoryEntries() {
+    return readJsonArrayStorage(MEMORY_ENTRIES_STORAGE_KEY, []);
+  }
+
+  function writeMemoryEntries(entries) {
+    if (typeof localStorage === 'undefined') {
+      return;
+    }
+    localStorage.setItem(MEMORY_ENTRIES_STORAGE_KEY, JSON.stringify(entries));
+    try {
+      if (typeof document !== 'undefined' && typeof CustomEvent === 'function') {
+        document.dispatchEvent(new CustomEvent('memoryCue:entriesUpdated'));
+      }
+    } catch {
+      // Ignore event dispatch failures.
+    }
   }
 
   function extractTitle(text) {
@@ -1391,11 +1427,15 @@ export async function initReminders(sel = {}) {
 
   function buildInboxSearchEntries() {
     const reminderEntries = (Array.isArray(items) ? items : []).map((item) => ({
-      type: 'Reminder',
+      id: item?.id || '',
+      type: 'reminder',
       title: item?.title || '',
       body: item?.notes || '',
       category: item?.category || '',
       tags: Array.isArray(item?.tags) ? item.tags : [],
+      relatedIds: [],
+      createdAt: Number.isFinite(item?.createdAt) ? new Date(item.createdAt).toISOString() : '',
+      updatedAt: Number.isFinite(item?.updatedAt) ? new Date(item.updatedAt).toISOString() : '',
       timestamp: Number.isFinite(item?.createdAt) ? item.createdAt : null,
       semanticEmbedding: normalizeSemanticEmbedding(item?.semanticEmbedding),
     }));
@@ -1403,18 +1443,41 @@ export async function initReminders(sel = {}) {
       const noteTime = typeof note?.updatedAt === 'string' ? Date.parse(note.updatedAt) : Number.NaN;
       const createdTime = typeof note?.createdAt === 'string' ? Date.parse(note.createdAt) : Number.NaN;
       return {
-        type: 'Note',
+        id: note?.id || '',
+        type: 'note',
         title: note?.title || '',
         body: note?.bodyText || note?.body || '',
         category: note?.metadata?.type || '',
         tags: Array.isArray(note?.metadata?.tags) ? note.metadata.tags : [],
+        relatedIds: Array.isArray(note?.relatedIds) ? note.relatedIds : [],
+        createdAt: typeof note?.createdAt === 'string' ? note.createdAt : '',
+        updatedAt: typeof note?.updatedAt === 'string' ? note.updatedAt : '',
         timestamp: Number.isFinite(noteTime) ? noteTime : (Number.isFinite(createdTime) ? createdTime : null),
         semanticEmbedding: normalizeSemanticEmbedding(note?.semanticEmbedding),
       };
     });
 
-    return [...reminderEntries, ...noteEntries];
+    const memoryEntries = readMemoryEntries().map((entry) => {
+      const updatedTime = typeof entry?.updatedAt === 'string' ? Date.parse(entry.updatedAt) : Number.NaN;
+      const createdTime = typeof entry?.createdAt === 'string' ? Date.parse(entry.createdAt) : Number.NaN;
+      return {
+        id: typeof entry?.id === 'string' ? entry.id : '',
+        type: normalizeMemoryEntryType(entry?.type),
+        title: typeof entry?.title === 'string' ? entry.title : '',
+        body: typeof entry?.body === 'string' ? entry.body : '',
+        category: typeof entry?.category === 'string' ? entry.category : '',
+        tags: Array.isArray(entry?.tags) ? entry.tags : [],
+        relatedIds: Array.isArray(entry?.relatedIds) ? entry.relatedIds : [],
+        createdAt: typeof entry?.createdAt === 'string' ? entry.createdAt : '',
+        updatedAt: typeof entry?.updatedAt === 'string' ? entry.updatedAt : '',
+        timestamp: Number.isFinite(updatedTime) ? updatedTime : (Number.isFinite(createdTime) ? createdTime : null),
+        semanticEmbedding: null,
+      };
+    });
+
+    return [...reminderEntries, ...noteEntries, ...memoryEntries];
   }
+
 
   function buildSearchHaystack(entry) {
     const tags = Array.isArray(entry?.tags) ? entry.tags.join(' ') : '';
@@ -1506,23 +1569,36 @@ export async function initReminders(sel = {}) {
 
   async function askAssistant(query) {
     const context = await buildRagContext(query);
-    const prompt = `You are an assistant that must answer ONLY using the provided MEMORY CONTEXT.
-Do not invent new information.
-If answer not in context, say: "I do not have enough information."
+    const entries = buildInboxSearchEntries();
+    const relevantType = inferRelevantEntryType(query);
+    const filteredEntries = relevantType
+      ? entries.filter((entry) => entry.type === relevantType)
+      : entries;
+    const selectedEntries = (filteredEntries.length ? filteredEntries : entries)
+      .slice(0, 8)
+      .map((entry) => ({
+        id: entry.id,
+        type: normalizeMemoryEntryType(entry.type),
+        title: entry.title,
+        body: entry.body,
+        tags: Array.isArray(entry.tags) ? entry.tags : [],
+        relatedIds: Array.isArray(entry.relatedIds) ? entry.relatedIds : [],
+        createdAt: entry.createdAt,
+        updatedAt: entry.updatedAt,
+      }));
 
-MEMORY CONTEXT:
-${context}
-
-USER QUESTION:
-${query}`;
-    console.log('[RAG assistant] Prompt:\n', prompt);
     try {
       const response = await fetch('/api/assistant', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ query: prompt }),
+        body: JSON.stringify({
+          question: query,
+          contextText: context,
+          entries: selectedEntries,
+          schemaVersion: 2,
+        }),
       });
 
       if (!response.ok) {
@@ -1546,6 +1622,7 @@ ${query}`;
       return 'Sorry, something went wrong while contacting the assistant.';
     }
   }
+
 
   function setupInboxSearch() {
     const inboxSearchInput = typeof document !== 'undefined' ? document.getElementById('inboxSearchInput') : null;
@@ -1947,26 +2024,33 @@ ${query}`;
 
       const category = await classifyBrainDumpCategory(cleanText);
 
+      const nowIso = new Date().toISOString();
       const payload = {
         id:
           reminderEntry && reminderEntry.id
             ? reminderEntry.id
             : `entry-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
-        text: cleanText,
+        type: normalizeMemoryEntryType(
+          reminderEntry?.category === 'Footy – Drills' ? 'drill' : classifyInput(cleanText),
+        ),
+        title: extractTitle(cleanText),
+        body: cleanText,
+        tags: sanitizeTags(extractTags(cleanText)),
+        relatedIds: [],
         category,
         createdAt:
           reminderEntry && reminderEntry.createdAt
             ? new Date(reminderEntry.createdAt).toISOString()
-            : new Date().toISOString(),
+            : nowIso,
+        updatedAt: nowIso,
       };
 
       try {
-        const existing = JSON.parse(localStorage.getItem('reminderEntries') || '[]');
-        const entries = Array.isArray(existing) ? existing : [];
+        const entries = readMemoryEntries();
         entries.unshift(payload);
-        localStorage.setItem('reminderEntries', JSON.stringify(entries));
+        writeMemoryEntries(entries);
       } catch (error) {
-        console.warn('Failed to persist reminderEntries', error);
+        console.warn('Failed to persist memory entries', error);
       }
     };
 
@@ -1987,7 +2071,7 @@ ${query}`;
     const fallbackClassify = (text) => {
       const fallback = parseSmartEntryWithFallback(text);
       return {
-        type: typeof fallback?.type === 'string' ? fallback.type : 'general_note',
+        type: typeof fallback?.type === 'string' ? fallback.type : 'note',
         title: typeof fallback?.title === 'string' ? fallback.title : '',
         reminderDate:
           typeof fallback?.reminderDate === 'string' && fallback.reminderDate.trim()
@@ -1998,12 +2082,8 @@ ${query}`;
 
     const mapSmartTypeToCategory = (type) => {
       switch (type) {
-        case 'footy_drill':
+        case 'drill':
           return 'Footy – Drills';
-        case 'netball_note':
-          return 'Netball';
-        case 'teaching_note':
-          return 'Teaching';
         case 'task':
           return 'Tasks';
         default:


### PR DESCRIPTION
### Motivation
- Convert the app from storing opaque text blobs to a small structured object schema so AI retrieval stays accurate as the dataset grows.
- Let the capture and assistant flows classify and prefer entries by type (note, reminder, drill, idea, task) to improve relevance for queries and UI rendering.

### Description
- Persist captured items as structured `memoryEntries[]` objects with fields including `id`, `type`, `title`, `body`, `tags`, `createdAt`, `updatedAt`, and `relatedIds`, and added helper `readMemoryEntries()` / `writeMemoryEntries()` for storage.【F:js/reminders.js】【F:js/entries.js】
- Normalised quick-capture classification to the new types and updated quick-add to save structured entries (and still preserve reminder behaviour and legacy notes where appropriate).【F:js/reminders.js】【F:api/capture.js】
- Updated assistant flows to send trimmed structured entries and apply a type-first filter (e.g., queries mentioning “drill” prefer drill entries) before calling the AI, and extended server sanitization to keep `updatedAt` and `relatedIds`.【F:js/reminders.js】【F:api/assistant.js】
- UI read/write key switched to `memoryEntries`, and entry cards now surface a type badge (e.g., “Drill card”, “Reminder card”) while retaining category and inbox views; parse/capture API schemas were adjusted to match the new type set.【F:js/entries.js】【F:api/parse-entry.js】【F:api/capture.js】

### Testing
- Ran the focused unit test suite `npm test -- reminders.quick-add.test.js`, which passed (7 tests).
- Ran the full test suite `npm test`, which revealed unrelated failures in mobile/service-worker test suites in this environment (these failures pre-existed or are outside the scope of the storage/type changes).
- Launched the app locally with `npm start` and exercised the categories view to validate `memoryEntries` rendering (screenshot artifact produced during validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aebf38e53483248e1811e415a63d0d)