### PR TITLE
Improve floating capture button UX

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -3311,7 +3311,7 @@ body, main, section, div, p, span, li {
   .brain-dump-fab {
     position: fixed;
     right: 1rem;
-    bottom: calc(6.5rem + env(safe-area-inset-bottom, 0px));
+    bottom: calc(var(--mobile-bottom-nav-height, 80px) + 0.75rem + env(safe-area-inset-bottom, 0px));
     width: 3.5rem;
     height: 3.5rem;
     border: none;
@@ -3324,7 +3324,33 @@ body, main, section, div, p, span, li {
     font-size: 2rem;
     line-height: 1;
     box-shadow: 0 12px 30px rgba(81, 38, 99, 0.3);
+    transition: transform 0.15s ease;
     z-index: 95;
+  }
+
+  .brain-dump-fab:active {
+    transform: scale(0.92);
+  }
+
+  .brain-dump-fab-tip {
+    position: fixed;
+    right: 1rem;
+    bottom: calc(var(--mobile-bottom-nav-height, 80px) + 5rem + env(safe-area-inset-bottom, 0px));
+    background: rgba(17, 24, 39, 0.94);
+    color: #ffffff;
+    border-radius: 0.75rem;
+    padding: 0.45rem 0.6rem;
+    font-size: 0.76rem;
+    font-weight: 600;
+    line-height: 1.2;
+    letter-spacing: 0.01em;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.26);
+    z-index: 96;
+    max-width: 11.5rem;
+  }
+
+  .brain-dump-fab-tip[hidden] {
+    display: none;
   }
 
   .capture-modal {
@@ -5382,6 +5408,7 @@ body, main, section, div, p, span, li {
       </button>
     </div>
   </nav>
+  <div id="brainDumpFabTip" class="brain-dump-fab-tip" role="status" aria-live="polite" hidden>Tap + to capture ideas</div>
   <button type="button" id="brainDumpFab" class="brain-dump-fab" aria-label="Quick capture" title="Quick capture">+</button>
 
   <div id="captureModal" class="capture-modal" role="dialog" aria-modal="true" aria-labelledby="captureModalTitle" hidden>
@@ -5402,9 +5429,11 @@ body, main, section, div, p, span, li {
       const fabButton = document.getElementById('mobile-fab-button');
       const fabMenu = document.getElementById('mobile-fab-menu');
       const brainDumpFab = document.getElementById('brainDumpFab');
+      const brainDumpFabTip = document.getElementById('brainDumpFabTip');
       const captureModal = document.getElementById('captureModal');
       const quickAddForm = document.getElementById('quickAddForm');
       const quickCaptureInput = document.getElementById('universalInput');
+      const FAB_TOOLTIP_STORAGE_KEY = 'memoryCueFabTooltipSeen';
 
       const updateBottomNavHeight = () => {
         if (!navFooter) return;
@@ -5446,7 +5475,35 @@ body, main, section, div, p, span, li {
         }
       };
 
-      brainDumpFab?.addEventListener('click', openCaptureModal);
+      const hideFabTip = () => {
+        if (brainDumpFabTip instanceof HTMLElement) {
+          brainDumpFabTip.setAttribute('hidden', '');
+        }
+
+        try {
+          window.localStorage?.setItem(FAB_TOOLTIP_STORAGE_KEY, 'true');
+        } catch (error) {
+          console.warn(error);
+        }
+      };
+
+      const shouldShowFabTip = () => {
+        try {
+          return window.localStorage?.getItem(FAB_TOOLTIP_STORAGE_KEY) !== 'true';
+        } catch (error) {
+          console.warn(error);
+          return false;
+        }
+      };
+
+      if (brainDumpFabTip instanceof HTMLElement && shouldShowFabTip()) {
+        brainDumpFabTip.removeAttribute('hidden');
+      }
+
+      brainDumpFab?.addEventListener('click', () => {
+        hideFabTip();
+        openCaptureModal();
+      });
 
       quickAddForm?.addEventListener('submit', () => {
         closeCaptureModal();


### PR DESCRIPTION
### Motivation
- Make the primary capture entry more polished and discoverable on mobile by adding tactile feedback, a first-use hint, and ensuring it sits above the bottom navigation.

### Description
- Add press-scale animation and `transition` to the capture FAB by updating the `.brain-dump-fab` styles and adding `.brain-dump-fab:active { transform: scale(0.92); }` to provide tactile feedback. 
- Anchor FAB placement above the navigation by using the `--mobile-bottom-nav-height` variable in the bottom offset (`bottom: calc(var(--mobile-bottom-nav-height, 80px) + 0.75rem + env(safe-area-inset-bottom, 0px));`).
- Add a one-time tooltip element `#brainDumpFabTip` with styles and z-index so the message appears above the nav bar and is visually distinct (`Tap + to capture ideas`).
- Wire tooltip lifecycle in the inline mobile script: show the tooltip on first load when localStorage key `memoryCueFabTooltipSeen` is not present, hide it on FAB tap, and persist dismissal with `localStorage.setItem(FAB_TOOLTIP_STORAGE_KEY, 'true')`.

### Testing
- Ran `npm run build` and the build completed successfully. ✅
- Ran `npm test -- --runInBand`; test run exposed pre-existing failing suites unrelated to these UI-only changes (some failing suites include mobile auth/sheet tests, `mobile.new-folder`, `service-worker.test.js`, and `reminders.categories.test.js`), so the change did not introduce new test failures but the repo has existing failures. ⚠️
- Performed manual visual verification by running `npm start` and capturing a mobile viewport screenshot via Playwright to confirm placement, tooltip rendering, and press animation. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b28f79c2b083248489da168ffc3991)