### PR TITLE
Add /api/chat orchestrator endpoint for conversation + RAG flow

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -1,0 +1,108 @@
+async function generateLLMResponse(prompt: string) {
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error('Missing OpenAI API key');
+  }
+
+  const response = await fetch('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      max_output_tokens: 400,
+      store: false,
+      input: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'input_text',
+              text: prompt
+            }
+          ]
+        }
+      ]
+    })
+  });
+
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(`LLM request failed: ${details}`);
+  }
+
+  const data = await response.json();
+  return (
+    data.output_text ||
+    (data.output &&
+      data.output[0] &&
+      data.output[0].content &&
+      data.output[0].content[0] &&
+      data.output[0].content[0].text) ||
+    ''
+  );
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const body = req.body && typeof req.body === 'object' ? req.body : {};
+  const { message, history = [] } = body;
+
+  if (!message) {
+    return res.status(400).json({ error: 'Missing message' });
+  }
+
+  try {
+    const searchRes = await fetch(process.env.APP_URL + '/api/search', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: message })
+    });
+
+    const { results = [] } = await searchRes.json();
+
+    const contextNotes = results
+      .map((n) => `• ${n.text}`)
+      .join('\n');
+
+    const conversationHistory = history
+      .slice(-10)
+      .map((m) => `${m.role}: ${m.content}`)
+      .join('\n');
+
+    const prompt = `
+SYSTEM:
+You are Memory Cue, a personal memory assistant.
+
+Use stored notes when answering questions.
+
+CONVERSATION:
+${conversationHistory}
+
+MEMORY NOTES:
+${contextNotes}
+
+USER QUESTION:
+${message}
+
+Respond clearly and helpfully.
+`;
+
+    const reply = await generateLLMResponse(prompt);
+
+    return res.json({
+      success: true,
+      reply,
+      contextUsed: results
+    });
+  } catch (error) {
+    return res.status(500).json({
+      error: 'Failed to process chat request',
+      message: error instanceof Error ? error.message : 'Unknown error'
+    });
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a single orchestrator endpoint that accepts a user message, retrieves relevant stored notes (RAG), assembles a structured assistant prompt including recent conversation memory, calls the LLM, and returns a chat-style reply.

### Description
- Added `api/chat.ts` which exposes a `POST`-only handler that validates a required `message` and optional `history` payloads.
- Implemented `generateLLMResponse(prompt)` to call the OpenAI `responses` API and return the LLM output, with a check for `OPENAI_API_KEY` and basic error handling.
- Orchestrator calls the existing `/api/search` (via `process.env.APP_URL + '/api/search'`) to retrieve matching notes, formats them into `contextNotes`, and trims `history` to the last 10 turns to produce `conversationHistory`.
- Builds the assistant prompt with `SYSTEM`, `CONVERSATION`, `MEMORY NOTES`, and `USER QUESTION` sections, invokes the LLM, and returns `{ success: true, reply, contextUsed }` or a 500 error with message on failure.

### Testing
- Ran the test suite with `npm test -- --runInBand` and observed repository-wide test results rather than chat-endpoint-specific tests.
- Test run completed with some pre-existing unrelated failures (5 failing suites, 9 failing tests in `mobile.*` and `service-worker.test.js`); no new endpoint-specific tests were added and the failures appear unrelated to the new `api/chat` endpoint.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b10275229083248b978331d972ac8b)