### PR TITLE
Convert Weekly Reflection into collapsible insight card

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -3012,6 +3012,49 @@ body, main, section, div, p, span, li {
       min-height: 0;
     }
 
+    .insight-card {
+      margin: 0;
+      padding: 0.75rem;
+      border-radius: 0.75rem;
+      background: color-mix(in srgb, var(--accent-color) 8%, #f7f5fb);
+      border: 1px solid color-mix(in srgb, var(--accent-color) 14%, transparent);
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .insight-header {
+      font-weight: 600;
+      margin-bottom: 0.1rem;
+      color: var(--text-main);
+    }
+
+    .insight-summary {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      margin: 0;
+    }
+
+    .insight-details {
+      display: none;
+      gap: 0.5rem;
+    }
+
+    .insight-card.expanded .insight-details {
+      display: grid;
+    }
+
+    .insight-card.expanded .insight-summary {
+      display: none;
+    }
+
+    .insight-reflection-content {
+      font-size: 0.9rem;
+      line-height: 1.4;
+      white-space: pre-wrap;
+      color: var(--text-main);
+      margin: 0;
+    }
+
     #assistantMessages,
     .assistant-messages {
       display: grid;
@@ -5202,7 +5245,14 @@ body, main, section, div, p, span, li {
             </div>
     <section data-view="assistant" id="assistantView" class="view hidden" aria-hidden="true">
       <div class="assistant-panel">
-        <button id="weeklyReflectionButton" type="button" class="btn btn-outline btn-sm">Weekly Reflection</button>
+        <div id="weeklyReflectionCard" class="insight-card" aria-live="polite">
+          <div class="insight-header">Weekly Reflection</div>
+          <p id="weeklyReflectionSummary" class="insight-summary">Get a quick summary of what you captured this week.</p>
+          <button id="weeklyReflectionButton" type="button" class="btn btn-outline btn-sm view-reflection-btn">View Reflection</button>
+          <div id="weeklyReflectionDetails" class="insight-details" aria-hidden="true">
+            <p id="weeklyReflectionContent" class="insight-reflection-content">Tap “View Reflection” to generate this week’s insight.</p>
+          </div>
+        </div>
         <div id="thinkingBarStatus" class="hidden" aria-live="polite"></div>
         <div id="thinkingBarResults" aria-live="polite"></div>
         <div id="assistantMessages" class="assistant-messages" aria-live="polite" aria-label="Assistant conversation"></div>

--- a/mobile.js
+++ b/mobile.js
@@ -56,7 +56,10 @@ function initAssistant() {
     const quickAddForm = document.getElementById('quickAddForm');
     const thinkingBarStatus = document.getElementById('thinkingBarStatus');
     const thinkingBarResults = document.getElementById('thinkingBarResults');
+    const weeklyReflectionCard = document.getElementById('weeklyReflectionCard');
     const weeklyReflectionButton = document.getElementById('weeklyReflectionButton');
+    const weeklyReflectionDetails = document.getElementById('weeklyReflectionDetails');
+    const weeklyReflectionContent = document.getElementById('weeklyReflectionContent');
     let isAssistantSending = false;
     let latestThinkingSearchRequest = 0;
     const assistantConversationHistory = [];
@@ -519,6 +522,20 @@ function initAssistant() {
 
     if (weeklyReflectionButton instanceof HTMLElement) {
       weeklyReflectionButton.addEventListener('click', async () => {
+        if (!(weeklyReflectionCard instanceof HTMLElement)) {
+          return;
+        }
+
+        const hasReflection = weeklyReflectionCard.dataset.loaded === 'true';
+        if (hasReflection) {
+          const isExpanded = weeklyReflectionCard.classList.toggle('expanded');
+          weeklyReflectionButton.textContent = isExpanded ? 'Hide Reflection' : 'View Reflection';
+          if (weeklyReflectionDetails instanceof HTMLElement) {
+            weeklyReflectionDetails.setAttribute('aria-hidden', isExpanded ? 'false' : 'true');
+          }
+          return;
+        }
+
         if (isAssistantSending) {
           return;
         }
@@ -534,6 +551,17 @@ function initAssistant() {
           const summaryText = typeof weeklySummary?.summary === 'string' && weeklySummary.summary.trim()
             ? weeklySummary.summary.trim()
             : 'No weekly summary was returned.';
+
+          if (weeklyReflectionContent instanceof HTMLElement) {
+            weeklyReflectionContent.textContent = summaryText;
+          }
+          weeklyReflectionCard.dataset.loaded = 'true';
+          weeklyReflectionCard.classList.add('expanded');
+          weeklyReflectionButton.textContent = 'Hide Reflection';
+          if (weeklyReflectionDetails instanceof HTMLElement) {
+            weeklyReflectionDetails.setAttribute('aria-hidden', 'false');
+          }
+
           appendAssistantMessage('Weekly Reflection', 'assistant-message');
           appendAssistantMessage(summaryText, 'assistant-message assistant-message--reply');
           setThinkingBarStatus('Weekly reflection ready');


### PR DESCRIPTION
### Motivation
- Make the Weekly Reflection UI non-dominant by turning it into an optional, collapsible insight card that appears above the assistant messages instead of occupying the main screen.

### Description
- Added compact `insight-card` styling and supporting classes (`.insight-header`, `.insight-summary`, `.insight-details`, `.insight-reflection-content`) in `mobile.html` to present a small card-like summary block.  
- Replaced the single `#weeklyReflectionButton` area with a card markup in `mobile.html` containing header, short summary, `#weeklyReflectionButton`, and a hidden `#weeklyReflectionDetails` content area.  
- Updated `mobile.js` to wire the card: on first click call `generateWeeklySummary()`, populate `#weeklyReflectionContent`, set `data-loaded`, expand the card and change the button label to `Hide Reflection`, and on subsequent clicks toggle the card `expanded` state and `aria-hidden` accordingly.  
- Preserved all reflection generation logic and assistant integrations (calls to `generateWeeklySummary()` and `appendAssistantMessage()` remain unchanged) and did not touch storage or assistant backend code.

### Testing
- Ran unit tests with `npm test -- --runInBand`, which executed the repo test suite (24 test suites total) and resulted in `18` passing and `6` failing suites (10 failed tests, 69 passed tests), these failures appear to be pre-existing and unrelated to this UI-only change.  
- Launched a local dev server and captured a mobile screenshot of the updated assistant view using Playwright (artifact: `artifacts/weekly-reflection-card.png`).  
- No backend or reflection generation logic was modified, so runtime behavior of `generateWeeklySummary()` and assistant message appending remains the same.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b281e602948324ae9607651cecc405)