### PR TITLE
Unify Brain Dump storage with Inbox capture flow

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5345,18 +5345,28 @@ body, main, section, div, p, span, li {
           return;
         }
 
+        // Brain Dump now feeds Inbox and should not maintain a separate raw capture store.
+        const capturedAt = new Date();
         const item = {
           text,
-          type: 'inbox',
-          processed: false,
-          timestamp: Date.now()
+          type: 'uncategorized',
+          timestamp: Date.now(),
+          createdAt: capturedAt.getTime(),
+          date: `${capturedAt.getFullYear()}-${String(capturedAt.getMonth() + 1).padStart(2, '0')}-${String(capturedAt.getDate()).padStart(2, '0')}`,
+          source: 'brain-dump'
         };
 
         try {
-          const raw = window.localStorage?.getItem('brainDumpItems');
-          const existing = raw ? JSON.parse(raw) : [];
-          const nextItems = Array.isArray(existing) ? [...existing, item] : [item];
-          window.localStorage?.setItem('brainDumpItems', JSON.stringify(nextItems));
+          const rawEntries = window.localStorage?.getItem('memoryEntries');
+          const parsedEntries = rawEntries ? JSON.parse(rawEntries) : [];
+          const existingEntries = Array.isArray(parsedEntries)
+            ? parsedEntries
+            : Array.isArray(parsedEntries?.entries)
+              ? parsedEntries.entries
+              : [];
+          existingEntries.unshift(item);
+          window.localStorage?.setItem('memoryEntries', JSON.stringify(existingEntries));
+          document.dispatchEvent(new CustomEvent('memoryCue:entriesUpdated'));
         } catch (error) {
           console.warn('Unable to save brain dump item', error);
         }


### PR DESCRIPTION
### Motivation
- Remove the duplicate `brainDumpItems` raw store so Brain Dump writes into the app's single Inbox/raw capture store (`memoryEntries`), preserving existing UI and inbox visibility without changing Notes, Reminders, or Assistant behavior.

### Description
- Updated the `saveBrainDump` logic in `mobile.html` to build an Inbox-style capture object (adds `createdAt`, `date`, and `source`) instead of the previous minimal brain-dump shape.
- Replaced writes to `brainDumpItems` with an insertion into `memoryEntries` and dispatched `memoryCue:entriesUpdated` so existing Inbox views refresh.
- Added the inline comment: "Brain Dump now feeds Inbox and should not maintain a separate raw capture store." and preserved the Brain Dump modal/FAB UI and interactions.

### Testing
- Ran the targeted Jest suite: `npm test -- --runInBand js/__tests__/reminders.quick-add.test.js`, which passed (7 tests passed); test run included non-fatal environment warnings about Firebase/fetch but completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1feb53044832486f37feab30d5204)