### PR TITLE
UI improvement: structured reminders layout

### DIFF
--- a/css/reminders-ui.css
+++ b/css/reminders-ui.css
@@ -1,0 +1,101 @@
+/* Reminders screen layout and visual hierarchy */
+
+.reminders-screen-controls {
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.reminders-quick-add-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.5rem;
+}
+
+.reminders-quick-add-input {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--card-border) 72%, transparent);
+  border-radius: 0.8rem;
+  background: var(--surface-elevated);
+  color: var(--text-main);
+}
+
+.reminders-top-controls-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.reminders-tabs {
+  display: inline-flex;
+  gap: 0.35rem;
+  overflow-x: auto;
+}
+
+.reminders-sort-btn {
+  border: 1px solid color-mix(in srgb, var(--card-border) 72%, transparent);
+  background: var(--surface-elevated);
+  color: var(--text-main);
+  border-radius: 0.8rem;
+  padding: 0.45rem 0.75rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+#reminderList {
+  display: grid;
+  grid-template-columns: 1fr !important;
+  gap: 0.5rem !important;
+}
+
+.reminder-group-heading {
+  margin-top: 0.25rem;
+}
+
+.reminder-group-heading-label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 700;
+  color: var(--text-secondary);
+}
+
+#view-reminders .reminder-row {
+  border-radius: 0.9rem;
+  border: 1px solid color-mix(in srgb, var(--card-border) 72%, transparent);
+  background: var(--surface-elevated);
+  padding: 0.75rem;
+}
+
+#view-reminders .reminder-row-main {
+  gap: 0.3rem;
+}
+
+#view-reminders .reminder-row-title {
+  font-weight: 600;
+  color: var(--text-main);
+}
+
+#view-reminders .reminder-row-meta {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+#view-reminders .reminder-overdue {
+  border-color: color-mix(in srgb, #c92828 55%, var(--card-border));
+  background: color-mix(in srgb, #fff2f2 70%, var(--surface-elevated));
+}
+
+#view-reminders .reminder-overdue .reminder-row-meta {
+  color: #a61d24;
+}
+
+#view-reminders .reminder-today {
+  border-color: color-mix(in srgb, var(--accent-color) 30%, var(--card-border));
+}
+
+#view-reminders .reminder-upcoming {
+  border-color: color-mix(in srgb, #94a3b8 30%, var(--card-border));
+}

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -5555,7 +5555,6 @@ export async function initReminders(sel = {}) {
       itemEl.setAttribute('role', 'button');
       itemEl.tabIndex = 0;
       itemEl.setAttribute('aria-label', `Edit reminder: ${reminderTitle}`);
-      attachReminderLongPress(itemEl, reminder);
 
       applyPriorityTokensToCard(itemEl, summary.priority);
 
@@ -5667,18 +5666,28 @@ export async function initReminders(sel = {}) {
         titleWrapper.appendChild(titleToggle);
         rowMain.appendChild(titleWrapper);
 
-        const metaParts = [dueLabel, summary.category].filter(Boolean);
-        if (metaParts.length) {
-          const metaText = document.createElement('div');
-          metaText.className = 'reminder-meta reminder-date reminder-row-meta';
-          metaText.textContent = metaParts.join(' • ');
-          rowMain.appendChild(metaText);
+        if (dueLabel) {
+          const dueLine = document.createElement('div');
+          dueLine.className = 'reminder-meta reminder-date reminder-row-meta';
+          dueLine.textContent = `Due: ${dueLabel}`;
+          rowMain.appendChild(dueLine);
+        }
+
+        if (summary.category && summary.category !== DEFAULT_CATEGORY) {
+          const categoryLine = document.createElement('div');
+          categoryLine.className = 'reminder-meta reminder-category reminder-row-meta';
+          categoryLine.textContent = `Category: ${summary.category}`;
+          rowMain.appendChild(categoryLine);
         }
 
         if (summary.done) {
           itemEl.classList.add('reminder-row-completed');
         } else if (dueDate && dueDate < now) {
-          itemEl.classList.add('reminder-row-overdue');
+          itemEl.classList.add('reminder-row-overdue', 'reminder-overdue');
+        } else if (dueIsToday) {
+          itemEl.classList.add('reminder-today');
+        } else {
+          itemEl.classList.add('reminder-upcoming');
         }
 
         itemEl.append(cardCheckbox, rowMain);
@@ -5803,6 +5812,9 @@ export async function initReminders(sel = {}) {
     }
 
     const resolveDueDateGroup = (reminder) => {
+      if (reminder?.done) {
+        return 'COMPLETED';
+      }
       const dueDate = reminder?.due ? new Date(reminder.due) : null;
       if (dueDate && dueDate >= t0 && dueDate <= t1) {
         return 'TODAY';
@@ -5813,10 +5825,18 @@ export async function initReminders(sel = {}) {
     const grouped = new Map([
       ['TODAY', []],
       ['UPCOMING', []],
+      ['COMPLETED', []],
     ]);
     rows.forEach((r) => {
       grouped.get(resolveDueDateGroup(r)).push(r);
     });
+
+    const labelMap = {
+      TODAY: 'Today',
+      UPCOMING: 'Upcoming',
+      COMPLETED: 'Completed',
+    };
+
     const sortedGroups = Array.from(grouped.entries()).filter(([, groupedRows]) => groupedRows.length > 0);
     let firstGroup = true;
     sortedGroups.forEach(([groupLabel, groupRows]) => {
@@ -5826,18 +5846,16 @@ export async function initReminders(sel = {}) {
         headingWrapper.setAttribute('role', 'presentation');
         headingWrapper.style.listStyle = 'none';
       }
-      headingWrapper.className = 'reminder-group-heading text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-500';
+      headingWrapper.className = 'reminder-group-heading';
       if (!firstGroup) {
         headingWrapper.style.marginTop = variant === 'desktop' ? '1.25rem' : '1rem';
       }
       const headingInner = document.createElement('div');
       headingInner.setAttribute('role', 'heading');
       headingInner.setAttribute('aria-level', '3');
-      headingInner.className = variant === 'desktop'
-        ? 'flex items-center justify-between gap-2 px-1 text-gray-500 dark:text-gray-500'
-        : 'flex items-center justify-between gap-2 text-gray-500 dark:text-gray-500';
+      headingInner.className = 'reminder-group-heading-label';
       const headingLabel = document.createElement('span');
-      headingLabel.textContent = groupLabel;
+      headingLabel.textContent = labelMap[groupLabel] || groupLabel;
       headingInner.append(headingLabel);
       headingWrapper.appendChild(headingInner);
       frag.appendChild(headingWrapper);

--- a/mobile.html
+++ b/mobile.html
@@ -25,6 +25,7 @@ Legacy shells remain for reference only.
   <link rel="stylesheet" href="./css/components.css" />
   <link rel="stylesheet" href="./css/capture.css" />
   <link rel="stylesheet" href="./css/reminders.css" />
+  <link rel="stylesheet" href="./css/reminders-ui.css" />
   <link rel="stylesheet" href="./css/assistant.css" />
   <style>
     :root {
@@ -4776,9 +4777,6 @@ body, main, section, div, p, span, li {
       <button id="openSavedNotesGlobal" type="button" class="search icon-button control-icon-button" aria-label="Search">
         🔍
       </button>
-      <button id="reminderSortToggle" type="button" class="sort icon-button control-icon-button" aria-label="Sort reminders" title="Sort reminders">
-        ↕
-      </button>
       <button id="overflowMenuBtn" type="button" class="menu icon-button control-icon-button" aria-haspopup="true" aria-expanded="false" aria-controls="overflowMenu" aria-label="Open menu">☰</button>
     <div id="overflowMenu" class="overflow-menu quick-actions-panel hidden" role="menu" aria-hidden="true">
         <div class="overflow-menu-section">
@@ -4865,6 +4863,22 @@ body, main, section, div, p, span, li {
     <!-- BEGIN GPT CHANGE: reminders view -->
     <section data-view="reminders" id="view-reminders" class="view-panel">
       <div class="reminders-mobile-flow reminders-content-shell">
+        <section class="reminders-screen-controls" aria-label="Reminder controls">
+          <form id="quickAddForm" class="reminders-quick-add-form" aria-label="Quick add reminder">
+            <label for="reminderQuickAdd" class="sr-only">Quick add reminder</label>
+            <input id="reminderQuickAdd" class="reminders-quick-add-input" type="text" placeholder="Quick add reminder" />
+            <button id="quickAddSubmit" type="submit" class="reminders-sort-btn" data-quick-add-submit>Add</button>
+          </form>
+          <div class="reminders-top-controls-row">
+            <div class="reminders-tabs" role="tablist" aria-label="Filter reminders by status">
+              <button type="button" class="reminder-tab reminders-tab-active" data-reminders-tab="all" aria-pressed="true">All</button>
+              <button type="button" class="reminder-tab" data-reminders-tab="today" aria-pressed="false">Today</button>
+              <button type="button" class="reminder-tab" data-reminders-tab="upcoming" aria-pressed="false">Upcoming</button>
+              <button type="button" class="reminder-tab" data-reminders-tab="completed" aria-pressed="false">Completed</button>
+            </div>
+            <button id="reminderSortToggle" type="button" class="reminders-sort-btn" data-reminder-sort-toggle aria-label="Sort reminders" title="Sort reminders">Sort</button>
+          </div>
+        </section>
         <div
           id="reminderCategoryFilters"
           class="category-filter-bar"


### PR DESCRIPTION
### Motivation
- Improve readability by grouping reminders into Today, Upcoming, and Completed sections with clear headers. 
- Surface key reminder information (checkbox, title, due date, optional category) so items are easier to scan. 
- Emphasise urgency visually via distinct classes and consolidate controls for faster interaction. 

### Description
- Added `css/reminders-ui.css` containing layout rules, single-column list, section header styling, and urgency state styles (`.reminder-overdue`, `.reminder-today`, `.reminder-upcoming`).
- Updated `mobile.html` to load the new stylesheet and move reminder controls to the top of the Reminders screen, adding a quick-add input, filter tabs (`All`, `Today`, `Upcoming`, `Completed`), and a sort button in a consolidated controls row. 
- Updated `js/reminders.js` rendering to show structured metadata lines `Due: ...` and `Category: ...` on mobile reminder cards, apply the urgency classes above, and group reminders under the section headers "Today", "Upcoming", and "Completed" without changing reminder logic. 
- Removed the long-press opener hookup for reminder overflow actions so actions are not accessed via an overflow menu on cards (controls remain in-card / in-header). 

### Testing
- Ran `npm run build` which completed successfully. 
- Ran the test suite via `npm test -- --runInBand`; several pre-existing test suites failed (ESM/import and environment-related failures) that are unrelated to these UI-only presentation changes. 
- Attempted an automated UI screenshot run but the headless browser invocation failed in this environment (not caused by code changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3c946e5d48324a340eed00cdfa98b)