### PR TITLE
Improve UI density and reminder card hierarchy

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -5232,6 +5232,26 @@ export async function initReminders(sel = {}) {
       render();
     });
 
+    const sortToggleBtn = document.getElementById('reminderSortToggle');
+    if (sortToggleBtn instanceof HTMLElement) {
+      sortToggleBtn.addEventListener('click', () => {
+        const modes = [
+          REMINDER_SORT_OPTIONS.newest,
+          REMINDER_SORT_OPTIONS.oldest,
+          REMINDER_SORT_OPTIONS.category,
+        ];
+        const currentIndex = modes.indexOf(reminderSortMode);
+        const nextMode = modes[(currentIndex + 1) % modes.length];
+        reminderSortMode = nextMode;
+        sortSelect.value = nextMode;
+        sortToggleBtn.setAttribute('aria-label', `Sort reminders (${nextMode})`);
+        sortToggleBtn.title = `Sort reminders (${nextMode})`;
+        render();
+      });
+      sortToggleBtn.setAttribute('aria-label', `Sort reminders (${reminderSortMode})`);
+      sortToggleBtn.title = `Sort reminders (${reminderSortMode})`;
+    }
+
     setupReminderSortControl._wired = true;
   }
 
@@ -5650,10 +5670,11 @@ export async function initReminders(sel = {}) {
         titleWrapper.appendChild(titleToggle);
         rowMain.appendChild(titleWrapper);
 
-        if (dueLabel) {
+        const metaParts = [dueLabel, summary.category].filter(Boolean);
+        if (metaParts.length) {
           const metaText = document.createElement('div');
           metaText.className = 'reminder-meta reminder-date reminder-row-meta';
-          metaText.textContent = dueLabel;
+          metaText.textContent = metaParts.join(' • ');
           rowMain.appendChild(metaText);
         }
 

--- a/mobile.html
+++ b/mobile.html
@@ -2153,15 +2153,15 @@ body, main, section, div, p, span, li {
     /* New Header Styles */
     .mobile-header,
     .app-header {
-      height: 56px;
-      min-height: 56px;
-      max-height: 56px;
+      height: 52px;
+      min-height: 52px;
+      max-height: 52px;
       display: flex;
       align-items: center;
       justify-content: center;
       position: sticky;
       top: 0;
-      padding: 0 16px;
+      padding: 4px 12px;
       z-index: 1000;
       background: rgba(255, 255, 255, 0.85);
       backdrop-filter: blur(10px);
@@ -2208,6 +2208,11 @@ body, main, section, div, p, span, li {
       right: 12px;
     }
 
+    .sort {
+      position: absolute;
+      right: 56px;
+    }
+
     .header-quick-add,
     .header-search {
       width: 100%;
@@ -2241,7 +2246,7 @@ body, main, section, div, p, span, li {
     }
 
     .reminder-card {
-      padding: 10px 14px;
+      padding: 8px 10px;
       border-radius: 14px;
     }
 
@@ -2257,7 +2262,7 @@ body, main, section, div, p, span, li {
     }
 
     .reminders-mobile-flow > * + * {
-      margin-top: var(--space-2);
+      margin-top: 12px;
     }
 
     .quick-add-form {
@@ -4726,6 +4731,9 @@ body, main, section, div, p, span, li {
       <button id="openSavedNotesGlobal" type="button" class="search icon-button control-icon-button" aria-label="Search">
         🔍
       </button>
+      <button id="reminderSortToggle" type="button" class="sort icon-button control-icon-button" aria-label="Sort reminders" title="Sort reminders">
+        ↕
+      </button>
       <button id="overflowMenuBtn" type="button" class="menu icon-button control-icon-button" aria-haspopup="true" aria-expanded="false" aria-controls="overflowMenu" aria-label="Open menu">☰</button>
     <div id="overflowMenu" class="overflow-menu quick-actions-panel hidden" role="menu" aria-hidden="true">
         <!-- Reminders -->
@@ -4866,7 +4874,7 @@ body, main, section, div, p, span, li {
             id="reminderListSection"
             class="w-full relative memory-glass-card-soft"
           >
-            <div class="mb-2 flex items-center justify-end gap-2 px-1">
+            <div class="sr-only" aria-hidden="true">
               <label for="reminderSort" class="text-xs font-semibold uppercase tracking-wide text-base-content/70">Sort by:</label>
               <select id="reminderSort" class="select select-bordered select-xs max-w-[10rem]" aria-label="Sort reminders">
                 <option value="newest">Newest</option>
@@ -6381,7 +6389,7 @@ body, main, section, div, p, span, li {
       gap: 8px;
       overflow-x: auto;
       padding: 0 4px 2px;
-      margin-bottom: 8px;
+      margin-bottom: 4px;
       -webkit-overflow-scrolling: touch;
     }
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -133,7 +133,7 @@ html, body {
   padding: 12px 16px;
   background: rgba(255, 255, 255, 0.04);
   border-radius: 12px;
-  margin-bottom: 8px;
+  margin-bottom: 6px;
   font-size: 1rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   position: relative;
@@ -154,9 +154,12 @@ html, body {
   font-size: 1rem;
   font-weight: 600;
   color: var(--text-primary, #e5e7eb);
-  white-space: nowrap;
+  line-height: 1.25;
+  white-space: normal;
   overflow: hidden;
-  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   margin: 0;
 }
 
@@ -341,7 +344,7 @@ h2,
   font-weight: 600;
   line-height: 1.15;
   margin-top: 16px;
-  margin-bottom: 8px;
+  margin-bottom: 6px;
 }
 
 .content-container {
@@ -1336,7 +1339,7 @@ html[data-theme="professional"] {
   align-items: flex-start;
   justify-content: flex-start;
   gap: 10px;
-  padding: 14px 16px;
+  padding: 8px 10px;
   border-radius: 12px;
   margin-bottom: 8px;
   background: #f8f8fb;
@@ -1381,16 +1384,18 @@ html[data-theme="professional"] {
   font-size: 0.95rem;
   font-weight: 500;
   color: var(--text-primary);
-  white-space: nowrap;
+  line-height: 1.25;
+  white-space: normal;
   overflow: hidden;
-  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 .reminder-row-meta {
-  margin-top: 0.05rem;
+  margin-top: 0.12rem;
   font-size: 12px;
-  opacity: 0.6;
-  color: var(--text-muted);
+  color: #777;
 }
 
 .reminder-row-overflow {


### PR DESCRIPTION
### Motivation
- Reduce excessive vertical spacing and header bulk so more reminders are visible on mobile while keeping controls vertically centered.
- Improve reminder card hierarchy by moving from a cramped single-line layout to a clear two-line title + metadata presentation without changing reminder logic.

### Description
- Tighter header: reduced mobile header height and horizontal padding and ensured title/buttons remain centered (`mobile.html`).
- Collapsed sort row into a compact header control: the visible "Sort by" row is hidden and a small `#reminderSortToggle` icon was added to the header to cycle sort modes while preserving the existing `#reminderSort` select for logic (`mobile.html`, `js/reminders.js`).
- Reminder card layout: reduced card padding and restructured mobile reminder rendering to show a two-line layout (title + metadata) and render metadata as `due • category` (`js/reminders.js`, `mobile.html`).
- Styling tweaks: adjusted section spacing, reduced category filter margin, clamped reminder titles to two lines, and styled the metadata line to `12px` and muted color `#777` for improved visual hierarchy (`styles/index.css`, `mobile.html`).

### Testing
- Ran the repository verification script with `npm run verify`, which passed (`Build verification passed`).
- Rendered a mobile viewport screenshot using Playwright after serving the app to confirm visual changes (screenshot artifact generated successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2939e153c8324b428914612822940)