### PR TITLE
Restore mobile notebook view routing and inbox→notebook transfer

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -378,15 +378,27 @@
 // Global navigation handler: treat 'new' as a dedicated view that shows the notebook and
 // prepares a new entry (focus/clear). This keeps the center tab as a navigable view.
 (function() {
+  const renderNotebookList = () => {
+    if (typeof window.renderNotebookList === 'function') {
+      window.renderNotebookList();
+    }
+  };
+
+  function showNotesView() {
+    showViewFor('notebook');
+    renderNotebookList();
+  }
+
   const views = {
     reminders: document.querySelector('[data-view="reminders"]'),
     notebook: document.querySelector('[data-view="notebook"]'),
+    notes: document.querySelector('[data-view="notebook"]'),
     categories: document.querySelector('[data-view="categories"]'),
     inbox: document.querySelector('[data-view="inbox"]'),
     assistant: document.querySelector('[data-view="assistant"]')
   };
 
-  const order = ['reminders', 'new', 'notebook', 'categories', 'inbox', 'assistant'];
+  const order = ['reminders', 'new', 'notebook', 'notes', 'categories', 'inbox', 'assistant'];
 
   const triggerReminderQuickAdd = window.triggerReminderQuickAdd || function triggerReminderQuickAdd() {
     if (triggerReminderQuickAdd._locked) return;
@@ -456,7 +468,14 @@
     try {
       const view = ev?.detail?.view;
       if (!view || !order.includes(view)) return;
+      if (view === 'notes') {
+        showNotesView();
+        return;
+      }
       showViewFor(view);
+      if (view === 'notebook') {
+        renderNotebookList();
+      }
     } catch (e) {
       console.error('Error handling app:navigate', e);
     }

--- a/mobile.html
+++ b/mobile.html
@@ -4771,6 +4771,8 @@ body, main, section, div, p, span, li {
     </section>
     <!-- END GPT CHANGE -->
     <!-- BEGIN GPT CHANGE: notebook view -->
+    <div id="notesView" class="view hidden" aria-hidden="true"></div>
+
     <section data-view="notebook" id="view-notebook" class="view-panel hidden mobile-panel--notes mobile-panel--notes-size-small">
         <div class="mobile-view-inner mx-auto w-full px-0 pt-2 pb-2 space-y-0" style="padding: 0 !important; max-width: 100%;">
         <!-- notebook view header removed to keep UI minimal -->
@@ -5547,6 +5549,43 @@ body, main, section, div, p, span, li {
         }
       };
 
+      const appendProcessedEntriesToNotebook = (entries) => {
+        if (!Array.isArray(entries) || !entries.length) return;
+
+        try {
+          const raw = window.localStorage?.getItem('memoryCueNotes');
+          const existing = raw ? JSON.parse(raw) : [];
+          const next = Array.isArray(existing) ? existing.slice() : [];
+
+          entries.forEach((entry) => {
+            if (!entry || typeof entry !== 'object') return;
+            const text = getEntryText(entry);
+            const timestamp = new Date().toISOString();
+            const normalizedType = typeof entry.type === 'string' && entry.type.trim()
+              ? entry.type.trim().toLowerCase()
+              : 'note';
+
+            next.unshift({
+              id: entry.id ? String(entry.id) : `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+              title: text.split(/\s+/).slice(0, 8).join(' ') || 'Untitled note',
+              body: text,
+              bodyHtml: text,
+              bodyText: text,
+              type: normalizedType,
+              metadata: { type: normalizedType },
+              createdAt: timestamp,
+              updatedAt: timestamp,
+              pinned: false
+            });
+          });
+
+          window.localStorage?.setItem('memoryCueNotes', JSON.stringify(next));
+          document.dispatchEvent(new CustomEvent('memoryCue:notesUpdated'));
+        } catch (error) {
+          console.warn('Unable to move processed inbox entries into notebook notes', error);
+        }
+      };
+
       const getEntryText = (entry) => {
         if (!entry || typeof entry !== 'object') return 'Untitled entry';
         const title = typeof entry.title === 'string' && entry.title.trim() ? entry.title.trim() : '';
@@ -5747,7 +5786,7 @@ body, main, section, div, p, span, li {
           'task',
           'idea',
           'note',
-          'knowledge',
+          'memory',
           '',
           'Also extract:',
           '',
@@ -5785,6 +5824,7 @@ body, main, section, div, p, span, li {
               .map((item) => [String(item.id), item])
           );
 
+          const processedNotebookEntries = [];
           const nextEntries = allEntries.map((entry) => {
             const entryId = entry?.id ? String(entry.id) : '';
             if (!entryId || !updatesById.has(entryId)) {
@@ -5792,7 +5832,7 @@ body, main, section, div, p, span, li {
             }
 
             const update = updatesById.get(entryId);
-            return {
+            const processedEntry = {
               ...entry,
               type: typeof update.type === 'string' ? update.type : entry.type,
               context: typeof update.context === 'string' ? update.context : entry.context,
@@ -5803,9 +5843,12 @@ body, main, section, div, p, span, li {
               status: 'processed',
               updatedAt: new Date().toISOString()
             };
+            processedNotebookEntries.push(processedEntry);
+            return processedEntry;
           });
 
           writeEntries(nextEntries);
+          appendProcessedEntriesToNotebook(processedNotebookEntries);
           renderInboxEntries();
         } catch (error) {
           console.error('Unable to process inbox entries.', error);

--- a/mobile.js
+++ b/mobile.js
@@ -1792,6 +1792,9 @@ const initMobileNotes = () => {
     return visibleNotes;
   };
 
+  const renderNotebookList = () => refreshFromStorage({ preserveDraft: true });
+  window.renderNotebookList = renderNotebookList;
+
   // Expose the refresh helper via the shared notes refresh hook
   requestNotesRefresh = (options = {}) => {
     try {


### PR DESCRIPTION
### Motivation
- Re-enable the mobile "notebook"/`notes` view and routing so stored notes render again on mobile navigation. 
- Ensure the inbox processing can still move processed items into the notebook data store and that supported entry types (`note`, `task`, `idea`, `memory`) remain usable.

### Description
- Add a `showNotesView()` handler and register a `notes` alias mapped to the existing notebook panel so `app:navigate` can target `notes` as an alias for the notebook (`js/navigation.js`).
- Wire notebook refresh into navigation by calling a small `renderNotebookList()` helper from the navigation handler (no UI nav button added).
- Expose the notebook refresh hook by setting `window.renderNotebookList = renderNotebookList;` so external navigation can trigger notebook rendering (`mobile.js`).
- Add the notebook container element `<div id="notesView" class="view hidden" aria-hidden="true"></div>` to `mobile.html` to restore the expected DOM anchor.
- Restore Inbox → notebook transfer by adding `appendProcessedEntriesToNotebook()` and calling it after inbox items are processed so items classified by the assistant are pushed into `memoryCueNotes` and `memoryCue:notesUpdated` is dispatched (`mobile.html`).
- Update the inbox assistant prompt classification list to include `memory` (replacing `knowledge`) so processed entries map to the expected set of types (`note`, `task`, `idea`, `memory`).

### Testing
- Ran `npm run verify` which passed successfully.
- Ran `npx jest js/__tests__/mobile.footer-nav.test.js --runInBand` which passed successfully.
- Performed a browser smoke test using a local server + Playwright: seeded `localStorage.memoryCueNotes`, navigated to `app:navigate` `{ view: 'notes' }`, and confirmed notes render (`notes_count=1`).
- Ran full test suite with `npm test -- --runInBand`; several pre-existing, unrelated test suites failed (including `mobile.auth`, `mobile.sheet`, `mobile.open-sheet`, `mobile.new-folder`, and `service-worker`), but these failures are not caused by the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1d0aec05c832495afd6fb8af3cc61)