### PR TITLE
Add routed feedback responses with contextual quick actions

### DIFF
--- a/src/chat/actionRouter.js
+++ b/src/chat/actionRouter.js
@@ -25,9 +25,20 @@ const resolveReminderHandler = (dependencies = {}) => {
   return null;
 };
 
+const QUICK_ACTIONS_BY_INTENT = {
+  capture: [{ label: 'Open Inbox', targetView: 'capture' }],
+  reminder: [{ label: 'Edit Reminder', targetView: 'reminders' }],
+  assistant: [{ label: 'View Notes', targetView: 'notes' }],
+};
+
+const createActionResult = (intent, message) => ({
+  message,
+  quickActions: QUICK_ACTIONS_BY_INTENT[intent] || [],
+});
+
 const routeCapture = async (text) => {
   await captureInput(text, 'capture');
-  return 'Saved to Inbox.';
+  return createActionResult('capture', 'Saved to Inbox.');
 };
 
 const routeReminder = async (text, dependencies = {}) => {
@@ -37,7 +48,7 @@ const routeReminder = async (text, dependencies = {}) => {
   }
 
   await createReminder({ title: text });
-  return 'Reminder created.';
+  return createActionResult('reminder', 'Reminder created.');
 };
 
 const routeAssistant = async (text) => {
@@ -52,7 +63,7 @@ const routeAssistant = async (text) => {
   }
 
   const payload = await response.json();
-  return parseAssistantReply(payload);
+  return createActionResult('assistant', parseAssistantReply(payload));
 };
 
 export const routeAction = async (intent, text, dependencies = {}) => {

--- a/src/chat/chatManager.js
+++ b/src/chat/chatManager.js
@@ -11,25 +11,38 @@ const generateMessageId = () => {
   return `chat-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
 };
 
-const createMessage = (role, content) => ({
+const createMessage = (role, content, quickActions = []) => ({
   id: generateMessageId(),
   role,
   content,
+  quickActions,
   timestamp: Date.now(),
 });
+
+const normalizeRouteResult = (result) => {
+  if (typeof result === 'string') {
+    return { message: result, quickActions: [] };
+  }
+
+  return {
+    message: typeof result?.message === 'string' ? result.message : '',
+    quickActions: Array.isArray(result?.quickActions) ? result.quickActions : [],
+  };
+};
 
 export const handleChatMessage = async (text, dependencies = {}) => {
   const userText = typeof text === 'string' ? text.trim() : '';
   if (!userText) {
-    return '';
+    return { message: '', quickActions: [] };
   }
 
   addMessage(createMessage('user', userText));
 
   const intent = parseIntent(userText);
-  const response = await routeAction(intent, userText, dependencies);
+  const routeResult = await routeAction(intent, userText, dependencies);
+  const response = normalizeRouteResult(routeResult);
 
-  addMessage(createMessage('assistant', response));
+  addMessage(createMessage('assistant', response.message, response.quickActions));
   return response;
 };
 

--- a/src/components/ChatPanel.js
+++ b/src/components/ChatPanel.js
@@ -20,6 +20,54 @@ const createNode = (tag, styles = {}) => {
   return node;
 };
 
+const runQuickAction = (targetView) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (window.navigationService && typeof window.navigationService.navigate === 'function') {
+    window.navigationService.navigate(targetView);
+    return;
+  }
+
+  window.dispatchEvent(new CustomEvent('app:navigate', { detail: { view: targetView } }));
+};
+
+const createQuickActionBar = (quickActions = []) => {
+  if (!Array.isArray(quickActions) || quickActions.length === 0) {
+    return null;
+  }
+
+  const bar = createNode('div', {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '0.4rem',
+    marginTop: '0.5rem',
+  });
+
+  quickActions.forEach((action) => {
+    if (!action || typeof action.label !== 'string' || typeof action.targetView !== 'string') {
+      return;
+    }
+
+    const button = createNode('button', {
+      border: '1px solid color-mix(in srgb, var(--fg) 18%, transparent)',
+      borderRadius: '999px',
+      background: 'transparent',
+      color: 'var(--fg)',
+      padding: '0.25rem 0.6rem',
+      fontSize: '0.8rem',
+      cursor: 'pointer',
+    });
+    button.type = 'button';
+    button.textContent = action.label;
+    button.addEventListener('click', () => runQuickAction(action.targetView));
+    bar.appendChild(button);
+  });
+
+  return bar.childElementCount > 0 ? bar : null;
+};
+
 const createMessageBubble = (message) => {
   const role = message?.role === 'user' ? 'user' : 'assistant';
   const bubble = createNode('div', {
@@ -33,11 +81,19 @@ const createMessageBubble = (message) => {
     ...bubbleStyles[role],
   });
   bubble.textContent = typeof message?.content === 'string' ? message.content : '';
+
+  if (role === 'assistant') {
+    const quickActionBar = createQuickActionBar(message?.quickActions);
+    if (quickActionBar) {
+      bubble.appendChild(quickActionBar);
+    }
+  }
+
   return bubble;
 };
 
-const appendMessage = (list, role, content) => {
-  const message = { role, content };
+const appendMessage = (list, role, content, quickActions = []) => {
+  const message = { role, content, quickActions };
   list.appendChild(createMessageBubble(message));
   list.scrollTop = list.scrollHeight;
 };
@@ -100,7 +156,7 @@ export const createChatPanel = () => {
     input.value = '';
 
     const assistantReply = await handleMessage(userInput);
-    appendMessage(messageList, 'assistant', assistantReply);
+    appendMessage(messageList, 'assistant', assistantReply.message, assistantReply.quickActions);
   });
 
   inputBar.append(input, sendButton);


### PR DESCRIPTION
### Motivation
- Provide clear assistant feedback after routed actions and surface quick action shortcuts so users can immediately follow up (e.g. “Saved to Inbox.” with an “Open Inbox” action).

### Description
- Updated `src/chat/actionRouter.js` to return structured action results (`{ message, quickActions }`) and added `QUICK_ACTIONS_BY_INTENT` plus a helper `createActionResult` so capture, reminder, and assistant routes return explicit feedback and intent-specific quick actions.
- Updated `src/chat/chatManager.js` to normalize routed results, persist quick-action metadata with assistant messages via `createMessage(..., quickActions)`, and maintain backward compatibility with string replies.
- Updated `src/components/ChatPanel.js` to render an assistant quick-action bar, wire quick-action buttons to `navigationService.navigate` with an `app:navigate` fallback, and pass `quickActions` when appending assistant messages.

### Testing
- Ran `npm test -- --runInBand`, which reported failures, but the failures are from pre-existing repository issues (ESM-in-VM test harness errors and service worker test failures) and are unrelated to these UI-focused changes.
- Ran `npm run build`, which completed (with non-fatal warnings) and `npm run verify`, which passed successfully.
- All changes were committed and a lightweight smoke check of the UI was performed during development.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3d3d77c1883249a254c30bc342568)