### PR TITLE
Add architecture safeguards to PRODUCT_RULES.md

### DIFF
--- a/PRODUCT_RULES.md
+++ b/PRODUCT_RULES.md
@@ -1,0 +1,90 @@
+## Single Capture Pipeline Rule
+
+Memory Cue must have **one capture pipeline**.
+
+All freeform input must be processed through the same capture logic.
+
+Examples of capture entry points:
+
+* Brain Dump
+* Quick Add
+* Floating Action Button (FAB)
+* Assistant capture
+* Voice capture (future)
+
+All of these must create **Inbox items** through the same capture logic (typically implemented in `capture.js`).
+
+No feature may directly create Notes or Reminders from raw input without first creating an Inbox item.
+
+## Inbox → Conversion Rule
+
+Inbox acts as the processing layer of the system.
+
+Typical flow:
+
+User Capture
+↓
+Inbox Item
+↓
+User or Assistant processes item
+↓
+Convert to Note or Reminder
+
+Notes and Reminders should normally originate from Inbox items unless the user intentionally creates them directly.
+
+This keeps capture simple and prevents fragmented storage paths.
+
+## Assistant Mutation Safety Rule
+
+The Assistant must never silently mutate the user's data.
+
+Assistant behavior must follow these rules:
+
+* Assistant may analyse Inbox, Notes, and Reminders.
+* Assistant may suggest conversions or edits.
+* Assistant must not directly create Notes or Reminders without user confirmation.
+* Assistant should normally operate on Inbox items before converting them into structured items.
+
+This prevents hidden AI-driven data mutations.
+
+## Storage Duplication Rule
+
+The application must not introduce multiple storage locations for the same concept.
+
+Approved storage domains:
+
+Inbox
+Notes
+Reminders
+
+Any new feature must store its data within one of these domains.
+
+New localStorage keys, tables, or structures must not represent duplicate versions of:
+
+* captured ideas
+* notes
+* reminders
+
+This prevents architecture drift.
+
+## Data Flow Diagram
+
+All information in Memory Cue should follow this lifecycle:
+
+Capture
+↓
+Inbox
+↓
+Process
+↓
+Notes or Reminders
+↓
+Assistant search / summarise / classify
+
+Inbox is the entry point for new information.
+
+Notes store written content.
+
+Reminders store actionable items with dates.
+
+Assistant operates across all three to help organise and retrieve information.


### PR DESCRIPTION
### Motivation
- Prevent future architectural drift by ensuring all freeform input funnels through a single capture pipeline and avoiding duplicate storage paths.
- Reduce risk of silent AI-driven data changes by restricting Assistant behavior around data mutation and conversion.
- Make the canonical lifecycle explicit so features and integrations consistently use `Inbox`, `Notes`, and `Reminders` domains.

### Description
- Appended new sections to `PRODUCT_RULES.md` that introduce the `Single Capture Pipeline Rule`, `Inbox → Conversion Rule`, `Assistant Mutation Safety Rule`, `Storage Duplication Rule`, and a `Data Flow Diagram` section. 
- The rules require all capture entry points to create `Inbox` items via the same capture logic (typically `capture.js`) and forbid features from directly creating `Notes` or `Reminders` from raw input. 
- The Assistant is restricted from silently creating or mutating `Notes`/`Reminders` and should operate on `Inbox` items and suggest edits or conversions requiring user confirmation. 
- The Storage Duplication Rule codifies approved domains (`Inbox`, `Notes`, `Reminders`) and forbids new storage keys/tables that duplicate captured ideas, notes, or reminders.

### Testing
- No automated tests were run because this is a documentation-only change and does not modify runtime code or test suites. 
- The change is limited to `PRODUCT_RULES.md` and does not affect existing code paths or tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1fd5703e083248c80cb02fb3df4b7)