### PR TITLE
Add idea linking system

### DIFF
--- a/js/modules/notes-storage.js
+++ b/js/modules/notes-storage.js
@@ -105,6 +105,15 @@ const sanitizeTags = (value) => {
     .filter((tag, index, list) => tag.length && list.indexOf(tag) === index);
 };
 
+const sanitizeLinks = (value) => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((linkId) => (typeof linkId === 'string' ? linkId.trim() : ''))
+    .filter((linkId, index, list) => linkId.length && list.indexOf(linkId) === index);
+};
+
 const sanitizeMetadata = (value) => {
   if (!value || typeof value !== 'object') {
     return null;
@@ -173,6 +182,7 @@ export const createNote = (title, bodyHtml, overrides = {}) => {
     folderId: overrides.folderId && typeof overrides.folderId === 'string' ? overrides.folderId : null,
     semanticEmbedding: normalizeSemanticEmbedding(overrides.semanticEmbedding),
     metadata: sanitizeMetadata(overrides.metadata),
+    links: sanitizeLinks(overrides.links),
   };
 };
 
@@ -211,6 +221,7 @@ const normalizeNotes = (value) => {
           pinned,
           semanticEmbedding: normalizeSemanticEmbedding(note.semanticEmbedding),
           metadata: sanitizeMetadata(note.metadata),
+          links: sanitizeLinks(note.links),
         });
       })
       .filter(Boolean);
@@ -243,6 +254,7 @@ const normalizeNotes = (value) => {
         pinned,
         semanticEmbedding: normalizeSemanticEmbedding(value.semanticEmbedding),
         metadata: sanitizeMetadata(value.metadata),
+        links: sanitizeLinks(value.links),
       }),
     ];
   }
@@ -329,6 +341,7 @@ export const saveAllNotes = (notes, options = {}) => {
       out.createdAt = isValidDateString(note.createdAt) ? note.createdAt : out.createdAt;
       out.semanticEmbedding = normalizeSemanticEmbedding(note.semanticEmbedding);
       out.metadata = sanitizeMetadata(note.metadata);
+      out.links = sanitizeLinks(note.links);
     }
     return out;
   }).filter(Boolean);
@@ -475,4 +488,74 @@ export const assignNoteToFolder = (noteId, folderId) => {
   }
   const saved = saveAllNotes(newNotes);
   return saved;
+};
+
+export const linkEntries = (sourceId, targetId) => {
+  if (!sourceId || typeof sourceId !== 'string' || !targetId || typeof targetId !== 'string') {
+    return false;
+  }
+
+  const sourceKey = sourceId.trim();
+  const targetKey = targetId.trim();
+
+  if (!sourceKey || !targetKey || sourceKey === targetKey) {
+    return false;
+  }
+
+  const notes = loadAllNotes();
+  if (!Array.isArray(notes) || !notes.length) {
+    return false;
+  }
+
+  let sourceFound = false;
+  let targetFound = false;
+  let changed = false;
+
+  const linkedNotes = notes.map((note) => {
+    if (!note || typeof note !== 'object') {
+      return note;
+    }
+
+    if (note.id === sourceKey) {
+      sourceFound = true;
+      const currentLinks = sanitizeLinks(note.links);
+      if (!currentLinks.includes(targetKey)) {
+        changed = true;
+        return {
+          ...note,
+          links: [...currentLinks, targetKey],
+          updatedAt: new Date().toISOString(),
+        };
+      }
+      return {
+        ...note,
+        links: currentLinks,
+      };
+    }
+
+    if (note.id === targetKey) {
+      targetFound = true;
+      const currentLinks = sanitizeLinks(note.links);
+      if (!currentLinks.includes(sourceKey)) {
+        changed = true;
+        return {
+          ...note,
+          links: [...currentLinks, sourceKey],
+          updatedAt: new Date().toISOString(),
+        };
+      }
+      return {
+        ...note,
+        links: currentLinks,
+      };
+    }
+
+    return note;
+  });
+
+  if (!sourceFound || !targetFound || !changed) {
+    return false;
+  }
+
+  return saveAllNotes(linkedNotes);
 };

