### PR TITLE
Use dynamic viewport units to stabilize mobile/PWA layout height

### DIFF
--- a/oauth/consent/index.html
+++ b/oauth/consent/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Memory Cue — OAuth Consent</title>
   <style>
-    body { font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial; display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#fafafa;color:#111 }
+    body { font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial; display:flex;align-items:center;justify-content:center;min-height:100dvh;margin:0;background:#fafafa;color:#111 }
     .card{background:#fff;border:1px solid #eee;padding:1.25rem 1.5rem;border-radius:12px;max-width:680px;width:94%;box-shadow:0 6px 18px rgba(38,26,64,0.06)}
     h1{margin:0 0 .25rem;font-size:1.1rem}
     p{margin:.25rem 0 .75rem;color:#444}

--- a/styles.css
+++ b/styles.css
@@ -17,7 +17,7 @@
 
 body {
   margin: 0;
-  min-height: 100vh;
+  min-height: 100dvh;
   background: linear-gradient(180deg, #0a1020, #0b1220);
   color: var(--text);
   font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;

--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,23 @@ html {
   scroll-behavior: smooth;
 }
 
+html, body {
+  height: auto;
+  margin: 0;
+  padding: 0;
+}
+
+.app {
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+}
+
+.content {
+  flex: 1;
+  overflow-y: auto;
+}
+
 .icon {
   width: 28px;
   height: 28px;
@@ -454,7 +471,7 @@ html[data-theme="professional"] {
     linear-gradient(180deg, var(--page-bg-muted), var(--page-bg-base));
   color: var(--desktop-text-main, var(--color-base-content, #0f172a));
   font-family: var(--font-body);
-  min-height: 100vh;
+  min-height: 100dvh;
 }
 
 /* PROFESSIONAL DESKTOP HEADER */

--- a/styles/mobile-compact.css
+++ b/styles/mobile-compact.css
@@ -12,14 +12,20 @@
   }
 
   /* Make the root container fill the viewport and use column flex layout */
-  html, body, #root, .app {
-    height: 100vh;
+  html, body {
+    height: auto;
+    margin: 0;
+    padding: 0;
+  }
+
+  #root, .app {
+    min-height: 100dvh;
     margin: 0;
   }
   .app {
     display: flex;
     flex-direction: column;
-    min-height: 0; /* important for children flex shrinking */
+    min-height: 100dvh;
     font-size: calc(1rem * var(--mc-font-scale));
   }
 
@@ -41,6 +47,11 @@
     flex-direction: column;
     gap: 6px;
     padding: var(--mc-app-padding);
+  }
+
+  .content {
+    flex: 1;
+    overflow-y: auto;
   }
 
   /* Note list and editor should share available space without forcing page scroll */

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -4796,7 +4796,7 @@ details.collapse summary::-webkit-details-marker {
 }
 
 .min-h-screen {
-  min-height: 100vh;
+  min-height: 100dvh;
 }
 
 .w-1\.5 {


### PR DESCRIPTION
### Motivation
- Mobile browsers treat `100vh` as the full layout viewport including browser UI, which causes extra blank space, layout jumps, and double-scrolling on mobile and PWA installs.
- Replace hard `vh` usage with the dynamic `dvh` unit and ensure the root layout uses a column flex model so header/content/footer are anchored reliably across desktop, mobile, and PWA contexts.

### Description
- Replaced app-facing `height: 100vh` / `min-height: 100vh` occurrences with `min-height: 100dvh` and applied the pattern to the OAuth consent page and generated Tailwind utility for `.min-h-screen`.
- Added an explicit reset for `html, body` to `height: auto; margin: 0; padding: 0;` and made `.app` a column flex container with `min-height: 100dvh` in `styles/index.css` and `styles/mobile-compact.css`.
- Ensured the middle content area can scroll without producing a second viewport scroll by adding `.content { flex: 1; overflow-y: auto; }` (applied in shared and mobile-compact styles).
- Files changed: `styles/mobile-compact.css`, `styles/index.css`, `styles.css`, `styles/tailwind.css`, and `oauth/consent/index.html`.

### Testing
- Repo scan for `height: 100vh` / `min-height: 100vh` was performed and updated occurrences were patched successfully. 
- Run `npm run verify` completed successfully. 
- Run `npm test -- --runInBand` executed but the test run failed due to unrelated existing test failures (Test Suites: 5 failed, 18 passed, 23 total), including failures in the mobile-related suites (`mobile.new-folder`, `mobile.auth`, `mobile.open-sheet`, `mobile.sheet`) and `service-worker.test.js` that are not introduced by these CSS-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af58e6213c8324afac58967c60dd39)