### PR TITLE
Use MemoryCueState entries for assistant context

### DIFF
--- a/assistant.js
+++ b/assistant.js
@@ -63,7 +63,7 @@
     });
   }
 
-  function loadEntriesFromStore() {
+  function loadEntriesFromState() {
     if (!window.MemoryCueState || typeof MemoryCueState.getEntries !== 'function') {
       return { settings: {}, entries: [] };
     }
@@ -73,12 +73,7 @@
         ? MemoryCueState.state.settings
         : {};
 
-    const stateEntries = MemoryCueState.getEntries().map(function (entry) {
-      return {
-        ...entry,
-        createdAt: entry.createdAt || entry.timestamp || entry.updatedAt || null
-      };
-    });
+    const stateEntries = MemoryCueState.getEntries();
 
     return {
       settings: stateSettings,
@@ -117,7 +112,7 @@
   function buildContext(entries, maxEntries, maxChars) {
     const safeMaxEntries = Number.isFinite(maxEntries) ? Math.max(1, Math.floor(maxEntries)) : DEFAULT_MAX_ENTRIES;
     const safeMaxChars = Number.isFinite(maxChars) ? Math.max(200, Math.floor(maxChars)) : DEFAULT_MAX_CHARS;
-    const selected = selectEntries(entries.map(normalizeEntry).filter(Boolean), safeMaxEntries, safeMaxChars);
+    const selected = selectEntries(entries, safeMaxEntries, safeMaxChars);
 
     return selected
       .map(function (entry) {
@@ -195,7 +190,7 @@
     const opts = options && typeof options === 'object' ? options : {};
     const maxEntries = Number.isFinite(opts.maxEntries) ? opts.maxEntries : DEFAULT_MAX_ENTRIES;
     const maxChars = Number.isFinite(opts.maxChars) ? opts.maxChars : DEFAULT_MAX_CHARS;
-    const loaded = loadEntriesFromStore();
+    const loaded = loadEntriesFromState();
     const relevantEntries = filterRelevantEntries(safeQuestion, loaded.entries);
     const selectedEntries = selectEntries(relevantEntries, maxEntries, maxChars);
     const contextText = buildContext(selectedEntries, maxEntries, maxChars);


### PR DESCRIPTION
### Motivation
- Ensure the assistant uses the exact same entries as the UI by sourcing data from `MemoryCueState.getEntries()` instead of duplicating DB-loading logic. 
- Remove the redundant per-entry remapping and keep the assistant API and offline fallback behavior unchanged.

### Description
- Replaced the old loader with `loadEntriesFromState()` which calls `MemoryCueState.getEntries()` directly. 
- Removed the duplicate per-entry remapping that previously recreated `createdAt` during state load. 
- Updated `buildContext` to accept the already-sourced entries array and stopped normalizing entries twice. 
- Updated `askMemoryCue` to call `loadEntriesFromState()` and left the assistant API request/response and offline fallback logic intact.

### Testing
- Ran the test suite with `npm test -- --runInBand`. 
- Test run summary: 24 test suites total, 11 passed and 13 failed, with 58 tests passing and 22 failing. 
- Failures are pre-existing and unrelated to this change (notably ESM import parsing in several modules and some service-worker assertions), and the assistant-related tests exercised the updated loader without runtime errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b380d1e7b0832493a412937f9ed6dc)