### PR TITLE
Fix mobile content padding for fixed capture bar and bottom nav

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -29,7 +29,7 @@ body.app-shell .content {
   padding: var(--space-2);
   padding-top: 8px;
   margin-top: 0;
-  padding-bottom: calc(var(--mobile-bottom-nav-height) + var(--mobile-input-bar-height) + (var(--space-1) * 3)) !important;
+  padding-bottom: 140px !important;
   width: 100%;
   box-sizing: border-box;
   display: flex;
@@ -44,6 +44,7 @@ body.app-shell .content > * {
 
 body.app-shell .capture-bar,
 body.app-shell #smartInputBar {
+  height: var(--mobile-input-bar-height);
   position: fixed;
   bottom: var(--mobile-bottom-nav-height);
   left: 0;
@@ -133,6 +134,7 @@ body.app-shell .content #contentFeed {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  padding-bottom: 20px;
 }
 
 body.app-shell .content .card,


### PR DESCRIPTION
### Motivation
- Ensure scrollable mobile content reserves space for the fixed capture bar and bottom navigation so items don’t appear too close to or hidden behind the bottom UI.

### Description
- Updated the mobile scroll container `.content` to use `padding-bottom: 140px !important` to reserve space for the capture bar (56px), bottom nav (64px), and a 20px buffer. (`mobile.css`)
- Explicitly set the capture bar height to the token `--mobile-input-bar-height` so the fixed bar has a consistent `56px` height. (`mobile.css`)
- Added `padding-bottom: 20px` to `#contentFeed` to give feed items breathing room above the fixed UI. (`mobile.css`)

### Testing
- Ran the test suite with `npm test -- --runInBand`; tests executed but the run reported failing suites unrelated to this CSS change: `Test Suites: 5 failed, 18 passed, 23 total` and `Tests: 9 failed, 68 passed, 77 total` (failures are in existing mobile/auth/sheet/new-folder and service-worker suites).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af57799ab88324a81ea8bed3f52e21)