### PR TITLE
Add daily log system

### DIFF
--- a/404.html
+++ b/404.html
@@ -86,6 +86,7 @@
   <!-- END GPT FIX: compact-skeleton-style -->
   <script src="./js/runtime-env-shim.js" defer></script>
   <script type="module" src="./js/main.js" defer></script>
+  <script type="module" src="./js/daily-log-view.js" defer></script>
 </head>
 <body id="top" class="bg-base-100 text-base-content antialiased leading-7 min-h-screen">
   <a class="skip-link" href="#mainContent">Skip to main content</a>
@@ -108,6 +109,9 @@
           </li>
           <li>
             <a href="#planner" data-route="planner" id="nav-planner" class="btn btn-sm btn-ghost">Planner</a>
+          </li>
+          <li>
+            <a href="#daily-log" data-route="daily-log" data-nav="daily-log" id="nav-daily-log" class="btn btn-sm btn-ghost">Daily Log</a>
           </li>
           <li>
             <a href="#notes" data-route="notes" id="nav-notes" class="btn btn-sm btn-ghost">Notes</a>
@@ -1093,6 +1097,35 @@
         </article>
       </div>
     </section>
+    <section data-view="daily-log" id="view-daily-log" class="app-view" hidden tabindex="-1">
+      <div class="view-container space-y-6">
+        <header class="space-y-1">
+          <h2 class="text-2xl font-semibold">Daily Log</h2>
+          <p id="daily-log-date" class="text-sm text-base-content/70"></p>
+        </header>
+
+        <section aria-labelledby="daily-log-tasks-heading" class="space-y-2">
+          <h3 id="daily-log-tasks-heading" class="text-lg font-semibold">Tasks</h3>
+          <ul id="daily-log-tasks" class="list-disc space-y-1 pl-5"></ul>
+        </section>
+
+        <section aria-labelledby="daily-log-ideas-heading" class="space-y-2">
+          <h3 id="daily-log-ideas-heading" class="text-lg font-semibold">Ideas</h3>
+          <ul id="daily-log-ideas" class="list-disc space-y-1 pl-5"></ul>
+        </section>
+
+        <section aria-labelledby="daily-log-notes-heading" class="space-y-2">
+          <h3 id="daily-log-notes-heading" class="text-lg font-semibold">Notes</h3>
+          <ul id="daily-log-notes" class="list-disc space-y-1 pl-5"></ul>
+        </section>
+
+        <section aria-labelledby="daily-log-knowledge-heading" class="space-y-2">
+          <h3 id="daily-log-knowledge-heading" class="text-lg font-semibold">Knowledge</h3>
+          <ul id="daily-log-knowledge" class="list-disc space-y-1 pl-5"></ul>
+        </section>
+      </div>
+    </section>
+
     <section data-view="notes" id="view-notes" class="app-view" hidden tabindex="-1">
       <div class="view-container view-container--narrow">
         <article class="view-panel view-panel--main bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm transition-shadow duration-200 hover:shadow-md">

