### PR TITLE
Replace mobile capture input UI and save raw uncategorized captures to Inbox

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -57,6 +57,21 @@ body.app-shell #smartInputBar {
   z-index: 58;
 }
 
+
+body.app-shell #smartInputBar.capture-bar {
+  height: auto;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+body.app-shell .capture-bar-examples {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 0 4px;
+  font-size: 12px;
+  color: var(--text-secondary, rgba(81, 38, 99, 0.72));
+}
 body.app-shell .smart-input-form {
   width: 100%;
   display: flex;

--- a/mobile.html
+++ b/mobile.html
@@ -5098,11 +5098,16 @@ body, main, section, div, p, span, li {
 
   <div id="smartInputBar" class="smart-input-bar capture-bar">
     <form id="quickAddForm" class="smart-input-form">
-      <input id="universalInput" class="control-input quick-add-input" type="text" placeholder="Capture, search, or ask..." autocomplete="off" />
+      <input id="universalInput" class="control-input quick-add-input" type="text" placeholder="Capture something…" autocomplete="off" />
       <button id="sendBtn" type="submit" class="smart-send-button" aria-label="Send">Send</button>
       <span id="quickAddParsingIndicator" class="text-xs text-base-content/70" hidden>Parsing…</span>
       <span id="quickAddSuccessIndicator" class="text-xs text-success" role="status" aria-live="polite" hidden>Saved ✓</span>
     </form>
+    <div class="capture-bar-examples" aria-hidden="true">
+      <div>Need cones for training</div>
+      <div>Idea dodgeball zones</div>
+      <div>Shayla asked for extension</div>
+    </div>
   </div>
 
   <nav id="mobile-nav-shell" class="bottom-nav inset-x-0 bottom-0 z-50 flex justify-center px-2 pb-3" aria-label="Bottom navigation">

--- a/mobile.js
+++ b/mobile.js
@@ -375,206 +375,37 @@ function initAssistant() {
         return;
       }
 
-      const isReminderMode = /\bremind\b/i.test(trimmedMessage);
-      const isAssistantMode = trimmedMessage.includes('?');
-      const isCaptureMode = !isReminderMode && !isAssistantMode;
-
-      console.log('[assistant] send handler executed', {
-        textLength: trimmedMessage.length,
-        mode: isReminderMode ? 'reminder' : isCaptureMode ? 'capture' : 'assistant',
-      });
       isAssistantSending = true;
 
-      if (assistantLoading instanceof HTMLElement) {
-        assistantLoading.classList.remove('hidden');
-      }
-
-      clearThinkingBarResults();
-      appendAssistantMessage(message);
-
-      thinkingBarInput.value = '';
-      thinkingBarInput.focus();
-
       try {
-        if (isReminderMode) {
-          const reminderOpenEvent = new CustomEvent('cue:open', { detail: { trigger: 'universal-input' } });
-          document.dispatchEvent(reminderOpenEvent);
+        const captureItem = {
+          text: trimmedMessage,
+          type: 'uncategorized',
+          timestamp: Date.now(),
+          source: 'capture',
+        };
 
-          const reminderTitleInput = document.getElementById('reminderText');
-          if (isInputElement(reminderTitleInput)) {
-            reminderTitleInput.value = trimmedMessage;
-            reminderTitleInput.dispatchEvent(new Event('input', { bubbles: true }));
-          }
+        const rawEntries = localStorage.getItem('memoryEntries');
+        const parsedEntries = rawEntries ? JSON.parse(rawEntries) : [];
+        const existingEntries = Array.isArray(parsedEntries)
+          ? parsedEntries
+          : Array.isArray(parsedEntries?.entries)
+            ? parsedEntries.entries
+            : [];
+        existingEntries.unshift(captureItem);
+        localStorage.setItem('memoryEntries', JSON.stringify(existingEntries));
+        document.dispatchEvent(new CustomEvent('memoryCue:entriesUpdated'));
 
-          const reminderSaveEvent = new CustomEvent('reminder:save', {
-            detail: { trigger: document.getElementById('saveReminder') },
-          });
-          document.dispatchEvent(reminderSaveEvent);
-          appendAssistantMessage('Reminder created.', 'assistant-message assistant-message--reply');
-          setThinkingBarStatus('Reminder saved');
-        } else if (isCaptureMode) {
-          const captureText = trimmedMessage.startsWith('+') ? trimmedMessage.slice(1).trim() : trimmedMessage;
-          const capturePayload = {
-            schemaVersion: 2,
-            input: captureText,
-          };
-          const response = await fetch('/api/capture', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(capturePayload),
-          });
-
-          if (!response.ok) {
-            throw new Error(`Capture request failed (${response.status})`);
-          }
-
-          const payload = await response.json();
-          const entry = payload?.entry;
-          if (!entry || typeof entry !== 'object') {
-            throw new Error('Capture response missing entry.');
-          }
-
-          await ensureFolderExistsByName('Inbox');
-
-          const confidence = typeof entry.confidence === 'number' ? entry.confidence : Number(entry.confidence);
-          const shouldRouteToInbox = Number.isFinite(confidence) && confidence < 0.7;
-          const aiSelectedFolderName = typeof entry.folder === 'string' && entry.folder.trim()
-            ? entry.folder.trim()
-            : 'Unsorted';
-          const targetFolderName = shouldRouteToInbox ? 'Inbox' : aiSelectedFolderName;
-
-          const entryToSave = {
-            ...entry,
-            folder: targetFolderName,
-          };
-
-          await saveCapturedEntryAsNote(entryToSave);
-
-          const title = typeof entry.title === 'string' && entry.title.trim()
-            ? entry.title.trim()
-            : 'Untitled note';
-          if (shouldRouteToInbox) {
-            appendAssistantMessage(`Saved to Inbox for review: ${title}`, 'assistant-message assistant-message--reply');
-          } else {
-            appendAssistantMessage(`Saved to ${targetFolderName}: ${title}`, 'assistant-message assistant-message--reply');
-          }
-          setThinkingBarStatus('Saved entry');
-
-          if (typeof entry.followUpQuestion === 'string' && entry.followUpQuestion.trim()) {
-            appendAssistantMessage(
-              `Follow-up: ${entry.followUpQuestion.trim()}`,
-              'assistant-message assistant-message--reply'
-            );
-          }
-        } else {
-          const assistantEntries = await buildAssistantEntries(trimmedMessage);
-          const memoryContext = buildMemoryContextBlock(trimmedMessage, assistantEntries);
-
-          assistantConversationHistory.push({
-            role: 'user',
-            content: trimmedMessage,
-          });
-
-          const sanitizeChatErrorMessage = (backendMessage) => {
-            if (typeof backendMessage !== 'string') {
-              return '';
-            }
-
-            const normalized = backendMessage.trim().replace(/\s+/g, ' ');
-            if (!normalized) {
-              return '';
-            }
-
-            if (/missing\s+openai\s+api\s+key/i.test(normalized)) {
-              return 'The assistant is not configured yet (missing OpenAI API key).';
-            }
-
-            if (/api\s*key|configuration|config/i.test(normalized)) {
-              return 'The assistant appears to be misconfigured.';
-            }
-
-            return '';
-          };
-
-          const response = await fetch('/api/chat', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-              message: trimmedMessage,
-              history: assistantConversationHistory,
-              memoryContext,
-              memoryEntries: assistantEntries,
-            }),
-          });
-
-          if (!response.ok) {
-            let backendMessage = '';
-            try {
-              const errorPayload = await response.json();
-              if (typeof errorPayload?.error === 'string') {
-                backendMessage = errorPayload.error;
-              } else if (typeof errorPayload?.message === 'string') {
-                backendMessage = errorPayload.message;
-              }
-            } catch {
-              // Keep fallback error message when backend payload is not parseable.
-            }
-
-            const normalizedBackendMessage = typeof backendMessage === 'string'
-              ? backendMessage.trim().replace(/\s+/g, ' ')
-              : '';
-            const fullErrorMessage = normalizedBackendMessage
-              ? `Failed to process chat request: ${normalizedBackendMessage}`
-              : `Assistant request failed (${response.status})`;
-            const chatError = new Error(fullErrorMessage);
-            chatError.chatSafeSummary = sanitizeChatErrorMessage(normalizedBackendMessage);
-            throw chatError;
-          }
-
-          const payload = await response.json();
-          const replyText = typeof payload?.reply === 'string'
-            ? payload.reply
-            : 'I could not read an assistant response.';
-          assistantConversationHistory.push({
-            role: 'assistant',
-            content: replyText,
-          });
-          appendAssistantMessage(replyText, 'assistant-message assistant-message--reply');
-          setThinkingBarStatus('Assistant answer');
-        }
+        thinkingBarInput.value = '';
+        thinkingBarInput.focus();
+        setThinkingBarStatus('Saved to Inbox');
       } catch (error) {
-        if (isReminderMode) {
-          console.error('[assistant] failed to create reminder from universal input', error);
-          appendAssistantMessage('Sorry, I couldn\'t create that reminder.', 'assistant-message assistant-message--error');
-        } else if (isCaptureMode) {
-          console.error('[assistant] request failed while calling /api/capture', error);
-          appendAssistantMessage('Sorry, I couldn\'t save that brain dump.', 'assistant-message assistant-message--error');
-        } else {
-          console.error('[assistant] request failed while calling /api/chat', error);
-          const safeSummary = typeof error?.chatSafeSummary === 'string' ? error.chatSafeSummary.trim() : '';
-          const baseMessage = 'Sorry, something went wrong while contacting the assistant.';
-          const userMessage = safeSummary
-            ? `${baseMessage} ${safeSummary}`
-            : baseMessage;
-          appendAssistantMessage(userMessage, 'assistant-message assistant-message--error');
-        }
+        console.error('[capture] failed to save input to Inbox', error);
+        appendAssistantMessage("Sorry, I couldn't save that capture.", 'assistant-message assistant-message--error');
       } finally {
         isAssistantSending = false;
-        if (assistantLoading instanceof HTMLElement) {
-          assistantLoading.classList.add('hidden');
-        }
       }
     };
