### PR TITLE
Add recurring reminder support to capture API

### DIFF
--- a/api/capture.js
+++ b/api/capture.js
@@ -1,3 +1,5 @@
+const { RRule } = require('rrule');
+
 const ALLOWED_ORIGINS = [
   'https://dmaher42.github.io',
   'https://memory-cue.vercel.app',
@@ -50,6 +52,47 @@ function classifyCapture(input) {
   return 'note';
 }
 
+function detectRecurrence(text) {
+  const t = text.toLowerCase();
+
+  if (t.includes('every') || t.includes('weekly') || t.includes('each')) {
+    return 'weekly';
+  }
+
+  if (t.includes('daily')) {
+    return 'daily';
+  }
+
+  if (t.includes('next two weeks')) {
+    return 'weekly';
+  }
+
+  return null;
+}
+
+function getWeekCount(text) {
+  if (text.toLowerCase().includes('next two weeks')) {
+    return 2;
+  }
+
+  return 4;
+}
+
+function extractByWeekday(text) {
+  const weekdays = [];
+  const t = text.toLowerCase();
+
+  if (t.includes('monday')) weekdays.push(RRule.MO);
+  if (t.includes('tuesday')) weekdays.push(RRule.TU);
+  if (t.includes('wednesday')) weekdays.push(RRule.WE);
+  if (t.includes('thursday')) weekdays.push(RRule.TH);
+  if (t.includes('friday')) weekdays.push(RRule.FR);
+  if (t.includes('saturday')) weekdays.push(RRule.SA);
+  if (t.includes('sunday')) weekdays.push(RRule.SU);
+
+  return weekdays;
+}
+
 module.exports = async function handler(req, res) {
   applyCors(req, res);
 
@@ -79,10 +122,40 @@ module.exports = async function handler(req, res) {
 
   const type = classifyCapture(body.input);
 
+  const recurrenceType = detectRecurrence(body.input);
+  let recurrenceRule = null;
+  let occurrences = [];
+
+  if (recurrenceType === 'weekly') {
+    const weekdays = extractByWeekday(body.input);
+    const weekCount = getWeekCount(body.input);
+
+    recurrenceRule = new RRule({
+      freq: RRule.WEEKLY,
+      interval: 1,
+      count: weekdays.length > 0 ? weekdays.length * weekCount : weekCount,
+      byweekday: weekdays.length > 0 ? weekdays : undefined,
+      dtstart: new Date()
+    });
+  } else if (recurrenceType === 'daily') {
+    recurrenceRule = new RRule({
+      freq: RRule.DAILY,
+      interval: 1,
+      count: 4,
+      dtstart: new Date()
+    });
+  }
+
+  if (recurrenceRule) {
+    occurrences = recurrenceRule.all();
+  }
+
   const record = {
     id: crypto.randomUUID(),
     text: body.input,
     type,
+    recurrence: recurrenceRule ? recurrenceRule.toString() : null,
+    occurrences,
     createdAt: Date.now()
   };
 
@@ -99,6 +172,8 @@ module.exports = async function handler(req, res) {
   return res.status(200).json({
     success: true,
     type,
+    recurrence: record.recurrence,
+    occurrences,
     record
   });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "puppeteer": "^24.32.0"
+        "puppeteer": "^24.32.0",
+        "rrule": "^2.8.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.56.1",
@@ -89,7 +90,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -642,7 +642,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -666,7 +665,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2727,7 +2725,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -3352,8 +3349,7 @@
     "node_modules/devtools-protocol": {
       "version": "0.0.1534754",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1534754.tgz",
-      "integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ==",
-      "peer": true
+      "integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ=="
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -5357,7 +5353,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -6171,7 +6166,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6655,6 +6649,15 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rrule": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
+      "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/rrweb-cssom": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memory-cue",
   "version": "1.0.0",
-  "description": "Memory Cue \u2013 a PWA for reminders, notes, and study aids",
+  "description": "Memory Cue – a PWA for reminders, notes, and study aids",
   "main": "service-worker.js",
   "scripts": {
     "start": "serve .",
@@ -35,6 +35,7 @@
     "tailwindcss": "^3.4.13"
   },
   "dependencies": {
-    "puppeteer": "^24.32.0"
+    "puppeteer": "^24.32.0",
+    "rrule": "^2.8.1"
   }
 }


### PR DESCRIPTION
### Motivation

- Enable recurring reminder detection so captures containing phrases like `every`, `weekly`, or `next two weeks` expand into multiple reminder instances instead of a single event. 

### Description

- Installed the `rrule` dependency and added it to `package.json` to generate recurrence rules. 
- Imported `RRule` and added recurrence helpers in `api/capture.js`: `detectRecurrence`, `getWeekCount`, and `extractByWeekday`. 
- Generate `RRule` instances for weekly and daily recurrences (weekday-aware `byweekday` and `count`), expand occurrences with `recurrenceRule.all()`, and attach `recurrence` and `occurrences` to reminder records. 
- API responses now include `recurrence` and `occurrences` alongside the saved `record` for client usage. 

### Testing

- Ran `npm test -- --runInBand`, which completed but reported unrelated existing test failures in `mobile.*` and `service-worker` suites (these failures are pre-existing and not caused by the capture API changes). 
- Executed a smoke test by invoking `api/capture.js` with input `NAPLAN Tuesday lesson 1-2 Friday lesson 3-4 next two weeks`, which classified the input as a `reminder` and returned `occurrences.length === 4` and a non-null `recurrence` rule.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0c5bbc44083248edccc4749d3d1bb)