### PR TITLE
Fix capture API response to return `entry` field

### DIFF
--- a/api/capture.js
+++ b/api/capture.js
@@ -174,6 +174,6 @@ module.exports = async function handler(req, res) {
     type,
     recurrence: record.recurrence,
     occurrences,
-    record
+    entry: record
   });
 };


### PR DESCRIPTION
### Motivation
- `mobile.js` expects `data.entry` from the capture API but the endpoint returned `record`, causing the runtime error `Capture response missing entry.`

### Description
- Modified the `/api/capture` success response to return the captured object under `entry` instead of `record`, keeping `success`, `type`, `recurrence`, and `occurrences` unchanged.

### Testing
- Ran `npm test -- --runInBand`; the test run completed with most suites passing but several unrelated tests failed (5 suites, 9 tests) due to ESM/module loading errors in `mobile.*` tests and service-worker tests, which are not caused by this payload key rename.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0c85436d48324b72c57b068b9d5f6)