### PR TITLE
Add weekly reflection generator and UI button

### DIFF
--- a/js/modules/weekly-summary.js
+++ b/js/modules/weekly-summary.js
@@ -1,0 +1,109 @@
+import { loadAllNotes } from './notes-storage.js';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const toTimestamp = (value) => {
+  if (typeof value !== 'string') {
+    return 0;
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+const normalizeType = (note) => {
+  const metadata = note && typeof note.metadata === 'object' && note.metadata ? note.metadata : {};
+  const type = typeof metadata.type === 'string' && metadata.type.trim()
+    ? metadata.type.trim()
+    : typeof note?.type === 'string' && note.type.trim()
+      ? note.type.trim()
+      : 'note';
+  return type;
+};
+
+const getRecentEntries = () => {
+  const cutoff = Date.now() - (7 * MS_PER_DAY);
+  const notes = Array.isArray(loadAllNotes()) ? loadAllNotes() : [];
+
+  return notes
+    .map((note) => {
+      const timestamp = toTimestamp(note?.updatedAt) || toTimestamp(note?.createdAt);
+      return {
+        id: typeof note?.id === 'string' ? note.id : '',
+        title: typeof note?.title === 'string' && note.title.trim() ? note.title.trim() : 'Untitled note',
+        body: typeof note?.bodyText === 'string' ? note.bodyText.trim() : '',
+        type: normalizeType(note),
+        createdAt: timestamp ? new Date(timestamp).toISOString() : null,
+        timestamp,
+      };
+    })
+    .filter((entry) => entry.timestamp >= cutoff)
+    .sort((a, b) => b.timestamp - a.timestamp);
+};
+
+const groupByType = (entries) => entries.reduce((groups, entry) => {
+  const key = entry.type || 'note';
+  if (!groups[key]) {
+    groups[key] = [];
+  }
+  groups[key].push(entry);
+  return groups;
+}, {});
+
+const buildContextFromGroups = (groupedEntries) => {
+  const typeNames = Object.keys(groupedEntries);
+  if (!typeNames.length) {
+    return 'No entries were captured in the last 7 days.';
+  }
+
+  return typeNames
+    .map((typeName) => {
+      const rows = groupedEntries[typeName]
+        .map((entry) => {
+          const preview = entry.body ? ` — ${entry.body.slice(0, 220)}` : '';
+          return `- ${entry.title}${preview}`;
+        })
+        .join('\n');
+      return `Type: ${typeName}\n${rows}`;
+    })
+    .join('\n\n');
+};
+
+export const generateWeeklySummary = async () => {
+  const recentEntries = getRecentEntries();
+  const groupedEntries = groupByType(recentEntries);
+  const memoryContext = buildContextFromGroups(groupedEntries);
+
+  const response = await fetch('/api/chat', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      message: [
+        'Summarise the week.',
+        'Return exactly these sections as markdown headings:',
+        'Teaching observations',
+        'Student conversations',
+        'Ideas generated',
+        'Outstanding tasks',
+      ].join('\n'),
+      history: [],
+      memoryContext,
+      memoryEntries: recentEntries,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Weekly summary request failed (${response.status})`);
+  }
+
+  const payload = await response.json();
+  const summary = typeof payload?.reply === 'string' ? payload.reply.trim() : '';
+
+  return {
+    summary,
+    groupedEntries,
+  };
+};
+

--- a/mobile.html
+++ b/mobile.html
@@ -5080,6 +5080,7 @@ body, main, section, div, p, span, li {
             </div>
     <section data-view="assistant" id="view-assistant" class="view-panel hidden" aria-hidden="true">
       <div class="assistant-panel">
+        <button id="weeklyReflectionButton" type="button" class="btn btn-outline btn-sm">Weekly Reflection</button>
         <div id="thinkingBarStatus" class="hidden" aria-live="polite"></div>
         <div id="thinkingBarResults" aria-live="polite"></div>
         <div id="assistantThread" aria-live="polite" aria-label="Assistant conversation"></div>

--- a/mobile.js
+++ b/mobile.js
@@ -13,6 +13,7 @@ import { initNotesSync } from './js/modules/notes-sync.js';
 import { ModalController } from './js/modules/modal-controller.js';
 import { saveFolders } from './js/modules/notes-storage.js';
 import { buildDashboard } from './js/modules/dashboard-data.js';
+import { generateWeeklySummary } from './js/modules/weekly-summary.js';
 
 const aiCaptureSaveModulePromise = import('./js/modules/ai-capture-save.js').catch(() => ({}));
 
@@ -55,6 +56,7 @@ function initAssistant() {
     const quickAddForm = document.getElementById('quickAddForm');
     const thinkingBarStatus = document.getElementById('thinkingBarStatus');
     const thinkingBarResults = document.getElementById('thinkingBarResults');
+    const weeklyReflectionButton = document.getElementById('weeklyReflectionButton');
     let isAssistantSending = false;
     let latestThinkingSearchRequest = 0;
     const assistantConversationHistory = [];
@@ -591,6 +593,40 @@ function initAssistant() {
 
       renderSearchResults(query);
     });
+
+
+    if (weeklyReflectionButton instanceof HTMLElement) {
+      weeklyReflectionButton.addEventListener('click', async () => {
+        if (isAssistantSending) {
+          return;
+        }
+
+        isAssistantSending = true;
+        if (assistantLoading instanceof HTMLElement) {
+          assistantLoading.classList.remove('hidden');
+        }
+        setThinkingBarStatus('Generating weekly reflection');
+
+        try {
+          const weeklySummary = await generateWeeklySummary();
+          const summaryText = typeof weeklySummary?.summary === 'string' && weeklySummary.summary.trim()
+            ? weeklySummary.summary.trim()
+            : 'No weekly summary was returned.';
+          appendAssistantMessage('Weekly Reflection', 'assistant-message');
+          appendAssistantMessage(summaryText, 'assistant-message assistant-message--reply');
+          setThinkingBarStatus('Weekly reflection ready');
+        } catch (error) {
+          console.error('[assistant] failed to generate weekly reflection', error);
+          appendAssistantMessage("Sorry, I couldn't generate a weekly reflection right now.", 'assistant-message assistant-message--error');
+          setThinkingBarStatus('');
+        } finally {
+          isAssistantSending = false;
+          if (assistantLoading instanceof HTMLElement) {
+            assistantLoading.classList.add('hidden');
+          }
+        }
+      });
+    }
 
     if (isFormElement(quickAddForm) && isInputElement(universalInput)) {
       quickAddForm.addEventListener('submit', (event) => {


### PR DESCRIPTION
### Motivation
- Provide a quick way to generate a structured weekly reflection from recent notes. 
- Summaries should use local notes from the last 7 days and be grouped by `type` to surface teaching observations, conversations, ideas, and tasks. 
- Expose the feature in the assistant UI so users can generate a reflection with a single action.

### Description
- Add a new module `js/modules/weekly-summary.js` exporting `generateWeeklySummary()` which collects notes from the last 7 days, groups them by type, builds a memory context, and posts a structured prompt to `/api/chat` requesting the four headings. 
- Insert a `Weekly Reflection` button into the assistant view in `mobile.html` with id `weeklyReflectionButton`. 
- Import and wire `generateWeeklySummary()` in `mobile.js` to call the generator on click, show loading/status via existing UI functions, and append the returned summary to the assistant thread with basic error handling. 
- Keep changes minimal and follow existing patterns for note loading, grouping and UI messaging.

### Testing
- Ran `npm run build`, which completed successfully. 
- Ran repository tests via `npm test -- --runInBand`, which surfaced pre-existing unrelated failures in other suites (not introduced by this change). 
- Ran `npx jest js/__tests__/mobile.new-folder.test.js --runInBand`, which shows one existing unrelated expectation failure remaining after development iterations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b149c27a6883249b00c143f2ed4dee)