### PR TITLE
Replace category sections with filter chip bar

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -403,6 +403,7 @@ export async function initReminders(sel = {}) {
   const priority = $(sel.prioritySel);
   const categoryInput = $(sel.categorySel);
   const sortSelect = $(sel.sortSel);
+  const categoryFilterBar = $(sel.categoryFilterBarSel || '#reminderCategoryFilters');
   const saveBtn = $(sel.saveBtnSel);
   const cancelEditBtn = $(sel.cancelEditBtnSel);
   const list = $(sel.listSel);
@@ -622,6 +623,9 @@ export async function initReminders(sel = {}) {
     category: 'category',
   });
   let reminderSortMode = REMINDER_SORT_OPTIONS.newest;
+  const CATEGORY_FILTER_ALL = '__all__';
+  let activeCategoryFilter = CATEGORY_FILTER_ALL;
+  let mobileCategoryFilterSignature = '';
 
   function getReminderSortTimestamp(reminder) {
     const createdAt = Number(reminder?.createdAt);
@@ -5112,6 +5116,57 @@ export async function initReminders(sel = {}) {
     setupReminderSortControl._wired = true;
   }
 
+  function applyMobileCategoryFilter(rows) {
+    if (!Array.isArray(rows) || activeCategoryFilter === CATEGORY_FILTER_ALL) {
+      return rows;
+    }
+    return rows.filter((row) => normalizeCategory(row?.category) === activeCategoryFilter);
+  }
+
+  function updateMobileCategoryFilterBar(categories = []) {
+    if (variant !== 'mobile' || !(categoryFilterBar instanceof HTMLElement)) {
+      return;
+    }
+
+    const normalizedCategories = categories.map((category) => normalizeCategory(category));
+    const options = [CATEGORY_FILTER_ALL, ...normalizedCategories];
+
+    if (!options.includes(activeCategoryFilter)) {
+      activeCategoryFilter = CATEGORY_FILTER_ALL;
+    }
+
+    const signature = `${activeCategoryFilter}::${options.join('||')}`;
+    if (signature === mobileCategoryFilterSignature) {
+      return;
+    }
+    mobileCategoryFilterSignature = signature;
+
+    categoryFilterBar.replaceChildren();
+
+    options.forEach((option) => {
+      const chip = document.createElement('button');
+      chip.type = 'button';
+      chip.className = 'category-chip';
+      chip.textContent = option === CATEGORY_FILTER_ALL ? 'All' : option;
+      chip.dataset.categoryFilter = option;
+      chip.setAttribute('aria-pressed', option === activeCategoryFilter ? 'true' : 'false');
+
+      if (option === activeCategoryFilter) {
+        chip.classList.add('active');
+      }
+
+      chip.addEventListener('click', () => {
+        if (activeCategoryFilter === option) {
+          return;
+        }
+        activeCategoryFilter = option;
+        render();
+      });
+
+      categoryFilterBar.appendChild(chip);
+    });
+  }
+
   function setupMobileReminderTabs() {
     if (variant !== 'mobile' || typeof document === 'undefined') {
       return;
@@ -5164,6 +5219,8 @@ export async function initReminders(sel = {}) {
     });
     const allCategories = Array.from(categorySet).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
 
+    updateMobileCategoryFilterBar(allCategories);
+
     if (categoryDatalist) {
       const existing = new Set();
       Array.from(categoryDatalist.querySelectorAll('option')).forEach(opt => {
@@ -5204,6 +5261,7 @@ export async function initReminders(sel = {}) {
     if (variant === 'mobile') {
       mobileRemindersCache = rows.slice();
       rows = filterMobileReminderRows(mobileRemindersCache, mobileRemindersFilterMode, todayRange);
+      rows = applyMobileCategoryFilter(rows);
       updateMobileRemindersHeaderSubtitle();
     }
 
@@ -5266,7 +5324,7 @@ export async function initReminders(sel = {}) {
     const frag = document.createDocumentFragment();
     const listIsSemantic = list.tagName === 'UL' || list.tagName === 'OL';
 
-    const shouldGroupCategories = true;
+    const shouldGroupCategories = variant === 'desktop';
 
     const priorityClassTokens = ['priority-high', 'priority-medium', 'priority-low'];
     const applyPriorityTokensToCard = (card, priorityValue) => {

--- a/mobile.html
+++ b/mobile.html
@@ -4723,11 +4723,12 @@ body, main, section, div, p, span, li {
     <!-- BEGIN GPT CHANGE: reminders view -->
     <section data-view="reminders" id="view-reminders" class="view-panel">
       <div class="reminders-mobile-flow reminders-content-shell">
-        <div class="flex flex-wrap items-center gap-2 px-1" aria-label="Entry filters">
-          <span class="badge badge-outline badge-sm">Inbox</span>
-          <span class="badge badge-outline badge-sm">Teaching</span>
-          <span class="badge badge-outline badge-sm">Coaching</span>
-          <span class="badge badge-outline badge-sm">Recent</span>
+        <div
+          id="reminderCategoryFilters"
+          class="category-filter-bar"
+          role="toolbar"
+          aria-label="Filter reminders by category"
+        >
         </div>
         <div id="inboxSearchResults"></div>
 
@@ -6124,6 +6125,38 @@ body, main, section, div, p, span, li {
       border-color: var(--accent-color, #512663);
       color: #fff;
       box-shadow: 0 4px 12px rgba(81, 38, 99, 0.28);
+    }
+
+    .category-filter-bar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      overflow-x: auto;
+      padding: 0 4px 2px;
+      margin-bottom: 8px;
+      -webkit-overflow-scrolling: touch;
+    }
+
+    .category-filter-bar::-webkit-scrollbar {
+      display: none;
+    }
+
+    .category-chip {
+      border-radius: 999px;
+      border: 1px solid rgba(47, 27, 63, 0.18);
+      background: rgba(255, 255, 255, 0.92);
+      padding: 6px 12px;
+      font-size: 0.82rem;
+      line-height: 1;
+      color: var(--primary-dark);
+      white-space: nowrap;
+      transition: background-color 0.14s ease, border-color 0.14s ease, color 0.14s ease;
+    }
+
+    .category-chip.active {
+      background: #5c4b8a;
+      border-color: #5c4b8a;
+      color: #fff;
     }
 
     .reminder-actions {

--- a/reminders.categories.test.js
+++ b/reminders.categories.test.js
@@ -143,6 +143,7 @@ test('mobile reminders group uncategorised items under General', async () => {
     <button id="saveBtn" type="button"></button>
     <button id="cancelEditBtn" type="button"></button>
     <div id="wrapper"><div id="list"></div></div>
+    <div id="reminderCategoryFilters"></div>
     <div id="status"></div>
     <div id="syncStatus"></div>
     <select id="categoryFilter"><option value="all" selected>All</option></select>
@@ -173,13 +174,26 @@ test('mobile reminders group uncategorised items under General', async () => {
   ]);
 
   const headings = Array.from(document.querySelectorAll('[data-category-heading]'));
-  expect(headings.map((heading) => heading.dataset.categoryHeading)).toEqual(['Excursion']);
+  expect(headings).toHaveLength(0);
+
+  const chips = Array.from(document.querySelectorAll('#reminderCategoryFilters .category-chip')).map((chip) => chip.textContent);
+  expect(chips[0]).toBe('All');
+  expect(chips).toContain('Excursion');
+  expect(chips).toContain('General');
 
   const generalItems = document.querySelectorAll('[data-category="General"]');
   expect(generalItems).toHaveLength(1);
 
   const excursionItems = document.querySelectorAll('[data-category="Excursion"]');
   expect(excursionItems).toHaveLength(1);
+
+  const excursionChip = document.querySelector('#reminderCategoryFilters .category-chip[data-category-filter="Excursion"]');
+  expect(excursionChip).not.toBeNull();
+  excursionChip.click();
+
+  const visibleAfterFilter = document.querySelectorAll('[data-reminder-item="true"]');
+  expect(visibleAfterFilter).toHaveLength(1);
+  expect(visibleAfterFilter[0].dataset.category).toBe('Excursion');
 });
 
 test('category selectors include school and general presets', async () => {


### PR DESCRIPTION
### Motivation
- Convert static category headings/badges on the mobile reminders screen into interactive visual filters so categories behave as toggleable filters rather than section headings.
- Keep reminder data and persistence logic unchanged and implement filtering as a purely UI-level behavior.

### Description
- Replace the static category badges in the mobile reminders view with a new horizontal filter container `#reminderCategoryFilters` and add chip CSS (`.category-chip`, `.category-chip.active`) for rounded buttons, subtle borders, and an active filled state (styles added to `mobile.html`).
- Add UI logic in `js/reminders.js` to render category chips from available categories, toggle the active chip state (`aria-pressed` + `.active`), and filter the in-memory reminder rows on mobile without navigating to another screen (`applyMobileCategoryFilter` and `updateMobileCategoryFilterBar`).
- Stop grouping reminders by category on mobile by only grouping categories for desktop (`shouldGroupCategories = variant === 'desktop'`) so mobile now displays a single list filtered by chips.
- Update `reminders.categories.test.js` to assert the presence of the chip bar and to verify that clicking a category chip filters the visible reminders.

### Testing
- Ran `npm test -- reminders.categories.test.js`, which executed the updated test file and passed (3/3 tests green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2515fcb2c8324b7fcddebdd36d429)