### PR TITLE
Restore Inbox as default capture destination and reintroduce Inbox view

### DIFF
--- a/js/entries.js
+++ b/js/entries.js
@@ -370,7 +370,13 @@
   };
 
   const renderInboxEntries = () => {
-    const entries = readEntries().filter((entry) => getEntryCategory(entry).toLowerCase() === 'inbox');
+    const entries = readEntries()
+      .filter((entry) => getEntryCategory(entry).toLowerCase() === 'inbox')
+      .sort((a, b) => {
+        const left = Number(new Date(a?.createdAt || a?.created || a?.date || 0).getTime()) || 0;
+        const right = Number(new Date(b?.createdAt || b?.created || b?.date || 0).getTime()) || 0;
+        return left - right;
+      });
     inboxEntriesList.innerHTML = '';
 
     if (!entries.length) {
@@ -671,7 +677,7 @@
     } finally {
       if (processInboxButton) {
         processInboxButton.disabled = false;
-        processInboxButton.textContent = 'Process Inbox';
+        processInboxButton.textContent = 'Process Notes';
       }
     }
   }

--- a/js/services/navigation-service.js
+++ b/js/services/navigation-service.js
@@ -1,5 +1,5 @@
 (function () {
-  const VIEW_ORDER = ['capture', 'reminders', 'notes', 'assistant', 'settings'];
+  const VIEW_ORDER = ['capture', 'inbox', 'reminders', 'notes', 'assistant', 'settings'];
 
   const normalizeViewName = (name) => {
     if (!name) return 'capture';

--- a/mobile.html
+++ b/mobile.html
@@ -4924,10 +4924,10 @@ body, main, section, div, p, span, li {
         <div id="categoryEntriesList" class="category-entry-list"></div>
       </div>
     </div>
-    <div id="view-inbox" class="view-panel hidden" aria-hidden="true">
+    <div id="view-inbox" data-view="inbox" class="view-panel hidden" aria-hidden="true">
       <div class="space-y-3">
         <h2 class="text-lg font-semibold">Inbox</h2>
-        <button id="processInboxButton" type="button" class="btn btn-sm btn-primary">Process Inbox</button>
+        <button id="processInboxButton" type="button" class="btn btn-sm btn-primary">Process Notes</button>
         <ul id="inboxEntriesList" class="category-entry-list list-disc pl-4" aria-live="polite"></ul>
       </div>
     </div>
@@ -5452,6 +5452,33 @@ body, main, section, div, p, span, li {
       </button>
 
 
+
+      <button
+        type="button"
+        class="floating-card nav-item btn-inbox"
+        id="mobile-footer-inbox"
+        data-nav-target="inbox"
+        data-tab="inbox"
+        aria-label="Go to Inbox"
+      >
+        <svg
+          class="icon icon-inbox"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.75"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M4.5 7.5h15v9a2 2 0 0 1-2 2h-11a2 2 0 0 1-2-2v-9Z" />
+          <path d="M4.5 12h4l1.5 2h4l1.5-2h4" />
+        </svg>
+        <span>Inbox</span>
+      </button>
+
       <button
         type="button"
         class="floating-card nav-item btn-assistant"
@@ -5674,7 +5701,7 @@ body, main, section, div, p, span, li {
       const renderInboxEntries = () => {
         const entries = readEntries()
           .filter((entry) => isUnprocessedEntry(entry))
-          .sort((a, b) => getEntryTimestamp(b) - getEntryTimestamp(a));
+          .sort((a, b) => getEntryTimestamp(a) - getEntryTimestamp(b));
         inboxEntriesList.innerHTML = '';
 
         if (!entries.length) {
@@ -5952,7 +5979,7 @@ body, main, section, div, p, span, li {
         } finally {
           if (processInboxButton) {
             processInboxButton.disabled = false;
-            processInboxButton.textContent = 'Process Inbox';
+            processInboxButton.textContent = 'Process Notes';
           }
         }
       };

--- a/src/chat/actionRouter.js
+++ b/src/chat/actionRouter.js
@@ -1,7 +1,7 @@
 import { executeCommand } from '../core/commandEngine.js';
 
 const QUICK_ACTIONS_BY_INTENT = {
-  capture: [{ label: 'Open Inbox', targetView: 'capture' }],
+  capture: [{ label: 'Open Inbox', targetView: 'inbox' }],
   reminder: [{ label: 'Edit Reminder', targetView: 'reminders' }],
   assistant: [{ label: 'View Notes', targetView: 'notes' }],
 };

--- a/src/core/commandEngine.js
+++ b/src/core/commandEngine.js
@@ -1,4 +1,4 @@
-import { captureInput } from '../../js/services/capture-service.js';
+import { saveToInbox } from '../services/inboxService.js';
 import { loadAllNotes, saveAllNotes } from '../../js/modules/notes-storage.js';
 import { searchMemoryIndex } from '../../js/modules/memory-index.js';
 
@@ -119,8 +119,7 @@ export const executeCommand = async (type, payload = {}) => {
     switch (type) {
       case 'capture': {
         const text = typeof payload?.text === 'string' ? payload.text : '';
-        const source = typeof payload?.source === 'string' ? payload.source : 'capture';
-        const entry = await captureInput(text, source);
+        const entry = saveToInbox(text);
         result = {
           status: 'success',
           message: 'Saved to Inbox.',

--- a/src/services/inboxService.js
+++ b/src/services/inboxService.js
@@ -1,0 +1,73 @@
+const INBOX_STORAGE_KEY = 'memoryCueInbox';
+
+const generateId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `inbox-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+};
+
+const sanitizeText = (value) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.replace(/\s+/g, ' ').trim();
+};
+
+export const getInboxEntries = () => {
+  if (typeof localStorage === 'undefined') {
+    return [];
+  }
+
+  try {
+    const raw = localStorage.getItem(INBOX_STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.warn('[inbox-service] Failed to load inbox entries', error);
+    return [];
+  }
+};
+
+const persistInboxEntries = (entries) => {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+
+  try {
+    localStorage.setItem(INBOX_STORAGE_KEY, JSON.stringify(entries));
+  } catch (error) {
+    console.warn('[inbox-service] Failed to persist inbox entries', error);
+  }
+};
+
+const dispatchInboxUpdated = () => {
+  if (typeof document === 'undefined' || typeof CustomEvent !== 'function') {
+    return;
+  }
+
+  document.dispatchEvent(new CustomEvent('memoryCue:entriesUpdated'));
+};
+
+export const saveToInbox = (text) => {
+  const normalizedText = sanitizeText(text);
+  if (!normalizedText) {
+    return null;
+  }
+
+  const entry = {
+    id: generateId(),
+    text: normalizedText,
+    createdAt: Date.now(),
+    processed: false,
+    tags: [],
+  };
+
+  const entries = getInboxEntries();
+  entries.push(entry);
+  persistInboxEntries(entries);
+  dispatchInboxUpdated();
+
+  return entry;
+};


### PR DESCRIPTION
### Motivation

- Reintroduce an Inbox as the canonical daily notebook where all captured thoughts are stored before organization.  
- Make `capture` commands save into the Inbox and restore the Inbox screen and navigation so users can review and process captures.

### Description

- Added a new Inbox service at `src/services/inboxService.js` that persists entries to localStorage with the requested shape (`id`, `text`, `createdAt`, `processed:false`, `tags:[]`) and dispatches `memoryCue:entriesUpdated`.  
- Updated the command pipeline so `executeCommand('capture')` uses `saveToInbox` (`src/core/commandEngine.js`) and returns the unchanged message `Saved to Inbox.`.  
- Restored Inbox UI and navigation by adding `data-view="inbox"` for the Inbox panel in `mobile.html`, inserting an Inbox button in the mobile footer, and adding `inbox` to `VIEW_ORDER` in the navigation service (`js/services/navigation-service.js`).  
- Adjusted Inbox behavior and labels: inbox lists are rendered chronologically (oldest → newest) in `js/entries.js` and the action button label was changed to `Process Notes` in both mobile and entries code paths, and the chat quick action now targets the Inbox (`src/chat/actionRouter.js`).

### Testing

- Ran `npm run verify` which completed successfully (build verification passed).  
- Ran the focused Jest suite with `npm test -- chat-system.prompt12.test.js`, which failed due to the test harness encountering a module format mismatch (`SyntaxError: Cannot use import statement outside a module`).  
- Attempted an automated Playwright UI check to capture the Inbox screen, but the browser run could not reach the local server (`ERR_EMPTY_RESPONSE`) so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3dd6ea2988324985a4d4152295cfd)