### PR TITLE
Simplify mobile note list items for faster scanning

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1096,22 +1096,25 @@ body[data-active-view="notebook"] #view-notebook .card-body {
     padding: 0;
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 2px;
   }
 
-  /* Remove old row dividers & stripes; use cards instead */
+  /* Minimal list rows for faster scanning */
   #savedNotesSheet .note-item-mobile {
-    border-bottom: none;
+    border-bottom: 1px solid color-mix(in srgb, var(--text-secondary, #cbd5e1) 22%, transparent);
     margin: 0;
   }
 
   #savedNotesSheet .note-card {
-    padding: 12px 16px;
-    background: rgba(255, 255, 255, 0.04);
-    border-radius: 12px;
-    margin-bottom: 8px;
-    font-size: 1rem;
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 8px 10px;
+    background: transparent;
+    border-radius: 0;
+    margin-bottom: 0;
+    font-size: 0.95rem;
+    border: 0;
   }
 
   #savedNotesSheet .note-card-header {
@@ -1125,8 +1128,8 @@ body[data-active-view="notebook"] #view-notebook .card-body {
   #savedNotesSheet .note-card-title {
     flex: 1 1 auto;
     min-width: 0;
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: 0.95rem;
+    font-weight: 500;
     color: var(--text-primary, #e5e7eb);
     white-space: nowrap;
     overflow: hidden;
@@ -1138,13 +1141,13 @@ body[data-active-view="notebook"] #view-notebook .card-body {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 32px;
-    height: 32px;
+    width: 24px;
+    height: 24px;
     border-radius: 999px;
     border: 0;
     background: transparent;
     padding: 0;
-    font-size: 1.1rem;
+    font-size: 0.95rem;
     line-height: 1;
     color: var(--text-secondary, #cbd5e1);
   }
@@ -1157,10 +1160,11 @@ body[data-active-view="notebook"] #view-notebook .card-body {
   #savedNotesSheet .note-card-meta {
     display: flex;
     align-items: center;
-    gap: 0.4rem;
-    margin-top: 2px;
-    font-size: 0.85rem;
+    gap: 0.3rem;
+    margin-top: 1px;
+    font-size: 0.74rem;
     color: var(--text-secondary, #cbd5e1);
+    letter-spacing: 0.01em;
   }
 
   #savedNotesSheet .note-card-meta-dot {
@@ -1174,9 +1178,8 @@ body[data-active-view="notebook"] #view-notebook .card-body {
   /* Selected note card: subtle accent, no heavy band */
   #savedNotesSheet .note-list-item.is-active,
   #savedNotesSheet .note-item-mobile.is-active .note-list-item {
-    background: color-mix(in srgb, #ffffff 88%, var(--accent-color, #6b46c1) 12%);
-    border-color: color-mix(in srgb, var(--accent-color, #6b46c1) 55%, #e5e7eb 45%);
-    box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent-color, #6b46c1) 45%, transparent);
+    background: color-mix(in srgb, var(--accent-color, #6b46c1) 8%, transparent);
+    border-left: 2px solid color-mix(in srgb, var(--accent-color, #6b46c1) 72%, transparent);
   }
 
   #savedNotesSheet .note-list-item.is-active .note-list-title,


### PR DESCRIPTION
### Motivation
- Replace the heavy rounded note-card UI with a minimalist list-row treatment to reduce padding, remove heavy borders, and improve scan speed on the mobile saved-notes sheet.

### Description
- Updated `mobile.html` CSS for the saved notes list to reduce `gap`, add a subtle `border-bottom` for rows, remove card background/border, and reduce padding to make rows denser and faster to scan.
- Tightened typography and control sizing by reducing `font-size` and `padding` for `.note-card-title`, `.note-card-action`, and `.note-card-meta`, and changed the active state to a subtle tint with a left accent border instead of a full highlighted card.

### Testing
- Ran `npm test -- --runInBand`; the test run completed but the repository has existing unrelated failures in several mobile and service-worker suites (summary: 24 suites total, 5 failed, 19 passed; 79 tests total, 9 failed, 70 passed), and the style-only change did not introduce new JS failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b158b4b7988324a82dce49ae837907)