### PR TITLE
Wire mobile assistant to /api/chat orchestrator with conversation history

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -57,6 +57,7 @@ function initAssistant() {
     const thinkingBarResults = document.getElementById('thinkingBarResults');
     let isAssistantSending = false;
     let latestThinkingSearchRequest = 0;
+    const assistantConversationHistory = [];
 
     if (!isInputElement(thinkingBarInput) || !(assistantThread instanceof HTMLElement)) {
       return;
@@ -445,13 +446,19 @@ function initAssistant() {
             );
           }
         } else {
-          const response = await fetch('/api/assistant', {
+          assistantConversationHistory.push({
+            role: 'user',
+            content: trimmedMessage,
+          });
+
+          const response = await fetch('/api/chat', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
             },
             body: JSON.stringify({
-              input: trimmedMessage,
+              message: trimmedMessage,
+              history: assistantConversationHistory,
             }),
           });
 
@@ -463,6 +470,10 @@ function initAssistant() {
           const replyText = typeof payload?.reply === 'string'
             ? payload.reply
             : 'I could not read an assistant response.';
+          assistantConversationHistory.push({
+            role: 'assistant',
+            content: replyText,
+          });
           appendAssistantMessage(replyText, 'assistant-message assistant-message--reply');
           setThinkingBarStatus('Assistant answer');
         }
@@ -474,7 +485,7 @@ function initAssistant() {
           console.error('[assistant] request failed while calling /api/capture', error);
           appendAssistantMessage('Sorry, I couldn\'t save that brain dump.', 'assistant-message assistant-message--error');
         } else {
-          console.error('[assistant] request failed while calling /api/assistant', error);
+          console.error('[assistant] request failed while calling /api/chat', error);
           appendAssistantMessage('Sorry, something went wrong while contacting the assistant.', 'assistant-message assistant-message--error');
         }
       } finally {


### PR DESCRIPTION
### Motivation
- Route assistant-mode messages through the new chat orchestrator so the client and backend responsibilities match the intended architecture.
- Preserve recent conversation turns on the client so the orchestrator can assemble context for RAG and LLM calls.

### Description
- Added an in-memory `assistantConversationHistory` array in `mobile.js` to track recent user and assistant turns.
- On assistant-mode sends, push the user turn and POST to `/api/chat` with a payload shaped as `{ message, history }` instead of the legacy `/api/assistant` payload.
- Append the assistant reply into the same history after receiving the response and update error logging references from `/api/assistant` to `/api/chat`.

### Testing
- Ran the test suite with `npm test -- --runInBand` after the change; many suites passed but some existing tests failed. 
- Failures observed are unrelated repository tests (including `js/__tests__/mobile.auth.test.js`, `js/__tests__/mobile.sheet.test.js`, `js/__tests__/mobile.new-folder.test.js`, and `service-worker.test.js`) and are preexisting outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1366bcc2c8324b102fe8773cd99c0)