### PR TITLE
Add AI inbox processing

### DIFF
--- a/js/entries.js
+++ b/js/entries.js
@@ -127,6 +127,7 @@
   const entriesTitle = document.getElementById('categoryEntriesTitle');
   const entriesList = document.getElementById('categoryEntriesList');
   const inboxEntriesList = document.getElementById('inboxEntriesList');
+  const processInboxButton = document.getElementById('processInboxButton');
 
   if (!(cardGrid instanceof HTMLElement) || !(entriesList instanceof HTMLElement) || !(inboxEntriesList instanceof HTMLElement)) {
     return;
@@ -313,6 +314,94 @@
     });
   };
 
+  const processInboxEntries = async () => {
+    const allEntries = readEntries();
+    const inboxEntries = allEntries.filter((entry) => String(entry?.status || '').toLowerCase() === 'inbox');
+    if (!inboxEntries.length) {
+      return;
+    }
+
+    if (processInboxButton) {
+      processInboxButton.disabled = true;
+      processInboxButton.textContent = 'Processing...';
+    }
+
+    const prompt = [
+      'Read these inbox items.',
+      '',
+      'Classify each item into:',
+      '',
+      'task',
+      'idea',
+      'note',
+      'knowledge',
+      '',
+      'Also extract:',
+      '',
+      'context (teaching / training / personal)',
+      'person if mentioned',
+      '',
+      'Return JSON.'
+    ].join('\n');
+
+    try {
+      const response = await fetch('/api/assistant', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          prompt,
+          entries: inboxEntries
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error(`Assistant request failed (${response.status})`);
+      }
+
+      const data = await response.json();
+      const updates = Array.isArray(data) ? data : [];
+      if (!updates.length) {
+        return;
+      }
+
+      const updatesById = new Map(
+        updates
+          .filter((item) => item && typeof item === 'object' && item.id)
+          .map((item) => [String(item.id), item])
+      );
+
+      const nextEntries = allEntries.map((entry) => {
+        const entryId = entry?.id ? String(entry.id) : '';
+        if (!entryId || !updatesById.has(entryId)) {
+          return entry;
+        }
+
+        const update = updatesById.get(entryId);
+        return {
+          ...entry,
+          type: typeof update.type === 'string' ? update.type : entry.type,
+          context: typeof update.context === 'string' ? update.context : entry.context,
+          person: typeof update.person === 'string' || update.person === null ? update.person : entry.person,
+          text: typeof update.rewrite === 'string' ? update.rewrite : entry.text,
+          status: 'processed',
+          updatedAt: new Date().toISOString()
+        };
+      });
+
+      writeEntries(nextEntries);
+      renderInboxEntries();
+    } catch (error) {
+      console.error('Unable to process inbox entries.', error);
+    } finally {
+      if (processInboxButton) {
+        processInboxButton.disabled = false;
+        processInboxButton.textContent = 'Process Inbox';
+      }
+    }
+  };
+
   const renderCategoryCards = () => {
     cardGrid.innerHTML = '';
     categories.forEach((categoryName) => {
@@ -334,6 +423,8 @@
   backButton?.addEventListener('click', () => {
     window.dispatchEvent(new CustomEvent('app:navigate', { detail: { view: 'reminders' } }));
   });
+
+  processInboxButton?.addEventListener('click', processInboxEntries);
 
   document.addEventListener('memoryCue:entriesUpdated', renderInboxEntries);
   window.addEventListener('storage', (event) => {
@@ -1771,4 +1862,3 @@ document.querySelectorAll('[data-close]').forEach((btn) => {
     }
   });
 })();
-

--- a/mobile.html
+++ b/mobile.html
@@ -4694,6 +4694,7 @@ body, main, section, div, p, span, li {
     <div data-view="inbox" id="view-inbox" class="view-panel hidden" aria-hidden="true">
       <div class="space-y-3">
         <h2 class="text-lg font-semibold">Inbox</h2>
+        <button id="processInboxButton" type="button" class="btn btn-sm btn-primary">Process Inbox</button>
         <div id="inboxEntriesList" class="category-entry-list" aria-live="polite"></div>
       </div>
       </div>
@@ -5401,6 +5402,7 @@ body, main, section, div, p, span, li {
       const entriesTitle = document.getElementById('categoryEntriesTitle');
       const categoryEntriesListEl = document.getElementById('categoryEntriesList');
       const inboxEntriesList = document.getElementById('inboxEntriesList');
+      const processInboxButton = document.getElementById('processInboxButton');
 
       if (!(cardGrid instanceof HTMLElement) || !(categoryEntriesListEl instanceof HTMLElement) || !(inboxEntriesList instanceof HTMLElement)) {
         return;
@@ -5582,6 +5584,94 @@ body, main, section, div, p, span, li {
         });
       };
 
+      const processInboxEntries = async () => {
+        const allEntries = readEntries();
+        const inboxEntries = allEntries.filter((entry) => String(entry?.status || '').toLowerCase() === 'inbox');
+        if (!inboxEntries.length) {
+          return;
+        }
+
+        if (processInboxButton) {
+          processInboxButton.disabled = true;
+          processInboxButton.textContent = 'Processing...';
+        }
+
+        const prompt = [
+          'Read these inbox items.',
+          '',
+          'Classify each item into:',
+          '',
+          'task',
+          'idea',
+          'note',
+          'knowledge',
+          '',
+          'Also extract:',
+          '',
+          'context (teaching / training / personal)',
+          'person if mentioned',
+          '',
+          'Return JSON.'
+        ].join('\n');
+
+        try {
+          const response = await fetch('/api/assistant', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              prompt,
+              entries: inboxEntries
+            })
+          });
+
+          if (!response.ok) {
+            throw new Error(`Assistant request failed (${response.status})`);
+          }
+
+          const data = await response.json();
+          const updates = Array.isArray(data) ? data : [];
+          if (!updates.length) {
+            return;
+          }
+
+          const updatesById = new Map(
+            updates
+              .filter((item) => item && typeof item === 'object' && item.id)
+              .map((item) => [String(item.id), item])
+          );
+
+          const nextEntries = allEntries.map((entry) => {
+            const entryId = entry?.id ? String(entry.id) : '';
+            if (!entryId || !updatesById.has(entryId)) {
+              return entry;
+            }
+
+            const update = updatesById.get(entryId);
+            return {
+              ...entry,
+              type: typeof update.type === 'string' ? update.type : entry.type,
+              context: typeof update.context === 'string' ? update.context : entry.context,
+              person: typeof update.person === 'string' || update.person === null ? update.person : entry.person,
+              text: typeof update.rewrite === 'string' ? update.rewrite : entry.text,
+              status: 'processed',
+              updatedAt: new Date().toISOString()
+            };
+          });
+
+          writeEntries(nextEntries);
+          renderInboxEntries();
+        } catch (error) {
+          console.error('Unable to process inbox entries.', error);
+        } finally {
+          if (processInboxButton) {
+            processInboxButton.disabled = false;
+            processInboxButton.textContent = 'Process Inbox';
+          }
+        }
+      };
+
       const renderCategoryCards = () => {
         cardGrid.innerHTML = '';
         categories.forEach((categoryName) => {
@@ -5603,6 +5693,8 @@ body, main, section, div, p, span, li {
       backButton?.addEventListener('click', () => {
         window.dispatchEvent(new CustomEvent('app:navigate', { detail: { view: 'reminders' } }));
       });
+
+      processInboxButton?.addEventListener('click', processInboxEntries);
 
       document.addEventListener('memoryCue:entriesUpdated', renderInboxEntries);
       window.addEventListener('storage', (event) => {


### PR DESCRIPTION
### Motivation
- Provide a one-click way to process Inbox items with the AI assistant and convert uncategorized items into structured entries.
- Automate classification and extraction (type, context, person, rewrite) and mark items as processed to streamline user workflow.

### Description
- Added a `Process Inbox` button to the Inbox view in `mobile.html` and wired it into the page DOM as `#processInboxButton`.
- Implemented `processInboxEntries` which filters entries with `status === 'inbox'`, sends them to `/api/assistant` with the requested prompt, and expects a JSON array of updates back.
- Applied the same inbox-processing implementation to the shared entries script (`js/entries.js`) and the inline mobile inbox script, updating matched entries with `type`, `context`, `person`, `text` (from `rewrite`), `status: 'processed'`, and `updatedAt` timestamps, and disabled the button while processing.
- Added minimal error handling for the assistant request and restored the button state in a `finally` block.

### Testing
- Ran the unit test command `npm test -- --runInBand sample.test.js` which passed.
- Executed an automated Playwright script to load `mobile.html` and capture a screenshot showing the new `Process Inbox` button (screenshot artifact created successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1432a28248324a2fec13740f7b421)