### PR TITLE
Add inbox brain dump capture

### DIFF
--- a/js/__tests__/reminders.quick-add.test.js
+++ b/js/__tests__/reminders.quick-add.test.js
@@ -109,8 +109,13 @@ test('quick add routes footy drill prefix to Footy – Drills category', async (
 
   const memoryEntries = JSON.parse(localStorage.getItem('memoryEntries') || '[]');
   expect(memoryEntries).toHaveLength(1);
-  expect(memoryEntries[0].type).toBe('drill');
-  expect(Array.isArray(memoryEntries[0].relatedIds)).toBe(true);
+  expect(memoryEntries[0].text).toBe('footy drill: cone sprint ladders');
+  expect(memoryEntries[0].status).toBe('inbox');
+  expect(memoryEntries[0].type).toBeNull();
+  expect(memoryEntries[0].context).toBeNull();
+  expect(memoryEntries[0].person).toBeNull();
+  expect(Number.isFinite(memoryEntries[0].createdAt)).toBe(true);
+  expect(memoryEntries[0].date).toBe('2024-05-15');
 });
 
 test('quick add routes task prefix to Tasks category', async () => {

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -1967,52 +1967,6 @@ export async function initReminders(sel = {}) {
     const t = typeof text === 'string' ? text.trim() : '';
     if (!t) return null;
 
-    const classifyBrainDumpCategory = async (rawText) => {
-      const cleanText = String(rawText || '').trim();
-      if (!cleanText) {
-        return 'Inbox';
-      }
-
-      const prompt = `Classify this note into one of these categories:\nTeaching\nCoaching\nIdeas\nTasks\nInbox\n\nNote: ${cleanText}`;
-
-      try {
-        const response = await fetch('/api/assistant', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ query: prompt }),
-        });
-
-        if (!response.ok) {
-          throw new Error(`Assistant classification request failed (${response.status})`);
-        }
-
-        const payload = await response.json();
-        const reply = typeof payload?.reply === 'string'
-          ? payload.reply
-          : typeof payload?.text === 'string'
-            ? payload.text
-            : typeof payload?.message === 'string'
-              ? payload.message
-              : '';
-
-        const normalizedReply = String(reply || '').trim().toLowerCase();
-        const categoryMap = {
-          teaching: 'Teaching',
-          coaching: 'Coaching',
-          ideas: 'Ideas',
-          tasks: 'Tasks',
-          inbox: 'Inbox',
-        };
-
-        return categoryMap[normalizedReply] || 'Inbox';
-      } catch (error) {
-        console.warn('Assistant classification failed, defaulting to Inbox', error);
-        return 'Inbox';
-      }
-    };
-
     const saveBrainDumpEntry = async (sourceText, reminderEntry) => {
       if (typeof localStorage === 'undefined') {
         return;
@@ -2021,28 +1975,21 @@ export async function initReminders(sel = {}) {
       if (!cleanText) {
         return;
       }
-
-      const category = await classifyBrainDumpCategory(cleanText);
-
-      const nowIso = new Date().toISOString();
+      const now = new Date();
+      const nowMs = Date.now();
+      const dateStamp = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
       const payload = {
         id:
           reminderEntry && reminderEntry.id
             ? reminderEntry.id
             : `entry-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
-        type: normalizeMemoryEntryType(
-          reminderEntry?.category === 'Footy – Drills' ? 'drill' : classifyInput(cleanText),
-        ),
-        title: extractTitle(cleanText),
-        body: cleanText,
-        tags: sanitizeTags(extractTags(cleanText)),
-        relatedIds: [],
-        category,
-        createdAt:
-          reminderEntry && reminderEntry.createdAt
-            ? new Date(reminderEntry.createdAt).toISOString()
-            : nowIso,
-        updatedAt: nowIso,
+        text: cleanText,
+        status: 'inbox',
+        type: null,
+        context: null,
+        person: null,
+        createdAt: nowMs,
+        date: dateStamp,
       };
 
       try {

--- a/mobile.html
+++ b/mobile.html
@@ -5475,13 +5475,13 @@ body, main, section, div, p, span, li {
       };
 
       const renderInboxEntries = () => {
-        const entries = readEntries().filter((entry) => getEntryCategory(entry).toLowerCase() === 'inbox');
+        const entries = readEntries().filter((entry) => String(entry?.status || '').toLowerCase() === 'inbox');
         inboxEntriesList.innerHTML = '';
 
         if (!entries.length) {
           const empty = document.createElement('p');
           empty.className = 'text-sm opacity-70';
-          empty.textContent = 'No uncategorized entries in Inbox.';
+          empty.textContent = 'No entries in Inbox.';
           inboxEntriesList.appendChild(empty);
           return;
         }
@@ -5499,7 +5499,7 @@ body, main, section, div, p, span, li {
 
           const categoryTag = document.createElement('span');
           categoryTag.className = 'badge badge-outline badge-sm';
-          categoryTag.textContent = getEntryCategory(entry);
+          categoryTag.textContent = String(entry?.status || 'inbox');
 
           const createdAt = document.createElement('span');
           createdAt.textContent = getEntryCreatedDate(entry);
@@ -5535,6 +5535,7 @@ body, main, section, div, p, span, li {
             if (entryIndex === -1) return;
             allEntries[entryIndex] = {
               ...allEntries[entryIndex],
+              status: moveSelect.value.toLowerCase(),
               category: moveSelect.value,
               updatedAt: new Date().toISOString()
             };


### PR DESCRIPTION
### Motivation
- Implement an Inbox / Brain Dump capture so all quick captures persist into an inbox-first schema. 
- Add the requested fields (`status`, `type`, `context`, `person`, `createdAt`, `date`) to new quick-capture entries while leaving existing note storage behavior unchanged.

### Description
- Updated the quick-capture pipeline in `js/reminders.js` (`quickAddNow`) to persist brain-dump entries as an inbox payload with fields: `text`, `status: 'inbox'`, `type: null`, `context: null`, `person: null`, `createdAt` (timestamp ms) and `date` (`YYYY-MM-DD`).
- Removed the previous AI classification/Inbox-routing call for the quick-capture path and write the new inbox payload directly into `memoryEntries` via `readMemoryEntries()` / `writeMemoryEntries()`.
- Updated `mobile.html` Inbox rendering to show entries where `status === 'inbox'`, display the entry `status` in the meta tag, and set `status` when moving an Inbox entry to another category so it leaves the Inbox view correctly.
- Adjusted the quick-add test `js/__tests__/reminders.quick-add.test.js` to expect the new inbox capture schema fields.

### Testing
- Ran the focused test suite with `npx jest js/__tests__/reminders.quick-add.test.js --runInBand`, which passed successfully.
- Ran the full test run with `npm test -- --runInBand`; several pre-existing suites unrelated to this change (e.g. `mobile.auth`, `service-worker`) failed but those failures are not introduced by this change.
- Launched the app locally and ran a Playwright script to seed an inbox entry and capture a screenshot of the mobile Inbox view, confirming the UI displays the seeded inbox entry.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b141bf02148324962beecd8d1e4a2d)