### PR TITLE
Add automatic capture classification in /api/capture

### DIFF
--- a/api/capture.js
+++ b/api/capture.js
@@ -7,6 +7,10 @@ const ALLOWED_ORIGINS = [
 
 const MAX_INPUT_CHARS = 6000;
 
+const notes = [];
+const reminders = [];
+const tasks = [];
+
 function applyCors(req, res) {
   const origin = req.headers.origin;
   if (origin && ALLOWED_ORIGINS.includes(origin)) {
@@ -15,6 +19,35 @@ function applyCors(req, res) {
     res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
   }
+}
+
+function classifyCapture(input) {
+  const text = input.toLowerCase();
+
+  if (
+    text.includes('remind') ||
+    text.includes('tomorrow') ||
+    text.includes('today') ||
+    text.includes('monday') ||
+    text.includes('tuesday') ||
+    text.includes('wednesday') ||
+    text.includes('thursday') ||
+    text.includes('friday') ||
+    text.includes('lesson') ||
+    text.includes('week')
+  ) {
+    return 'reminder';
+  }
+
+  if (
+    text.startsWith('todo') ||
+    text.startsWith('task') ||
+    text.includes('need to')
+  ) {
+    return 'task';
+  }
+
+  return 'note';
 }
 
 module.exports = async function handler(req, res) {
@@ -28,13 +61,9 @@ module.exports = async function handler(req, res) {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  if (!process.env.OPENAI_API_KEY) {
-    return res.status(500).json({ error: 'Server misconfiguration: missing OpenAI API key.' });
-  }
-
-  const payload = req.body && typeof req.body === 'object' ? req.body : {};
-  const schemaVersion = payload.schemaVersion;
-  const input = typeof payload.input === 'string' ? payload.input.trim() : '';
+  const body = req.body && typeof req.body === 'object' ? req.body : {};
+  const schemaVersion = body.schemaVersion;
+  const input = typeof body.input === 'string' ? body.input.trim() : '';
 
   if (schemaVersion !== 2) {
     return res.status(400).json({ error: 'Invalid schemaVersion.' });
@@ -48,118 +77,28 @@ module.exports = async function handler(req, res) {
     return res.status(400).json({ error: 'input too large.' });
   }
 
-  let response;
-  try {
-    response = await fetch('https://api.openai.com/v1/responses', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`
-      },
-      body: JSON.stringify({
-        model: 'gpt-4o-mini',
-        store: false,
-        input: [
-          {
-            role: 'system',
-            content: [
-              {
-                type: 'input_text',
-                text: [
-                  'Turn the user\'s free-text input into one structured Memory Cue entry.',
-                  'Keep titles short and useful.',
-                  'Preserve the user\'s meaning.',
-                  'Classify into one type only: note, reminder, drill, idea, or task.',
-                  'Generate 0 to 5 short lowercase tags.',
-                  'Never return markdown.',
-                  'Never return extra keys.'
-                ].join(' ')
-              }
-            ]
-          },
-          {
-            role: 'user',
-            content: [
-              {
-                type: 'input_text',
-                text: input
-              }
-            ]
-          }
-        ],
-        text: {
-          format: {
-            type: 'json_schema',
-            name: 'memory_cue_capture_entry',
-            strict: true,
-            schema: {
-              type: 'object',
-              additionalProperties: false,
-              properties: {
-                type: {
-                  type: 'string',
-                  enum: ['note', 'reminder', 'drill', 'idea', 'task']
-                },
-                title: { type: 'string' },
-                body: { type: 'string' },
-                tags: {
-                  type: 'array',
-                  items: { type: 'string' }
-                },
-                relatedIds: {
-                  type: 'array',
-                  items: { type: 'string' }
-                }
-              },
-              required: [
-                'type',
-                'title',
-                'body',
-                'tags',
-                'relatedIds'
-              ]
-            }
-          }
-        }
-      })
-    });
-  } catch (_error) {
-    return res.status(500).json({ error: 'Capture failed.' });
+  const type = classifyCapture(body.input);
+
+  const record = {
+    id: crypto.randomUUID(),
+    text: body.input,
+    type,
+    createdAt: Date.now()
+  };
+
+  if (type === 'reminder') {
+    reminders.push(record);
+  } else if (type === 'task') {
+    tasks.push(record);
+  } else {
+    notes.push(record);
   }
 
-  if (!response.ok) {
-    return res.status(response.status === 429 ? 429 : 500).json({
-      error: response.status === 429 ? 'Rate limit exceeded.' : 'Capture failed.'
-    });
-  }
+  console.log('[capture classified]', type);
 
-  try {
-    const data = await response.json();
-    const outputText =
-      data.output_text ||
-      (data.output &&
-        data.output[0] &&
-        data.output[0].content &&
-        data.output[0].content[0] &&
-        data.output[0].content[0].text) ||
-      null;
-
-    if (!outputText) {
-      return res.status(502).json({ error: 'Capture returned no output.' });
-    }
-
-    const result = JSON.parse(outputText);
-
-    return res.status(200).json({
-      entry: {
-        type: result.type,
-        title: result.title,
-        body: result.body,
-        tags: Array.isArray(result.tags) ? result.tags : [],
-        relatedIds: Array.isArray(result.relatedIds) ? result.relatedIds : []
-      }
-    });
-  } catch (_error) {
-    return res.status(500).json({ error: 'Capture failed.' });
-  }
+  return res.status(200).json({
+    success: true,
+    type,
+    record
+  });
 };


### PR DESCRIPTION
### Motivation
- Captured free-text entries were all landing as unsorted notes making the app feel like a plain list instead of an assistant. 
- A lightweight in-pipeline classifier lets Memory Cue route entries as a `note`, `reminder`, or `task` so the app can surface them differently. 

### Description
- Added `classifyCapture(input)` implementing the provided keyword/prefix rules to return `'reminder'`, `'task'`, or `'note'`.
- Introduced in-memory collections `notes`, `reminders`, and `tasks` and updated the capture handler to call the classifier, construct a record (`id`, `text`, `type`, `createdAt`), and push it into the appropriate collection.
- Preserved CORS and `schemaVersion`/input validation but replaced the previous OpenAI structured-capture call with the local classifier and removed the `OPENAI_API_KEY` dependency in the handler.
- Added a classification log `console.log('[capture classified]', type)` and changed the successful response to return `{ success: true, type, record }`.

### Testing
- Ran `npm test -- --runInBand` which reported unrelated failing suites in `mobile.*` and `service-worker.test.js`, so test run is not fully green but failures are pre-existing and unrelated to this change.
- Executed a direct Node invocation of the handler (`require('./api/capture')`) with the sample multiline input and confirmed the handler logged `[capture classified] reminder` and returned HTTP `200` with `type: "reminder"` and the created `record`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0bdfdf86c83249d4aac79e49a5dce)