### PR TITLE
Adjust processInbox handling for unprocessed inbox entries

### DIFF
--- a/js/entries.js
+++ b/js/entries.js
@@ -333,7 +333,7 @@
 
   async function processInbox() {
     const allEntries = readEntries();
-    const inboxEntries = allEntries.filter((entry) => entry?.processed !== true);
+    const inboxEntries = allEntries.filter((entry) => entry?.processed === false);
     if (!inboxEntries.length) {
       return;
     }
@@ -394,7 +394,7 @@
       const timestamp = new Date().toISOString();
       const processedNotes = [];
 
-      allEntries.forEach((entry) => {
+      inboxEntries.forEach((entry) => {
         const entryId = entry?.id ? String(entry.id) : '';
         if (!entryId || !updatesById.has(entryId)) {
           return;
@@ -428,8 +428,8 @@
       }
 
       appendToMainNotesDatabase(processedNotes);
-      const processedIds = new Set(processedNotes.map((entry) => entry.id));
-      const nextEntries = allEntries.filter((entry) => !processedIds.has(String(entry?.id || '')));
+      const inboxIds = new Set(inboxEntries.map((entry) => String(entry?.id || '')));
+      const nextEntries = allEntries.filter((entry) => !inboxIds.has(String(entry?.id || '')));
       writeEntries(nextEntries);
       renderInboxEntries();
     } catch (error) {


### PR DESCRIPTION
### Motivation
- Ensure `processInbox()` only selects items explicitly marked `processed === false` and moves that exact inbox batch to the main notes database so the Inbox is cleared for processed items in a run.

### Description
- Changed the inbox selector to `entry?.processed === false` to avoid processing entries with `undefined` or other values for `processed`.
- Restricted the transformation loop to iterate over `inboxEntries` instead of `allEntries` so only the selected batch is converted and annotated with `processed: true` and `timestamp`.
- Updated the cleanup step to remove all items that were in the inbox batch using an `inboxIds` set before calling `writeEntries` so the batch is cleared from Inbox.

### Testing
- Ran `npm test -- js/__tests__/reminders.quick-add.test.js` and the suite passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b156ab1c208324886ae033a56ee440)