### PR TITLE
Add AI-assisted suggestion system for inbox processing

### DIFF
--- a/js/__tests__/reminders.quick-add.test.js
+++ b/js/__tests__/reminders.quick-add.test.js
@@ -12,6 +12,10 @@ function loadRemindersModule() {
     "import { setAuthContext, startSignInFlow, startSignOutFlow } from './supabase-auth.js';\n",
     'const setAuthContext = () => {}; const startSignInFlow = () => {}; const startSignOutFlow = () => {};\n',
   );
+  source = source.replace(
+    "import { analyseText } from './services/suggestion-service.js';\n",
+    "const analyseText = (text) => {\n      const normalized = typeof text === 'string' ? text.toLowerCase() : '';\n      if (normalized.includes('tomorrow') || /\\d+\\s*(am|pm)\\b/i.test(normalized)) {\n        return { type: 'reminder', reason: 'Contains time reference' };\n      }\n      if (normalized.length > 60) {\n        return { type: 'note', reason: 'Long text likely a note' };\n      }\n      return { type: 'none', reason: '' };\n    };\n",
+  );
   source = source.replace(/export\s+async\s+function\s+initReminders/, 'async function initReminders');
   source += '\nmodule.exports = { initReminders };\n';
   const module = { exports: {} };
@@ -114,6 +118,10 @@ test('quick add routes footy drill prefix to Footy – Drills category', async (
   expect(memoryEntries[0].type).toBeNull();
   expect(memoryEntries[0].context).toBeNull();
   expect(memoryEntries[0].person).toBeNull();
+  expect(memoryEntries[0].suggestion).toEqual({
+    type: 'none',
+    reason: '',
+  });
   expect(Number.isFinite(memoryEntries[0].createdAt)).toBe(true);
   expect(memoryEntries[0].date).toBe('2024-05-15');
 });
