### PR TITLE
Fix /api/capture response shape for mobile entry parsing

### DIFF
--- a/api/capture.js
+++ b/api/capture.js
@@ -171,9 +171,6 @@ module.exports = async function handler(req, res) {
 
   return res.status(200).json({
     success: true,
-    type,
-    recurrence: record.recurrence,
-    occurrences,
-    record
+    entry: record
   });
 };


### PR DESCRIPTION
### Motivation
- The mobile client expects the captured object at `data.entry` but the API returned the object under different keys, causing the client error “Capture response missing entry.”

### Description
- Updated `api/capture.js` success response to always return the stored capture object under the `entry` field.
- Removed the previous top-level response fields (`type`, `recurrence`, `occurrences`, `record`) from the success payload so the client reads `entry` consistently.
- The stored object shape is unchanged and includes `id`, `text`, `type`, and `createdAt` (plus existing recurrence metadata) so callers still receive the same record data.

### Testing
- Ran `npm install` to restore dependencies and ensure module resolution succeeded; this completed successfully.
- Executed a direct handler smoke-check by invoking the module with a mock request and asserting `res.body.entry` exists and contains `id`, `text`, `type`, and `createdAt`; this check passed.
- Ran the full test suite with `npm test -- --runInBand`; unrelated test suites in `mobile.*` and `service-worker.test.js` failed pre-existing issues, but the change to `api/capture.js` is isolated and does not cause those failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0c9a06d3483248d46a34da12879ce)