### PR TITLE
Add natural-language date parsing for captured reminders

### DIFF
--- a/api/capture.js
+++ b/api/capture.js
@@ -1,3 +1,5 @@
+const chrono = require('chrono-node');
+
 const ALLOWED_ORIGINS = [
   'https://dmaher42.github.io',
   'https://memory-cue.vercel.app',
@@ -77,16 +79,25 @@ module.exports = async function handler(req, res) {
     return res.status(400).json({ error: 'input too large.' });
   }
 
-  const type = classifyCapture(body.input);
+  let type = classifyCapture(body.input);
+  const parsedDates = chrono.parse(body.input);
+  let reminderTime = null;
+
+  if (parsedDates.length > 0) {
+    reminderTime = parsedDates[0].start.date();
+    type = 'reminder';
+    console.log('[reminder detected]', reminderTime);
+  }
 
   const record = {
     id: crypto.randomUUID(),
     text: body.input,
     type,
+    reminderTime,
     createdAt: Date.now()
   };
 
-  if (type === 'reminder') {
+  if (reminderTime) {
     reminders.push(record);
   } else if (type === 'task') {
     tasks.push(record);
@@ -99,6 +110,7 @@ module.exports = async function handler(req, res) {
   return res.status(200).json({
     success: true,
     type,
+    reminderTime,
     record
   });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "chrono-node": "^2.9.0",
         "puppeteer": "^24.32.0"
       },
       "devDependencies": {
@@ -89,7 +90,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -642,7 +642,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -666,7 +665,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2727,7 +2725,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -2904,6 +2901,15 @@
       },
       "peerDependencies": {
         "devtools-protocol": "*"
+      }
+    },
+    "node_modules/chrono-node": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.9.0.tgz",
+      "integrity": "sha512-glI4YY2Jy6JII5l3d5FN6rcrIbKSQqKPhWsIRYPK2IK8Mm4Q1ZZFdYIaDqglUNf7gNwG+kWIzTn0omzzE0VkvQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/ci-info": {
@@ -3352,8 +3358,7 @@
     "node_modules/devtools-protocol": {
       "version": "0.0.1534754",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1534754.tgz",
-      "integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ==",
-      "peer": true
+      "integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ=="
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -5357,7 +5362,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -6171,7 +6175,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memory-cue",
   "version": "1.0.0",
-  "description": "Memory Cue \u2013 a PWA for reminders, notes, and study aids",
+  "description": "Memory Cue – a PWA for reminders, notes, and study aids",
   "main": "service-worker.js",
   "scripts": {
     "start": "serve .",
@@ -35,6 +35,7 @@
     "tailwindcss": "^3.4.13"
   },
   "dependencies": {
+    "chrono-node": "^2.9.0",
     "puppeteer": "^24.32.0"
   }
 }


### PR DESCRIPTION
### Motivation
- Improve capture pipeline so free-form reminder text automatically yields a parsed reminder timestamp and is stored as a reminder rather than a generic note.

### Description
- Added `chrono-node` to `package.json` to support natural-language date/time parsing and updated `package-lock.json` accordingly.
- Imported `chrono-node` in `api/capture.js` and added `const parsedDates = chrono.parse(body.input)` to analyze incoming capture text.
- When a parsed date is found the code sets `reminderTime = parsedDates[0].start.date()`, forces `type = 'reminder'`, logs detection, includes `reminderTime` on the saved record, and pushes the record to the `reminders` array.
- The API response now includes `reminderTime` alongside `type` and `record` for clients to surface reminders in the Reminders section.

### Testing
- Installed the new dependency with `npm install chrono-node` and updated lockfile (succeeded).
- Ran unit tests with `npm test -- --runInBand`, which executed the test suite but reported unrelated pre-existing failures in several `mobile/*` and `service-worker` tests; the failures are not caused by this change and are present in the repository test baseline.
- Performed a quick require check with `node -e "const h=require('./api/capture'); console.log(typeof h)"` which returned `function`, confirming the handler exports correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0c3d685788324983666f62529bb76)