### PR TITLE
Wire saved note memory index into assistant chat requests

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -50,7 +50,7 @@ export default async function handler(req, res) {
   }
 
   const body = req.body && typeof req.body === 'object' ? req.body : {};
-  const { message, history = [] } = body;
+  const { message, history = [], memoryContext = '', memoryEntries = [] } = body;
   const configuredAppUrl = process.env.APP_URL?.trim();
 
   if (!message) {
@@ -85,16 +85,33 @@ export default async function handler(req, res) {
       searchUrl = `${proto.trim()}://${host.toString().trim()}/api/search`;
     }
 
-    const searchRes = await fetch(searchUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ query: message })
-    });
+    let results = Array.isArray(memoryEntries) ? memoryEntries : [];
 
-    const { results = [] } = await searchRes.json();
+    if (!results.length) {
+      const searchRes = await fetch(searchUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: message })
+      });
+
+      const payload = await searchRes.json();
+      results = Array.isArray(payload?.results) ? payload.results : [];
+    }
 
     const contextNotes = results
-      .map((n) => `• ${n.text}`)
+      .map((n) => {
+        if (typeof n?.text === 'string' && n.text.trim()) {
+          return `• ${n.text}`;
+        }
+        const title = typeof n?.title === 'string' ? n.title.trim() : '';
+        const summary = typeof n?.summary === 'string'
+          ? n.summary.trim()
+          : typeof n?.body === 'string'
+            ? n.body.trim().slice(0, 200)
+            : '';
+        const tags = Array.isArray(n?.tags) && n.tags.length ? ` (${n.tags.join(', ')})` : '';
+        return [title ? `• ${title}${tags}` : '• Note', summary].filter(Boolean).join(' — ');
+      })
       .join('\n');
 
     const conversationHistory = history
@@ -112,6 +129,7 @@ CONVERSATION:
 ${conversationHistory}
 
 MEMORY NOTES:
+${typeof memoryContext === 'string' && memoryContext.trim() ? `${memoryContext}\n\n` : ''}
 ${contextNotes}
 
 USER QUESTION:

--- a/js/modules/memory-index.js
+++ b/js/modules/memory-index.js
@@ -1,6 +1,6 @@
 import { getFolderNameById, loadAllNotes } from './notes-storage.js';
 
