### PR TITLE
Fix mobile app-shell layout so content starts below header

### DIFF
--- a/css/theme-mobile.css
+++ b/css/theme-mobile.css
@@ -1,6 +1,6 @@
 /* Base Styles */
 body {
-  min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
   overflow-x: hidden;
@@ -27,7 +27,13 @@ body.mobile-theme footer {
 
 .mobile-header,
 .app-header {
-  flex: 0 0 auto;
+  height: 56px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 16px;
+  box-sizing: border-box;
 }
 
 #mobile-shell {
@@ -41,9 +47,15 @@ body.mobile-theme footer {
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
+  justify-content: flex-start;
+  align-items: stretch;
   box-sizing: border-box;
   padding-bottom: 80px;
   overflow-y: auto;
+}
+
+#mobile-shell #main > * {
+  margin-top: 0;
 }
 
 /* Micro-gap under the mobile header so content sits just below the quick bar */
@@ -114,7 +126,7 @@ body.mobile-shell #mobile-shell #reminderList,
 .mobile-shell #reminderList {
   width: 100%;
   max-width: 100%;
-  margin: 50px auto;
+  margin: 0 auto;
   padding-inline: 0;
   padding-top: 5px;
   box-sizing: border-box;


### PR DESCRIPTION
### Motivation
- The reminders/notes content was vertically centered due to legacy centering rules and large top margins, causing a large blank gap under the header. 
- The page should be a proper header/content app-shell so content flows immediately under a fixed header (no vertical centering).

### Description
- Update `css/theme-mobile.css` to use a proper app-shell: set the root mobile body `min-height` to `100dvh` so the shell respects the viewport height. 
- Normalize header sizing by giving `.mobile-header, .app-header` an explicit `height: 56px`, `flex-shrink: 0`, and center alignment/padding so it behaves as a top bar. 
- Make `#mobile-shell #main` a top-aligned flex column by adding `justify-content: flex-start` and `align-items: stretch`, and add `#mobile-shell #main > * { margin-top: 0; }` to ensure inner content starts at the top. 
- Remove the large reminders top gap by changing the reminders list margin from `50px auto` to `0 auto`.

### Testing
- Ran the test suite with `npm test -- --runInBand`; the run completed but several unrelated suites failed (mobile auth/open-sheet/sheet/new-folder tests and `service-worker.test.js`) which pre-exist and are not caused by this CSS-only change. 
- Started a local server with `npm run start` and captured a mobile screenshot of `/mobile.html` using Playwright to validate the visual fix (screenshot produced). 
- No JS changes were made and the CSS change is minimal and targeted to the mobile app-shell styles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af55f226648324bf52133c934b45ae)