### PR TITLE
Fix oversized mobile header by enforcing standard 56px app bar

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -27,6 +27,8 @@ body.app-shell .content {
   min-height: 0;
   overflow-y: auto;
   padding: var(--space-2);
+  padding-top: 8px;
+  margin-top: 0;
   padding-bottom: calc(var(--mobile-bottom-nav-height) + var(--mobile-input-bar-height) + (var(--space-1) * 3)) !important;
   width: 100%;
   box-sizing: border-box;

--- a/mobile.html
+++ b/mobile.html
@@ -2103,17 +2103,22 @@ body, main, section, div, p, span, li {
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
   <style>
     /* New Header Styles */
-    .mobile-header {
-      background: var(--cauliflower-blue);
-      padding: 10px 16px;
+    .mobile-header,
+    .app-header {
+      height: 56px;
+      min-height: 56px;
+      max-height: 56px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       position: sticky;
       top: 0;
+      padding: 0 16px;
       z-index: 1000;
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-      background: rgba(255,255,255,0.85);
+      background: rgba(255, 255, 255, 0.85);
       backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+      box-sizing: border-box;
     }
 
     #view-reminders h1,
@@ -2129,21 +2134,30 @@ body, main, section, div, p, span, li {
     }
 
     .header-main-row {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
+      display: contents;
     }
 
-    .header-title {
+    .header-title,
+    .title {
       font-size: 18px;
       font-weight: 600;
-      letter-spacing: -0.2px;
       margin: 0;
+      line-height: 1.2;
     }
 
-    .header-actions {
-      display: flex;
-      gap: var(--space-1);
+    .app-header button {
+      width: 40px;
+      height: 40px;
+    }
+
+    .menu {
+      position: absolute;
+      left: 12px;
+    }
+
+    .search {
+      position: absolute;
+      right: 12px;
     }
 
     .header-quick-add,
@@ -2278,8 +2292,8 @@ body, main, section, div, p, span, li {
     }
 
     .icon-button.control-icon-button {
-      width: var(--control-size-md);
-      height: var(--control-size-md);
+      width: 40px;
+      height: 40px;
     }
 
     .inbox-search-clear {
@@ -4353,17 +4367,22 @@ body, main, section, div, p, span, li {
     }
 
     /* NEW: Sticky lilac header with separated shell layout */
-    #reminders-slim-header {
-      position: relative;
+#reminders-slim-header {
+      position: sticky;
+      top: 0;
       z-index: 10;
       width: 100%;
-      padding: 8px 16px;
+      height: 56px;
+      min-height: 56px;
+      max-height: 56px;
+      padding: 0 16px;
       background: rgba(255, 255, 255, 0.75);
       backdrop-filter: blur(14px);
       -webkit-backdrop-filter: blur(14px);
       border-bottom: 1px solid rgba(255, 255, 255, 0.55);
       box-shadow: 0 8px 20px rgba(0, 0, 0, 0.05);
       color: var(--text-strong, #34163f);
+      box-sizing: border-box;
     }
 
     /* Tighter header sizing for small mobile viewports */
@@ -4404,7 +4423,7 @@ body, main, section, div, p, span, li {
     /* Responsive adjustments for narrow screens */
     @media (max-width: 380px) {
       #reminders-slim-header {
-        padding: 0.35rem 0.65rem;
+        padding: 0 16px;
       }
 
       #reminders-slim-header .header-actions {
@@ -4497,15 +4516,11 @@ body, main, section, div, p, span, li {
 
   <!-- Unified Mobile Header -->
   <header id="reminders-slim-header" class="mobile-header app-header" role="banner">
-    <div class="header-main-row">
       <button id="overflowMenuBtn" type="button" class="menu icon-button control-icon-button" aria-haspopup="true" aria-expanded="false" aria-controls="overflowMenu" aria-label="Open menu">☰</button>
-      <h1 class="header-title">Memory Cue</h1>
-      <div class="header-actions">
-        <button id="openSavedNotesGlobal" type="button" class="search icon-button control-icon-button" aria-label="Search">
-          🔍
-        </button>
-      </div>
-    </div>
+      <h1 class="header-title title">Memory Cue</h1>
+      <button id="openSavedNotesGlobal" type="button" class="search icon-button control-icon-button" aria-label="Search">
+        🔍
+      </button>
     <div id="overflowMenu" class="overflow-menu quick-actions-panel hidden" role="menu" aria-hidden="true">
         <!-- Reminders -->
         <div class="overflow-menu-section">


### PR DESCRIPTION
### Motivation
- The mobile header was taking excessive vertical space and pushing main content down, so it needs to match standard mobile app bar height (~56px) and avoid vertical expansion.
- Icons and title must align vertically and the page content should start immediately below the header.

### Description
- Updated header markup in `mobile.html` to a compact single-row structure with menu button, centered title (`.title`), and search button placed directly in the header while keeping the overflow menu attached below it.
- Enforced a fixed app-bar height by setting `height`, `min-height`, and `max-height` to `56px` for `.mobile-header`, `.app-header`, and `#reminders-slim-header` in the embedded header styles in `mobile.html` and ensured `box-sizing` and `sticky` positioning are applied.
- Prevented vertical expansion and aligned icons by sizing icon controls to `40x40` and absolutely positioning `.menu` (left) and `.search` (right); simplified title styling to `font-size: 18px` and `font-weight: 600`.
- Ensured content begins immediately under the header by adding `padding-top: 8px` and `margin-top: 0` to the content shell in `mobile.css` and removed extra header paddings that caused extra vertical space.

### Testing
- Ran unit/header tests with `npm test -- --runTestsByPath js/__tests__/mobile.header.test.js` which passed (test suite for header overflow behavior succeeded). 
- Started the local server with `npm run start` and captured a mobile viewport screenshot via Playwright (390x844) to validate visual layout, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af2b7617d083248f15c18cf2b319e5)