### PR TITLE
Contextual quick actions for Inbox and Reminder items (long-press menu)

### DIFF
--- a/js/entries.js
+++ b/js/entries.js
@@ -177,6 +177,165 @@
     return Number.isNaN(dt.getTime()) ? String(value) : dt.toLocaleString();
   };
 
+  const QUICK_ACTION_LONG_PRESS_MS = 500;
+  let activeQuickActionsMenu = null;
+  let activeQuickActionsCleanup = null;
+
+  const closeQuickActionsMenu = () => {
+    if (typeof activeQuickActionsCleanup === 'function') {
+      activeQuickActionsCleanup();
+    }
+    activeQuickActionsCleanup = null;
+    if (activeQuickActionsMenu instanceof HTMLElement) {
+      activeQuickActionsMenu.remove();
+    }
+    activeQuickActionsMenu = null;
+  };
+
+  const sendToAssistant = (text) => {
+    const assistantFormEl = document.getElementById('assistantForm');
+    const assistantInputEl = document.getElementById('assistantInput');
+    const isAssistantInput = assistantInputEl instanceof HTMLInputElement || assistantInputEl instanceof HTMLTextAreaElement;
+    if (!(assistantFormEl instanceof HTMLFormElement) || !isAssistantInput) {
+      return false;
+    }
+
+    if (window.location.hash !== '#assistant') {
+      window.location.hash = '#assistant';
+      if (typeof window.renderRoute === 'function') {
+        window.renderRoute();
+      }
+    }
+
+    assistantInputEl.value = text;
+    assistantFormEl.requestSubmit();
+    return true;
+  };
+
+  const openInboxQuickActions = (entry) => {
+    if (!(entry && typeof entry === 'object')) {
+      return;
+    }
+
+    closeQuickActionsMenu();
+    const menu = document.createElement('div');
+    menu.className = 'quick-actions-menu';
+    menu.setAttribute('role', 'menu');
+
+    const allEntries = readEntries();
+    const resolveEntryIndex = () => allEntries.findIndex((item) => (entry?.id && item?.id ? item.id === entry.id : item === entry));
+
+    const runAction = (handler) => {
+      handler();
+      closeQuickActionsMenu();
+      renderInboxEntries();
+    };
+
+    const actions = [
+      {
+        label: 'Create Reminder',
+        action: () => dispatchReminderSheetOpen(null, getEntryText(entry)),
+      },
+      {
+        label: 'Convert to Note',
+        action: () => {
+          appendToMainNotesDatabase([
+            {
+              id: `entry-${Date.now()}`,
+              title: getEntryText(entry),
+              body: getEntryText(entry),
+              bodyHtml: getEntryText(entry),
+              bodyText: getEntryText(entry),
+              updatedAt: new Date().toISOString(),
+            },
+          ]);
+        },
+      },
+      {
+        label: 'Ask Assistant',
+        action: () => {
+          sendToAssistant(getEntryText(entry));
+        },
+      },
+      {
+        label: 'Archive',
+        action: () => {
+          const entryIndex = resolveEntryIndex();
+          if (entryIndex === -1) return;
+          const nextEntries = allEntries.filter((_, index) => index !== entryIndex);
+          writeEntries(nextEntries);
+        },
+      },
+    ];
+
+    actions.forEach((item) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.dataset.action = item.label.toLowerCase().replace(/\s+/g, '-');
+      button.textContent = item.label;
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        runAction(item.action);
+      });
+      menu.appendChild(button);
+    });
+
+    document.body.appendChild(menu);
+    activeQuickActionsMenu = menu;
+
+    const handleOutsidePress = (event) => {
+      if (!(event.target instanceof Node)) {
+        return;
+      }
+      if (!menu.contains(event.target)) {
+        closeQuickActionsMenu();
+      }
+    };
+
+    const handleEscape = (event) => {
+      if (event.key === 'Escape') {
+        closeQuickActionsMenu();
+      }
+    };
+
+    document.addEventListener('pointerdown', handleOutsidePress, true);
+    document.addEventListener('keydown', handleEscape);
+    activeQuickActionsCleanup = () => {
+      document.removeEventListener('pointerdown', handleOutsidePress, true);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  };
+
+  const attachInboxLongPress = (itemEl, entry) => {
+    if (!(itemEl instanceof HTMLElement)) {
+      return;
+    }
+    let pressTimer = null;
+
+    const start = () => {
+      pressTimer = window.setTimeout(() => {
+        openInboxQuickActions(entry);
+      }, QUICK_ACTION_LONG_PRESS_MS);
+    };
+
+    const cancel = () => {
+      if (pressTimer) {
+        window.clearTimeout(pressTimer);
+      }
+      pressTimer = null;
+    };
+
+    itemEl.addEventListener('touchstart', start, { passive: true });
+    itemEl.addEventListener('touchend', cancel);
+    itemEl.addEventListener('touchcancel', cancel);
+    itemEl.addEventListener('pointerdown', (event) => {
+      if (event.pointerType === 'mouse' && event.button !== 0) return;
+      start();
+    });
+    itemEl.addEventListener('pointerup', cancel);
+    itemEl.addEventListener('pointerleave', cancel);
+  };
+
   const renderCategoryEntries = (categoryName) => {
     const targetCategory = String(categoryName || '').trim().toLowerCase();
     const entries = readEntries().filter((entry) => getEntryCategory(entry).toLowerCase() === targetCategory);
@@ -310,6 +469,7 @@
 
       actions.append(moveSelect, editBtn, deleteBtn);
       card.append(text, meta, actions);
+      attachInboxLongPress(card, entry);
       inboxEntriesList.appendChild(card);
     });
   };

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -428,8 +428,127 @@ export async function initReminders(sel = {}) {
     offline: "Offline. Changes are saved on this device until you reconnect.",
   };
   const UNDO_DELETE_TIMEOUT_MS = 6000;
