### PR TITLE
Fix mobile content spacing below header

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -2344,7 +2344,7 @@ body, main, section, div, p, span, li {
     #remindersListMobile {
       position: relative;
       margin-top: 0;
-      padding-top: var(--quickbar-height);
+      padding-top: 0;
       display: flex;
       flex-direction: column;
       gap: var(--space-1);


### PR DESCRIPTION
### Motivation
- Remove the large blank area between the header and the reminders/notes feed so content appears directly beneath the header on mobile views.

### Description
- Set `padding-top` to `0` for `#remindersListMobile` in `mobile.html` (removed `var(--quickbar-height)` spacer) so the feed sits immediately under the header.

### Testing
- Ran the targeted header test: `npm test -- --runTestsByPath js/__tests__/mobile.header.test.js` and it passed.
- Verified the change visually by launching a local server and capturing a Playwright screenshot of `http://127.0.0.1:3000/mobile.html` (artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af2cdbfa548324a554184c54470b21)