### PR TITLE
Fix responsive width for Memory Cue content feed layout

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -117,11 +117,37 @@ body.app-shell #mobile-nav-shell .floating-card[aria-current='page'] {
   outline: 2px solid color-mix(in srgb, var(--accent-color, #512663) 40%, transparent);
 }
 
+
+body.app-shell .content .content-container {
+  width: 100%;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 16px;
+  line-height: 1.4;
+}
+
+body.app-shell .content #contentFeed {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+body.app-shell .content .card,
+#contentFeed .entry,
+#assistantThread .assistant-message,
+#inboxSearchResults .entry {
+  width: 100%;
+  border-radius: 12px;
+  padding: 14px;
+  background: var(--surface-elevated, #fff);
+}
+
 #contentFeed .entry,
 #assistantThread .assistant-message,
 #inboxSearchResults .entry {
   border-radius: 12px;
-  padding: 12px;
+  padding: 14px;
   margin-bottom: 12px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 }

--- a/mobile.html
+++ b/mobile.html
@@ -4620,11 +4620,12 @@ body, main, section, div, p, span, li {
 
 
   <!-- quickAddBar is now integrated in the header -->
-  <main id="main" class="app-content content mx-auto w-full max-w-none sm:max-w-lg"
+  <main id="main" class="app-content content mx-auto w-full max-w-none"
         tabindex="-1"
         data-active-view="reminders"
       >
-    <div id="contentFeed">
+    <div class="content-container">
+      <div id="contentFeed">
     <!-- BEGIN GPT CHANGE: create form moved to bottom sheet -->
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: reminders view -->
@@ -4679,6 +4680,7 @@ body, main, section, div, p, span, li {
       <div class="space-y-3">
         <h2 class="text-lg font-semibold">Inbox</h2>
         <div id="inboxEntriesList" class="category-entry-list" aria-live="polite"></div>
+      </div>
       </div>
     </div>
     <!-- END GPT CHANGE -->


### PR DESCRIPTION
### Motivation
- The mobile/desktop feed was appearing narrow and centered with large empty margins on larger screens, reducing readability and wasting space. 
- The change implements a simple responsive container so the feed fills small screens and caps width on wide viewports for readable line lengths. 
- This keeps the existing mobile-first layout and card patterns while allowing the UI to expand naturally on tablet/desktop.

### Description
- Wrapped `#contentFeed` inside a new `.content-container` in `mobile.html` and removed the `sm:max-w-lg` constraint from the `<main>` element so the page can use available width on larger viewports. 
- Added `.content-container` CSS with `width: 100%`, `max-width: 900px`, `margin: 0 auto`, `padding: 16px`, and `line-height: 1.4` to provide a centered readable column on desktop while remaining full-width on mobile. 
- Made `#contentFeed` a full-width vertical flex column with `gap: 12px` so feed items stack and stretch correctly. 
- Applied card-style responsive rules so feed entries/messages and existing `.card` elements use `width: 100%`, `border-radius: 12px`, `padding: 14px`, and `background: var(--surface-elevated)` so reminders/notes/inbox entries behave as flexible cards.

### Testing
- Ran `npm run build` which completed successfully. 
- Ran `npm test -- --runInBand` which exercised the test suite but reported failures in pre-existing mobile/auth/sheet and service-worker tests (5 failing suites, 9 failing tests: `mobile.new-folder`, `mobile.auth`, `mobile.open-sheet`, `mobile.sheet`, and `service-worker`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af260a790c8324a2040570b208cce6)