+  const QUICK_ACTION_LONG_PRESS_MS = 500;
   let deleteUndoState = null;
   let detailSelectionId = null;
+  let activeReminderQuickActionsMenu = null;
+  let activeReminderQuickActionsCleanup = null;
+
+  function closeReminderQuickActionsMenu() {
+    if (typeof activeReminderQuickActionsCleanup === 'function') {
+      activeReminderQuickActionsCleanup();
+    }
+    activeReminderQuickActionsCleanup = null;
+    if (activeReminderQuickActionsMenu instanceof HTMLElement) {
+      activeReminderQuickActionsMenu.remove();
+    }
+    activeReminderQuickActionsMenu = null;
+  }
+
+  function openReminderQuickActions(reminder) {
+    if (!reminder || typeof reminder !== 'object') {
+      return;
+    }
+
+    closeReminderQuickActionsMenu();
+    const menu = document.createElement('div');
+    menu.className = 'quick-actions-menu';
+    menu.setAttribute('role', 'menu');
+
+    const addAction = (label, dataAction, handler) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.dataset.action = dataAction;
+      button.textContent = label;
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        handler();
+        closeReminderQuickActionsMenu();
+        render();
+      });
+      menu.appendChild(button);
+    };
+
+    addAction('Create Reminder', 'reminder', () => {
+      addItem({
+        title: reminder.title,
+        priority: reminder.priority || 'Medium',
+        category: reminder.category || DEFAULT_CATEGORY,
+        due: reminder.due || null,
+        notes: typeof reminder.notes === 'string' ? reminder.notes : '',
+      });
+    });
+
+    addAction('Convert to Note', 'note', () => {
+      const content = [reminder.title, reminder.notes].filter((value) => typeof value === 'string' && value.trim()).join('\n\n');
+      saveReflectionQuickNote(content || reminder.title || 'Reminder note');
+    });
+
+    addAction('Ask Assistant', 'assistant', () => {
+      askAssistant(reminder.title || '').catch((error) => {
+        console.warn('Ask assistant quick action failed', error);
+      });
+    });
+
+    addAction('Archive', 'archive', () => {
+      removeItem(reminder.id);
+    });
+
+    document.body.appendChild(menu);
+    activeReminderQuickActionsMenu = menu;
+
+    const handleOutsidePress = (event) => {
+      if (!(event.target instanceof Node)) {
+        return;
+      }
+      if (!menu.contains(event.target)) {
+        closeReminderQuickActionsMenu();
+      }
+    };
+
+    const handleEscape = (event) => {
+      if (event.key === 'Escape') {
+        closeReminderQuickActionsMenu();
+      }
+    };
+
+    document.addEventListener('pointerdown', handleOutsidePress, true);
+    document.addEventListener('keydown', handleEscape);
+    activeReminderQuickActionsCleanup = () => {
+      document.removeEventListener('pointerdown', handleOutsidePress, true);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }
+
+  function attachReminderLongPress(itemEl, reminder) {
+    if (!(itemEl instanceof HTMLElement)) {
+      return;
+    }
+    let pressTimer = null;
+
+    const start = () => {
+      pressTimer = window.setTimeout(() => {
+        openReminderQuickActions(reminder);
+      }, QUICK_ACTION_LONG_PRESS_MS);
+    };
+
+    const cancel = () => {
+      if (pressTimer) {
+        window.clearTimeout(pressTimer);
+      }
+      pressTimer = null;
+    };
+
+    itemEl.addEventListener('touchstart', start, { passive: true });
+    itemEl.addEventListener('touchend', cancel);
+    itemEl.addEventListener('touchcancel', cancel);
+    itemEl.addEventListener('pointerdown', (event) => {
+      if (event.pointerType === 'mouse' && event.button !== 0) return;
+      start();
+    });
+    itemEl.addEventListener('pointerup', cancel);
+    itemEl.addEventListener('pointerleave', cancel);
+  }
 
   function clearUndoDeleteState(tokenId, { clearMessage = true } = {}) {
     if (!deleteUndoState) {
@@ -5419,6 +5538,7 @@ export async function initReminders(sel = {}) {
       itemEl.setAttribute('role', 'button');
       itemEl.tabIndex = 0;
       itemEl.setAttribute('aria-label', `Edit reminder: ${reminder.title}`);
+      attachReminderLongPress(itemEl, reminder);
 
       applyPriorityTokensToCard(itemEl, summary.priority);
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -4532,3 +4532,36 @@ section[data-route="dashboard"] .dashboard-shortcuts {
   background-color: var(--accent-color);
   color: white;
 }
+
+.quick-actions-menu {
+  position: fixed;
+  left: 50%;
+  bottom: 120px;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 220px;
+  padding: 10px;
+  border-radius: 12px;
+  background: #fff;
+  border: 1px solid color-mix(in srgb, #dcd3ec 65%, transparent);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  z-index: 1001;
+}
+
+.quick-actions-menu button {
+  width: 100%;
+  border: 0;
+  background: color-mix(in srgb, #ffffff 88%, #f2edf8);
+  color: var(--text-main, #231b2e);
+  border-radius: 10px;
+  padding: 8px 10px;
+  text-align: left;
+  font-size: 0.9rem;
+}
+
+.quick-actions-menu button:active,
+.quick-actions-menu button:hover {
+  background: color-mix(in srgb, var(--accent-color, #512663) 14%, #ffffff);
+}


### PR DESCRIPTION
### Motivation

- Add a contextual quick-actions UI so users can perform common actions from Inbox and Reminder items without navigating away. 
- Provide long-press activation on mobile-like interactions to surface common actions: Create Reminder, Convert to Note, Ask Assistant, and Archive.
- Reuse existing app flows and storage (reminder sheet, notes storage, assistant form, item removal) and avoid schema or storage changes.

### Description

- Added long-press detection (500ms) for Inbox entry cards and attached a floating quick-actions menu that exposes Create Reminder, Convert to Note, Ask Assistant, and Archive actions in `js/entries.js`.
- Added long-press detection (500ms) for Reminder cards and a matching quick-actions menu wired to existing reminder flows, note save helpers and `askAssistant` in `js/reminders.js`.
- Implemented the quick-actions menu markup/handlers to call existing functions: open reminder sheet, append to notes storage, submit the assistant form, and remove/archive entries, without changing any storage schemas.
- Added styling for the floating action sheet (`.quick-actions-menu`) in `styles/index.css` to match the requested floating card appearance.

### Testing

- Ran `npm run build`, which completed successfully.
- Ran `npm test -- --runInBand`; the test run reported failures in several pre-existing/unrelated suites in this environment (not introduced by this change), including mobile auth/sheet/open tests, `reminders.categories.test.js`, `service-worker.test.js`, and one mobile new-folder test. 
- Performed a Playwright smoke run against the running app and captured screenshots demonstrating the quick-actions menu appears on long-press during manual/automated UI validation (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2857fe31c8324962217b1e4d23d64)