--- a/js/daily-log-view.js
+++ b/js/daily-log-view.js
@@ -1,0 +1,82 @@
+import { DAILY_LOG_GROUPS, getDailyLog } from './modules/daily-log.js';
+
+const getCurrentRoute = () => {
+  if (typeof window === 'undefined') {
+    return 'dashboard';
+  }
+  const hash = window.location.hash || '#dashboard';
+  const route = hash.startsWith('#') ? hash.slice(1) : hash;
+  return route || 'dashboard';
+};
+
+const getTodayDateKey = () => {
+  const date = new Date();
+  const year = String(date.getFullYear());
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const formatDateHeading = (dateValue) => {
+  const parsed = new Date(dateValue);
+  if (Number.isNaN(parsed.getTime())) {
+    return '';
+  }
+  return parsed.toLocaleDateString(undefined, { month: 'long', day: 'numeric' });
+};
+
+const renderDailyLog = () => {
+  if (getCurrentRoute() !== 'daily-log') {
+    return;
+  }
+
+  const todayDate = new Date();
+  const entries = getDailyLog(getTodayDateKey());
+  const grouped = {
+    tasks: [],
+    ideas: [],
+    notes: [],
+    knowledge: [],
+  };
+
+  entries.forEach((entry) => {
+    const group = DAILY_LOG_GROUPS.includes(entry.group) ? entry.group : 'notes';
+    grouped[group].push(entry);
+  });
+
+  const dateNode = document.getElementById('daily-log-date');
+  if (dateNode) {
+    dateNode.textContent = formatDateHeading(todayDate);
+  }
+
+  DAILY_LOG_GROUPS.forEach((group) => {
+    const container = document.getElementById(`daily-log-${group}`);
+    if (!container) {
+      return;
+    }
+
+    container.innerHTML = '';
+    const items = grouped[group];
+    if (!items.length) {
+      const empty = document.createElement('li');
+      empty.className = 'text-base-content/70';
+      empty.textContent = 'No entries';
+      container.appendChild(empty);
+      return;
+    }
+
+    items.forEach((entry) => {
+      const row = document.createElement('li');
+      row.textContent = entry.text;
+      container.appendChild(row);
+    });
+  });
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', renderDailyLog, { once: true });
+} else {
+  renderDailyLog();
+}
+
+window.addEventListener('hashchange', renderDailyLog);

--- a/js/modules/daily-log.js
+++ b/js/modules/daily-log.js
@@ -1,0 +1,72 @@
+import { loadAllNotes } from './notes-storage.js';
+
+const DAILY_LOG_GROUPS = ['tasks', 'ideas', 'notes', 'knowledge'];
+
+const normalizeString = (value) => (typeof value === 'string' ? value.trim() : '');
+
+const normalizeDateKey = (value) => {
+  const raw = normalizeString(value);
+  if (!raw) {
+    return null;
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+    return raw;
+  }
+
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  const year = String(parsed.getFullYear());
+  const month = String(parsed.getMonth() + 1).padStart(2, '0');
+  const day = String(parsed.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const toDailyLogGroup = (note) => {
+  const metadataType = normalizeString(note?.metadata?.type).toLowerCase();
+  const noteType = normalizeString(note?.type).toLowerCase();
+  const value = metadataType || noteType;
+
+  if (value.includes('task')) {
+    return 'tasks';
+  }
+  if (value.includes('idea')) {
+    return 'ideas';
+  }
+  if (value.includes('knowledge')) {
+    return 'knowledge';
+  }
+  return 'notes';
+};
+
+const toDailyLogEntry = (note) => {
+  const title = normalizeString(note?.title);
+  const bodyText = normalizeString(note?.bodyText);
+  const body = normalizeString(note?.body);
+
+  return {
+    id: normalizeString(note?.id),
+    group: toDailyLogGroup(note),
+    text: title || bodyText || body || 'Untitled note',
+  };
+};
+
+export const getDailyLog = (date) => {
+  const dateKey = normalizeDateKey(date);
+  if (!dateKey) {
+    return [];
+  }
+
+  return loadAllNotes()
+    .filter((note) => {
+      const metadataDate = normalizeDateKey(note?.metadata?.aiActionDate);
+      const createdDate = normalizeDateKey(note?.createdAt);
+      return metadataDate === dateKey || createdDate === dateKey;
+    })
+    .map((note) => toDailyLogEntry(note));
+};
+
+export { DAILY_LOG_GROUPS };

--- a/js/router.js
+++ b/js/router.js
@@ -3,9 +3,9 @@ const groupedRoutes = new Set(['notes', 'resources', 'templates']);
 function renderRoute() {
   const rawRoute = (window.location.hash || '#dashboard').replace('#', '');
   const activeRoute = rawRoute === '' ? 'dashboard' : rawRoute;
-  const routeNodes = document.querySelectorAll('[data-route]');
+  const routeNodes = document.querySelectorAll('[data-route], [data-view]');
   routeNodes.forEach((node) => {
-    const nodeRoute = node.dataset.route;
+    const nodeRoute = node.dataset.route || node.dataset.view;
     const isDashboardFallback = rawRoute === '' && nodeRoute === 'dashboard';
     const shouldShow = isDashboardFallback || nodeRoute === activeRoute;
 
@@ -14,8 +14,9 @@ function renderRoute() {
     node.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
   });
 
-  document.querySelectorAll('[data-nav]').forEach((link) => {
-    const isActive = link.dataset.nav === activeRoute;
+  document.querySelectorAll('[data-nav], [data-route]').forEach((link) => {
+    const linkRoute = link.dataset.nav || link.dataset.route;
+    const isActive = linkRoute === activeRoute;
     link.classList.toggle('btn-active', isActive);
     if (isActive) {
       link.setAttribute('aria-current', 'page');
@@ -25,8 +26,9 @@ function renderRoute() {
   });
 
   const isGroupedRoute = groupedRoutes.has(activeRoute);
-  document.querySelectorAll('#nav-more-menu [data-nav]').forEach((link) => {
-    const isActive = link.dataset.nav === activeRoute;
+  document.querySelectorAll('#nav-more-menu [data-nav], #nav-more-menu [data-route]').forEach((link) => {
+    const linkRoute = link.dataset.nav || link.dataset.route;
+    const isActive = linkRoute === activeRoute;
     link.classList.toggle('btn-active', isActive);
     if (isActive) {
       link.setAttribute('aria-current', 'page');
@@ -121,6 +123,8 @@ function initRouter() {
   initMobileNavHandlers();
   renderRoute();
 }
+
+window.renderRoute = renderRoute;
 
 window.addEventListener('hashchange', renderRoute);
 


### PR DESCRIPTION
### Motivation
- Provide a Daily Log view that surfaces notes for a given date and organises them into the requested groups (`tasks`, `ideas`, `notes`, `knowledge`).
- Make it easy to navigate to a date’s entries from the app navigation and render the grouped lists in the existing app view structure.

### Description
- Added a new data module `js/modules/daily-log.js` that exports `getDailyLog(date)` which loads notes, filters by date, maps each note into one of the groups, and returns compact entries; it also exports `DAILY_LOG_GROUPS`.
- Added a Daily Log UI and nav link to `404.html` that includes a date heading and four grouped lists with IDs `daily-log-tasks`, `daily-log-ideas`, `daily-log-notes`, and `daily-log-knowledge`.
- Added `js/daily-log-view.js` which reads `getDailyLog()` for today, groups entries by `DAILY_LOG_GROUPS`, and renders them into the new DOM containers when `#daily-log` is active.
- Updated router behavior in `js/router.js` to recognise sections using `data-view` in addition to `data-route`, bind active state for elements using either `data-nav` or `data-route`, and expose `window.renderRoute` so view renderers can refresh when routes change.

### Testing
- Ran the full test suite (`npm test -- --runInBand`) and observed pre-existing unrelated failures in other suites; those failures are not caused by these changes.
- Ran focused tests which passed: `npm test -- --runInBand theme-toggle.test.js` (passed) and `npm test -- --runInBand js/tests/daily-tasks.test.js` (passed).
- Confirmed the Daily Log screen renders in a running dev server and captured a visual screenshot of `#daily-log` (manual visual check, not an automated test).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1444db49c8324abff9b5aa4088239)