### PR TITLE
Switch assistant model to gpt-5-nano for lower API cost

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -11,6 +11,8 @@ async function generateLLMResponse(prompt: string) {
     throw new Error('Missing OpenAI API key');
   }
 
+  console.log('AI model:', 'gpt-5-nano');
+
   const response = await fetch('https://api.openai.com/v1/responses', {
     method: 'POST',
     headers: {
@@ -18,7 +20,7 @@ async function generateLLMResponse(prompt: string) {
       Authorization: `Bearer ${process.env.OPENAI_API_KEY}`
     },
     body: JSON.stringify({
-      model: 'gpt-4o-mini',
+      model: 'gpt-5-nano',
       max_output_tokens: 400,
       store: false,
       input: [


### PR DESCRIPTION
### Motivation
- Reduce API cost by switching the assistant chat model to `gpt-5-nano` while preserving existing assistant logic, prompts, endpoints, and response handling.

### Description
- Updated the assistant API call in `api/chat.ts` to use `model: 'gpt-5-nano'` and added a temporary runtime log `console.log('AI model:', 'gpt-5-nano')`; no other assistant logic, prompts, routes, or response parsing were changed.

### Testing
- Ran repository-wide searches (`rg`) to confirm assistant model usage was updated and then executed the test suite with `npm test -- --runInBand`; the repository has pre-existing unrelated failing tests (mobile/reminders/service-worker) and no failures were introduced by this single-file model switch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b31db6b15883248702b5c9619df041)