### PR TITLE
Improve mobile layout by using full-width content container

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -123,10 +123,18 @@ body.app-shell #mobile-nav-shell .floating-card[aria-current='page'] {
 
 body.app-shell .content .content-container {
   width: 100%;
-  max-width: 900px;
+  max-width: 600px;
   margin: 0 auto;
-  padding: 16px;
+  padding: 0 12px;
   line-height: 1.4;
+}
+
+body.app-shell .content #reminderList,
+body.app-shell .content .reminder-card,
+body.app-shell .content #inboxEntriesList,
+body.app-shell .content .category-entry-item,
+body.app-shell .content .note-card {
+  width: 100%;
 }
 
 body.app-shell .content #contentFeed {


### PR DESCRIPTION
### Motivation
- Fix the mobile layout so main content and list items use the full available screen width (reduce empty side space and improve list readability) while preserving centered layout on larger screens.

### Description
- Updated `mobile.css` to set the mobile content wrapper to `width: 100%`, `max-width: 600px`, and `padding: 0 12px` so narrow screens no longer show a constrained centered column.
- Added width rules to ensure reminder, inbox, category-entry, and note list cards expand to the container (`#reminderList`, `.reminder-card`, `#inboxEntriesList`, `.category-entry-item`, `.note-card { width: 100% }`).
- No data logic or navigation behavior was changed.

### Testing
- Ran the targeted Jest test `js/__tests__/mobile.footer-nav.test.js` which passed.
- Executed an automated Playwright script that loaded `mobile.html` at a 390x844 viewport and verified the `.content-container` width matches the viewport and captured a screenshot (successful).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b291c1b5b08324bdb272b859d326b5)