-
-    thinkingBarInput.addEventListener('keydown', (event) => {
-      if (event.key === 'Enter' && !event.shiftKey) {
-        sendAssistantMessage(event);
-      }
-    });
 
     thinkingBarInput.addEventListener('input', () => {
       const query = typeof thinkingBarInput.value === 'string' ? thinkingBarInput.value.trim() : '';


### PR DESCRIPTION
### Motivation
- Replace the previous universal placeholder and behavior so the capture field matches the requested UI copy and examples. 
- Persist raw user captures immediately to the Inbox as uncategorized items without running AI categorization yet.

### Description
- Updated `mobile.html` to change the input placeholder to `Capture something…` and added the three example lines below the field. 
- Added CSS in `mobile.css` to stack and style the example lines beneath the input (`.capture-bar-examples`) and allow the capture bar to auto-size. 
- Replaced the previous assistant/categorization send flow in `mobile.js` with a simple capture handler that creates an object `{ text, type: "uncategorized", timestamp: Date.now(), source: "capture" }`, prepends it to `memoryEntries` in `localStorage`, and dispatches `memoryCue:entriesUpdated`. 
- Simplified status and error handling for the capture path to reflect direct saving to the Inbox and avoid classifying or routing entries at this stage.

### Testing
- Ran `npm test -- --runInBand` which exposed unrelated failing suites in the repo and a temporary syntax error introduced during editing; the syntax issue in `mobile.js` was fixed but the overall test run still includes unrelated failures. 
- Ran `npx jest js/__tests__/reminders.quick-add.test.js --runInBand` which passed. 
- Ran `npx jest js/__tests__/mobile.new-folder.test.js --runInBand` which showed a single unrelated failing test in the new-folder retry wiring path.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1511db9dc83248ee6d7b7fd2cf574)