### PR TITLE
UI improvement: improved bottom navigation clarity

### DIFF
--- a/css/navigation.css
+++ b/css/navigation.css
@@ -1,0 +1,59 @@
+#mobile-nav-shell.bottom-nav {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 100;
+}
+
+#mobile-nav-shell.bottom-nav .bottom-nav-list {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  align-items: stretch;
+  gap: 0.25rem;
+  width: 100%;
+  padding: 0.4rem 0.5rem calc(0.4rem + env(safe-area-inset-bottom, 0px));
+  background: var(--surface-elevated, rgba(255, 255, 255, 0.9));
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  border-top: 1px solid rgba(0, 0, 0, 0.07);
+  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.06);
+}
+
+#mobile-nav-shell.bottom-nav .bottom-nav-list .nav-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.2rem;
+  min-height: 48px;
+  padding: 0.35rem 0.3rem;
+  border: none;
+  border-radius: 0.75rem;
+  background: transparent;
+  color: var(--icon-inactive);
+  line-height: 1.1;
+}
+
+#mobile-nav-shell.bottom-nav .bottom-nav-list .nav-item .icon {
+  width: 20px;
+  height: 20px;
+  stroke: currentColor;
+}
+
+#mobile-nav-shell.bottom-nav .bottom-nav-list .nav-item span {
+  font-size: 0.72rem;
+  font-weight: 500;
+}
+
+#mobile-nav-shell.bottom-nav .bottom-nav-list .nav-item.active,
+#mobile-nav-shell.bottom-nav .bottom-nav-list .nav-item.nav-active {
+  color: var(--accent-color);
+  background: color-mix(in srgb, var(--accent-color) 12%, transparent);
+  font-weight: 700;
+}
+
+#mobile-nav-shell.bottom-nav .bottom-nav-list .nav-item.active .icon,
+#mobile-nav-shell.bottom-nav .bottom-nav-list .nav-item.nav-active .icon {
+  stroke-width: 2;
+}

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -461,7 +461,9 @@
       .querySelectorAll('#mobile-nav-shell .floating-card')
       .forEach((btn) => {
         if (!(btn instanceof HTMLElement)) return;
-        btn.classList.toggle('active', btn.id === buttonId);
+        const isActive = btn.id === buttonId;
+        btn.classList.toggle('active', isActive);
+        btn.classList.toggle('nav-active', isActive);
       });
   };
 

--- a/mobile.html
+++ b/mobile.html
@@ -27,6 +27,7 @@ Legacy shells remain for reference only.
   <link rel="stylesheet" href="./css/reminders.css" />
   <link rel="stylesheet" href="./css/reminders-ui.css" />
   <link rel="stylesheet" href="./css/assistant.css" />
+  <link rel="stylesheet" href="./css/navigation.css" />
   <style>
     :root {
       --card-bg: color-mix(in srgb, #ffffff 92%, #f8f4ec 8%); /* off-white card surface */
@@ -5369,10 +5370,10 @@ body, main, section, div, p, span, li {
   </div>
 
   <nav id="mobile-nav-shell" class="bottom-nav inset-x-0 bottom-0 z-50 flex justify-center px-2 pb-3" aria-label="Bottom navigation">
-    <div class="floating-footer">
+    <div class="floating-footer bottom-nav-list">
       <button
         type="button"
-        class="floating-card btn-capture"
+        class="floating-card nav-item btn-capture active nav-active"
         id="mobile-footer-capture"
         data-nav-target="capture"
         data-tab="capture"
@@ -5398,7 +5399,7 @@ body, main, section, div, p, span, li {
 
       <button
         type="button"
-        class="floating-card btn-reminders"
+        class="floating-card nav-item btn-reminders"
         id="mobile-footer-reminders"
         data-nav-target="reminders"
         data-tab="reminders"
@@ -5424,7 +5425,7 @@ body, main, section, div, p, span, li {
 
       <button
         type="button"
-        class="floating-card btn-notes"
+        class="floating-card nav-item btn-notes"
         id="mobile-footer-notes"
         data-nav-target="notes"
         data-tab="notes"
@@ -5453,18 +5454,7 @@ body, main, section, div, p, span, li {
 
       <button
         type="button"
-        class="floating-card btn-settings"
-        id="mobile-footer-settings"
-        data-nav-target="settings"
-        data-tab="settings"
-        aria-label="Go to Settings"
-      >
-        <span>Settings</span>
-      </button>
-
-      <button
-        type="button"
-        class="floating-card btn-assistant"
+        class="floating-card nav-item btn-assistant"
         id="mobile-footer-assistant"
         data-nav-target="assistant"
         data-tab="assistant"
@@ -5482,9 +5472,7 @@ body, main, section, div, p, span, li {
           stroke-linejoin="round"
           aria-hidden="true"
         >
-          <path d="M12 4.75C8 4.75 4.75 7.75 4.75 11.5C4.75 13.55 5.72 15.4 7.3 16.65V19.25L10.1 17.8C10.7 17.95 11.34 18.03 12 18.03C16 18.03 19.25 15.03 19.25 11.28C19.25 7.53 16 4.75 12 4.75Z" />
-          <path d="M9.2 11.2h5.6" />
-          <path d="M9.2 13.45h3.5" />
+          <path d="M12 3.5l1.58 3.24 3.57.52-2.58 2.52.61 3.56L12 11.78 8.82 13.34l.61-3.56-2.58-2.52 3.57-.52L12 3.5Z" />
         </svg>
         <span>Assistant</span>
       </button>


### PR DESCRIPTION
### Motivation
- Improve visual clarity and consistency of the mobile bottom navigation by enforcing a four-item layout, clear active state, icon-over-label stacking, and consistent spacing for touch targets.
- Keep navigation behavior unchanged and only adjust visual structure and styling.

### Description
- Added a new stylesheet `css/navigation.css` that defines `.bottom-nav`, `.nav-item`, and `.nav-active` rules for a 4-column grid, minimum 48px tap areas, icon-over-label stacking, and active highlighting.
- Updated `mobile.html` to load `css/navigation.css`, simplified the bottom nav to exactly four items (`Capture`, `Reminders`, `Notes`, `Assistant`), removed the Settings button from the footer, and applied `nav-item`/`nav-active` classes to match the new styles.
- Replaced the Assistant icon with a sparkle-style SVG to match the requested icon set and ensured icons are placed above labels.
- Adjusted `js/navigation.js` so `setActiveFooterIcon` applies both `.active` and `.nav-active` classes to the active footer button for consistent visual state without changing navigation logic.

### Testing
- Ran `git diff --check` to validate diffs and it completed without reported problems.
- Verified presence and IDs of the four footer buttons with a search (`rg`) which confirmed `mobile-footer-capture`, `mobile-footer-reminders`, `mobile-footer-notes`, and `mobile-footer-assistant` were present.
- Started a local HTTP server with `python -m http.server` to validate serving assets and it started successfully.
- Attempted an automated Playwright screenshot of the updated `mobile.html`, but the Playwright run failed with `ERR_EMPTY_RESPONSE` in this environment and no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3cc1a76d883249e088aea1e8663df)