### PR TITLE
Adjust mobile header to standard 56px app bar

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -189,10 +189,13 @@ body.mobile-theme header,
 body.mobile-theme .top-bar {
   background-color: #5080BF;
   color: #FFFFFF;
-  padding: 1rem 1.10rem;
+  height: 56px;
+  min-height: 56px;
+  max-height: 56px;
+  padding: 0 16px;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   gap: 0.75rem;
 }
 
@@ -203,7 +206,7 @@ body.mobile-theme .app-header h2,
 body.mobile-theme header h2,
 body.mobile-theme .top-bar h2 {
   margin: 0;
-  font-size: 1.25rem;
+  font-size: 18px;
   font-weight: 600;
 }
 


### PR DESCRIPTION
### Motivation
- Reduce the Memory Cue mobile header height to match standard mobile app bar dimensions (56px) and remove oversized vertical padding so the header aligns with typical mobile UI expectations.

### Description
- Update `css/theme-mobile.css` to set `height`, `min-height`, and `max-height` to `56px` for `body.mobile-theme .app-header, body.mobile-theme header, body.mobile-theme .top-bar`, replace large vertical padding with `padding: 0 16px`, center header content with `justify-content: center`, and set header title font-size to `18px` while preserving `margin: 0`.

### Testing
- Ran the test suite with `npm test -- --runInBand`, which completed but reported failing suites (5 failed, 18 passed; 9 tests failed, 68 passed) — failing suites include `js/__tests__/mobile.new-folder.test.js`, `js/__tests__/mobile.auth.test.js`, `js/__tests__/mobile.open-sheet.test.js`, `js/__tests__/mobile.sheet.test.js`, and `service-worker.test.js`, and these failures are unrelated to the CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af42f4483483249f4bcfffb094cbec)