### PR TITLE
Remove capture bar examples from mobile input bar

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -57,21 +57,6 @@ body.app-shell #smartInputBar {
   z-index: 58;
 }
 
-
-body.app-shell #smartInputBar.capture-bar {
-  height: auto;
-  flex-direction: column;
-  align-items: stretch;
-}
-
-body.app-shell .capture-bar-examples {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: 0 4px;
-  font-size: 12px;
-  color: var(--text-secondary, rgba(81, 38, 99, 0.72));
-}
 body.app-shell .smart-input-form {
   width: 100%;
   display: flex;

--- a/mobile.html
+++ b/mobile.html
@@ -5167,18 +5167,13 @@ body, main, section, div, p, span, li {
     </div>
   </div>
 
-  <div id="smartInputBar" class="smart-input-bar capture-bar">
+  <div id="smartInputBar" class="smart-input-bar">
     <form id="quickAddForm" class="smart-input-form">
       <input id="universalInput" class="control-input quick-add-input" type="text" placeholder="Capture something…" autocomplete="off" />
       <button id="sendBtn" type="submit" class="smart-send-button" aria-label="Send">Send</button>
       <span id="quickAddParsingIndicator" class="text-xs text-base-content/70" hidden>Parsing…</span>
       <span id="quickAddSuccessIndicator" class="text-xs text-success" role="status" aria-live="polite" hidden>Saved ✓</span>
     </form>
-    <div class="capture-bar-examples" aria-hidden="true">
-      <div>Need cones for training</div>
-      <div>Idea dodgeball zones</div>
-      <div>Shayla asked for extension</div>
-    </div>
   </div>
 
   <nav id="mobile-nav-shell" class="bottom-nav inset-x-0 bottom-0 z-50 flex justify-center px-2 pb-3" aria-label="Bottom navigation">


### PR DESCRIPTION
### Motivation
- Simplify the mobile capture UI by removing the example hint list shown beneath the quick-add input so the bar is cleaner and only shows the input and status indicators.

### Description
- Deleted the `capture-bar-examples` HTML block from `mobile.html`, removed the `capture-bar` class from `#smartInputBar`, and removed the now-unused CSS rules for the capture-bar example layout in `mobile.css`.

### Testing
- Ran the project test suite with `npm test -- --runInBand`, which exited non-green due to pre-existing unrelated failures in several `mobile.*` and `service-worker` test suites (5 failing suites, 19 passed, overall test run failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1587f746c8324b8c6b4bbba110698)