### PR TITLE
Refactor capture entry save to use MemoryCueState store

### DIFF
--- a/assistant.js
+++ b/assistant.js
@@ -256,4 +256,77 @@
     buildContext,
     askMemoryCue
   };
+
+  function parseCaptureInput(rawText) {
+    const trimmedText = typeof rawText === 'string' ? rawText.trim() : '';
+    const typeMatch = trimmedText.match(/^(task|idea|note|reflection|lesson|drill)\s*:\s*/i);
+    const type = typeMatch ? typeMatch[1].toLowerCase() : 'note';
+    const body = typeMatch ? trimmedText.replace(typeMatch[0], '').trim() : trimmedText;
+    const title = body.split('\n')[0].trim().slice(0, 80);
+
+    return {
+      type,
+      title,
+      body
+    };
+  }
+
+  function parseTags(rawTags) {
+    if (typeof rawTags !== 'string') {
+      return [];
+    }
+
+    return rawTags
+      .split(',')
+      .map(function (tag) {
+        return tag.trim();
+      })
+      .filter(Boolean);
+  }
+
+  function showToast(message) {
+    const toastLive = document.getElementById('toastLive');
+    if (!toastLive) {
+      return;
+    }
+
+    toastLive.textContent = message;
+    window.clearTimeout(showToast.timeoutId);
+    showToast.timeoutId = window.setTimeout(function () {
+      toastLive.textContent = '';
+    }, 1800);
+  }
+
+  function initCaptureSave() {
+    const captureButton = document.getElementById('captureButton');
+    const captureInput = document.getElementById('captureInput');
+    const tagsInput = document.getElementById('tagsInput');
+
+    if (!captureButton || !captureInput || !tagsInput || !window.MemoryCueState) {
+      return;
+    }
+
+    captureButton.addEventListener('click', function () {
+      const parsedInput = parseCaptureInput(captureInput.value);
+      if (!parsedInput.body) {
+        return;
+      }
+
+      MemoryCueState.addEntry({
+        type: parsedInput.type,
+        title: parsedInput.title,
+        body: parsedInput.body,
+        tags: parseTags(tagsInput.value)
+      });
+
+      captureInput.value = '';
+      showToast('Entry saved');
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initCaptureSave);
+  } else {
+    initCaptureSave();
+  }
 })();

--- a/index.html
+++ b/index.html
@@ -156,6 +156,7 @@
 
     <div id="toastLive" class="toast-live" aria-live="polite" aria-atomic="true"></div>
 
+    <script src="state.js"></script>
     <script src="assistant.js"></script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Centralize capture storage so the UI uses the shared `MemoryCueState` store instead of writing directly to `localStorage`.
- Ensure captured tags are parsed to an array, prevent saving empty bodies, and provide immediate UI feedback after save.

### Description
- Added `parseCaptureInput`, `parseTags`, `showToast`, and `initCaptureSave` helpers to `assistant.js` to parse capture text, parse comma-separated tags into an array, and show a short toast after save.
- Wired the capture button to call `MemoryCueState.addEntry({ type, title, body, tags })` and to clear the capture textarea after a successful save while preventing saves when `body` is empty.
- Ensured `state.js` is loaded before `assistant.js` in `index.html` so `MemoryCueState` exists when the capture handler initializes.

### Testing
- Ran the project unit test: `npm test -- --runInBand sample.test.js`, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b36e10fd248324b2e2b4b96057b3a1)