### PR TITLE
Add centralized MemoryCueState store with localStorage persistence

### DIFF
--- a/state.js
+++ b/state.js
@@ -1,0 +1,132 @@
+(function () {
+  const STORAGE_KEY = 'memoryCueState';
+  const SCHEMA_VERSION = 1;
+
+  const createDefaultState = () => ({
+    schemaVersion: SCHEMA_VERSION,
+    entries: [],
+    settings: {},
+    ui: {
+      activeTab: 'capture',
+      filters: {}
+    }
+  });
+
+  class MemoryCueStateStore {
+    constructor() {
+      this.state = createDefaultState();
+    }
+
+    load() {
+      let parsed = null;
+
+      try {
+        const rawState = window.localStorage.getItem(STORAGE_KEY);
+        if (!rawState) {
+          this.state = createDefaultState();
+          return this.state;
+        }
+        parsed = JSON.parse(rawState);
+      } catch (error) {
+        console.warn('MemoryCueState: Unable to load state from localStorage.', error);
+        this.state = createDefaultState();
+        return this.state;
+      }
+
+      this.state = this.migrate(parsed);
+      return this.state;
+    }
+
+    save() {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(this.state));
+      } catch (error) {
+        console.warn('MemoryCueState: Unable to save state to localStorage.', error);
+      }
+    }
+
+    addEntry(entry) {
+      const newEntry = {
+        ...(entry || {}),
+        id: this.generateId(),
+        timestamp: new Date().toISOString()
+      };
+
+      this.state.entries.push(newEntry);
+      this.save();
+      return newEntry;
+    }
+
+    deleteEntry(id) {
+      const originalLength = this.state.entries.length;
+      this.state.entries = this.state.entries.filter((entry) => entry.id !== id);
+
+      if (this.state.entries.length !== originalLength) {
+        this.save();
+      }
+    }
+
+    updateEntry(id, updates) {
+      const entryIndex = this.state.entries.findIndex((entry) => entry.id === id);
+      if (entryIndex === -1) {
+        return null;
+      }
+
+      this.state.entries[entryIndex] = {
+        ...this.state.entries[entryIndex],
+        ...(updates || {})
+      };
+
+      this.save();
+      return this.state.entries[entryIndex];
+    }
+
+    getEntries() {
+      return [...this.state.entries].sort((a, b) => {
+        const aTime = new Date(a.timestamp || 0).getTime();
+        const bTime = new Date(b.timestamp || 0).getTime();
+        return bTime - aTime;
+      });
+    }
+
+    migrate(stateCandidate) {
+      const baseState = createDefaultState();
+      const source = stateCandidate && typeof stateCandidate === 'object' ? stateCandidate : {};
+      const sourceVersion = Number(source.schemaVersion) || 0;
+
+      let migratedState = {
+        ...baseState,
+        ...source,
+        entries: Array.isArray(source.entries) ? source.entries : [],
+        settings: source.settings && typeof source.settings === 'object' ? source.settings : {},
+        ui: {
+          ...baseState.ui,
+          ...(source.ui && typeof source.ui === 'object' ? source.ui : {}),
+          filters:
+            source.ui && source.ui.filters && typeof source.ui.filters === 'object'
+              ? source.ui.filters
+              : {}
+        }
+      };
+
+      // Placeholder for future schema migrations.
+      if (sourceVersion < SCHEMA_VERSION) {
+        migratedState = {
+          ...migratedState,
+          schemaVersion: SCHEMA_VERSION
+        };
+      }
+
+      return migratedState;
+    }
+
+    generateId() {
+      return `entry_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    }
+  }
+
+  const memoryCueState = new MemoryCueStateStore();
+  memoryCueState.load();
+
+  window.MemoryCueState = memoryCueState;
+})();


### PR DESCRIPTION
### Motivation
- Consolidate app data into a single source of truth to avoid inconsistent reads/writes across the app.
- Provide a stable persisted state shape for entries, settings, and UI state so future features can rely on one store.
- Add a migration scaffold to support future schema upgrades without breaking existing data.

### Description
- Add a new `state.js` module that constructs a `MemoryCueStateStore` and exposes a singleton as `window.MemoryCueState`.
- Provide the default state shape with `entries: []`, `settings: {}`, and `ui: { activeTab: 'capture', filters: {} }` and persist a `schemaVersion` value.
- Implement `load()` and `save()` backed by `localStorage`, plus `addEntry(entry)` (auto-generates `id` and `timestamp`), `deleteEntry(id)`, `updateEntry(id, updates)`, and `getEntries()` (newest-first).
- Include a `migrate()` scaffold that normalizes loaded state and upgrades `schemaVersion`, and ensure the store auto-saves when entries are mutated.

### Testing
- Ran `npm test -- --runInBand`; the test run executed but many unrelated pre-existing tests failed, with `11` test suites passing and `13` failing and overall `58` tests passed and `22` failed. 
- The failures appear unrelated to `state.js` (ESM/CommonJS harness issues and existing service-worker/reminders test failures) and no new test suites were added or modified by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b36cdb17fc8324a40b5c647f559ee2)