### PR TITLE
Add simple RAG retrieval flow for assistant notes

### DIFF
--- a/api/assistant.js
+++ b/api/assistant.js
@@ -15,6 +15,17 @@ function applyCors(req, res) {
   }
 }
 
+async function generateLLMResponse(prompt) {
+  const contextMatch = prompt.match(/CONTEXT:\n([\s\S]*)\n\nAnswer the question using the context\./);
+  const contextText = contextMatch ? contextMatch[1].trim() : '';
+
+  if (!contextText) {
+    return "I don't know.";
+  }
+
+  return contextText.split('\n').find((line) => line.trim()) || "I don't know.";
+}
+
 module.exports = async function handler(req, res) {
   applyCors(req, res);
 
@@ -27,21 +38,50 @@ module.exports = async function handler(req, res) {
   }
 
   const body = req.body && typeof req.body === 'object' ? req.body : {};
-  const input = typeof body.input === 'string' ? body.input.trim() : '';
+  const input = typeof body.input === 'string'
+    ? body.input.trim()
+    : (typeof body.question === 'string' ? body.question.trim() : '');
 
   if (!input) {
     return res.status(400).json({ error: 'Missing input' });
   }
 
-  console.log('[assistant request]', input);
+  const host = req.headers.host;
+  const protocol = req.headers['x-forwarded-proto'] || 'http';
+  const searchUrl = host ? `${protocol}://${host}/api/search` : '/api/search';
 
-  // TODO: Replace placeholder assistant response with real AI call.
-  const reply = `You said: ${input}`;
+  let results = [];
+  try {
+    const search = await fetch(searchUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: input })
+    });
 
-  console.log('[assistant response]', reply);
+    const payload = await search.json();
+    results = Array.isArray(payload && payload.results) ? payload.results : [];
+  } catch (error) {
+    console.error('[assistant] search failed', error);
+  }
+
+  const context = results.map((n) => n.text).join('\n\n');
+
+  const prompt = `
+QUESTION:
+${input}
+
+CONTEXT:
+${context}
+
+Answer the question using the context.
+If the context does not contain the answer, say you don't know.
+`;
+
+  const reply = await generateLLMResponse(prompt);
 
   return res.status(200).json({
     success: true,
-    reply
+    reply,
+    contextUsed: results
   });
 };

--- a/api/assistant.ts
+++ b/api/assistant.ts
@@ -1,0 +1,3 @@
+const handler = require('./assistant.js');
+
+export default handler;

--- a/api/capture.js
+++ b/api/capture.js
@@ -1,4 +1,5 @@
 const { RRule } = require('rrule');
+const { addRecord } = require('./memory-store');
 
 const ALLOWED_ORIGINS = [
   'https://dmaher42.github.io',
@@ -8,10 +9,6 @@ const ALLOWED_ORIGINS = [
 ];
 
 const MAX_INPUT_CHARS = 6000;
-
-const notes = [];
-const reminders = [];
-const tasks = [];
 
 function applyCors(req, res) {
   const origin = req.headers.origin;
@@ -159,13 +156,7 @@ module.exports = async function handler(req, res) {
     createdAt: Date.now()
   };
 
-  if (type === 'reminder') {
-    reminders.push(record);
-  } else if (type === 'task') {
-    tasks.push(record);
-  } else {
-    notes.push(record);
-  }
+  addRecord(type, record);
 
   console.log('[capture classified]', type);
 

--- a/api/memory-store.js
+++ b/api/memory-store.js
@@ -1,0 +1,29 @@
+const notes = [];
+const reminders = [];
+const tasks = [];
+
+function addRecord(type, record) {
+  if (type === 'reminder') {
+    reminders.push(record);
+    return;
+  }
+
+  if (type === 'task') {
+    tasks.push(record);
+    return;
+  }
+
+  notes.push(record);
+}
+
+function getAllNotes() {
+  return [...notes, ...reminders, ...tasks];
+}
+
+module.exports = {
+  addRecord,
+  getAllNotes,
+  notes,
+  reminders,
+  tasks
+};

--- a/api/search.ts
+++ b/api/search.ts
@@ -1,0 +1,64 @@
+const { getAllNotes } = require('./memory-store');
+
+const ALLOWED_ORIGINS = [
+  'https://dmaher42.github.io',
+  'https://memory-cue.vercel.app',
+  'http://localhost:3000',
+  'http://localhost:5173'
+];
+
+function applyCors(req, res) {
+  const origin = req.headers.origin;
+  if (origin && ALLOWED_ORIGINS.includes(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Vary', 'Origin');
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  }
+}
+
+function similarity(query, text) {
+  const q = String(query || '').toLowerCase();
+  const t = String(text || '').toLowerCase();
+
+  let score = 0;
+
+  q.split(' ').forEach((word) => {
+    if (word && t.includes(word)) score += 1;
+  });
+
+  return score;
+}
+
+module.exports = async function handler(req, res) {
+  applyCors(req, res);
+
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end();
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const body = req.body && typeof req.body === 'object' ? req.body : {};
+  const query = typeof body.query === 'string' ? body.query.trim() : '';
+
+  if (!query) {
+    return res.status(400).json({ error: 'Missing query' });
+  }
+
+  const notes = await getAllNotes();
+
+  const results = notes
+    .map((note) => ({
+      note,
+      score: similarity(query, note.text)
+    }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 3);
+
+  return res.status(200).json({
+    results: results.map((result) => result.note)
+  });
+};


### PR DESCRIPTION
### Motivation
- Provide a Retrieval-Augmented Generation (RAG) flow so the assistant can answer questions using stored Memory Cue notes without a vector DB by adding a simple semantic retrieval endpoint and wiring captured entries into a shared in-memory store.

### Description
- Added a shared in-memory note store with `addRecord` and `getAllNotes` in `api/memory-store.js` to make captured notes/reminders/tasks queryable.
- Updated `api/capture.js` to persist captured records into the shared store via `addRecord(type, record)` so newly captured entries are available for retrieval.
- Implemented a new `/api/search` endpoint in `api/search.ts` that scores notes with a simple token-overlap `similarity` function and returns the top 3 matches for a given `query`.
- Updated `api/assistant.js` to call `/api/search`, build a `CONTEXT` from returned notes, assemble the `QUESTION/CONTEXT` prompt, call `generateLLMResponse(prompt)` (local stub), and return `{ success, reply, contextUsed }`, and added `api/assistant.ts` as a wrapper export.

### Testing
- Ran the test suite with `npm test -- --runInBand`. 
- Test summary: `23` suites total, `18` passed and `5` failed; `77` tests total, `68` passed and `9` failed. 
- The failing suites are pre-existing mobile and service-worker tests and are not caused by the API RAG changes; no new test failures were introduced by these changes to the API endpoints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0eb7109f08324a6d6915af025141b)