### PR TITLE
Redesign Weekly Reflection as optional Insights panel

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -3013,11 +3013,12 @@ body, main, section, div, p, span, li {
     }
 
     .insight-card {
+      border: 1px solid #eee;
+      border-radius: 12px;
+      padding: 12px;
       margin: 0;
-      padding: 0.75rem;
-      border-radius: 0.75rem;
-      background: color-mix(in srgb, var(--accent-color) 8%, #f7f5fb);
-      border: 1px solid color-mix(in srgb, var(--accent-color) 14%, transparent);
+      margin-top: 16px;
+      background: #fafafa;
       display: grid;
       gap: 0.5rem;
     }
@@ -3034,25 +3035,39 @@ body, main, section, div, p, span, li {
       margin: 0;
     }
 
-    .insight-details {
-      display: none;
-      gap: 0.5rem;
+    .reflection-modal {
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.35);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 1000;
+      padding: 1rem;
     }
 
-    .insight-card.expanded .insight-details {
+    .reflection-modal.hidden {
+      display: none;
+    }
+
+    .reflection-content {
+      background: white;
+      padding: 24px;
+      border-radius: 16px;
+      max-width: 500px;
+      width: min(500px, 100%);
       display: grid;
+      gap: 0.75rem;
     }
 
-    .insight-card.expanded .insight-summary {
-      display: none;
-    }
-
-    .insight-reflection-content {
+    .reflection-text {
       font-size: 0.9rem;
       line-height: 1.4;
       white-space: pre-wrap;
       color: var(--text-main);
       margin: 0;
+      max-height: min(60vh, 420px);
+      overflow-y: auto;
     }
 
     #assistantMessages,
@@ -5245,14 +5260,6 @@ body, main, section, div, p, span, li {
             </div>
     <section data-view="assistant" id="assistantView" class="view hidden" aria-hidden="true">
       <div class="assistant-panel">
-        <div id="weeklyReflectionCard" class="insight-card" aria-live="polite">
-          <div class="insight-header">Weekly Reflection</div>
-          <p id="weeklyReflectionSummary" class="insight-summary">Get a quick summary of what you captured this week.</p>
-          <button id="weeklyReflectionButton" type="button" class="btn btn-outline btn-sm view-reflection-btn">View Reflection</button>
-          <div id="weeklyReflectionDetails" class="insight-details" aria-hidden="true">
-            <p id="weeklyReflectionContent" class="insight-reflection-content">Tap “View Reflection” to generate this week’s insight.</p>
-          </div>
-        </div>
         <div id="thinkingBarStatus" class="hidden" aria-live="polite"></div>
         <div id="thinkingBarResults" aria-live="polite"></div>
         <div id="assistantMessages" class="assistant-messages" aria-live="polite" aria-label="Assistant conversation"></div>
@@ -5265,8 +5272,21 @@ body, main, section, div, p, span, li {
           <button type="submit">Send</button>
         </form>
         <div id="assistantLoading" class="hidden" aria-live="polite">Assistant is thinking…</div>
+        <div id="weeklyReflectionCard" class="insight-card" aria-live="polite">
+          <div class="insight-header"><span>Insights</span></div>
+          <p id="weeklyReflectionSummary" class="insight-summary">You captured items this week.</p>
+          <button id="weeklyReflectionButton" type="button" class="btn btn-outline btn-sm view-reflection-btn">Weekly Reflection</button>
+        </div>
       </div>
     </section>
+
+    <div id="weeklyReflectionModal" class="reflection-modal hidden" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="weeklyReflectionModalTitle">
+      <div class="reflection-content">
+        <h2 id="weeklyReflectionModalTitle">Weekly Reflection</h2>
+        <div id="weeklyReflectionContent" class="reflection-text">Tap “Weekly Reflection” to generate this week’s insight.</div>
+        <button id="closeWeeklyReflectionButton" type="button" class="btn btn-outline btn-sm close-reflection">Close</button>
+      </div>
+    </div>
     </div>
 </main>
 

--- a/mobile.js
+++ b/mobile.js
@@ -58,7 +58,8 @@ function initAssistant() {
     const thinkingBarResults = document.getElementById('thinkingBarResults');
     const weeklyReflectionCard = document.getElementById('weeklyReflectionCard');
     const weeklyReflectionButton = document.getElementById('weeklyReflectionButton');
-    const weeklyReflectionDetails = document.getElementById('weeklyReflectionDetails');
+    const weeklyReflectionModal = document.getElementById('weeklyReflectionModal');
+    const closeWeeklyReflectionButton = document.getElementById('closeWeeklyReflectionButton');
     const weeklyReflectionContent = document.getElementById('weeklyReflectionContent');
     let isAssistantSending = false;
     let latestThinkingSearchRequest = 0;
@@ -522,17 +523,14 @@ function initAssistant() {
 
     if (weeklyReflectionButton instanceof HTMLElement) {
       weeklyReflectionButton.addEventListener('click', async () => {
-        if (!(weeklyReflectionCard instanceof HTMLElement)) {
+        if (!(weeklyReflectionCard instanceof HTMLElement) || !(weeklyReflectionModal instanceof HTMLElement)) {
           return;
         }
 
         const hasReflection = weeklyReflectionCard.dataset.loaded === 'true';
         if (hasReflection) {
-          const isExpanded = weeklyReflectionCard.classList.toggle('expanded');
-          weeklyReflectionButton.textContent = isExpanded ? 'Hide Reflection' : 'View Reflection';
-          if (weeklyReflectionDetails instanceof HTMLElement) {
-            weeklyReflectionDetails.setAttribute('aria-hidden', isExpanded ? 'false' : 'true');
-          }
+          weeklyReflectionModal.classList.remove('hidden');
+          weeklyReflectionModal.setAttribute('aria-hidden', 'false');
           return;
         }
 
@@ -556,14 +554,8 @@ function initAssistant() {
             weeklyReflectionContent.textContent = summaryText;
           }
           weeklyReflectionCard.dataset.loaded = 'true';
-          weeklyReflectionCard.classList.add('expanded');
-          weeklyReflectionButton.textContent = 'Hide Reflection';
-          if (weeklyReflectionDetails instanceof HTMLElement) {
-            weeklyReflectionDetails.setAttribute('aria-hidden', 'false');
-          }
-
-          appendAssistantMessage('Weekly Reflection', 'assistant-message');
-          appendAssistantMessage(summaryText, 'assistant-message assistant-message--reply');
+          weeklyReflectionModal.classList.remove('hidden');
+          weeklyReflectionModal.setAttribute('aria-hidden', 'false');
           setThinkingBarStatus('Weekly reflection ready');
         } catch (error) {
           console.error('[assistant] failed to generate weekly reflection', error);
@@ -574,6 +566,20 @@ function initAssistant() {
           if (assistantLoading instanceof HTMLElement) {
             assistantLoading.classList.add('hidden');
           }
+        }
+      });
+    }
+
+    if (closeWeeklyReflectionButton instanceof HTMLElement && weeklyReflectionModal instanceof HTMLElement) {
+      closeWeeklyReflectionButton.addEventListener('click', () => {
+        weeklyReflectionModal.classList.add('hidden');
+        weeklyReflectionModal.setAttribute('aria-hidden', 'true');
+      });
+
+      weeklyReflectionModal.addEventListener('click', (event) => {
+        if (event.target === weeklyReflectionModal) {
+          weeklyReflectionModal.classList.add('hidden');
+          weeklyReflectionModal.setAttribute('aria-hidden', 'true');
         }
       });
     }


### PR DESCRIPTION
### Motivation
- Weekly Reflection was visually dominant and interrupted the primary Capture → Inbox → Process → Notes/Reminders workflow, so it should be demoted to a secondary Insights affordance. 
- The goal is to keep the reflection available but unobtrusive and non-blocking to the main flow. 
- Reflection generation logic must remain unchanged; only presentation and interaction should be updated.

### Description
- Replaced the large inline Weekly Reflection block in the assistant view with a compact `insight-card` (header, one-line summary, and `Weekly Reflection` button) located in the assistant panel so it doesn’t push main content down (`mobile.html`).
- Moved the reflection body into a modal (`#weeklyReflectionModal`) and reflection container (`.reflection-content` / `.reflection-text`) so generated text is displayed in an overlay rather than inline (`mobile.html`).
- Updated styling for the compact card and modal (`.insight-card`, `.reflection-modal`, `.reflection-content`, `.reflection-text`) to match the requested compact look and overlay behavior (`mobile.html`).
- Updated interaction logic to open the modal on button press, generate the summary on first open using the existing `generateWeeklySummary` flow, and added close/backdrop handlers to dismiss the modal; the reflection generation and data/storage logic were not changed (`mobile.js`).

### Testing
- Ran `npm run verify` and it completed successfully. 
- Ran `npm test -- --runInBand`; the test run reported failures, but those failures are pre-existing and unrelated to this UI-only change (several mobile/auth and service-worker suites failed in the repo environment). 
- Performed a headless visual smoke test (Playwright) to confirm the Insights card and modal render on mobile and captured a screenshot of the assistant view with the insights panel open.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b289f243c88324b49bd9f2a60a29b7)