### PR TITLE
Standardize UI spacing using 8px grid values

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -141,7 +141,8 @@ body.app-shell .content .card,
 #inboxSearchResults .entry {
   width: 100%;
   border-radius: 12px;
-  padding: 14px;
+  padding: 16px;
+  margin-bottom: 12px;
   background: var(--surface-elevated, #fff);
 }
 
@@ -149,7 +150,7 @@ body.app-shell .content .card,
 #assistantThread .assistant-message,
 #inboxSearchResults .entry {
   border-radius: 12px;
-  padding: 14px;
+  padding: 16px;
   margin-bottom: 12px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -322,6 +322,17 @@ h2,
   font-size: clamp(1.6rem, 1.2rem + 1.2vw, 2.15rem);
   font-weight: 600;
   line-height: 1.15;
+  margin-top: 16px;
+  margin-bottom: 8px;
+}
+
+.content-container {
+  padding: 16px;
+}
+
+.card {
+  padding: 16px;
+  margin-bottom: 12px;
 }
 
 h3,


### PR DESCRIPTION
### Motivation

- Align UI spacing with an 8px spacing grid (4px micro, 8px element, 16px section padding, 24px large) to create consistent rhythm across the app.
- Replace ad-hoc numeric paddings/margins with canonical values (16px for element padding, 12px gap for stacked cards) to reduce visual inconsistencies.

### Description

- Updated `styles/index.css` to add `margin-top: 16px` and `margin-bottom: 8px` for `.section-title` to standardize heading spacing.
- Added a shared `.content-container { padding: 16px; }` rule in `styles/index.css` to enforce section padding.
- Added a shared `.card { padding: 16px; margin-bottom: 12px; }` rule in `styles/index.css` to standardize card padding and spacing between stacked cards.
- Updated `mobile.css` to change mobile content card-like surfaces from `padding: 14px` to `padding: 16px` and to add `margin-bottom: 12px` for consistent vertical spacing of entries and message bubbles.

Files changed: `styles/index.css`, `mobile.css`.

### Testing

- Ran `npm test -- --runInBand`; test suite executed but several pre-existing unrelated tests failed (failing suites included `js/__tests__/mobile.auth.test.js`, `js/__tests__/mobile.open-sheet.test.js`, `js/__tests__/mobile.sheet.test.js`, `js/__tests__/mobile.new-folder.test.js`, and `service-worker.test.js`), indicating these failures are not introduced by this spacing-only change.
- Ran `npm run build` successfully and produced a production build without errors.
- Captured a UI screenshot after the changes to validate visual spacing (artifact created during the build/serve run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af47e5b32c8324bec4ec150624b95b)