### PR TITLE
Anchor floating action button to bottom-right corner

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -2254,7 +2254,7 @@ const initMobileNotes = () => {
     buildFolderFilterSelect(chipModel);
   };
 
-  // Ensure a floating action button (FAB) exists inside the saved notes sheet
+  // Ensure a floating action button (FAB) exists and is anchored to the viewport
   const ensureFloatingNewFolderFab = () => {
     if (!savedNotesSheet) return;
 
@@ -2270,16 +2270,6 @@ const initMobileNotes = () => {
     }
 
     if (document.getElementById('fabNewFolder')) return;
-
-    // ensure the sheet can anchor absolute children
-    try {
-      const currentPosition = savedNotesSheet.style?.position;
-      if (!currentPosition || currentPosition === 'relative') {
-        savedNotesSheet.style.position = 'fixed';
-      }
-    } catch (e) {
-      /* ignore */
-    }
 
     const fab = document.createElement('button');
     fab.id = 'fabNewFolder';
@@ -2300,7 +2290,7 @@ const initMobileNotes = () => {
       }
     });
 
-    savedNotesSheet.appendChild(fab);
+    document.body.appendChild(fab);
   };
 
   /* New Folder modal setup */

--- a/styles/index.css
+++ b/styles/index.css
@@ -224,12 +224,13 @@ html {
   opacity: 0.7;
 }
 
+.fab,
 .fab-button {
   position: fixed;
-  bottom: 20px;
-  right: 20px;
-  width: 48px;
-  height: 48px;
+  bottom: 96px;
+  right: 16px;
+  width: 56px;
+  height: 56px;
   border-radius: 50%;
   background: var(--primary, #512663);
   color: #ffffff;


### PR DESCRIPTION
### Motivation
- Anchor the floating action button to the viewport bottom-right with the requested offsets and size so it is always accessible. 
- Ensure the FAB is not placed inside a centered container to avoid clipping and layout interference.

### Description
- Updated `styles/index.css` to add a `.fab` selector and adjust `.fab-button` to use `position: fixed`, `bottom: 96px`, `right: 16px`, `width: 56px`, `height: 56px`, and `border-radius: 50%` for the requested placement and size. 
- Modified `mobile.js` in `ensureFloatingNewFolderFab` to append the new-folder FAB to `document.body` instead of the `savedNotesSheet`, preventing it from being nested inside centered containers. 
- Removed the code that attempted to change `savedNotesSheet.style.position` and updated the inline comment to reflect viewport anchoring.

### Testing
- Ran unit tests with `npm test -- --runInBand`; test run completed but some unrelated suites failed (5 failed, 18 passed); failing suites include `mobile.new-folder`, `mobile.auth`, `mobile.open-sheet`, `mobile.sheet` and `service-worker` which appear to fail due to import/module and service-worker test harness issues rather than the FAB change. 
- Served the app with `python -m http.server 8000` and performed an automated visual check using Playwright to capture a screenshot showing the FAB anchored to the bottom-right (artifact: `artifacts/fab-bottom-right.png`). 
- No further automated tests were added or modified as the change is a focused UI/layout adjustment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af526b5c14832480ac4e3658ddfa52)