### PR TITLE
Phase 3: unified UI shell and navigation architecture

### DIFF
--- a/assistant.js
+++ b/assistant.js
@@ -1,8 +1,10 @@
 /*
-LEGACY APP SHELL
-This code belongs to the older Memory Cue UI.
-It is not the primary runtime and should not be extended.
+LEGACY UI SHELL
+This file belongs to the previous Memory Cue interface.
+It should not be extended.
+All new UI work must occur in mobile.html.
 */
+
 (function () {
   const SCHEMA_VERSION = 2;
   const DEFAULT_MAX_ENTRIES = 50;

--- a/css/assistant.css
+++ b/css/assistant.css
@@ -1,0 +1,2 @@
+/* Phase 3 assistant scoped surface */
+#view-assistant .assistant-panel { min-height: 100%; }

--- a/css/components.css
+++ b/css/components.css
@@ -1,0 +1,32 @@
+/* Phase 3 component primitives */
+.btn-primary {
+  border: 1px solid color-mix(in srgb, var(--accent-color, #512663) 55%, #ffffff);
+  background: var(--accent-color, #512663);
+  color: #fff;
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.85rem;
+  font-weight: 600;
+}
+
+.btn-secondary {
+  border: 1px solid var(--card-border, #ddd);
+  background: #fff;
+  color: var(--text-main, #231B2E);
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.85rem;
+}
+
+.card-standard {
+  background: var(--card-bg, #fff);
+  border: 1px solid var(--card-border, #ddd);
+  border-radius: 1rem;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.05);
+}
+
+.input-standard {
+  width: 100%;
+  border: 1px solid var(--card-border, #ddd);
+  background: #fff;
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.75rem;
+}

--- a/css/layout.css
+++ b/css/layout.css
@@ -1,0 +1,3 @@
+/* Phase 3 layout shell */
+.view-panel.hidden { display: none !important; }
+#mobile-nav-shell .floating-footer { grid-template-columns: repeat(5, minmax(0, 1fr)); }

--- a/css/reminders.css
+++ b/css/reminders.css
@@ -1,0 +1,2 @@
+/* Phase 3 reminders view ownership */
+#view-reminders .reminders-mobile-flow { padding-bottom: calc(var(--mobile-bottom-nav-height, 96px) + 0.5rem); }

--- a/docs/UI_ARCHITECTURE.md
+++ b/docs/UI_ARCHITECTURE.md
@@ -1,0 +1,42 @@
+# UI Architecture (Phase 3)
+
+## Canonical runtime shell
+- `mobile.html` is the primary runtime shell for the app UI.
+- Legacy shell files are retained for reference only.
+
+## Navigation system
+- Single navigation runtime: `js/services/navigation-service.js`.
+- Navigation entrypoint: `navigationService.navigate(viewName)`.
+- Supported views:
+  - `capture`
+  - `reminders`
+  - `notes`
+  - `assistant`
+  - `settings`
+- `app:navigate` events are normalized into the same navigation service.
+
+## View structure
+- Views are identified by `data-view`.
+- The navigation service enforces one visible view at a time.
+- Bottom navigation buttons use `data-nav-target` and dispatch navigation.
+
+## Component system
+- Standard utility classes:
+  - `.btn-primary`
+  - `.btn-secondary`
+  - `.card-standard`
+  - `.input-standard`
+- DaisyUI utilities remain in place; shared custom overrides are centralized.
+
+## CSS organization
+- `css/layout.css`: shell/view layout rules.
+- `css/components.css`: shared components.
+- `css/reminders.css`: reminders-specific view styling.
+- `css/assistant.css`: assistant-specific view styling.
+- Existing inline CSS remains for compatibility and should be incrementally migrated.
+
+## Naming conventions
+- `notebook` UI naming standardized to `notes` at the view/navigation layer.
+- `universalInput` standardized to `captureInput`.
+- `quickAddInput` standardized to `reminderQuickAdd`.
+- New navigation and UI work should use standardized names only.

--- a/index.html
+++ b/index.html
@@ -1,8 +1,11 @@
 <!doctype html>
 <!--
-LEGACY APP SHELL
-This code belongs to the older Memory Cue UI.
-It is not the primary runtime and should not be extended.
+/*
+LEGACY UI SHELL
+This file belongs to the previous Memory Cue interface.
+It should not be extended.
+All new UI work must occur in mobile.html.
+*/
 -->
 <html lang="en">
   <head>

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -7,7 +7,7 @@
   const drawerSyncStatus = document.getElementById('mcStatusText');
   const drawerSyncDot = document.getElementById('mcStatus');
   const quickAddPanel = document.getElementById('quickAddBar');
-  const quickAddInputField = document.getElementById('quickAddInput');
+  const quickAddInputField = document.getElementById('reminderQuickAdd') || document.getElementById('quickAddInput');
   const quickAddSelector = '[data-open-quick-add]';
   let activeQuickAddTrigger = null;
   const isPersistentQuickAdd =
@@ -375,123 +375,38 @@
   }
 })();
 
-// Global navigation handler: treat 'new' as a dedicated view that shows the notebook and
-// prepares a new entry (focus/clear). This keeps the center tab as a navigable view.
-(function() {
-  const renderNotebookList = () => {
-    if (typeof window.renderNotebookList === 'function') {
-      window.renderNotebookList();
-    }
-  };
-
-  function showNotesView() {
-    showViewFor('notebook');
-    renderNotebookList();
-  }
-
-  function showAssistantView() {
-    showViewFor('assistant');
-  }
-
-  const views = {
-    capture: document.querySelector('[data-view="capture"]'),
-    reminders: document.querySelector('[data-view="reminders"]'),
-    notebook: document.querySelector('[data-view="notebook"]'),
-    notes: document.querySelector('[data-view="notebook"]'),
-    categories: document.querySelector('[data-view="categories"]'),
-    inbox: document.querySelector('[data-view="inbox"]'),
-    assistant: document.querySelector('[data-view="assistant"]')
-  };
-
-  const order = ['capture', 'reminders', 'new', 'notebook', 'notes', 'categories', 'inbox', 'assistant'];
-
+// Global navigation handler (Phase 3): use navigationService as the single view controller.
+(function () {
   const triggerReminderQuickAdd = window.triggerReminderQuickAdd || function triggerReminderQuickAdd() {
-    if (triggerReminderQuickAdd._locked) return;
-    triggerReminderQuickAdd._locked = true;
-    setTimeout(() => { triggerReminderQuickAdd._locked = false; }, 0);
-
     const quickAddTrigger =
       document.getElementById('mobile-footer-new-reminder') ||
       document.querySelector('[data-open-add-task]');
 
     if (quickAddTrigger) {
       const detail = { mode: 'create', trigger: quickAddTrigger };
-      try {
-        document.dispatchEvent(new CustomEvent('cue:prepare', { detail }));
-        document.dispatchEvent(new CustomEvent('cue:open', { detail }));
-        return;
-      } catch (e) {
-        console.warn('Failed to dispatch cue events for quick add', e);
-      }
+      document.dispatchEvent(new CustomEvent('cue:prepare', { detail }));
+      document.dispatchEvent(new CustomEvent('cue:open', { detail }));
+      return;
     }
 
-    const quickAdd = document.getElementById('quickAddInput') || document.getElementById('quickAdd');
+    const quickAdd = document.getElementById('reminderQuickAdd') || document.getElementById('quickAdd');
     if (quickAdd && typeof quickAdd.focus === 'function') quickAdd.focus();
   };
 
   window.triggerReminderQuickAdd = triggerReminderQuickAdd;
 
-  function showViewFor(name) {
-    // When navigating to 'new', we display the reminders view but keep the
-    // body/main active view set to 'new' so the bottom-tab can be highlighted.
-    const target = name === 'new' ? 'reminders' : name;
-    Object.keys(views).forEach((k) => {
-      const el = views[k];
-      if (!el) return;
-      const isActive = k === target;
-      el.classList.toggle('hidden', !isActive);
-      el.setAttribute('aria-hidden', String(!isActive));
-    });
+  window.addEventListener('app:navigate', (ev) => {
+    const view = ev?.detail?.view;
+    if (!view || !window.navigationService?.navigate) return;
+    const activeView = window.navigationService.navigate(view);
 
-    const main = document.getElementById('main') || document.querySelector('main');
-    if (main) {
-      main.setAttribute('data-active-view', name);
-      // Force padding for notebook view to avoid header overlap
-      if (name === 'notebook') {
-        // Use the CSS variable for the header height (default 112px) plus breathing room
-        const headerHeight = getComputedStyle(document.documentElement).getPropertyValue('--mobile-header-height').trim();
-        const heightVal = headerHeight ? headerHeight : '112px';
-        // We use calc in CSS, but here we set a safe inline style fallback
-        // If the variable is "112px", we want "calc(112px + 18px)"
-        main.style.setProperty('padding-top', `calc(${heightVal} + 18px)`, 'important');
-      } else {
-        const headerHeight = getComputedStyle(document.documentElement).getPropertyValue('--mobile-header-height').trim();
-        const heightVal = headerHeight ? headerHeight : '112px';
-        main.style.setProperty('padding-top', heightVal, 'important');
-      }
-    }
-    if (document.body) document.body.setAttribute('data-active-view', name);
-
-    // If this is the 'new' view, trigger the add reminder action so the
-    // quick-add UI is ready.
-    if (name === 'new') {
-      triggerReminderQuickAdd();
-    }
-
-    if (name === 'capture') {
-      const captureInput = document.getElementById('universalInput');
+    if (activeView === 'capture') {
+      const captureInput = document.getElementById('captureInput');
       if (captureInput && typeof captureInput.focus === 'function') captureInput.focus();
     }
-  }
 
-  window.addEventListener('app:navigate', (ev) => {
-    try {
-      const view = ev?.detail?.view;
-      if (!view || !order.includes(view)) return;
-      if (view === 'notes') {
-        showNotesView();
-        return;
-      }
-      if (view === 'assistant') {
-        showAssistantView();
-        return;
-      }
-      showViewFor(view);
-      if (view === 'notebook') {
-        renderNotebookList();
-      }
-    } catch (e) {
-      console.error('Error handling app:navigate', e);
+    if (activeView === 'notes' && typeof window.renderNotebookList === 'function') {
+      window.renderNotebookList();
     }
   });
 })();
@@ -557,7 +472,7 @@
         return;
       }
 
-      const quickAdd = document.getElementById('quickAddInput') || document.getElementById('quickAdd');
+      const quickAdd = document.getElementById('reminderQuickAdd') || document.getElementById('quickAddInput') || document.getElementById('quickAdd');
       if (quickAdd && typeof quickAdd.focus === 'function') {
         quickAdd.focus();
       }
@@ -581,10 +496,10 @@
   const navigateToNotebook = () => {
     window.dispatchEvent(
       new CustomEvent('app:navigate', {
-        detail: { view: 'notebook' }
+        detail: { view: 'notes' }
       })
     );
-    setActiveFooterIcon('mobile-footer-notebook');
+    setActiveFooterIcon('mobile-footer-notes');
     focusNotebookInputs();
     closeSavedNotesSheet();
   };
@@ -662,7 +577,7 @@
     closeFabMenu();
     setActiveFooterIcon(button.id);
 
-    if (view === 'notebook') {
+    if (view === 'notes') {
       navigateToNotebook();
       return;
     }

--- a/js/router.js
+++ b/js/router.js
@@ -1,135 +1,14 @@
-const groupedRoutes = new Set(['notes', 'resources', 'templates']);
+/*
+LEGACY HASH ROUTER (DEPRECATED)
+Phase 3 unified runtime navigation uses js/services/navigation-service.js.
+This file remains as a compatibility no-op for legacy shells.
+*/
 
-function renderRoute() {
-  const rawRoute = (window.location.hash || '#dashboard').replace('#', '');
-  const activeRoute = rawRoute === '' ? 'dashboard' : rawRoute;
-  const routeNodes = document.querySelectorAll('[data-route], [data-view]');
-  routeNodes.forEach((node) => {
-    const nodeRoute = node.dataset.route || node.dataset.view;
-    const isDashboardFallback = rawRoute === '' && nodeRoute === 'dashboard';
-    const shouldShow = isDashboardFallback || nodeRoute === activeRoute;
-
-    node.style.display = shouldShow ? '' : 'none';
-    node.hidden = !shouldShow;
-    node.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
-  });
-
-  document.querySelectorAll('[data-nav], [data-route]').forEach((link) => {
-    const linkRoute = link.dataset.nav || link.dataset.route;
-    const isActive = linkRoute === activeRoute;
-    link.classList.toggle('btn-active', isActive);
-    if (isActive) {
-      link.setAttribute('aria-current', 'page');
-    } else {
-      link.removeAttribute('aria-current');
-    }
-  });
-
-  const isGroupedRoute = groupedRoutes.has(activeRoute);
-  document.querySelectorAll('#nav-more-menu [data-nav], #nav-more-menu [data-route]').forEach((link) => {
-    const linkRoute = link.dataset.nav || link.dataset.route;
-    const isActive = linkRoute === activeRoute;
-    link.classList.toggle('btn-active', isActive);
-    if (isActive) {
-      link.setAttribute('aria-current', 'page');
-    } else {
-      link.removeAttribute('aria-current');
-    }
-  });
-
-  const moreSummary = document.querySelector('[data-nav-group="more"]');
-  const moreDetails = moreSummary ? moreSummary.closest('details') : null;
-  if (moreSummary && moreDetails) {
-    if (isGroupedRoute) {
-      moreDetails.setAttribute('open', '');
-    } else {
-      moreDetails.removeAttribute('open');
-    }
-    moreSummary.classList.toggle('btn-active', isGroupedRoute);
-    moreSummary.setAttribute('aria-expanded', moreDetails.open ? 'true' : 'false');
-    moreSummary.classList.toggle('more-active', moreDetails.open);
-  }
-
-}
-
-function initGroupedNavHandlers() {
-  const navMoreDetails = document.querySelector('.nav-more-details');
-  const navMoreSummary = document.querySelector('[data-nav-group="more"]');
-  if (navMoreDetails && navMoreSummary) {
-    navMoreSummary.setAttribute('aria-expanded', navMoreDetails.open ? 'true' : 'false');
-    navMoreSummary.classList.toggle('more-active', navMoreDetails.open);
-    navMoreDetails.addEventListener('toggle', () => {
-      navMoreSummary.setAttribute('aria-expanded', navMoreDetails.open ? 'true' : 'false');
-      navMoreSummary.classList.toggle('more-active', navMoreDetails.open);
-    });
-  }
-}
-
-function initMobileNavHandlers() {
-  const navMobileDetails = document.querySelector('.nav-mobile');
-  if (!navMobileDetails) {
-    return;
-  }
-
-  const navMobileSummary = navMobileDetails.querySelector('.nav-mobile-summary');
-  const syncExpanded = () => {
-    if (navMobileSummary) {
-      navMobileSummary.setAttribute('aria-expanded', navMobileDetails.open ? 'true' : 'false');
+(function () {
+  window.renderRoute = function renderRoute() {
+    if (window.navigationService && typeof window.navigationService.navigate === 'function') {
+      const current = document.body?.getAttribute('data-active-view') || 'capture';
+      window.navigationService.navigate(current);
     }
   };
-
-  syncExpanded();
-
-  navMobileDetails.addEventListener('toggle', syncExpanded);
-
-  const navMobileMoreDetails = navMobileDetails.querySelector('.nav-mobile-more');
-  if (navMobileMoreDetails) {
-    const navMobileMoreSummary = navMobileMoreDetails.querySelector('.nav-mobile-more-summary');
-    const syncMobileMoreExpanded = () => {
-      if (navMobileMoreSummary) {
-        navMobileMoreSummary.setAttribute('aria-expanded', navMobileMoreDetails.open ? 'true' : 'false');
-      }
-    };
-
-    syncMobileMoreExpanded();
-
-    navMobileMoreDetails.addEventListener('toggle', syncMobileMoreExpanded);
-
-    navMobileDetails.addEventListener('toggle', () => {
-      if (!navMobileDetails.open) {
-        navMobileMoreDetails.removeAttribute('open');
-        syncMobileMoreExpanded();
-      }
-    });
-
-    navMobileMoreDetails.querySelectorAll('[data-nav]').forEach((link) => {
-      link.addEventListener('click', () => {
-        navMobileMoreDetails.removeAttribute('open');
-        syncMobileMoreExpanded();
-      });
-    });
-  }
-
-  navMobileDetails.querySelectorAll('[data-nav]').forEach((link) => {
-    link.addEventListener('click', () => {
-      navMobileDetails.removeAttribute('open');
-      syncExpanded();
-    });
-  });
-}
-
-function initRouter() {
-  initGroupedNavHandlers();
-  initMobileNavHandlers();
-  renderRoute();
-}
-
-window.renderRoute = renderRoute;
-
-window.addEventListener('hashchange', renderRoute);
-
-if (document.readyState === 'loading') {
-  window.addEventListener('DOMContentLoaded', initRouter, { once: true });
-} else {
-  initRouter();
-}
+})();

--- a/js/services/navigation-service.js
+++ b/js/services/navigation-service.js
@@ -1,0 +1,64 @@
+(function () {
+  const VIEW_ORDER = ['capture', 'reminders', 'notes', 'assistant', 'settings'];
+
+  const normalizeViewName = (name) => {
+    if (!name) return 'capture';
+    const value = String(name).toLowerCase();
+    if (value === 'notebook') return 'notes';
+    return value;
+  };
+
+  const getViewNodes = () => {
+    const nodes = Array.from(document.querySelectorAll('[data-view]'));
+    return nodes.filter((node) => VIEW_ORDER.includes(normalizeViewName(node.dataset.view)));
+  };
+
+  const updateActiveNav = (viewName) => {
+    document.querySelectorAll('[data-nav-target]').forEach((button) => {
+      const target = normalizeViewName(button.getAttribute('data-nav-target'));
+      const active = target === viewName;
+      button.classList.toggle('active', active);
+      button.setAttribute('aria-current', active ? 'page' : 'false');
+    });
+  };
+
+  const navigate = (requestedViewName) => {
+    const viewName = normalizeViewName(requestedViewName);
+    const viewNodes = getViewNodes();
+
+    viewNodes.forEach((node) => {
+      const nodeView = normalizeViewName(node.dataset.view);
+      const isActive = nodeView === viewName;
+      node.classList.toggle('hidden', !isActive);
+      node.hidden = !isActive;
+      node.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+    });
+
+    document.body?.setAttribute('data-active-view', viewName);
+    document.getElementById('main')?.setAttribute('data-active-view', viewName);
+    updateActiveNav(viewName);
+
+    window.dispatchEvent(new CustomEvent('memorycue:navigation:changed', { detail: { view: viewName } }));
+    return viewName;
+  };
+
+  const navigationService = { navigate, VIEW_ORDER: [...VIEW_ORDER] };
+  window.navigationService = navigationService;
+
+  window.addEventListener('app:navigate', (event) => {
+    const view = event?.detail?.view;
+    if (!view) return;
+    navigate(view);
+  });
+
+  const init = () => {
+    const initial = document.querySelector('[data-nav-target].active')?.getAttribute('data-nav-target') || 'capture';
+    navigate(initial);
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+})();

--- a/mobile.html
+++ b/mobile.html
@@ -1,4 +1,13 @@
 <!DOCTYPE html>
+<!--
+/*
+Memory Cue Primary Runtime Shell
+All UI development should occur here.
+Legacy shells remain for reference only.
+*/
+-->
+
+
 <html lang="en" data-theme="light" class="h-full">
 <head>
   <!-- === SUPABASE CONFIG (put before your main JS) === -->
@@ -11,6 +20,10 @@
   <!-- Production CSS: compiled via Tailwind/PostCSS; build rewrites this to a hashed asset -->
   <link rel="stylesheet" href="./styles/index.css" />
   <link rel="stylesheet" href="./mobile.css" />
+  <link rel="stylesheet" href="./css/layout.css" />
+  <link rel="stylesheet" href="./css/components.css" />
+  <link rel="stylesheet" href="./css/reminders.css" />
+  <link rel="stylesheet" href="./css/assistant.css" />
   <style>
     :root {
       --card-bg: color-mix(in srgb, #ffffff 92%, #f8f4ec 8%); /* off-white card surface */
@@ -108,8 +121,8 @@
       box-shadow: 0 5px 14px rgba(81, 38, 99, 0.06);
     }
 
-    .reminders-quick-bar input#universalInput,
-    .reminders-quick-bar input#quickAddInput {
+    .reminders-quick-bar input#captureInput,
+    .reminders-quick-bar input#reminderQuickAdd {
       flex: 1 1 auto;
       min-width: 0;
       border: none;
@@ -119,8 +132,8 @@
       padding: 0.3rem 0.2rem;
     }
 
-    .reminders-quick-bar input#universalInput::placeholder,
-    .reminders-quick-bar input#quickAddInput::placeholder {
+    .reminders-quick-bar input#captureInput::placeholder,
+    .reminders-quick-bar input#reminderQuickAdd::placeholder {
       color: var(--text-muted);
     }
 
@@ -418,26 +431,26 @@
     padding-right: 0;
   }
 
-  body[data-active-view="notebook"] .container {
+  body[data-active-view="notes"] .container {
     max-width: none;
     margin: 0;
     padding: 0;
   }
 
-  body[data-active-view="notebook"] #main {
+  body[data-active-view="notes"] #main {
     max-width: none;
     margin: 0;
     padding-bottom: calc(var(--mobile-bottom-nav-height, 80px) + 8px);
   }
 
   /* Ensure notebook content sits comfortably beneath the header */
-  body[data-active-view="notebook"] #main {
+  body[data-active-view="notes"] #main {
     /* Use the variable set by JS, with a safe fallback and extra breathing room */
     padding-top: calc(var(--mobile-header-height, 112px) + 18px) !important;
     margin-top: 0 !important;
   }
 
-  body[data-active-view="notebook"] #view-notebook .card-body {
+  body[data-active-view="notes"] #view-notebook .card-body {
     margin-top: 0 !important;
   }
 
@@ -466,11 +479,11 @@
     display: none !important;
   }
 
-  body[data-active-view="notebook"] #view-notebook {
+  body[data-active-view="notes"] #view-notebook {
     background: #ffffff;
   }
 
-  body[data-active-view="notebook"] #view-notebook .card {
+  body[data-active-view="notes"] #view-notebook .card {
     margin: 0;
     border: none;
     border-radius: 0;
@@ -487,12 +500,12 @@
     background: #ffffff;
   }
 
-  [data-view="notebook"] .textarea {
+  [data-view="notes"] .textarea {
     min-height: 0 !important;
   }
 
   /* Notebook: no extra top padding from card-body */
-body[data-active-view="notebook"] #view-notebook .card-body {
+body[data-active-view="notes"] #view-notebook .card-body {
   padding: 0rem 0.75rem 0.6rem;
   margin-top: 0 !important;
   min-height: auto;
@@ -1814,8 +1827,8 @@ body[data-active-view="notebook"] #view-notebook .card-body {
       overflow: hidden;
     }
 
-    .reminders-quick-bar #universalInput,
-    .reminders-quick-bar #quickAddInput {
+    .reminders-quick-bar #captureInput,
+    .reminders-quick-bar #reminderQuickAdd {
       flex: 1;
       min-width: 0;
       border: none;
@@ -1902,7 +1915,7 @@ body[data-active-view="notebook"] #view-notebook .card-body {
   overflow: hidden;
 }
 
-#universalInput, #quickAddInput {
+#captureInput, #reminderQuickAdd {
   flex: 1;
   min-width: 0;
   border: none;
@@ -2004,7 +2017,7 @@ body {
 }
 
 /* Quick-add input */
-#universalInput, #quickAddInput {
+#captureInput, #reminderQuickAdd {
   color: #000 !important;
   font-weight: 500;
   letter-spacing: -0.01em;
@@ -2069,7 +2082,7 @@ body, main, section, div, p, span, li {
 }
 
 /* 5) Quick reminder input in header */
-#universalInput, #quickAddInput {
+#captureInput, #reminderQuickAdd {
   color: #000000 !important;
   font-weight: 500;
   letter-spacing: -0.01em;
@@ -2996,7 +3009,7 @@ body, main, section, div, p, span, li {
       color: var(--text-primary);
     }
 
-    #assistantView {
+    #view-assistant {
       align-content: start;
       display: flex;
       flex-direction: column;
@@ -3870,13 +3883,13 @@ body, main, section, div, p, span, li {
   </style>
  <style>
   /* 1. Match the page padding to the header so content starts just below it */
-  body[data-active-view="notebook"] #main {
+  body[data-active-view="notes"] #main {
     padding-top: calc(var(--mobile-header-height, 112px) + 18px) !important;
     margin-top: 0 !important; /* Keep content immediately below the header */
   }
 
   /* 2. Strip inner layout padding */
-  body[data-active-view="notebook"] .mobile-view-inner {
+  body[data-active-view="notes"] .mobile-view-inner {
     padding: 0 !important;
     margin: 0 !important;
     width: 100% !important;
@@ -3884,7 +3897,7 @@ body, main, section, div, p, span, li {
   }
 
   /* 3. Card Reset: Full width, no shadow, no rounded corners */
-  body[data-active-view="notebook"] #scratch-notes-card {
+  body[data-active-view="notes"] #scratch-notes-card {
     padding: 0 !important;
     margin: 0 !important;
     border-radius: 0 !important;
@@ -3894,7 +3907,7 @@ body, main, section, div, p, span, li {
   }
 
   /* 4. Remove internal card padding so Title touches the top */
-  body[data-active-view="notebook"] .note-editor-card {
+  body[data-active-view="notes"] .note-editor-card {
     padding-top: 4px !important; /* Tiny breathing room only */
     padding-left: 16px !important;
     padding-right: 16px !important;
@@ -4746,6 +4759,7 @@ body, main, section, div, p, span, li {
     </div>
   </aside>
 
+  <script defer src="./js/services/navigation-service.js"></script>
   <script defer src="./js/navigation.js"></script>
   <script defer src="./js/entries.js"></script>
   <script defer src="./js/ui.js"></script>
@@ -4765,30 +4779,6 @@ body, main, section, div, p, span, li {
       </button>
       <button id="overflowMenuBtn" type="button" class="menu icon-button control-icon-button" aria-haspopup="true" aria-expanded="false" aria-controls="overflowMenu" aria-label="Open menu">☰</button>
     <div id="overflowMenu" class="overflow-menu quick-actions-panel hidden" role="menu" aria-hidden="true">
-        <!-- Reminders -->
-        <div class="overflow-menu-section">
-          <div class="overflow-menu-section-label">Reminders</div>
-          <button
-            type="button"
-            id="menuShowCompleted"
-            class="overflow-menu-item"
-            data-menu-action="completed"
-          >
-            Completed reminders
-          </button>
-          <button
-            type="button"
-            id="viewToggleMenu"
-            class="overflow-menu-item"
-            aria-pressed="false"
-            aria-live="polite"
-            data-layout="list"
-          >
-            <span id="viewToggleLabel">View layout: Stacked</span>
-          </button>
-        </div>
-
-        <!-- Settings / App -->
         <div class="overflow-menu-section">
           <div class="overflow-menu-section-label">App</div>
           <button
@@ -4855,24 +4845,6 @@ body, main, section, div, p, span, li {
             Pro dark
           </button>
         </div>
-
-        <div class="overflow-menu-section" aria-label="Layout">
-          <p class="overflow-menu-section-label">Layout</p>
-          <button
-            type="button"
-            class="overflow-menu-item"
-            data-menu-action="layout-cozy"
-          >
-            Cozy
-          </button>
-          <button
-            type="button"
-            class="overflow-menu-item"
-            data-menu-action="layout-compact"
-          >
-            Compact
-          </button>
-        </div>
       </div>
   </header>
 
@@ -4890,9 +4862,9 @@ body, main, section, div, p, span, li {
       <div class="space-y-3">
         <h2 class="text-lg font-semibold">Capture</h2>
         <form id="quickAddForm" class="space-y-2">
-          <label for="universalInput" class="sr-only">Capture something</label>
+          <label for="captureInput" class="sr-only">Capture something</label>
           <input
-            id="universalInput"
+            id="captureInput"
             class="control-input quick-add-input w-full"
             type="text"
             placeholder="Capture something..."
@@ -4962,7 +4934,7 @@ body, main, section, div, p, span, li {
     <!-- BEGIN GPT CHANGE: notebook view -->
     <div id="notesView" class="view hidden" aria-hidden="true"></div>
 
-    <section data-view="notebook" id="view-notebook" class="view-panel hidden mobile-panel--notes mobile-panel--notes-size-small">
+    <section data-view="notes" id="view-notebook" class="view-panel hidden mobile-panel--notes mobile-panel--notes-size-small">
         <div class="mobile-view-inner mx-auto w-full px-0 pt-2 pb-2 space-y-0" style="padding: 0 !important; max-width: 100%;">
         <!-- notebook view header removed to keep UI minimal -->
         <!-- Enhanced Notebook Card -->
@@ -5339,7 +5311,7 @@ body, main, section, div, p, span, li {
                 <button type="button" class="note-action-btn note-action-delete">Delete note</button>
               </div>
             </div>
-    <section data-view="assistant" id="assistantView" class="view hidden" aria-hidden="true">
+    <section data-view="assistant" id="view-assistant" class="view hidden" aria-hidden="true">
       <div class="assistant-panel">
         <div id="thinkingBarStatus" class="hidden" aria-live="polite"></div>
         <div id="thinkingBarResults" aria-live="polite"></div>
@@ -5365,6 +5337,14 @@ body, main, section, div, p, span, li {
             </div>
           </div>
         </div>
+      </div>
+    </section>
+
+    <section data-view="settings" id="view-settings" class="view-panel hidden" aria-hidden="true">
+      <div class="space-y-3">
+        <h2 class="text-lg font-semibold">Settings</h2>
+        <p class="text-sm text-base-content/70">Manage account, theme, and sync preferences.</p>
+        <button type="button" id="settingsOpenFromView" class="btn-primary" data-menu-action="settings">Open settings panel</button>
       </div>
     </section>
 
@@ -5444,14 +5424,14 @@ body, main, section, div, p, span, li {
 
       <button
         type="button"
-        class="floating-card btn-notebook"
-        id="mobile-footer-notebook"
-        data-nav-target="notebook"
-        data-tab="notebook"
+        class="floating-card btn-notes"
+        id="mobile-footer-notes"
+        data-nav-target="notes"
+        data-tab="notes"
         aria-label="Go to Notes"
       >
         <svg
-          class="icon icon-notebook"
+          class="icon icon-notes"
           width="20"
           height="20"
           viewBox="0 0 24 24"
@@ -5468,6 +5448,18 @@ body, main, section, div, p, span, li {
           <path d="M9 15.5h4" />
         </svg>
         <span>Notes</span>
+      </button>
+
+
+      <button
+        type="button"
+        class="floating-card btn-settings"
+        id="mobile-footer-settings"
+        data-nav-target="settings"
+        data-tab="settings"
+        aria-label="Go to Settings"
+      >
+        <span>Settings</span>
       </button>
 
       <button
@@ -5555,7 +5547,7 @@ body, main, section, div, p, span, li {
             return;
           }
 
-          const quickAdd = document.getElementById('universalInput') || document.getElementById('quickAddInput') || document.getElementById('quickAdd');
+          const quickAdd = document.getElementById('captureInput') || document.getElementById('reminderQuickAdd') || document.getElementById('quickAdd');
           if (quickAdd && typeof quickAdd.focus === 'function') {
             quickAdd.focus();
           }
@@ -5624,7 +5616,7 @@ body, main, section, div, p, span, li {
         if (action === 'new-note') {
           window.dispatchEvent(
             new CustomEvent('app:navigate', {
-              detail: { view: 'notebook' }
+              detail: { view: 'notes' }
             })
           );
           closeSavedNotesSheet();
@@ -5654,7 +5646,8 @@ body, main, section, div, p, span, li {
         const routeMap = {
           capture: 'capture',
           reminders: 'reminders',
-          notebook: 'notebook',
+          notes: 'notes',
+          settings: 'settings',
           assistant: 'assistant'
         };
 
@@ -6453,7 +6446,7 @@ body, main, section, div, p, span, li {
       overflow: hidden;
     }
 
-    #universalInput, #quickAddInput {
+    #captureInput, #reminderQuickAdd {
       flex: 1;
       min-width: 0;
       border: none;
@@ -6471,10 +6464,10 @@ body, main, section, div, p, span, li {
         0 4px 10px rgba(15, 10, 41, 0.08);
     }
 
-    #universalInput:focus,
-    #universalInput:focus-visible,
-    #quickAddInput:focus,
-    #quickAddInput:focus-visible {
+    #captureInput:focus,
+    #captureInput:focus-visible,
+    #reminderQuickAdd:focus,
+    #reminderQuickAdd:focus-visible {
       background: color-mix(in srgb, var(--accent-color) 7%, transparent);
     }
 

--- a/mobile.js
+++ b/mobile.js
@@ -46,12 +46,12 @@ function initAssistant() {
     const assistantThread = document.getElementById('assistantMessages') || document.getElementById('assistantThread');
     const assistantLoading = document.getElementById('assistantLoading');
     const thinkingBarInput = document.getElementById('thinkingBarInput')
-      || document.getElementById('universalInput')
-      || document.getElementById('quickAddInput');
-    const universalInput = document.getElementById('universalInput')
-      || document.getElementById('quickAddInput')
+      || document.getElementById('captureInput') || document.getElementById('universalInput')
+      || document.getElementById('reminderQuickAdd') || document.getElementById('quickAddInput');
+    const universalInput = document.getElementById('captureInput') || document.getElementById('universalInput')
+      || document.getElementById('reminderQuickAdd') || document.getElementById('quickAddInput')
       || thinkingBarInput;
-    if (isInputElement(universalInput) && !document.getElementById('quickAddInput')) {
+    if (isInputElement(universalInput) && (!document.getElementById('reminderQuickAdd') || document.getElementById('quickAddInput'))) {
       universalInput.setAttribute('data-legacy-input', 'quickAddInput');
     }
     const quickAddForm = document.getElementById('quickAddForm');
@@ -1822,7 +1822,7 @@ const initMobileNotes = () => {
       hideSavedNotesSheet();
     }
 
-    document.dispatchEvent(new CustomEvent('app:navigate', { detail: { view: 'notebook' } }));
+    document.dispatchEvent(new CustomEvent('app:navigate', { detail: { view: 'notes' } }));
   };
 
   document.addEventListener('thinkingBar:openNote', (event) => {

--- a/state.js
+++ b/state.js
@@ -1,8 +1,10 @@
 /*
-LEGACY APP SHELL
-This code belongs to the older Memory Cue UI.
-It is not the primary runtime and should not be extended.
+LEGACY UI SHELL
+This file belongs to the previous Memory Cue interface.
+It should not be extended.
+All new UI work must occur in mobile.html.
 */
+
 (function () {
   const STORAGE_KEY = 'memoryCueState';
   const SCHEMA_VERSION = 1;

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,10 @@
+/*
+LEGACY UI SHELL
+This file belongs to the previous Memory Cue interface.
+It should not be extended.
+All new UI work must occur in mobile.html.
+*/
+
 :root {
   --bg: #0b1220;
   --card: #101a2f;


### PR DESCRIPTION
### Motivation
- Consolidate multiple UI shells and overlapping navigation systems into a single canonical runtime to reduce duplication and confusion.  
- Provide one view-based navigation controller to make view switching predictable and centrally managed.  
- Standardize view and input naming to simplify cross-module references and future UI work.

### Description
- Declare `mobile.html` as the canonical runtime shell by adding a top banner comment and wiring in structured CSS files `css/layout.css`, `css/components.css`, `css/reminders.css`, and `css/assistant.css`.  
- Add a new navigation controller `js/services/navigation-service.js` exposing `navigationService.navigate(viewName)` which normalizes view names, shows one `data-view` at a time, updates bottom-nav active state, and dispatches `memorycue:navigation:changed`.  
- Migrate mobile runtime wiring to use the navigation service: update `js/navigation.js` to dispatch/consume `app:navigate` via the service and focus inputs on view change, and replace/deprecate the hash router in `js/router.js` with a compatibility no-op.  
- Standardize naming and view IDs in `mobile.html` and code: `notebook` → `notes`, `universalInput` → `captureInput`, `quickAddInput` → `reminderQuickAdd`, add a `settings` view and bottom-nav item, and simplify the overflow menu to app/account/theme/sync actions.  
- Add component primitives (`.btn-primary`, `.btn-secondary`, `.card-standard`, `.input-standard`) in `css/components.css` and document the new UI architecture in `docs/UI_ARCHITECTURE.md`.

### Testing
- Ran quick syntax checks for navigation-related scripts with `node -c js/navigation.js && node -c js/router.js && node -c js/services/navigation-service.js`, which succeeded.  
- Ran the project test suite with `npm test -- --runInBand`; the run completed but many unrelated pre-existing test failures were reported (module-loading and service-worker tests); navigation-specific changes did not introduce syntax errors.  
- Launched the app locally with `npm start` and loaded `mobile.html` in a headless browser to verify the shell renders and bottom navigation exists; a screenshot was captured from the running server to confirm the runtime shell and nav (artifact available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3ae8d839883249b8f5dcc1ed50a40)