### PR TITLE
Improve UX: rename "Today" tab to "Reminders" to match screen content

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5375,10 +5375,10 @@ body, main, section, div, p, span, li {
       <button
         type="button"
         class="floating-card btn-reminders"
-        id="mobile-footer-today"
-        data-nav-target="today"
-        data-tab="today"
-        aria-label="Go to Today"
+        id="mobile-footer-reminders"
+        data-nav-target="reminders"
+        data-tab="reminders"
+        aria-label="Go to Reminders"
       >
         <svg
           class="icon icon-clock"
@@ -5395,7 +5395,7 @@ body, main, section, div, p, span, li {
           <circle cx="12" cy="12" r="7" />
           <path d="M12 9v3.5l2 1.5" />
         </svg>
-        <span>Today</span>
+        <span>Reminders</span>
       </button>
 
       <button
@@ -5683,7 +5683,7 @@ body, main, section, div, p, span, li {
         if (!view) return;
 
         const routeMap = {
-          today: 'reminders',
+          reminders: 'reminders',
           inbox: 'inbox',
           assistant: 'assistant'
         };


### PR DESCRIPTION
### Motivation
- The bottom navigation label `Today` was misleading because the tab displays all reminders rather than only today's items, so the label should reflect the actual content.

### Description
- Updated the bottom navigation in `mobile.html` by renaming the footer button and attributes from `today` to `reminders` (updated `id`, `data-nav-target`, `data-tab`, `aria-label`, and visible `<span>` text) and adjusted the route mapping key to `reminders`; no reminder logic or filtering was changed.

### Testing
- Ran the footer navigation unit test `npm test -- --runTestsByPath js/__tests__/mobile.footer-nav.test.js` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b323af38d883249c7f8318a335427e)