### PR TITLE
Improve rule-based intent parsing reliability

### DIFF
--- a/src/chat/intentParser.js
+++ b/src/chat/intentParser.js
@@ -5,6 +5,14 @@ export const parseIntent = (text) => {
     return 'reminder';
   }
 
+  if (normalized.includes('note')) {
+    return 'note';
+  }
+
+  if (normalized.includes('idea')) {
+    return 'capture';
+  }
+
   if (normalized.endsWith('?')) {
     return 'assistant';
   }


### PR DESCRIPTION
### Motivation

- Make local intent parsing deterministic and more reliable by adding simple rule-based checks so the system can classify common inputs without requiring AI and without crashing on empty input.

### Description

- Updated `src/chat/intentParser.js` to add rule checks for text containing `note` (returns `note`) and `idea` (returns `capture`) while keeping the existing `remind` → `reminder` and question-mark `?` → `assistant` rules.
- Input normalization (`typeof text === 'string' ? text.trim().toLowerCase() : ''`) is preserved so empty or non-string input will not crash the parser.
- The default fallback intent remains `capture` if no rule matches.

### Testing

- Ran `npm test -- --runInBand`, which exercised the test suite but failed due to multiple pre-existing, unrelated test-suite issues (ESM/CommonJS and other test failures) and not because of the small intent-parser change.
- Performed a direct Node import check for `parseIntent`, which failed due to the repository runtime module configuration (CommonJS/ESM mismatch) rather than the parser logic itself.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3d7ba0c8c83248f3e684a6927f6de)