### PR TITLE
Handle missing APP_URL when calling chat search endpoint

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -51,13 +51,41 @@ export default async function handler(req, res) {
 
   const body = req.body && typeof req.body === 'object' ? req.body : {};
   const { message, history = [] } = body;
+  const configuredAppUrl = process.env.APP_URL?.trim();
 
   if (!message) {
     return res.status(400).json({ error: 'Missing message' });
   }
 
   try {
-    const searchRes = await fetch(process.env.APP_URL + '/api/search', {
+    let searchUrl = configuredAppUrl ? `${configuredAppUrl}/api/search` : '';
+
+    if (!searchUrl) {
+      const forwardedProto = req.headers['x-forwarded-proto'];
+      const forwardedHost = req.headers['x-forwarded-host'];
+      const hostHeader = req.headers.host;
+
+      const proto = Array.isArray(forwardedProto)
+        ? forwardedProto[0]
+        : forwardedProto?.split(',')[0];
+      const host = Array.isArray(forwardedHost)
+        ? forwardedHost[0]
+        : Array.isArray(hostHeader)
+          ? hostHeader[0]
+          : forwardedHost || hostHeader;
+
+      if (!proto || !host) {
+        return res.status(500).json({
+          error: 'Failed to process chat request',
+          message:
+            'Unable to resolve search endpoint URL. Set APP_URL or provide x-forwarded-proto and host headers.'
+        });
+      }
+
+      searchUrl = `${proto.trim()}://${host.toString().trim()}/api/search`;
+    }
+
+    const searchRes = await fetch(searchUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ query: message })


### PR DESCRIPTION
### Motivation
- Prevent the chat handler from throwing a URL parse error when `APP_URL` is not set by resolving the search endpoint more robustly from configuration or request headers and returning a controlled error if neither is available.

### Description
- Read `process.env.APP_URL` into a trimmed local variable (`configuredAppUrl`) and prefer `${configuredAppUrl}/api/search` when present.
- When `APP_URL` is absent, derive an absolute base URL from `x-forwarded-proto` plus `x-forwarded-host` or `host` and build `${derivedBase}/api/search`.
- Return a controlled `500` JSON response with a clear configuration error message if neither `APP_URL` nor the required headers are available.
- Preserve the existing search `fetch` behavior (same `POST` body and downstream response handling) and the rest of the handler logic.

### Testing
- Ran `npm test -- --runInBand`; test runner executed the repository test suites but reported failures unrelated to this change (several `mobile.*` and `service-worker.test.js` suites failed), so overall the test command completed with failing suites.  
- The change is limited to `api/chat.ts` and keeps the `fetch` payload/response handling unchanged, and no new unit tests were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1384c18688324b7e0a35de215bfc0)