@@ -180,6 +188,21 @@ test('inbox search parser falls back to keyword-only when no time pattern exists
 
   expect(parsed.keywordQuery).toBe('mark reports');
   expect(parsed.timeRange).toBeNull();
+});
+
+
+test('quick add stores reminder suggestion when text contains time reference', async () => {
+  const quickInput = document.getElementById('quickAddInput');
+  quickInput.value = 'Call parents tomorrow 1pm';
+
+  await window.memoryCueQuickAddNow();
+
+  const memoryEntries = JSON.parse(localStorage.getItem('memoryEntries') || '[]');
+  expect(memoryEntries).toHaveLength(1);
+  expect(memoryEntries[0].suggestion).toEqual({
+    type: 'reminder',
+    reason: 'Contains time reference',
+  });
 });
 
 test('quick add parses natural language time into due date', async () => {

--- a/js/entries.js
+++ b/js/entries.js
@@ -212,6 +212,23 @@
     return true;
   };
 
+  const convertToReminder = (entry) => {
+    dispatchReminderSheetOpen(null, getEntryText(entry));
+  };
+
+  const convertToNote = (entry) => {
+    appendToMainNotesDatabase([
+      {
+        id: `entry-${Date.now()}`,
+        title: getEntryText(entry),
+        body: getEntryText(entry),
+        bodyHtml: getEntryText(entry),
+        bodyText: getEntryText(entry),
+        updatedAt: new Date().toISOString(),
+      },
+    ]);
+  };
+
   const openInboxQuickActions = (entry) => {
     if (!(entry && typeof entry === 'object')) {
       return;
@@ -234,21 +251,12 @@
     const actions = [
       {
         label: 'Create Reminder',
-        action: () => dispatchReminderSheetOpen(null, getEntryText(entry)),
+        action: () => convertToReminder(entry),
       },
       {
         label: 'Convert to Note',
         action: () => {
-          appendToMainNotesDatabase([
-            {
-              id: `entry-${Date.now()}`,
-              title: getEntryText(entry),
-              body: getEntryText(entry),
-              bodyHtml: getEntryText(entry),
-              bodyText: getEntryText(entry),
-              updatedAt: new Date().toISOString(),
-            },
-          ]);
+          convertToNote(entry);
         },
       },
       {
@@ -396,6 +404,67 @@
       createdAt.textContent = getEntryCreatedDate(entry);
 
       meta.append(typeTag, categoryTag, createdAt);
+
+      const suggestion = entry?.suggestion && typeof entry.suggestion === 'object' ? entry.suggestion : null;
+      const suggestionType = typeof suggestion?.type === 'string' ? suggestion.type.trim().toLowerCase() : 'none';
+      const suggestionReason = typeof suggestion?.reason === 'string' ? suggestion.reason.trim() : '';
+      const shouldShowSuggestion = (suggestionType === 'reminder' || suggestionType === 'note') && suggestionReason;
+
+      if (shouldShowSuggestion) {
+        const suggestionPanel = document.createElement('section');
+        suggestionPanel.className = 'rounded-md border border-base-300 bg-base-200/50 p-2 text-xs space-y-2';
+
+        const suggestionLabel = document.createElement('p');
+        suggestionLabel.className = 'font-medium';
+        suggestionLabel.textContent = 'Suggested action';
+
+        const suggestionAction = document.createElement('p');
+        suggestionAction.className = 'opacity-80';
+        suggestionAction.textContent = suggestionType === 'reminder' ? 'Create Reminder' : 'Convert to Note';
+
+        const suggestionReasonEl = document.createElement('p');
+        suggestionReasonEl.className = 'opacity-70';
+        suggestionReasonEl.textContent = suggestionReason;
+
+        const suggestionActions = document.createElement('div');
+        suggestionActions.className = 'flex items-center gap-2';
+
+        const acceptButton = document.createElement('button');
+        acceptButton.type = 'button';
+        acceptButton.className = 'btn btn-xs btn-primary';
+        acceptButton.textContent = 'Accept';
+        acceptButton.addEventListener('click', () => {
+          if (suggestionType === 'reminder') {
+            convertToReminder(entry);
+          } else if (suggestionType === 'note') {
+            convertToNote(entry);
+          }
+        });
+
+        const ignoreButton = document.createElement('button');
+        ignoreButton.type = 'button';
+        ignoreButton.className = 'btn btn-xs btn-ghost';
+        ignoreButton.textContent = 'Ignore';
+        ignoreButton.addEventListener('click', () => {
+          const allEntries = readEntries();
+          const entryIndex = allEntries.findIndex((item) => item?.id && entry?.id ? item.id === entry.id : item === entry);
+          if (entryIndex === -1) return;
+          allEntries[entryIndex] = {
+            ...allEntries[entryIndex],
+            suggestion: {
+              type: 'none',
+              reason: ''
+            },
+            updatedAt: new Date().toISOString()
+          };
+          writeEntries(allEntries);
+          renderInboxEntries();
+        });
+
+        suggestionActions.append(acceptButton, ignoreButton);
+        suggestionPanel.append(suggestionLabel, suggestionAction, suggestionReasonEl, suggestionActions);
+        card.appendChild(suggestionPanel);
+      }
 
       const actions = document.createElement('div');
       actions.className = 'flex items-center gap-2 flex-wrap';

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -1,4 +1,5 @@
 import { setAuthContext, startSignInFlow, startSignOutFlow } from './supabase-auth.js';
+import { analyseText } from './services/suggestion-service.js';
 
 // Shared reminder logic used by both the mobile and desktop pages.
 // This module wires up Firebase/Firestore and all reminder UI handlers.
@@ -2111,6 +2112,7 @@ export async function initReminders(sel = {}) {
         type: null,
         context: null,
         person: null,
+        suggestion: analyseText(cleanText),
         createdAt: nowMs,
         date: dateStamp,
       };

--- a/js/services/suggestion-service.js
+++ b/js/services/suggestion-service.js
@@ -1,0 +1,22 @@
+export function analyseText(text) {
+  const normalized = typeof text === 'string' ? text.toLowerCase() : '';
+
+  if (normalized.includes('tomorrow') || /\d+\s*(am|pm)\b/i.test(normalized)) {
+    return {
+      type: 'reminder',
+      reason: 'Contains time reference'
+    };
+  }
+
+  if (normalized.length > 60) {
+    return {
+      type: 'note',
+      reason: 'Long text likely a note'
+    };
+  }
+
+  return {
+    type: 'none',
+    reason: ''
+  };
+}


### PR DESCRIPTION
### Motivation
- Provide AI-assisted suggestions for newly captured Inbox items to recommend converting them to a Reminder, Note, or leaving them alone. 
- Surface a human-reviewed recommendation to speed up processing while ensuring items are never auto-converted. 
- Keep architecture constraints: no new storage, no bypass of processing flows, and no automatic conversions.

### Description
- Added a lightweight suggestion service at `js/services/suggestion-service.js` that exports `analyseText(text)` and returns `{ type: 'reminder'|'note'|'none', reason: string }` using simple heuristics. 
- Wired suggestion attachment into the capture flow so new inbox `memoryEntries` include a `suggestion` field produced by `analyseText` in `js/reminders.js`. 
- Updated inbox rendering in `js/entries.js` to show a "Suggested action" panel with the recommended action and reason, and added `Accept` and `Ignore` buttons. 
- Implemented `Accept` to call existing conversion helpers (`convertToReminder` / `convertToNote`) and `Ignore` to clear the suggestion on that entry, preserving the rule that suggestions never auto-modify items.

### Testing
- Ran `npm test -- js/__tests__/reminders.quick-add.test.js`, which passed (8 tests, all succeeded). 
- Updated the test harness to stub the new `analyseText` import so the module can run under the test VM.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2951c292c8324843fb7f53349ede8)