### PR TITLE
Add foundational chat architecture modules (no UI changes)

### DIFF
--- a/src/chat/actionRouter.js
+++ b/src/chat/actionRouter.js
@@ -1,0 +1,68 @@
+import { captureInput } from '../../js/services/capture-service.js';
+
+const parseAssistantReply = (payload) => {
+  if (typeof payload?.reply === 'string' && payload.reply.trim()) {
+    return payload.reply;
+  }
+  if (typeof payload?.response === 'string' && payload.response.trim()) {
+    return payload.response;
+  }
+  if (typeof payload?.message === 'string' && payload.message.trim()) {
+    return payload.message;
+  }
+  return 'Assistant response unavailable.';
+};
+
+const resolveReminderHandler = (dependencies = {}) => {
+  if (typeof dependencies.createReminder === 'function') {
+    return dependencies.createReminder;
+  }
+
+  if (typeof window !== 'undefined' && typeof window.memoryCueCreateReminder === 'function') {
+    return window.memoryCueCreateReminder;
+  }
+
+  return null;
+};
+
+const routeCapture = async (text) => {
+  await captureInput(text, 'capture');
+  return 'Saved to Inbox.';
+};
+
+const routeReminder = async (text, dependencies = {}) => {
+  const createReminder = resolveReminderHandler(dependencies);
+  if (typeof createReminder !== 'function') {
+    throw new Error('Reminder creation logic is unavailable.');
+  }
+
+  await createReminder({ title: text });
+  return 'Reminder created.';
+};
+
+const routeAssistant = async (text) => {
+  const response = await fetch('/api/assistant', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message: text }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Assistant request failed (${response.status})`);
+  }
+
+  const payload = await response.json();
+  return parseAssistantReply(payload);
+};
+
+export const routeAction = async (intent, text, dependencies = {}) => {
+  if (intent === 'reminder') {
+    return routeReminder(text, dependencies);
+  }
+
+  if (intent === 'assistant') {
+    return routeAssistant(text);
+  }
+
+  return routeCapture(text);
+};

--- a/src/chat/chatManager.js
+++ b/src/chat/chatManager.js
@@ -1,0 +1,34 @@
+import { addMessage } from './messageStore.js';
+import { parseIntent } from './intentParser.js';
+import { routeAction } from './actionRouter.js';
+
+export const ENABLE_CHAT_INTERFACE = false;
+
+const generateMessageId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `chat-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+};
+
+const createMessage = (role, content) => ({
+  id: generateMessageId(),
+  role,
+  content,
+  timestamp: Date.now(),
+});
+
+export const handleChatMessage = async (text, dependencies = {}) => {
+  const userText = typeof text === 'string' ? text.trim() : '';
+  if (!userText) {
+    return '';
+  }
+
+  addMessage(createMessage('user', userText));
+
+  const intent = parseIntent(userText);
+  const response = await routeAction(intent, userText, dependencies);
+
+  addMessage(createMessage('assistant', response));
+  return response;
+};

--- a/src/chat/intentParser.js
+++ b/src/chat/intentParser.js
@@ -1,0 +1,13 @@
+export const parseIntent = (text) => {
+  const normalized = typeof text === 'string' ? text.trim().toLowerCase() : '';
+
+  if (normalized.includes('remind')) {
+    return 'reminder';
+  }
+
+  if (normalized.endsWith('?')) {
+    return 'assistant';
+  }
+
+  return 'capture';
+};

--- a/src/chat/messageStore.js
+++ b/src/chat/messageStore.js
@@ -1,0 +1,49 @@
+const CHAT_HISTORY_STORAGE_KEY = 'memoryCueChatHistory';
+
+const readMessages = () => {
+  if (typeof localStorage === 'undefined') {
+    return [];
+  }
+
+  try {
+    const raw = localStorage.getItem(CHAT_HISTORY_STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.warn('[chat/messageStore] Failed to read chat history', error);
+    return [];
+  }
+};
+
+const writeMessages = (messages) => {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+
+  try {
+    localStorage.setItem(CHAT_HISTORY_STORAGE_KEY, JSON.stringify(messages));
+  } catch (error) {
+    console.warn('[chat/messageStore] Failed to persist chat history', error);
+  }
+};
+
+export const addMessage = (message) => {
+  const messages = readMessages();
+  const nextMessages = [...messages, message];
+  writeMessages(nextMessages);
+  return message;
+};
+
+export const getMessages = () => readMessages();
+
+export const clearMessages = () => {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+
+  try {
+    localStorage.removeItem(CHAT_HISTORY_STORAGE_KEY);
+  } catch (error) {
+    console.warn('[chat/messageStore] Failed to clear chat history', error);
+  }
+};


### PR DESCRIPTION
### Motivation
- Introduce a chat architecture layer that can orchestrate user messages, intent parsing, routing, and history storage without altering existing capture, reminder, or assistant behavior.
- Provide a small, non-UI scaffold so future UI work can call into a single `handleChatMessage` API and toggle with a feature flag.

### Description
- Added `src/chat/messageStore.js` which persists chat messages in `localStorage` under `memoryCueChatHistory` using the message format `{ id, role: "user"|"assistant", content, timestamp }` and exports `addMessage`, `getMessages`, and `clearMessages`.
- Added `src/chat/intentParser.js` which exports `parseIntent(text)` and returns `reminder` if text contains `remind`, `assistant` if text ends with `?`, and `capture` otherwise.
- Added `src/chat/actionRouter.js` which exports `routeAction(intent, text, dependencies)` and routes intents to existing systems: `capture` → `captureInput(...)`, `reminder` → `dependencies.createReminder` or `window.memoryCueCreateReminder`, and `assistant` → POST to `/api/assistant`, returning simple response strings such as `Saved to Inbox.` and `Reminder created.`.
- Added `src/chat/chatManager.js` which exports `ENABLE_CHAT_INTERFACE = false` and `handleChatMessage(text, dependencies)` implementing the flow: store user message → parse intent → route action → store assistant response → return response, while not modifying existing storage or assistant APIs.

### Testing
- Ran the test suite with `npm test -- --runInBand` to validate repository compatibility.
- Test run completed but reported existing, pre-existing failures in multiple suites (14 failed, 10 passed); failures are related to baseline ESM/CommonJS and reminder/auth test harness issues and are not specific to the new chat modules.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3cdcea33483249e3abea763a3e0be)