### PR TITLE
UI improvement: simplified capture screen

### DIFF
--- a/css/capture.css
+++ b/css/capture.css
@@ -1,0 +1,78 @@
+#view-capture {
+  display: flex;
+  justify-content: center;
+  padding: 1rem 0.75rem 1.5rem;
+}
+
+.capture-container {
+  width: 100%;
+  max-width: 38rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.1rem;
+  border-radius: 1rem;
+  background: var(--card-bg, #ffffff);
+  border: 1px solid var(--card-border, #e5e7eb);
+  box-shadow: 0 10px 26px rgba(35, 27, 46, 0.08);
+}
+
+.capture-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.capture-input {
+  width: 100%;
+  min-height: 8.5rem;
+  padding: 1rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid color-mix(in srgb, var(--card-border, #d1d5db) 80%, #ffffff 20%);
+  background: var(--surface-elevated, #f9fafb);
+  color: var(--text-main, #1f2937);
+  font-size: 1rem;
+  line-height: 1.45;
+  resize: vertical;
+}
+
+.capture-input::placeholder {
+  color: var(--text-muted, #6b7280);
+}
+
+.capture-input:focus,
+.capture-input:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent-color, #512663) 45%, transparent);
+  outline-offset: 1px;
+  border-color: color-mix(in srgb, var(--accent-color, #512663) 45%, #d1d5db);
+}
+
+.capture-save-btn {
+  align-self: flex-start;
+  min-width: 7rem;
+}
+
+.capture-recent {
+  margin-top: 0.25rem;
+  padding-top: 0.4rem;
+  border-top: 1px solid color-mix(in srgb, var(--card-border, #e5e7eb) 75%, transparent);
+}
+
+.capture-recent-list {
+  margin-top: 0.55rem;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: var(--text-body, #4b5563);
+}
+
+.capture-recent-list li {
+  list-style: disc;
+}
+
+.capture-recent-empty {
+  list-style: none;
+  color: var(--text-muted, #6b7280);
+  margin-left: -1.1rem;
+}

--- a/mobile.html
+++ b/mobile.html
@@ -23,6 +23,7 @@ Legacy shells remain for reference only.
   <link rel="stylesheet" href="./mobile.css" />
   <link rel="stylesheet" href="./css/layout.css" />
   <link rel="stylesheet" href="./css/components.css" />
+  <link rel="stylesheet" href="./css/capture.css" />
   <link rel="stylesheet" href="./css/reminders.css" />
   <link rel="stylesheet" href="./css/assistant.css" />
   <style>
@@ -4842,21 +4843,23 @@ body, main, section, div, p, span, li {
     <!-- BEGIN GPT CHANGE: create form moved to bottom sheet -->
     <!-- END GPT CHANGE -->
     <section data-view="capture" id="view-capture" class="view-panel">
-      <div class="space-y-3">
+      <div class="capture-container">
         <h2 class="text-lg font-semibold">Capture</h2>
-        <form id="quickAddForm" class="space-y-2">
+        <form id="captureForm" class="capture-form">
           <label for="captureInput" class="sr-only">Capture something</label>
-          <input
+          <textarea
             id="captureInput"
-            class="control-input quick-add-input w-full"
-            type="text"
-            placeholder="Capture something..."
+            class="capture-input"
+            placeholder="Type anything you want to remember..."
             autocomplete="off"
-          />
-          <button id="sendBtn" type="submit" class="smart-send-button" aria-label="Save">Save</button>
-          <span id="quickAddParsingIndicator" class="text-xs text-base-content/70" hidden>Saving…</span>
-          <span id="quickAddSuccessIndicator" class="text-xs text-success" role="status" aria-live="polite" hidden>Saved ✓</span>
+            rows="4"
+          ></textarea>
+          <button id="captureSaveBtn" type="submit" class="btn btn-primary capture-save-btn" aria-label="Save">Save</button>
         </form>
+        <section class="capture-recent" aria-labelledby="captureRecentHeading">
+          <h3 id="captureRecentHeading" class="text-sm font-semibold">Recent Captures</h3>
+          <ul id="recentCapturesList" class="capture-recent-list" aria-live="polite"></ul>
+        </section>
       </div>
     </section>
     <!-- BEGIN GPT CHANGE: reminders view -->

--- a/mobile.js
+++ b/mobile.js
@@ -40,10 +40,15 @@ function initAssistant() {
       typeof HTMLFormElement !== 'undefined'
         ? value instanceof HTMLFormElement
         : value && value.tagName === 'FORM';
-    const isInputElement = (value) =>
-      typeof HTMLInputElement !== 'undefined'
-        ? value instanceof HTMLInputElement
-        : value && value.tagName === 'INPUT';
+    const isTextEntryElement = (value) => {
+      if (typeof HTMLInputElement !== 'undefined' && value instanceof HTMLInputElement) {
+        return true;
+      }
+      if (typeof HTMLTextAreaElement !== 'undefined' && value instanceof HTMLTextAreaElement) {
+        return true;
+      }
+      return Boolean(value && (value.tagName === 'INPUT' || value.tagName === 'TEXTAREA'));
+    };
     const assistantThread = document.getElementById('assistantMessages') || document.getElementById('assistantThread');
     const assistantLoading = document.getElementById('assistantLoading');
     const thinkingBarInput = document.getElementById('thinkingBarInput')
@@ -52,7 +57,8 @@ function initAssistant() {
     const captureInputField = document.getElementById('captureInput')
       || document.getElementById('reminderQuickAdd')
       || thinkingBarInput;
-    const quickAddForm = document.getElementById('quickAddForm');
+    const captureForm = document.getElementById('captureForm');
+    const recentCapturesList = document.getElementById('recentCapturesList');
     const thinkingBarStatus = document.getElementById('thinkingBarStatus');
     const thinkingBarResults = document.getElementById('thinkingBarResults');
     const weeklyReflectionCard = document.getElementById('weeklyReflectionCard');
@@ -66,7 +72,7 @@ function initAssistant() {
     let latestThinkingSearchRequest = 0;
     const assistantConversationHistory = [];
 
-    if (!isInputElement(thinkingBarInput) || !(assistantThread instanceof HTMLElement)) {
+    if (!isTextEntryElement(thinkingBarInput) || !(assistantThread instanceof HTMLElement)) {
       return;
     }
 
@@ -477,7 +483,7 @@ function initAssistant() {
     const getActiveView = () => document.body?.getAttribute('data-active-view') || '';
 
     const syncInboxSearchInput = () => {
-      if (!isInputElement(captureInputField)) {
+      if (!isTextEntryElement(captureInputField)) {
         return;
       }
       document.dispatchEvent(new CustomEvent('memoryCue:universalSearch', {
@@ -599,6 +605,59 @@ function initAssistant() {
 
       renderSearchResults(query);
     });
+
+    const renderRecentCaptures = () => {
+      if (!(recentCapturesList instanceof HTMLElement)) {
+        return;
+      }
+
+      const entries = getInboxEntries()
+        .slice(0, 5)
+        .map((entry) => (typeof entry?.text === 'string' ? entry.text.trim() : ''))
+        .filter(Boolean);
+
+      recentCapturesList.innerHTML = '';
+
+      if (!entries.length) {
+        const emptyItem = document.createElement('li');
+        emptyItem.className = 'capture-recent-empty';
+        emptyItem.textContent = 'No captures yet.';
+        recentCapturesList.appendChild(emptyItem);
+        return;
+      }
+
+      entries.forEach((text) => {
+        const item = document.createElement('li');
+        item.textContent = text;
+        recentCapturesList.appendChild(item);
+      });
+    };
+
+    captureForm?.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      if (!isTextEntryElement(captureInputField) || isAssistantSending) {
+        return;
+      }
+
+      const message = typeof captureInputField.value === 'string' ? captureInputField.value.trim() : '';
+      if (!message) {
+        return;
+      }
+
+      isAssistantSending = true;
+      try {
+        await captureInput(message, 'capture');
+        captureInputField.value = '';
+        renderRecentCaptures();
+      } catch (error) {
+        console.error('[capture] failed to save capture', error);
+      } finally {
+        isAssistantSending = false;
+      }
+    });
+
+    document.addEventListener('memoryCue:entriesUpdated', renderRecentCaptures);
+    renderRecentCaptures();
 
 
     if (weeklyReflectionButton instanceof HTMLElement) {


### PR DESCRIPTION
### Motivation
- Make quick capture the primary, focused action on the Capture screen by removing extra UI clutter and surface only the essentials. 
- Emphasise the capture input visually so users can quickly add items without changing the existing capture architecture.

### Description
- Added `css/capture.css` to provide a centered card layout (`.capture-container`), prominent textarea styling (`.capture-input`), and recent-captures list styles (`.capture-recent` / `.capture-recent-list`).
- Updated `mobile.html` to simplify the Capture view: replaced the inline quick input with a textarea, added a `Save` button (`#captureSaveBtn`) and a `Recent Captures` section with `#recentCapturesList`, and linked the new stylesheet.
- Updated `mobile.js` to accept textarea inputs by introducing `isTextEntryElement`, wired the new `captureForm` submit handler to call the existing `captureInput(...)` service, and added `renderRecentCaptures` which displays the 5 most recent inbox entries and listens for `memoryCue:entriesUpdated` to keep the list in sync.
- Preserved existing capture logic and services (no changes to `js/services/capture-service.js`) and retained DaisyUI button classes for visual consistency.

### Testing
- Ran `npm run build`, which completed successfully.
- Ran `npm test -- --runInBand`, which executed the project's test suite but reported failures; the failing suites appear to be unrelated baseline issues in the repository (ESM/CJS vm-loading expectations and service-worker tests) and not caused by the UI changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3c72851c88324b8e72fe3eee35b7d)