### PR TITLE
Refactor navigation to represent core sections (Reminders, Notes, Inbox, Assistant)

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5375,10 +5375,10 @@ body, main, section, div, p, span, li {
       <button
         type="button"
         class="floating-card btn-reminders"
-        id="mobile-footer-today"
-        data-nav-target="today"
-        data-tab="today"
-        aria-label="Go to Today"
+        id="mobile-footer-reminders"
+        data-nav-target="reminders"
+        data-tab="reminders"
+        aria-label="Go to Reminders"
       >
         <svg
           class="icon icon-clock"
@@ -5395,7 +5395,35 @@ body, main, section, div, p, span, li {
           <circle cx="12" cy="12" r="7" />
           <path d="M12 9v3.5l2 1.5" />
         </svg>
-        <span>Today</span>
+        <span>Reminders</span>
+      </button>
+
+      <button
+        type="button"
+        class="floating-card btn-notebook"
+        id="mobile-footer-notebook"
+        data-nav-target="notebook"
+        data-tab="notebook"
+        aria-label="Go to Notes"
+      >
+        <svg
+          class="icon icon-notebook"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.75"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <rect x="5" y="4.5" width="14" height="15" rx="2" />
+          <path d="M9 8.5h6" />
+          <path d="M9 12h6" />
+          <path d="M9 15.5h4" />
+        </svg>
+        <span>Notes</span>
       </button>
 
       <button
@@ -5683,7 +5711,8 @@ body, main, section, div, p, span, li {
         if (!view) return;
 
         const routeMap = {
-          today: 'reminders',
+          reminders: 'reminders',
+          notebook: 'notebook',
           inbox: 'inbox',
           assistant: 'assistant'
         };


### PR DESCRIPTION
### Motivation
- The bottom navigation mixed destinations and actions (e.g. a centered action tab for creating reminders) instead of exposing stable, top-level data sections.
- The app requires the nav to consistently represent main data views so users can switch between `reminders`, `notebook`, `inbox`, and `assistant` without triggering actions.

### Description
- Replaced the footer `Today` button with a `Reminders` button and updated its id/attributes to `id="mobile-footer-reminders"`, `data-nav-target="reminders"`, and `data-tab="reminders"` in `mobile.html`.
- Added a dedicated `Notes` tab to the footer nav (markup for `mobile-footer-notebook` with `data-nav-target="notebook"`/`data-tab="notebook"`) so the final order is `Reminders`, `Notes`, `Inbox`, `Assistant`.
- Updated the footer navigation route map to map footer targets directly to section views (`reminders`, `notebook`, `inbox`, `assistant`) and left FAB/menu actions (e.g. `new-reminder`, `new-note`) handled by the existing FAB/menu logic rather than as navigation tabs.
- Changes are limited to the mobile footer and the nav routing mapping in `mobile.html` so navigation state remains fixed and each tab corresponds to one main view.

### Testing
- Ran the targeted Jest spec `npm test -- mobile.footer-nav.test.js` which passed (footer navigation behavior confirmed).
- Served the site with `npx serve . -l 4173` and captured a mobile viewport screenshot using Playwright to visually verify the updated footer, which completed successfully.
- No other tests were modified or added; changes were kept minimal and scoped to `mobile.html`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b324be0d8483248650869b033d4a59)