### PR TITLE
Add person memory system

### DIFF
--- a/api/assistant.ts
+++ b/api/assistant.ts
@@ -1,4 +1,4 @@
-const { addRecord, getAllNotes, getCategory } = require('./memory-store');
+const { addRecord, getAllNotes, getCategory, searchByPerson } = require('./memory-store');
 const { classifyMemoryType, createStructuredMemory } = require('./memory-utils');
 
 const ALLOWED_ORIGINS = [
@@ -43,6 +43,12 @@ function pickRetrievalType(inputText) {
   return null;
 }
 
+function extractPersonQuery(inputText) {
+  const match = String(inputText || '').match(/\bwhat\s+did\s+([^?]+?)\s+say\??\s*$/i);
+  if (!match) return null;
+  return match[1].trim();
+}
+
 function keywordScore(query, memory) {
   const q = query.toLowerCase().split(/\s+/).filter(Boolean);
   const haystack = `${memory.text || ''} ${(memory.tags || []).join(' ')}`.toLowerCase();
@@ -78,6 +84,18 @@ export default async function handler(req, res) {
   const intent = detectIntent(input);
   let reply = "I don't know.";
   let results = [];
+
+  const personQuery = extractPersonQuery(input);
+  if (personQuery) {
+    results = searchByPerson(personQuery);
+    reply = formatMemoryList(`${personQuery} said`, results);
+
+    return res.status(200).json({
+      success: true,
+      reply,
+      contextUsed: results
+    });
+  }
 
   if (intent === 'save') {
     const type = classifyMemoryType(input);

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -1,3 +1,11 @@
+const { searchByPerson } = require('./memory-store');
+
+function extractPersonQuestion(message: string) {
+  const match = String(message || '').match(/\bwhat\s+did\s+([^?]+?)\s+say\??\s*$/i);
+  if (!match) return null;
+  return match[1].trim();
+}
+
 async function generateLLMResponse(prompt: string) {
   if (!process.env.OPENAI_API_KEY) {
     throw new Error('Missing OpenAI API key');
@@ -86,6 +94,16 @@ export default async function handler(req, res) {
     }
 
     let results = Array.isArray(memoryEntries) ? memoryEntries : [];
+
+    const personQuestion = extractPersonQuestion(message);
+    if (personQuestion) {
+      const personMatches = searchByPerson(personQuestion);
+      if (personMatches.length) {
+        results = personMatches;
+      } else if (results.length) {
+        results = results.filter((entry) => entry?.person === personQuestion);
+      }
+    }
 
     if (!results.length) {
       const searchRes = await fetch(searchUrl, {

--- a/api/memory-store.js
+++ b/api/memory-store.js
@@ -43,6 +43,10 @@ function getCategory(type) {
   return [...memoryCueData[toCollectionKey(type)]];
 }
 
+function searchByPerson(name) {
+  return getAllNotes().filter((entry) => entry?.person === name);
+}
+
 function getStoreSnapshot() {
   return {
     tasks: [...memoryCueData.tasks],
@@ -58,6 +62,7 @@ module.exports = {
   addRecord,
   getCategory,
   getAllNotes,
+  searchByPerson,
   getStoreSnapshot,
   memoryCueData,
 };

--- a/api/memory-utils.js
+++ b/api/memory-utils.js
@@ -48,6 +48,20 @@ function extractTags(inputText) {
   return [...new Set(tags)];
 }
 
+
+function extractPerson(inputText) {
+  const text = String(inputText || '').trim();
+  if (!text) return undefined;
+
+  const saidMatch = text.match(/^([A-Z][a-z]+)\s+said\b/);
+  if (saidMatch) return saidMatch[1];
+
+  const fromMatch = text.match(/\bfrom\s+([A-Z][a-z]+)\b/);
+  if (fromMatch) return fromMatch[1];
+
+  return undefined;
+}
+
 function cleanMemoryText(inputText) {
   return String(inputText || '')
     .replace(/^\s*(remember this|add a task|save this|note|idea|question|resource)\s*[:\-]?\s*/i, '')
@@ -60,6 +74,7 @@ function createStructuredMemory(inputText, forcedType) {
     id: crypto.randomUUID(),
     type,
     text: cleanMemoryText(inputText) || String(inputText || '').trim(),
+    person: extractPerson(inputText),
     tags: extractTags(inputText),
     createdAt: new Date().toISOString(),
   };


### PR DESCRIPTION
### Motivation
- Enable storing and querying memory entries by person so the assistant can answer person-specific questions like "What did Shayla say?".

### Description
- Added `searchByPerson(name)` to `api/memory-store.js` to return entries where `person === name` and exported it for API use. 
- Extended `api/memory-utils.js` with `extractPerson` and included a `person` field on `createStructuredMemory` so captured entries may carry optional `person` metadata. 
- Updated `api/assistant.ts` to detect queries of the form `What did <Name> say?` using `extractPersonQuery`, call `searchByPerson`, and return a formatted list of matches immediately. 
- Updated `api/chat.ts` to detect person-specific questions and prefer `searchByPerson` matches when building the memory context passed to the LLM.

### Testing
- Ran the existing test suite with `npm test -- --runInBand`; test run executed but reported failures unrelated to these changes: `Test Suites: 5 failed, 18 passed, 23 total` and `Tests: 9 failed, 68 passed, 77 total`. 
- Failures are in mobile/service-worker related tests (mobile new-folder/auth/open-sheet/sheet and service-worker suites) and appear pre-existing and unrelated to the memory/person changes introduced here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b148c1656483249a21c245e3563761)