--- a/js/tests/notes-storage.links.test.js
+++ b/js/tests/notes-storage.links.test.js
@@ -1,0 +1,64 @@
+/** @jest-environment jsdom */
+
+const { beforeEach, expect, test } = require('@jest/globals');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadNotesStorageModule() {
+  const filePath = path.resolve(__dirname, '../modules/notes-storage.js');
+  let source = fs.readFileSync(filePath, 'utf8');
+  source = source
+    .replace(/export\s+const/g, 'const')
+    .replace(/export\s+\{\s*NOTES_STORAGE_KEY\s*\};/g, '')
+    .replace(/export\s+\{\s*NOTES_STORAGE_KEY\s*\}/g, '')
+    .replace(/export\s+\{[^}]*\};?/g, '');
+  source += '\nmodule.exports = { createNote, loadAllNotes, saveAllNotes, linkEntries };\n';
+
+  const module = { exports: {} };
+  const sandbox = {
+    module,
+    exports: module.exports,
+    require,
+    console,
+    localStorage,
+    document,
+    window,
+    crypto: window.crypto,
+    Date,
+    setTimeout,
+    clearTimeout,
+  };
+
+  vm.runInNewContext(source, sandbox, { filename: filePath });
+  return module.exports;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test('createNote initializes links to an empty array', () => {
+  const { createNote } = loadNotesStorageModule();
+
+  const note = createNote('Idea', 'Dodgeball zones');
+
+  expect(Array.isArray(note.links)).toBe(true);
+  expect(note.links).toHaveLength(0);
+});
+
+test('linkEntries stores links on both source and target notes', () => {
+  const { createNote, saveAllNotes, loadAllNotes, linkEntries } = loadNotesStorageModule();
+
+  const source = createNote('Idea', 'Dodgeball zones', { id: 'chaos-ball' });
+  const target = createNote('Idea', 'Bench ball', { id: 'bench-ball' });
+  saveAllNotes([source, target]);
+
+  const linked = linkEntries('chaos-ball', 'bench-ball');
+
+  expect(linked).toBe(true);
+
+  const [updatedSource, updatedTarget] = loadAllNotes();
+  expect(updatedSource.links).toContain('bench-ball');
+  expect(updatedTarget.links).toContain('chaos-ball');
+});

