### PR TITLE
Enable chat-first capture input behind chat interface flag

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -16,6 +16,7 @@ import { buildDashboard } from './js/modules/dashboard-data.js';
 import { generateWeeklySummary } from './js/modules/weekly-summary.js';
 import { getRecallItems } from './js/services/recall-service.js';
 import { captureInput, getInboxEntries } from './js/services/capture-service.js';
+import { ENABLE_CHAT_INTERFACE, handleChatMessage } from './src/chat/chatManager.js';
 
 const aiCaptureSaveModulePromise = import('./js/modules/ai-capture-save.js').catch(() => ({}));
 
@@ -58,6 +59,7 @@ function initAssistant() {
       || document.getElementById('reminderQuickAdd')
       || thinkingBarInput;
     const captureForm = document.getElementById('captureForm');
+    const captureSaveBtn = document.getElementById('captureSaveBtn');
     const recentCapturesList = document.getElementById('recentCapturesList');
     const thinkingBarStatus = document.getElementById('thinkingBarStatus');
     const thinkingBarResults = document.getElementById('thinkingBarResults');
@@ -633,6 +635,13 @@ function initAssistant() {
       });
     };
 
+    if (ENABLE_CHAT_INTERFACE && isTextEntryElement(captureInputField)) {
+      captureInputField.placeholder = 'Message Memory Cue...';
+      if (captureSaveBtn instanceof HTMLElement) {
+        captureSaveBtn.textContent = 'Send';
+      }
+    }
+
     captureForm?.addEventListener('submit', async (event) => {
       event.preventDefault();
       if (!isTextEntryElement(captureInputField) || isAssistantSending) {
@@ -646,7 +655,14 @@ function initAssistant() {
 
       isAssistantSending = true;
       try {
-        await captureInput(message, 'capture');
+        if (ENABLE_CHAT_INTERFACE) {
+          const reply = await handleChatMessage(message);
+          if (typeof reply === 'string' && reply.trim()) {
+            setThinkingBarStatus(reply);
+          }
+        } else {
+          await captureInput(message, 'capture');
+        }
         captureInputField.value = '';
         renderRecentCaptures();
       } catch (error) {

--- a/src/chat/chatManager.js
+++ b/src/chat/chatManager.js
@@ -2,7 +2,7 @@ import { addMessage } from './messageStore.js';
 import { parseIntent } from './intentParser.js';
 import { routeAction } from './actionRouter.js';
 
-export const ENABLE_CHAT_INTERFACE = false;
+export const ENABLE_CHAT_INTERFACE = true;
 
 const generateMessageId = () => {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {


### PR DESCRIPTION
### Motivation
- Make chat the primary path for capture input when `ENABLE_CHAT_INTERFACE` is enabled so typed text is routed through the chat manager and still feeds the existing inbox/reminders systems.

### Description
- Flipped the feature flag by setting `ENABLE_CHAT_INTERFACE = true` in `src/chat/chatManager.js`.
- Wired the mobile capture flow to import `handleChatMessage` and `ENABLE_CHAT_INTERFACE` and to route capture form submissions through `handleChatMessage` when the flag is active, preserving `captureInput` as a fallback.
- Updated the capture UI affordance when chat mode is enabled by changing the input placeholder to `Message Memory Cue...` and the save button text to `Send`.
- Kept existing routing logic intact by relying on `src/chat/actionRouter.js` so captures, reminders, and assistant queries still populate the inbox/reminder systems.

### Testing
- Ran `npm run build` and the build completed successfully (`✅`).
- Ran the test suite with `npm test -- --runInBand` and test run failed (`14` suites failed, `10` passed) due to existing module/import and unrelated reminder test failures; failures appear unrelated to the small chat routing change (`⚠️`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3d21e28b08324a72e30afdbc31457)