### PR TITLE
Fix mobile capture schema version mismatch

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -390,15 +390,16 @@ function initAssistant() {
           setThinkingBarStatus('Reminder saved');
         } else if (isCaptureMode) {
           const captureText = trimmedMessage.startsWith('+') ? trimmedMessage.slice(1).trim() : trimmedMessage;
+          const capturePayload = {
+            schemaVersion: 2,
+            input: captureText,
+          };
           const response = await fetch('/api/capture', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
             },
-            body: JSON.stringify({
-              schemaVersion: 1,
-              input: captureText,
-            }),
+            body: JSON.stringify(capturePayload),
           });
 
           if (!response.ok) {


### PR DESCRIPTION
### Motivation
- The `/api/capture` endpoint validates `schemaVersion: 2` but the mobile client was sending `schemaVersion: 1`, causing capture requests to fail with HTTP 400.

### Description
- Update `mobile.js` to construct a `capturePayload` with `schemaVersion: 2` and send it via `body: JSON.stringify(capturePayload)` for the existing `fetch('/api/capture')` call, leaving server validation unchanged.

### Testing
- Ran `npm test -- --runInBand`, which executed the test suite but reported failures in unrelated tests (`js/__tests__/mobile.auth.test.js`, `js/__tests__/mobile.open-sheet.test.js`, `js/__tests__/mobile.sheet.test.js`, `service-worker.test.js`, and `js/__tests__/mobile.new-folder.test.js`); the change to the capture payload did not introduce new test failures for the affected capture code path.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0b4b6c3f8832482388b3906ee83d7)