### PR TITLE
Reposition mobile controls into thumb-reach zone

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -64,7 +64,13 @@ body.app-shell .quick-add-input {
   border-radius: 12px;
   background: #fff;
   padding: 0 var(--space-2);
-  min-height: 40px;
+  min-height: 48px;
+}
+
+body.app-shell .smart-send-button {
+  min-height: 48px;
+  min-width: 88px;
+  padding: 0 var(--space-2);
 }
 
 body.app-shell .bottom-nav,
@@ -80,6 +86,7 @@ body.app-shell #mobile-nav-shell {
   background: #fff;
   border-top: 1px solid var(--border-subtle, #e3d9f4);
   padding: 0 var(--space-1);
+  pointer-events: auto;
   z-index: 59;
 }
 
@@ -93,7 +100,12 @@ body.app-shell #mobile-nav-shell .floating-footer {
 
 body.app-shell #mobile-nav-shell .floating-card {
   min-height: 48px;
+  min-width: 48px;
   border-radius: 12px;
+}
+
+body.app-shell .reminders-quick-bar {
+  display: none !important;
 }
 
 body.app-shell #mobile-nav-shell .floating-card.active,

--- a/mobile.html
+++ b/mobile.html
@@ -5091,13 +5091,13 @@ body, main, section, div, p, span, li {
   <div id="smartInputBar" class="smart-input-bar capture-bar">
     <form id="quickAddForm" class="smart-input-form">
       <input id="universalInput" class="control-input quick-add-input" type="text" placeholder="Capture, search, or ask..." autocomplete="off" />
-      <button id="captureSend" type="submit" class="smart-send-button" aria-label="Send">Send</button>
+      <button id="sendBtn" type="submit" class="smart-send-button" aria-label="Send">Send</button>
       <span id="quickAddParsingIndicator" class="text-xs text-base-content/70" hidden>Parsing…</span>
       <span id="quickAddSuccessIndicator" class="text-xs text-success" role="status" aria-live="polite" hidden>Saved ✓</span>
     </form>
   </div>
 
-  <nav id="mobile-nav-shell" class="bottom-nav sticky inset-x-0 bottom-0 z-50 flex justify-center pointer-events-none px-2 pb-3" aria-label="Bottom navigation">
+  <nav id="mobile-nav-shell" class="bottom-nav sticky inset-x-0 bottom-0 z-50 flex justify-center px-2 pb-3" aria-label="Bottom navigation">
     <div class="floating-footer">
       <button
         type="button"


### PR DESCRIPTION
### Motivation
- Move primary mobile interactions into the bottom third (thumb zone) so one-handed users can reach capture, send and navigation controls without shifting grip.
- Remove duplicate/legacy quick-entry controls from the top area so all primary actions route through a single universal capture input at the bottom.

### Description
- Updated `mobile.css` to enforce thumb-zone sizing and spacing by raising the universal input to `min-height: 48px`, making the send button larger (`min-height: 48px`, `min-width: 88px`), and ensuring bottom nav and buttons meet minimum touch targets (`min-height: 48px`, `min-width: 48px`).
- Hid the legacy top quick-add strip by adding a rule to hide `.reminders-quick-bar` so primary input flows through the bottom capture bar.
- Ensured the bottom navigation is interactive by removing pointer-blocking utilities and keeping the nav fixed at the bottom with equal grid distribution for four tabs.
- Aligned HTML IDs to the requested layout by renaming the capture submit button from `id="captureSend"` to `id="sendBtn"` in `mobile.html` and removed `pointer-events-none` from the bottom nav wrapper so taps are delivered to the nav buttons.
- Files changed: `mobile.css` and `mobile.html` (small, focused edits only).

### Testing
- Ran unit test suite with `npm test -- --runInBand`, which executed Jest and reported mixed results: 18 suites passed, 5 suites failed, and the run included 9 failing tests (failures are in mobile auth/open-sheet/sheet/new-folder wiring and service-worker tests and appear related to pre-existing ESM/test-environment and service-worker mocks rather than these UI tweaks).
- Started a local server with `npx serve . -l tcp://0.0.0.0:4173` and executed a Playwright smoke script that loaded `http://127.0.0.1:4173/mobile.html` and captured a screenshot of the mobile thumb-zone layout, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aec732c1ac83248a0bf54f38f2c69d)