### PR TITLE
Add Daily Log view with date filter and persist capture dates

### DIFF
--- a/404.html
+++ b/404.html
@@ -1099,9 +1099,15 @@
     </section>
     <section data-view="daily-log" id="view-daily-log" class="app-view" hidden tabindex="-1">
       <div class="view-container space-y-6">
-        <header class="space-y-1">
+        <header class="space-y-3">
           <h2 class="text-2xl font-semibold">Daily Log</h2>
-          <p id="daily-log-date" class="text-sm text-base-content/70"></p>
+          <div class="flex flex-wrap items-end gap-3">
+            <label class="form-control w-full max-w-xs">
+              <span class="label-text text-sm">Filter by date</span>
+              <input id="daily-log-date-filter" type="date" class="input input-bordered input-sm w-full" />
+            </label>
+            <p id="daily-log-date" class="text-sm text-base-content/70"></p>
+          </div>
         </header>
 
         <section aria-labelledby="daily-log-tasks-heading" class="space-y-2">
@@ -1114,14 +1120,9 @@
           <ul id="daily-log-ideas" class="list-disc space-y-1 pl-5"></ul>
         </section>
 
-        <section aria-labelledby="daily-log-notes-heading" class="space-y-2">
-          <h3 id="daily-log-notes-heading" class="text-lg font-semibold">Notes</h3>
-          <ul id="daily-log-notes" class="list-disc space-y-1 pl-5"></ul>
-        </section>
-
-        <section aria-labelledby="daily-log-knowledge-heading" class="space-y-2">
-          <h3 id="daily-log-knowledge-heading" class="text-lg font-semibold">Knowledge</h3>
-          <ul id="daily-log-knowledge" class="list-disc space-y-1 pl-5"></ul>
+        <section aria-labelledby="daily-log-memories-heading" class="space-y-2">
+          <h3 id="daily-log-memories-heading" class="text-lg font-semibold">Memories</h3>
+          <ul id="daily-log-memories" class="list-disc space-y-1 pl-5"></ul>
         </section>
       </div>
     </section>