-const MAX_SEARCH_RESULTS = 20;
+const MAX_SEARCH_RESULTS = 5;
 const DEFAULT_RECENT_LIMIT = 20;
 const ALLOWED_MEMORY_TYPES = new Set([
   'task',
@@ -60,10 +60,13 @@ const buildIndexEntry = (note) => {
   const updatedAt = toTimestamp(note.updatedAt) || createdAt;
   const type = normalizeString(metadata.type).toLowerCase();
 
+  const body = normalizeString(note.bodyText) || normalizeString(note.body);
+
   return {
     id: normalizeString(note.id),
     title: normalizeString(note.title) || 'Untitled note',
-    body: normalizeString(note.bodyText) || normalizeString(note.body),
+    body,
+    summary: body.slice(0, 180),
     type,
     tags: normalizeTags(metadata.tags),
     folder: getFolderNameById(note.folderId),
@@ -72,7 +75,13 @@ const buildIndexEntry = (note) => {
   };
 };
 
+const tokenizeQuery = (query) => normalizeString(query)
+  .toLowerCase()
+  .split(/[^a-z0-9]+/)
+  .filter(Boolean);
+
 const scoreMemoryMatch = (entry, normalizedQuery) => {
+  const queryTokens = tokenizeQuery(normalizedQuery);
   const lowerTitle = entry.title.toLowerCase();
   const lowerBody = entry.body.toLowerCase();
   const lowerTags = entry.tags.map((tag) => tag.toLowerCase());
@@ -80,20 +89,22 @@ const scoreMemoryMatch = (entry, normalizedQuery) => {
   let score = 0;
   let matched = false;
 
-  if (lowerTitle.includes(normalizedQuery)) {
-    score += 1000;
-    matched = true;
-  }
+  queryTokens.forEach((token) => {
+    if (lowerTitle.includes(token)) {
+      score += 1000;
+      matched = true;
+    }
 
-  if (lowerTags.some((tag) => tag.includes(normalizedQuery))) {
-    score += 500;
-    matched = true;
-  }
+    if (lowerTags.some((tag) => tag.includes(token))) {
+      score += 500;
+      matched = true;
+    }
 
-  if (lowerBody.includes(normalizedQuery)) {
-    score += 100;
-    matched = true;
-  }
+    if (lowerBody.includes(token)) {
+      score += 100;
+      matched = true;
+    }
+  });
 
   // Recency is the final tie-breaker after relevance rules.
   const recencyBoost = entry.updatedAt > 0 ? Math.max(0, 50 - (Date.now() - entry.updatedAt) / (24 * 60 * 60 * 1000)) : 0;

--- a/mobile.js
+++ b/mobile.js
@@ -153,25 +153,22 @@ function initAssistant() {
 
     const searchMemoryIndex = async (question) => {
       try {
-        const activityIndexModule = await import('./js/modules/activity-index.js');
-        if (activityIndexModule && typeof activityIndexModule.searchMemoryIndex === 'function') {
-          return activityIndexModule.searchMemoryIndex(question);
-        }
-        if (activityIndexModule && typeof activityIndexModule.searchActivityIndex === 'function') {
-          return activityIndexModule.searchActivityIndex(question);
+        const memoryIndexModule = await import('./js/modules/memory-index.js');
+        if (memoryIndexModule && typeof memoryIndexModule.searchMemoryIndex === 'function') {
+          return memoryIndexModule.searchMemoryIndex(question);
         }
       } catch (error) {
-        console.warn('[assistant] failed to load activity index search module', error);
+        console.warn('[assistant] failed to load memory index search module', error);
       }
 
       return [];
     };
 
     const buildAssistantEntries = async (question) => {
-      const sourceEntries = (await searchMemoryIndex(question)).slice(0, 10);
+      const sourceEntries = (await searchMemoryIndex(question)).slice(0, 5);
 
       // Keep assistant payloads lightweight while still sending top memory matches.
-      const maxEntries = 10;
+      const maxEntries = 5;
 
       return sourceEntries
         .slice(0, maxEntries)
@@ -186,6 +183,7 @@ function initAssistant() {
             id: typeof entry?.id === 'string' ? entry.id : '',
             title,
             body,
+            summary: toAssistantEntryText(entry?.summary, 240) || toAssistantEntryText(entry?.body, 240),
             type: typeof entry?.type === 'string' ? entry.type : 'note',
             tags: Array.isArray(entry?.tags)
               ? entry.tags.map((tag) => toAssistantEntryText(tag, 64)).filter(Boolean).slice(0, 12)
@@ -196,6 +194,29 @@ function initAssistant() {
           };
         })
         .filter(Boolean);
+    };
+
+    const buildMemoryContextBlock = (question, entries) => {
+      if (!Array.isArray(entries) || !entries.length) {
+        return '';
+      }
+
+      const contextRows = entries.map((entry, index) => {
+        const title = toAssistantEntryText(entry?.title, 120) || 'Untitled note';
+        const tags = Array.isArray(entry?.tags) && entry.tags.length ? ` (${entry.tags.join(', ')})` : '';
+        const summarySource = toAssistantEntryText(entry?.summary, 160) || toAssistantEntryText(entry?.body, 160);
+        return `${index + 1}. ${title}${tags}${summarySource ? ` – ${summarySource}` : ''}`;
+      });
+
+      return [
+        'User question:',
+        `"${question}"`,
+        '',
+        'Context from saved notes:',
+        ...contextRows,
+        '',
+        'Use this context when answering.',
+      ].join('\n');
     };
 
     const buildAssistantContextText = () => {
@@ -446,6 +467,9 @@ function initAssistant() {
             );
           }
         } else {
+          const assistantEntries = await buildAssistantEntries(trimmedMessage);
+          const memoryContext = buildMemoryContextBlock(trimmedMessage, assistantEntries);
+
           assistantConversationHistory.push({
             role: 'user',
             content: trimmedMessage,
@@ -480,6 +504,8 @@ function initAssistant() {
             body: JSON.stringify({
               message: trimmedMessage,
               history: assistantConversationHistory,
+              memoryContext,
+              memoryEntries: assistantEntries,
             }),
           });
 


### PR DESCRIPTION
### Motivation
- The assistant could not reference the user’s saved notes because the local memory index wasn’t being included in assistant requests.
- The goal is to provide relevant saved-note context to the assistant for questions like “What drills have I saved?” without changing the UI.

### Description
- Implemented token-based local search and lightweight summaries in `js/modules/memory-index.js` by updating `searchMemoryIndex(query)` to tokenize the query, match against `title`, `tags`, and `body`, and return the top 5 results with a `summary` field. 
- Wired the mobile assistant flow in `mobile.js` to import and call `searchMemoryIndex(query)`, build compact assistant entries, and render a short `memoryContext` block via `buildMemoryContextBlock(question, entries)` when matches exist. 
- Included `memoryContext` and `memoryEntries` in the payload sent to the assistant endpoint and adjusted `api/chat.ts` to accept these fields and inject the provided context into the LLM prompt while falling back to the existing `/api/search` endpoint when no local matches are supplied. 

### Testing
- Ran `npm run build` and the build completed successfully. 
- Ran `npm run verify` and the build verification passed. 
- Ran `npm test -- --runInBand` and the test run failed with pre-existing unrelated failures (several `mobile.*` ESM parsing tests and `service-worker.test.js` expectations), so unit tests that fail are not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b13ff91ec88324b4e6b4d9ad67b15b)