### PR TITLE
Fix mobile header forced-fixed behavior and restore flex content layout

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -375,54 +375,6 @@
   }
 })();
 
-(function() {
-  const header = document.getElementById('reminders-slim-header');
-  const main = document.querySelector('main');
-
-  function applyFixedHeader() {
-    if (!header) return;
-
-    // Add sticky header class
-    header.classList.add('force-fixed');
-    header.style.backdropFilter = 'blur(14px)';
-    header.style.willChange = 'transform, top';
-
-    // Measure header height
-    const rect = header.getBoundingClientRect();
-    if (rect.height > 0) {
-      const height = Math.ceil(rect.height);
-      // Apply a small visual padding (6px gap)
-      const finalHeight = height + 6;
-
-      // Set the header height CSS variable
-      document.documentElement.style.setProperty('--mobile-header-height', `${finalHeight}px`);
-
-      // Apply top padding to main content so it doesn't go under the header
-      // But respect notebook view's own padding rule (which uses the variable)
-      if (main && !main.closest('[data-active-view="notebook"]')) {
-         main.style.paddingTop = `${finalHeight}px`;
-      }
-    }
-  }
-
-  // Update on load, resize, and mutations
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', applyFixedHeader);
-  } else {
-    applyFixedHeader();
-  }
-  window.addEventListener('resize', applyFixedHeader);
-  window.addEventListener('orientationchange', applyFixedHeader);
-
-  // Use ResizeObserver for robust height tracking
-  if (typeof ResizeObserver !== 'undefined' && header) {
-    const ro = new ResizeObserver(() => {
-      applyFixedHeader();
-    });
-    ro.observe(header);
-  }
-})();
-
 // Global navigation handler: treat 'new' as a dedicated view that shows the notebook and
 // prepares a new entry (focus/clear). This keeps the center tab as a navigable view.
 (function() {
@@ -772,4 +724,3 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   });
 });
-

--- a/mobile.css
+++ b/mobile.css
@@ -8,29 +8,24 @@
 
 body.app,
 body.app-shell {
-  height: 100vh;
   display: flex;
   flex-direction: column;
+  min-height: 100dvh;
   overflow: hidden;
 }
 
 body.app-shell .app-header {
   height: var(--mobile-header-height);
   flex-shrink: 0;
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 60;
 }
 
 body.app-shell .app-content,
 body.app-shell #main,
 body.app-shell .content {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: var(--space-2);
-  margin-top: var(--mobile-header-height);
   padding-bottom: calc(var(--mobile-bottom-nav-height) + var(--mobile-input-bar-height) + (var(--space-1) * 3)) !important;
   width: 100%;
   box-sizing: border-box;

--- a/mobile.html
+++ b/mobile.html
@@ -4355,9 +4355,8 @@ body, main, section, div, p, span, li {
 
     /* NEW: Sticky lilac header with separated shell layout */
     #reminders-slim-header {
-      position: fixed;
-      top: 0;
-      z-index: 999;
+      position: relative;
+      z-index: 10;
       width: 100%;
       padding: 8px 16px;
       background: rgba(255, 255, 255, 0.75);
@@ -4366,18 +4365,6 @@ body, main, section, div, p, span, li {
       border-bottom: 1px solid rgba(255, 255, 255, 0.55);
       box-shadow: 0 8px 20px rgba(0, 0, 0, 0.05);
       color: var(--text-strong, #34163f);
-    }
-
-    .force-fixed {
-      position: sticky;
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      z-index: 999;
-      background: rgba(255, 255, 255, 0.75);
-      backdrop-filter: blur(14px);
-      -webkit-backdrop-filter: blur(14px);
     }
 
     /* Tighter header sizing for small mobile viewports */


### PR DESCRIPTION
### Motivation
- The header was being force-fixed by runtime JS (adding a `force-fixed` class and injecting top padding), which caused the main content to collapse or render under the header on mobile.
- The goal is to stop JavaScript from mutating header layout and instead rely on a proper column flex layout so header, content, capture bar, and bottom nav behave predictably.

### Description
- Removed the runtime header mutation block in `js/navigation.js` that added `force-fixed`, set inline styles, and injected top padding / ResizeObserver tracking. 
- Updated `mobile.css` to use a proper shell layout by setting `min-height: 100dvh` on the app shell, removing the forced fixed header rules, and giving the content area `min-height: 0` with `overflow-y: auto` so it fills available space without collapsing. 
- Deleted the `.force-fixed` CSS rule and changed `#reminders-slim-header` to non-fixed positioning (`position: relative; z-index: 10`) in `mobile.html` so the header is not force-fixed by CSS or JS.
- Rebuilt the project assets with the repository `build` script to ensure changes compile into `dist` (no runtime JS header mutation remains).

### Testing
- Ran `npm run build` and the build completed successfully. 
- Ran the test suite with `npm test -- --runInBand`; the run executed but several unrelated suites failed, specifically: `js/__tests__/mobile.new-folder.test.js`, `js/__tests__/mobile.auth.test.js`, `js/__tests__/mobile.open-sheet.test.js`, `js/__tests__/mobile.sheet.test.js`, and `service-worker.test.js` (these failures appear unrelated to this layout-only change). 
- Performed an automated visual check by launching the local server and using Playwright to load `/mobile.html` at a mobile viewport (390×844) and capture a screenshot to validate the header/content/capture-bar/bottom-nav layout (screenshot saved as an artifact).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af1d26e044832491b0e6ba8deea171)