--- a/mobile.html
+++ b/mobile.html
@@ -4807,6 +4807,13 @@ body, main, section, div, p, span, li {
                 ></div>
               </div>
             </div>
+
+            <section id="relatedNotesPanel" class="px-3 pb-2 space-y-2" aria-live="polite">
+              <h3 class="text-sm font-semibold">Related notes</h3>
+              <div id="relatedNotesList" class="space-y-1 text-sm text-base-content/70">
+                <p>No related notes.</p>
+              </div>
+            </section>
             </div>
 
           <!-- Fixed bottom action bar for notebook -->

--- a/mobile.js
+++ b/mobile.js
@@ -1102,6 +1102,8 @@ const initMobileNotes = () => {
   const saveButton = document.getElementById('noteSaveMobile');
   const listElement = document.getElementById('notesListMobile');
   const countElement = document.getElementById('notesCountMobile');
+  const relatedNotesPanel = document.getElementById('relatedNotesPanel');
+  const relatedNotesList = document.getElementById('relatedNotesList');
   const filterInput = document.getElementById('notebook-search-input');
   const folderFilterSelect = document.getElementById('folderFilterSelect');
   const folderFilterNewButton = document.getElementById('folderFilterNewFolder');
@@ -1471,6 +1473,10 @@ const initMobileNotes = () => {
 
   bindSavedNotesSheetEvents();
 
+  if (relatedNotesPanel instanceof HTMLElement) {
+    relatedNotesPanel.classList.add('hidden');
+  }
+
   const getNormalizedFilterQuery = () =>
     typeof filterQuery === 'string' ? filterQuery.trim().toLowerCase() : '';
 
@@ -1559,7 +1565,10 @@ const initMobileNotes = () => {
 
   const setEditorValues = (note, options = {}) => {
     const { isNew = false } = options;
-    if (note && currentNoteId === note.id && !isNew) return;
+    if (note && currentNoteId === note.id && !isNew) {
+      renderRelatedNotes(note);
+      return;
+    }
     if (!note) {
       currentNoteIsNew = false;
       currentNoteHasChanged = false;
@@ -1572,6 +1581,7 @@ const initMobileNotes = () => {
       if (labelElClear) {
         labelElClear.textContent = getFolderNameById(currentEditingNoteFolderId || 'unsorted');
       }
+      renderRelatedNotes(null);
       return;
     }
     currentNoteIsNew = Boolean(isNew);
@@ -1591,6 +1601,7 @@ const initMobileNotes = () => {
     if (labelEl) {
       labelEl.textContent = getFolderNameById(currentEditingNoteFolderId);
     }
+    renderRelatedNotes(note);
   };
 
   const extractPlainText = (html = '') => getEditorBodyText(html);
@@ -1615,6 +1626,53 @@ const initMobileNotes = () => {
     }
     const body = getNoteBodyText(note).trim();
     return body || 'Untitled note';
+  };
+
+  const getNoteLinks = (note) => {
+    if (!Array.isArray(note?.links)) {
+      return [];
+    }
+    return note.links
+      .map((linkId) => (typeof linkId === 'string' ? linkId.trim() : ''))
+      .filter((linkId, index, links) => linkId && links.indexOf(linkId) === index);
+  };
+
+  const renderRelatedNotes = (note) => {
+    if (!(relatedNotesPanel instanceof HTMLElement) || !(relatedNotesList instanceof HTMLElement)) {
+      return;
+    }
+
+    relatedNotesList.innerHTML = '';
+
+    if (!note || typeof note.id !== 'string') {
+      relatedNotesPanel.classList.add('hidden');
+      return;
+    }
+
+    relatedNotesPanel.classList.remove('hidden');
+
+    const related = getNoteLinks(note)
+      .map((id) => allNotes.find((entry) => entry?.id === id))
+      .filter(Boolean);
+
+    if (!related.length) {
+      const empty = document.createElement('p');
+      empty.textContent = 'No related notes.';
+      relatedNotesList.appendChild(empty);
+      return;
+    }
+
+    related.forEach((relatedNote) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'btn btn-ghost btn-xs justify-start w-full';
+      button.textContent = getDashboardItemLabel(relatedNote);
+      button.addEventListener('click', () => {
+        setEditorValues(relatedNote);
+        updateListSelection();
+      });
+      relatedNotesList.appendChild(button);
+    });
   };
 
   const buildDashboardData = () => {


### PR DESCRIPTION
### Motivation
- Allow notes to reference other notes so users can link related ideas and surface them in the editor.
- Extend the note schema with a `links` array and provide an API to persist bidirectional relationships.

### Description
- Added `sanitizeLinks` and persisted `links` across note creation, normalization, and saving in `js/modules/notes-storage.js` so every note consistently has a `links` array. 
- Implemented `linkEntries(sourceId, targetId)` in `notes-storage.js` to validate IDs and store bidirectional links (updates both source and target notes and saves them).
- Added a Related notes panel to the mobile notebook UI (`mobile.html`) and implemented `getNoteLinks` + `renderRelatedNotes` in `mobile.js` to show clickable related notes and hide the panel when none are present.
- Wired the editor flow so `renderRelatedNotes` runs when opening/clearing a note and added tests covering link initialization and bidirectional linking behavior (`js/tests/notes-storage.links.test.js`).

### Testing
- Ran the new unit tests with `npm test -- --runInBand js/tests/notes-storage.links.test.js` and they passed.
- Re-ran existing folder tests with `npm test -- --runInBand js/tests/notes-storage.folders.test.js` and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1469145288324930fb8def874f119)