--- a/js/daily-log-view.js
+++ b/js/daily-log-view.js
@@ -1,4 +1,4 @@
-import { DAILY_LOG_GROUPS, getDailyLog } from './modules/daily-log.js';
+import { DAILY_LOG_GROUPS, getDailyLog, normalizeDateKey } from './modules/daily-log.js';
 
 const getCurrentRoute = () => {
   if (typeof window === 'undefined') {
@@ -25,28 +25,39 @@ const formatDateHeading = (dateValue) => {
   return parsed.toLocaleDateString(undefined, { month: 'long', day: 'numeric' });
 };
 
+const getSelectedDate = () => {
+  const picker = document.getElementById('daily-log-date-filter');
+  const selected = normalizeDateKey(picker?.value || '');
+  const today = getTodayDateKey();
+
+  if (picker && !picker.value) {
+    picker.value = today;
+  }
+
+  return selected || today;
+};
+
 const renderDailyLog = () => {
   if (getCurrentRoute() !== 'daily-log') {
     return;
   }
 
-  const todayDate = new Date();
-  const entries = getDailyLog(getTodayDateKey());
+  const selectedDate = getSelectedDate();
+  const entries = getDailyLog(selectedDate);
   const grouped = {
     tasks: [],
     ideas: [],
-    notes: [],
-    knowledge: [],
+    memories: [],
   };
 
   entries.forEach((entry) => {
-    const group = DAILY_LOG_GROUPS.includes(entry.group) ? entry.group : 'notes';
+    const group = DAILY_LOG_GROUPS.includes(entry.group) ? entry.group : 'memories';
     grouped[group].push(entry);
   });
 
   const dateNode = document.getElementById('daily-log-date');
   if (dateNode) {
-    dateNode.textContent = formatDateHeading(todayDate);
+    dateNode.textContent = formatDateHeading(selectedDate);
   }
 
   DAILY_LOG_GROUPS.forEach((group) => {
@@ -73,9 +84,24 @@ const renderDailyLog = () => {
   });
 };
 
+const bindDailyLogListeners = () => {
+  const dateFilter = document.getElementById('daily-log-date-filter');
+  if (dateFilter instanceof HTMLInputElement) {
+    dateFilter.value = getSelectedDate();
+    dateFilter.addEventListener('change', renderDailyLog);
+  }
+
+  document.addEventListener('memoryCue:entriesUpdated', renderDailyLog);
+  document.addEventListener('memoryCue:notesUpdated', renderDailyLog);
+};
+
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', renderDailyLog, { once: true });
+  document.addEventListener('DOMContentLoaded', () => {
+    bindDailyLogListeners();
+    renderDailyLog();
+  }, { once: true });
 } else {
+  bindDailyLogListeners();
   renderDailyLog();
 }
 

--- a/js/modules/daily-log.js
+++ b/js/modules/daily-log.js
@@ -1,6 +1,7 @@
 import { loadAllNotes } from './notes-storage.js';
 
-const DAILY_LOG_GROUPS = ['tasks', 'ideas', 'notes', 'knowledge'];
+const DAILY_LOG_GROUPS = ['tasks', 'ideas', 'memories'];
+const MEMORY_ENTRIES_STORAGE_KEY = 'memoryEntries';
 
 const normalizeString = (value) => (typeof value === 'string' ? value.trim() : '');
 
@@ -25,34 +26,75 @@ const normalizeDateKey = (value) => {
   return `${year}-${month}-${day}`;
 };
 
-const toDailyLogGroup = (note) => {
-  const metadataType = normalizeString(note?.metadata?.type).toLowerCase();
-  const noteType = normalizeString(note?.type).toLowerCase();
-  const value = metadataType || noteType;
+const toDateKeyFromTimestamp = (value) => {
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return normalizeDateKey(parsed.toISOString());
+};
 
-  if (value.includes('task')) {
+const toDailyLogGroup = (value = '') => {
+  const normalized = normalizeString(value).toLowerCase();
+
+  if (normalized.includes('task')) {
     return 'tasks';
   }
-  if (value.includes('idea')) {
+  if (normalized.includes('idea')) {
     return 'ideas';
   }
-  if (value.includes('knowledge')) {
-    return 'knowledge';
+  return 'memories';
+};
+
+const toDailyLogEntry = ({ id = '', group = 'memories', text = '' } = {}) => ({
+  id: normalizeString(id),
+  group: DAILY_LOG_GROUPS.includes(group) ? group : 'memories',
+  text: normalizeString(text) || 'Untitled item',
+});
+
+const readMemoryEntries = () => {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return [];
   }
-  return 'notes';
+
+  try {
+    const raw = window.localStorage.getItem(MEMORY_ENTRIES_STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.warn('Unable to read memory entries for Daily Log', error);
+    return [];
+  }
 };
 
-const toDailyLogEntry = (note) => {
-  const title = normalizeString(note?.title);
-  const bodyText = normalizeString(note?.bodyText);
-  const body = normalizeString(note?.body);
+const getNoteDateKey = (note) => (
+  normalizeDateKey(note?.metadata?.aiActionDate)
+  || normalizeDateKey(note?.createdAt)
+);
 
-  return {
-    id: normalizeString(note?.id),
-    group: toDailyLogGroup(note),
-    text: title || bodyText || body || 'Untitled note',
-  };
-};
+const getMemoryEntryDateKey = (entry) => (
+  normalizeDateKey(entry?.date)
+  || toDateKeyFromTimestamp(entry?.createdAt)
+  || toDateKeyFromTimestamp(entry?.timestamp)
+);
+
+const getNoteText = (note) => (
+  normalizeString(note?.title)
+  || normalizeString(note?.bodyText)
+  || normalizeString(note?.body)
+);
+
+const getMemoryEntryText = (entry) => (
+  normalizeString(entry?.text)
+  || normalizeString(entry?.title)
+  || normalizeString(entry?.body)
+);
 
 export const getDailyLog = (date) => {
   const dateKey = normalizeDateKey(date);
@@ -60,13 +102,23 @@ export const getDailyLog = (date) => {
     return [];
   }
 
-  return loadAllNotes()
-    .filter((note) => {
-      const metadataDate = normalizeDateKey(note?.metadata?.aiActionDate);
-      const createdDate = normalizeDateKey(note?.createdAt);
-      return metadataDate === dateKey || createdDate === dateKey;
-    })
-    .map((note) => toDailyLogEntry(note));
+  const noteEntries = loadAllNotes()
+    .filter((note) => getNoteDateKey(note) === dateKey)
+    .map((note) => toDailyLogEntry({
+      id: note?.id,
+      group: toDailyLogGroup(note?.metadata?.type || note?.type),
+      text: getNoteText(note),
+    }));
+
+  const memoryEntries = readMemoryEntries()
+    .filter((entry) => getMemoryEntryDateKey(entry) === dateKey)
+    .map((entry) => toDailyLogEntry({
+      id: entry?.id,
+      group: toDailyLogGroup(entry?.type),
+      text: getMemoryEntryText(entry),
+    }));
+
+  return [...memoryEntries, ...noteEntries];
 };
 
-export { DAILY_LOG_GROUPS };
+export { DAILY_LOG_GROUPS, normalizeDateKey };

--- a/mobile.js
+++ b/mobile.js
@@ -378,10 +378,13 @@ function initAssistant() {
       isAssistantSending = true;
 
       try {
+        const capturedAt = new Date();
         const captureItem = {
           text: trimmedMessage,
           type: 'uncategorized',
           timestamp: Date.now(),
+          createdAt: capturedAt.getTime(),
+          date: `${capturedAt.getFullYear()}-${String(capturedAt.getMonth() + 1).padStart(2, '0')}-${String(capturedAt.getDate()).padStart(2, '0')}`,
           source: 'capture',
         };
 


### PR DESCRIPTION
### Motivation
- Provide a Daily Log view that shows items captured on a specific date and groups them into Tasks, Ideas and Memories. 
- Ensure captured items include explicit date metadata so the Daily Log can reliably collect entries by day. 
- Allow users to filter the Daily Log by date, defaulting to today, and re-render when entries/notes change.

### Description
- Added `js/modules/daily-log.js` to aggregate daily-log items from saved notes and `localStorage` `memoryEntries`, normalize date keys, and map entries into three groups: `tasks`, `ideas`, and `memories`.
- Updated `js/daily-log-view.js` to add a date picker (`#daily-log-date-filter`), default the picker to today, fetch the daily log for the selected date, and bind listeners to `memoryCue:entriesUpdated` and `memoryCue:notesUpdated` to re-render on updates.
- Modified app markup in `404.html` to add a date filter control to the Daily Log header and rename the Notes/Knowledge sections into a single `Memories` section with matching IDs used by the view.
- Ensured mobile quick-capture in `mobile.js` now persists `createdAt` and a `date` (`YYYY-MM-DD`) on saved `memoryEntries` so captures are date-indexable by the Daily Log.
- Exported `normalizeDateKey` from the daily-log module for internal view logic.

### Testing
- Ran unit tests with `npm test -- --runInBand`, resulting in test summary: 19 passed, 5 failed (some failing suites are unrelated pre-existing mobile auth/sheet/new-folder and service-worker tests); the failures are unrelated to the Daily Log changes.
- Ran `npm run build` which started the build tooling and emitted Tailwind/daisyUI logs but did not complete to a finished build within the environment timeout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b15ab4e4108324a1ed66151582a7e7)