### PR TITLE
Persist assistant chat history and add Clear Chat History setting

### DIFF
--- a/js/services/assistant-service.js
+++ b/js/services/assistant-service.js
@@ -1,7 +1,6 @@
 import { loadAllNotes } from '../modules/notes-storage.js';
 import { getInboxEntries } from './capture-service.js';
-
-const SESSION_KEY = 'memoryCueAssistantConversation';
+import { addMessage, clearMessages, getMessages } from '../../src/chat/messageStore.js';
 
 const toTimestamp = (value) => {
   const parsed = Date.parse(typeof value === 'string' ? value : '');
@@ -19,25 +18,17 @@ const readReminders = () => {
   }
 };
 
-const readConversation = () => {
-  if (typeof sessionStorage === 'undefined') return [];
-  try {
-    const raw = sessionStorage.getItem(SESSION_KEY);
-    const parsed = raw ? JSON.parse(raw) : [];
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
-};
+const readConversation = () => getMessages();
 
-const saveConversation = (history) => {
-  if (typeof sessionStorage === 'undefined') return;
-  try {
-    sessionStorage.setItem(SESSION_KEY, JSON.stringify(history.slice(-20)));
-  } catch (error) {
-    console.warn('[assistant-service] Unable to save conversation', error);
-  }
-};
+const createStoredMessage = (role, content) => ({
+  id:
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `chat-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
+  role,
+  content,
+  timestamp: Date.now(),
+});
 
 const appendMessage = (container, text, className) => {
   const message = document.createElement('div');
@@ -46,6 +37,18 @@ const appendMessage = (container, text, className) => {
   container.appendChild(message);
   container.scrollTop = container.scrollHeight;
   return message;
+};
+
+const renderStoredConversation = (container) => {
+  const history = readConversation();
+  history.forEach((entry) => {
+    const role = entry?.role === 'assistant' ? 'assistant' : 'user';
+    const className = role === 'assistant'
+      ? 'assistant-message assistant-message--reply'
+      : 'assistant-message';
+    appendMessage(container, typeof entry?.content === 'string' ? entry.content : '', className);
+  });
+  container.scrollTop = container.scrollHeight;
 };
 
 const appendReferences = (container, references) => {
@@ -131,12 +134,21 @@ const sendAssistantRequest = async (payload) => {
     return;
   }
 
+  renderStoredConversation(assistantMessages);
+
+  const clearChatHistoryBtn = document.getElementById('clearChatHistoryBtn');
+  clearChatHistoryBtn?.addEventListener('click', () => {
+    clearMessages();
+    assistantMessages.innerHTML = '';
+  });
+
   assistantForm.addEventListener('submit', async (event) => {
     event.preventDefault();
     const message = typeof assistantInput.value === 'string' ? assistantInput.value.trim() : '';
     if (!message) return;
 
     appendMessage(assistantMessages, message, 'assistant-message');
+    addMessage(createStoredMessage('user', message));
     assistantInput.value = '';
 
     if (assistantLoading instanceof HTMLElement) {
@@ -150,8 +162,7 @@ const sendAssistantRequest = async (payload) => {
       const result = await sendAssistantRequest(payload);
       const replyNode = appendMessage(assistantMessages, result.reply, 'assistant-message assistant-message--reply');
       appendReferences(replyNode, result.references);
-      const nextHistory = [...history, { role: 'user', content: message }, { role: 'assistant', content: result.reply }];
-      saveConversation(nextHistory);
+      addMessage(createStoredMessage('assistant', result.reply));
     } catch (error) {
       console.error('[assistant-service] Assistant unavailable', error);
       appendMessage(assistantMessages, 'Assistant is unavailable.', 'assistant-message assistant-message--error');

--- a/mobile.html
+++ b/mobile.html
@@ -6517,6 +6517,7 @@ body, main, section, div, p, span, li {
               <button id="testSync" class="btn btn-outline flex-1" type="button">Test Connection</button>
             </div>
             <button id="syncAll" class="btn btn-primary w-full" type="button">Sync All</button>
+            <button id="clearChatHistoryBtn" class="btn btn-outline w-full" type="button">Clear Chat History</button>
           </div>
           <p class="text-xs text-base-content/60">Tip: In Google Apps Script choose <strong>Deploy → Web app</strong>, execute as yourself and allow access to anyone with the link.</p>
         </div>


### PR DESCRIPTION
### Motivation

- Persist the assistant conversation across page reloads so users can see previous chat messages when the app loads.
- Provide a settings control to clear only chat messages without affecting notes or reminders.

### Description

- Switch assistant conversation persistence from session storage to the existing chat message store by importing `getMessages`, `addMessage`, and `clearMessages` from `src/chat/messageStore.js` and use the `memoryCueChatHistory` key.  
- Hydrate and render stored messages on assistant initialization with `renderStoredConversation(...)` and scroll the thread to the latest message.  
- Persist outgoing user messages and assistant replies by calling `addMessage(createStoredMessage(...))` when messages are sent/received, and create a small helper `createStoredMessage` to shape stored entries.  
- Add a UI button `Clear Chat History` to the Settings modal (`mobile.html`) and wire it to call `clearMessages()` and clear the rendered assistant thread, leaving notes/reminders untouched.

### Testing

- Ran `npm run build` and the build completed successfully.  
- Ran `npm test -- --runInBand` and the test run failed due to pre-existing unrelated test/environment issues (many legacy tests erroring on ESM/import handling); failures are not caused by the chat persistence change.  
- Started a local server and used an automated Playwright script to open `mobile.html`, reveal Settings, and capture a screenshot confirming the `Clear Chat History` button appears in the Settings modal.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3d5c2444c8324beda01445cdeb98a)