### PR TITLE
Enforce single capture pipeline and source-of-truth rules in audit doc

### DIFF
--- a/REPO_AUDIT_AND_CLEANUP_PLAN.md
+++ b/REPO_AUDIT_AND_CLEANUP_PLAN.md
@@ -156,3 +156,56 @@ The intended Memory Cue experience should be:
 - AI as helper, not clutter
 
 This keeps the product focused, easier to maintain, and easier for non-technical owners to manage with Codex and ChatGPT.
+
+## 11. Capture System Rule (Critical)
+
+Memory Cue must only have **one raw capture pipeline**.
+
+All quick thoughts and unprocessed inputs must become **Inbox items**.
+
+This includes capture from:
+
+- Brain Dump
+- Quick Add
+- Assistant capture
+- Voice capture (if added later)
+
+Inbox acts as the **processing layer** where items can later be converted into:
+
+- Notes
+- Reminders
+
+No feature should introduce a separate raw storage path for captured thoughts.
+
+## 12. Single Source of Truth Rule
+
+Each core product area must have one clear storage authority.
+
+Inbox is the source of truth for unprocessed information.
+
+Notes are the source of truth for written content.
+
+Reminders are the source of truth for actionable items with due dates.
+
+No feature may introduce another storage layer representing the same concept.
+
+This rule prevents duplication of data models across the application.
+
+## 13. Assistant Behavior Rules
+
+The Assistant is a helper layer and must not become a parallel storage system.
+
+Assistant responsibilities:
+
+- search Notes, Reminders, and Inbox
+- summarise information
+- classify Inbox items
+- suggest conversions between item types
+
+Assistant must NOT:
+
+- create its own storage layer
+- silently create Notes or Reminders without user confirmation
+- introduce new capture flows
+
+Assistant suggestions should normally operate on Inbox items and then allow the user to convert them into Notes or Reminders.


### PR DESCRIPTION
### Motivation

- The repository shows architecture drift with duplicated capture paths and overlapping storage, so governance rules are needed to prevent future feature duplication.
- The change codifies that all raw captures must flow into a single Inbox processing pipeline and that core areas have single storage authorities to reduce model duplication.
- The Assistant must be constrained to helper roles to avoid it becoming a parallel storage or capture mechanism.

### Description

- Appended three new sections to `REPO_AUDIT_AND_CLEANUP_PLAN.md`: `11. Capture System Rule (Critical)`, `12. Single Source of Truth Rule`, and `13. Assistant Behavior Rules` that define capture and storage rules and assistant constraints.
- Preserved all existing content and appended the new governance sections near the end of the document without altering other sections.
- Changes were committed with the message `Add capture pipeline and source-of-truth rules to audit document`.

### Testing

- Verified the file contents with `tail -n 120 REPO_AUDIT_AND_CLEANUP_PLAN.md` and confirmed the three new sections were appended successfully.
- Checked repository status with `git status --short` and committed the change using `git commit -m "Add capture pipeline and source-of-truth rules to audit document"`, both of which completed successfully.
- No automated unit tests exist or were required for this documentation-only change, and the repository state shows the single file modification was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1ef1f097c832488ba1a3f7ea09727)