### PR TITLE
Add Memory Recall feature to surface past captured ideas

### DIFF
--- a/js/services/recall-service.js
+++ b/js/services/recall-service.js
@@ -1,0 +1,34 @@
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+const toTimestamp = (value) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+};
+
+export function getRecallItems(items = [], options = {}) {
+  const now = Date.now();
+  const maxItems = Math.min(3, Math.max(1, Number(options.limit) || 3));
+
+  return (Array.isArray(items) ? items : [])
+    .filter((item) => {
+      const createdAt = toTimestamp(item?.createdAt);
+      if (!createdAt) {
+        return false;
+      }
+
+      const age = now - createdAt;
+      return age > SEVEN_DAYS_MS;
+    })
+    .sort((a, b) => toTimestamp(b?.createdAt) - toTimestamp(a?.createdAt))
+    .slice(0, maxItems);
+}

--- a/mobile.html
+++ b/mobile.html
@@ -3040,6 +3040,35 @@ body, main, section, div, p, span, li {
       margin: 0;
     }
 
+
+    .memory-recall {
+      border-top: 1px solid var(--border-subtle);
+      margin-top: 0.5rem;
+      padding-top: 0.5rem;
+      display: grid;
+      gap: 0.4rem;
+    }
+
+    .memory-recall h3 {
+      margin: 0;
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: var(--text-main);
+    }
+
+    .recall-item {
+      font-size: 0.82rem;
+      color: var(--text-muted);
+      background: rgba(81, 38, 99, 0.06);
+      border-radius: 0.5rem;
+      padding: 0.4rem 0.55rem;
+    }
+
+    .recall-item--empty {
+      background: transparent;
+      border: 1px dashed var(--border-subtle);
+    }
+
     .reflection-modal {
       position: fixed;
       inset: 0;
@@ -5310,6 +5339,13 @@ body, main, section, div, p, span, li {
           <div class="insight-header"><span>Insights</span></div>
           <p id="weeklyReflectionSummary" class="insight-summary">You captured items this week.</p>
           <button id="weeklyReflectionButton" type="button" class="btn btn-outline btn-sm view-reflection-btn">Weekly Reflection</button>
+
+          <div class="memory-recall">
+            <h3>Memory Recall</h3>
+            <div id="memoryRecallList">
+              <div class="recall-item recall-item--empty">No recall suggestions yet.</div>
+            </div>
+          </div>
         </div>
       </div>
     </section>

--- a/mobile.js
+++ b/mobile.js
@@ -14,6 +14,7 @@ import { ModalController } from './js/modules/modal-controller.js';
 import { saveFolders } from './js/modules/notes-storage.js';
 import { buildDashboard } from './js/modules/dashboard-data.js';
 import { generateWeeklySummary } from './js/modules/weekly-summary.js';
+import { getRecallItems } from './js/services/recall-service.js';
 
 const aiCaptureSaveModulePromise = import('./js/modules/ai-capture-save.js').catch(() => ({}));
 
@@ -61,6 +62,8 @@ function initAssistant() {
     const weeklyReflectionModal = document.getElementById('weeklyReflectionModal');
     const closeWeeklyReflectionButton = document.getElementById('closeWeeklyReflectionButton');
     const weeklyReflectionContent = document.getElementById('weeklyReflectionContent');
+    const recallList = document.getElementById('memoryRecallList');
+    let lastRecallNotificationKey = '';
     let isAssistantSending = false;
     let latestThinkingSearchRequest = 0;
     const assistantConversationHistory = [];
@@ -95,6 +98,7 @@ function initAssistant() {
         thinkingBarResults.innerHTML = '';
       }
     };
+
 
     const renderSearchResults = async (query) => {
       const requestId = ++latestThinkingSearchRequest;
@@ -149,6 +153,137 @@ function initAssistant() {
         thinkingBarResults.appendChild(row);
       });
     };
+
+
+    const readRemindersForRecall = () => {
+      if (typeof localStorage === 'undefined') {
+        return [];
+      }
+      try {
+        const raw = localStorage.getItem('scheduledReminders');
+        const parsed = raw ? JSON.parse(raw) : {};
+        if (!parsed || typeof parsed !== 'object') {
+          return [];
+        }
+        return Object.values(parsed)
+          .filter((item) => item && typeof item === 'object')
+          .map((item) => ({
+            ...item,
+            sourceType: 'reminder',
+            recallText: typeof item.title === 'string' ? item.title : '',
+          }));
+      } catch {
+        return [];
+      }
+    };
+
+    const readInboxItemsForRecall = () => {
+      if (typeof localStorage === 'undefined') {
+        return [];
+      }
+      try {
+        const raw = localStorage.getItem('memoryEntries');
+        const parsed = raw ? JSON.parse(raw) : [];
+        const inboxItems = Array.isArray(parsed)
+          ? parsed.filter((entry) => entry?.processed === false || String(entry?.status || '').toLowerCase() === 'inbox')
+          : [];
+
+        return inboxItems.map((entry) => ({
+          ...entry,
+          sourceType: 'inbox',
+          recallText:
+            (typeof entry?.title === 'string' && entry.title.trim())
+              ? entry.title.trim()
+              : (typeof entry?.text === 'string' && entry.text.trim())
+                ? entry.text.trim()
+                : (typeof entry?.content === 'string' && entry.content.trim())
+                  ? entry.content.trim()
+                  : '',
+        }));
+      } catch {
+        return [];
+      }
+    };
+
+    const readNotesForRecall = () => {
+      const notes = Array.isArray(loadAllNotes()) ? loadAllNotes() : [];
+      return notes.map((note) => ({
+        ...note,
+        sourceType: 'note',
+        recallText:
+          (typeof note?.title === 'string' && note.title.trim())
+            ? note.title.trim()
+            : (typeof note?.bodyText === 'string' && note.bodyText.trim())
+              ? note.bodyText.trim()
+              : (typeof note?.body === 'string' && note.body.trim())
+                ? note.body.trim()
+                : '',
+      }));
+    };
+
+    const maybeNotifyRecallItem = (recallItems) => {
+      if (!Array.isArray(recallItems) || !recallItems.length) {
+        return;
+      }
+      if (typeof Notification === 'undefined' || Notification.permission !== 'granted') {
+        return;
+      }
+
+      const first = recallItems[0];
+      const message = typeof first?.recallText === 'string' ? first.recallText.trim() : '';
+      if (!message) {
+        return;
+      }
+
+      const notificationKey = `${first?.sourceType || 'item'}:${message}`;
+      if (notificationKey === lastRecallNotificationKey) {
+        return;
+      }
+
+      lastRecallNotificationKey = notificationKey;
+      try {
+        new Notification('Memory Recall', {
+          body: message.slice(0, 140),
+        });
+      } catch {
+        // Ignore notification failures to avoid interrupting assistant tools.
+      }
+    };
+
+    const renderMemoryRecall = () => {
+      if (!(recallList instanceof HTMLElement)) {
+        return;
+      }
+
+      const notes = readNotesForRecall();
+      const reminders = readRemindersForRecall();
+      const inboxItems = readInboxItemsForRecall();
+      const recallItems = getRecallItems([...inboxItems, ...notes, ...reminders], { limit: 3 });
+
+      recallList.innerHTML = '';
+      if (!recallItems.length) {
+        const empty = document.createElement('div');
+        empty.className = 'recall-item recall-item--empty';
+        empty.textContent = 'No recall suggestions yet.';
+        recallList.appendChild(empty);
+        return;
+      }
+
+      recallItems.forEach((item) => {
+        const row = document.createElement('div');
+        row.className = 'recall-item';
+        const text = typeof item?.recallText === 'string' ? item.recallText.trim() : '';
+        row.textContent = text || 'Untitled capture';
+        recallList.appendChild(row);
+      });
+
+      maybeNotifyRecallItem(recallItems);
+    };
+
+    renderMemoryRecall();
+    document.addEventListener('memoryCue:remindersUpdated', renderMemoryRecall);
+    document.addEventListener('memoryCue:entriesUpdated', renderMemoryRecall);
+    document.addEventListener('memoryCue:notesUpdated', renderMemoryRecall);
 
     const toAssistantEntryText = (value, maxChars = 1000) => {
       if (typeof value !== 'string') {


### PR DESCRIPTION
### Motivation
- Help users rediscover ideas by surfacing past captures (notes, reminders, inbox items) that are older than seven days without changing storage models.
- Keep suggestions lightweight (1–3 items) to avoid clutter and optionally surface a browser notification when a recall appears.

### Description
- Add a new recall service `getRecallItems` in `js/services/recall-service.js` that selects items older than 7 days, normalises `createdAt` values, sorts by recency, and caps results to 1–3 items (`limit` option supported).
- Wire the recall service into the assistant Insights card in `mobile.js` by importing `getRecallItems`, reading candidates only from existing stores (`memoryEntries` inbox items, `scheduledReminders`, and `loadAllNotes()`), rendering the items into the UI, and refreshing on `memoryCue:remindersUpdated`, `memoryCue:entriesUpdated`, and `memoryCue:notesUpdated` events.
- Add minimal Memory Recall UI markup and styles in `mobile.html` (`.memory-recall`, `#memoryRecallList`, `.recall-item`) and an empty-state message when no recalls exist.
- Implement optional notification triggering in `mobile.js` that sends a `Notification` for the top recall item only when `Notification.permission === 'granted'` and deduplicates repeated notifications.
- Preserve architecture and storage: the feature only reads from `inboxItems` (`memoryEntries`), `reminders` (`scheduledReminders`), and `notes` (`loadAllNotes()`), and does not introduce new persistent storage.

### Testing
- Ran `npm run build` which completed successfully and produced the distribution artifacts (`dist/assets/...`).
- Ran `npm test -- --runInBand`; the test run failed (multiple suites) due to existing repository test-harness/module-format issues (ESM import parsing and unrelated VM/context expectations), so unit test failures are unrelated to the recall feature itself.
- Manual smoke validation: loaded `mobile.html` in the dev server and captured a screenshot of the assistant Insights panel showing the Memory Recall UI (artifact produced during validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b296beb44083248061f05b0571e169)