### PR TITLE
Implement conversation memory capture with person indexing

### DIFF
--- a/js/__tests__/reminders.quick-add.test.js
+++ b/js/__tests__/reminders.quick-add.test.js
@@ -199,3 +199,17 @@ test('quick add parses natural language time into due date', async () => {
 
   expect(item.due).toBe(expectedIso);
 });
+
+test('quick add classifies capitalized name entries as conversation memory', async () => {
+  const quickInput = document.getElementById('quickAddInput');
+  quickInput.value = 'Shayla asked for extension';
+
+  await window.memoryCueQuickAddNow();
+
+  const memoryEntries = JSON.parse(localStorage.getItem('memoryEntries') || '[]');
+  expect(memoryEntries).toHaveLength(1);
+  expect(memoryEntries[0].type).toBe('memory');
+  expect(memoryEntries[0].person).toBe('Shayla');
+  expect(memoryEntries[0].note).toBe('asked for extension');
+  expect(memoryEntries[0].context).toBe('teaching');
+});

--- a/js/modules/memory-index.js
+++ b/js/modules/memory-index.js
@@ -59,6 +59,7 @@ const buildIndexEntry = (note) => {
   const createdAt = toTimestamp(note.createdAt);
   const updatedAt = toTimestamp(note.updatedAt) || createdAt;
   const type = normalizeString(metadata.type).toLowerCase();
+  const person = normalizeString(metadata.person);
 
   const body = normalizeString(note.bodyText) || normalizeString(note.body);
 
@@ -68,6 +69,7 @@ const buildIndexEntry = (note) => {
     body,
     summary: body.slice(0, 180),
     type,
+    person,
     tags: normalizeTags(metadata.tags),
     folder: getFolderNameById(note.folderId),
     createdAt,
@@ -146,6 +148,31 @@ export const searchMemoryIndex = (query) => {
     .slice(0, MAX_SEARCH_RESULTS)
     .map((result) => result.entry);
 };
+
+export const searchPersonMemoryIndex = (personQuery) => {
+  const normalizedPerson = normalizeString(personQuery).toLowerCase();
+  if (!normalizedPerson.length) {
+    return [];
+  }
+
+  return buildMemoryIndex()
+    .filter((entry) => normalizeString(entry.person).toLowerCase().includes(normalizedPerson))
+    .sort(sortByRecency)
+    .slice(0, MAX_SEARCH_RESULTS);
+};
+
+export const getPersonMemoryIndex = () => buildMemoryIndex().reduce((index, entry) => {
+  const person = normalizeString(entry.person);
+  if (!person) {
+    return index;
+  }
+
+  if (!Array.isArray(index[person])) {
+    index[person] = [];
+  }
+  index[person].push(entry);
+  return index;
+}, {});
 
 export const getRecentMemory = (limit = DEFAULT_RECENT_LIMIT) => {
   const normalizedLimit = Number(limit);

--- a/js/modules/notes-storage.js
+++ b/js/modules/notes-storage.js
@@ -125,6 +125,14 @@ const sanitizeMetadata = (value) => {
     metadata.type = value.type.trim();
   }
 
+  if (typeof value.person === 'string' && value.person.trim()) {
+    metadata.person = value.person.trim();
+  }
+
+  if (typeof value.context === 'string' && value.context.trim()) {
+    metadata.context = value.context.trim();
+  }
+
   const tags = sanitizeTags(value.tags);
   if (tags.length) {
     metadata.tags = tags;

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -1062,10 +1062,48 @@ export async function initReminders(sel = {}) {
 
   function normalizeMemoryEntryType(type) {
     const value = typeof type === 'string' ? type.trim().toLowerCase() : '';
-    if (value === 'note' || value === 'reminder' || value === 'drill' || value === 'idea' || value === 'task') {
+    if (
+      value === 'note'
+      || value === 'memory'
+      || value === 'reminder'
+      || value === 'drill'
+      || value === 'idea'
+      || value === 'task'
+    ) {
       return value;
     }
     return 'note';
+  }
+
+  function inferConversationContext(text) {
+    const normalized = typeof text === 'string' ? text.toLowerCase() : '';
+    if (normalized.includes('footy') || normalized.includes('drill') || normalized.includes('training')) {
+      return 'coaching';
+    }
+    return 'teaching';
+  }
+
+  function extractConversationMemory(text) {
+    const normalized = typeof text === 'string' ? text.trim() : '';
+    if (!normalized) return null;
+
+    const nameMatch = normalized.match(/\b([A-Z][a-z]+)\b/);
+    if (!nameMatch) return null;
+
+    const person = nameMatch[1];
+    const note = normalized
+      .replace(nameMatch[0], '')
+      .replace(/^[-,:;\s]+/, '')
+      .trim();
+
+    if (!note) return null;
+
+    return {
+      type: 'memory',
+      person,
+      note,
+      context: inferConversationContext(normalized),
+    };
   }
 
   function inferRelevantEntryType(query) {
@@ -1192,7 +1230,8 @@ export async function initReminders(sel = {}) {
     }
 
     const fallbackFields = parseSmartEntryWithFallback(normalizedText);
-    const resolvedType = fallbackFields.type;
+    const memoryFields = extractConversationMemory(normalizedText);
+    const resolvedType = memoryFields?.type || fallbackFields.type;
     const resolvedTitle = fallbackFields.title;
     const resolvedTags = sanitizeTags(fallbackFields.tags);
     const resolvedReminderDate = null;
@@ -1203,6 +1242,9 @@ export async function initReminders(sel = {}) {
       type: resolvedType,
       title: resolvedTitle || fallbackFields.title,
       content: normalizedText,
+      person: memoryFields?.person || null,
+      note: memoryFields?.note || null,
+      context: memoryFields?.context || null,
       tags: resolvedTags,
       reminderDate: resolvedReminderDate,
       dateCreated: nowIso,
@@ -1210,6 +1252,12 @@ export async function initReminders(sel = {}) {
       bodyHtml: normalizedText,
       bodyText: normalizedText,
       pinned: false,
+      metadata: {
+        type: resolvedType,
+        tags: resolvedTags,
+        person: memoryFields?.person || undefined,
+        context: memoryFields?.context || undefined,
+      },
       updatedAt: nowIso,
       folderId: 'unsorted',
       semanticEmbedding: null,
@@ -1258,6 +1306,14 @@ export async function initReminders(sel = {}) {
               ? parsedFields.title.trim().slice(0, 60)
               : existing.title,
           tags: sanitizeTags(parsedFields?.tags?.length ? parsedFields.tags : existing.tags),
+          metadata: {
+            ...(existing.metadata && typeof existing.metadata === 'object' ? existing.metadata : {}),
+            type:
+              typeof parsedFields.type === 'string' && parsedFields.type.trim()
+                ? parsedFields.type.trim()
+                : (existing?.metadata?.type || existing.type),
+            tags: sanitizeTags(parsedFields?.tags?.length ? parsedFields.tags : existing.tags),
+          },
           reminderDate:
             typeof parsedFields.reminderDate === 'string' && parsedFields.reminderDate.trim()
               ? parsedFields.reminderDate
@@ -1463,9 +1519,20 @@ export async function initReminders(sel = {}) {
       return {
         id: typeof entry?.id === 'string' ? entry.id : '',
         type: normalizeMemoryEntryType(entry?.type),
-        title: typeof entry?.title === 'string' ? entry.title : '',
-        body: typeof entry?.body === 'string' ? entry.body : '',
-        category: typeof entry?.category === 'string' ? entry.category : '',
+        title:
+          typeof entry?.title === 'string' && entry.title
+            ? entry.title
+            : (typeof entry?.person === 'string' ? entry.person : ''),
+        body:
+          typeof entry?.body === 'string' && entry.body
+            ? entry.body
+            : (typeof entry?.note === 'string' && entry.note
+              ? entry.note
+              : (typeof entry?.text === 'string' ? entry.text : '')),
+        category:
+          typeof entry?.category === 'string' && entry.category
+            ? entry.category
+            : (typeof entry?.context === 'string' ? entry.context : ''),
         tags: Array.isArray(entry?.tags) ? entry.tags : [],
         relatedIds: Array.isArray(entry?.relatedIds) ? entry.relatedIds : [],
         createdAt: typeof entry?.createdAt === 'string' ? entry.createdAt : '',
@@ -1986,11 +2053,20 @@ export async function initReminders(sel = {}) {
         text: cleanText,
         status: 'inbox',
         type: null,
+        note: null,
         context: null,
         person: null,
         createdAt: nowMs,
         date: dateStamp,
       };
+
+      const memoryFields = extractConversationMemory(cleanText);
+      if (memoryFields) {
+        payload.type = memoryFields.type;
+        payload.person = memoryFields.person;
+        payload.note = memoryFields.note;
+        payload.context = memoryFields.context;
+      }
 
       try {
         const entries = readMemoryEntries();


### PR DESCRIPTION
### Motivation

- Allow quick-add notes that mention a person (capitalized name) to be automatically captured as structured conversation memories for later lookup.
- Surface conversation memories in existing search and indexing systems by storing `person`, `note`, and an inferred `context` alongside notes.

### Description

- Added `extractConversationMemory` and `inferConversationContext` helpers and accepted `memory` as a valid entry type in `js/reminders.js`, and wired extraction into `createSmartEntry` and the quick-add `saveBrainDumpEntry` flow so detected memories persist with `person`, `note`, and `context` fields and are carried into `metadata` for notes.
- Updated inbox/universal search shaping in `js/reminders.js` to prefer `person`/`note`/`context` when legacy `title`/`body`/`category` are missing so memory entries surface correctly in searches.
- Extended `js/modules/memory-index.js` to include `person` in indexed entries and added `searchPersonMemoryIndex(personQuery)` and `getPersonMemoryIndex()` to provide searchable and grouped person indexes.
- Updated `js/modules/notes-storage.js` to sanitize and preserve `metadata.person` and `metadata.context`, and added a regression test `js/__tests__/reminders.quick-add.test.js` that verifies the example "Shayla asked for extension" is classified as a `memory` with the expected fields.

### Testing

- Ran `npm test -- reminders.quick-add.test.js` which passed all tests (8 passed, 0 failed) with expected console warnings about mocked Firebase/fetch in the test harness.
- Existing quick-add-related tests (e.g. drill/task/reflection routing and time parsing) remain green as part of that test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b15d30f77c8324b9bc89d3332d8daa)