### PR TITLE
Implement inbox processing service and connect Process Notes flow

### DIFF
--- a/js/entries.js
+++ b/js/entries.js
@@ -573,94 +573,22 @@
     if (!inboxEntries.length) {
       return [];
     }
-
-    const prompt = [
-      'Classify each note into one category:',
-      'Task',
-      'Idea',
-      'Memory',
-      'Note',
-      '',
-      'Return structured JSON.'
-    ].join('\n');
-
-    const response = await fetch('/api/assistant', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
+    const { processInbox } = await import('../src/ai/inboxProcessor.js');
+    const result = await processInbox(inboxEntries, {
+      createReminder: (payload) => {
+        if (typeof window.memoryCueCreateReminder === 'function') {
+          return window.memoryCueCreateReminder(payload);
+        }
+        return null;
       },
-      body: JSON.stringify({
-        prompt,
-        entries: inboxEntries.map((entry) => ({
-          id: entry?.id,
-          text: getEntryText(entry)
-        }))
-      })
+      removeInboxEntry: (id) => removeEntry(id),
     });
 
-    if (!response.ok) {
-      throw new Error(`Assistant request failed (${response.status})`);
-    }
-
-    const data = await response.json();
-    const updates = Array.isArray(data) ? data : [];
-    if (!updates.length) {
-      return [];
-    }
-
-    const updatesById = new Map();
-    updates.forEach((item, index) => {
-      if (!item || typeof item !== 'object') return;
-      if (item.id) {
-        updatesById.set(String(item.id), item);
-        return;
-      }
-      const fallback = inboxEntries[index];
-      if (fallback?.id) {
-        updatesById.set(String(fallback.id), item);
-      }
-    });
-
-    const timestamp = new Date().toISOString();
-    const processedNotes = [];
-
-    inboxEntries.forEach((entry) => {
-      const entryId = entry?.id ? String(entry.id) : '';
-      if (!entryId || !updatesById.has(entryId)) {
-        return;
-      }
-
-      const update = updatesById.get(entryId);
-      const type = typeof update.type === 'string' && update.type.trim()
-        ? update.type.trim().toLowerCase()
-        : (typeof entry.type === 'string' && entry.type.trim() ? entry.type.trim().toLowerCase() : 'note');
-      const text = typeof update.text === 'string' && update.text.trim()
-        ? update.text.trim()
-        : getEntryText(entry);
-
-      processedNotes.push({
-        text,
-        type,
-        processed: true,
-        timestamp,
-        id: entryId,
-        title: text.split(/\s+/).slice(0, 8).join(' '),
-        body: text,
-        bodyText: text,
-        bodyHtml: text,
-        createdAt: timestamp,
-        updatedAt: timestamp
-      });
-    });
-
-    if (!processedNotes.length) {
-      return [];
-    }
-
-    appendToMainNotesDatabase(processedNotes);
-    inboxEntries.forEach((entry) => removeEntry(String(entry?.id || '')));
     renderInboxEntries();
-    return processedNotes;
+    if (result?.summary) {
+      window.alert(result.summary);
+    }
+    return Array.isArray(result?.processedItems) ? result.processedItems : [];
   };
 
   async function processInbox() {

--- a/src/ai/inboxProcessor.js
+++ b/src/ai/inboxProcessor.js
@@ -1,0 +1,116 @@
+import { createNote, loadAllNotes, saveAllNotes } from '../../js/modules/notes-storage.js';
+
+const normalizeText = (value) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.replace(/\s+/g, ' ').trim();
+};
+
+const getEntryText = (entry) => {
+  if (!entry || typeof entry !== 'object') return '';
+  return normalizeText(entry.title || entry.text || entry.content || entry.body || '');
+};
+
+const reminderPattern = /\b(remind|reminder|tomorrow|today|tonight|next week|next month|call|schedule|due|deadline|meeting|appointment|follow up)\b/i;
+const ideaPattern = /\b(idea|brainstorm|concept|prototype|invent|explore|maybe build)\b/i;
+const trainingPattern = /\b(training|workout|practice|drill|exercise|run|gym|conditioning)\b/i;
+const personalPattern = /\b(personal|family|mom|dad|parent|home|self|doctor|health)\b/i;
+const teachingPattern = /\b(lesson|teaching|classroom|student|curriculum|pompeii)\b/i;
+
+const classifyEntry = (text) => {
+  if (!text) {
+    return { type: 'note', tags: [] };
+  }
+
+  if (reminderPattern.test(text)) {
+    return { type: 'reminder', tags: [] };
+  }
+
+  if (trainingPattern.test(text)) {
+    return { type: 'training', tags: ['training'] };
+  }
+
+  if (personalPattern.test(text)) {
+    return { type: 'personal', tags: ['personal'] };
+  }
+
+  if (teachingPattern.test(text)) {
+    return { type: 'note', tags: ['teaching'] };
+  }
+
+  if (ideaPattern.test(text)) {
+    return { type: 'idea', tags: ['idea'] };
+  }
+
+  return { type: 'note', tags: [] };
+};
+
+const addNotes = (notes) => {
+  if (!Array.isArray(notes) || !notes.length) {
+    return;
+  }
+
+  const existing = Array.isArray(loadAllNotes()) ? loadAllNotes() : [];
+  saveAllNotes([...notes, ...existing]);
+};
+
+export const processInbox = async (entries = [], options = {}) => {
+  const createReminder = typeof options.createReminder === 'function' ? options.createReminder : null;
+  const removeInboxEntry = typeof options.removeInboxEntry === 'function' ? options.removeInboxEntry : null;
+
+  const counts = {
+    note: 0,
+    reminder: 0,
+    idea: 0,
+    training: 0,
+    personal: 0,
+  };
+
+  const notesToSave = [];
+  const processedItems = [];
+
+  entries.forEach((entry) => {
+    const text = getEntryText(entry);
+    if (!text) {
+      return;
+    }
+
+    const { type, tags } = classifyEntry(text);
+    counts[type] += 1;
+    processedItems.push({ ...entry, type, tags, text });
+
+    if (type === 'reminder') {
+      if (createReminder) {
+        createReminder({ title: text, notes: 'Created from Inbox processing.' });
+      }
+    } else {
+      notesToSave.push(
+        createNote(text.split(/\s+/).slice(0, 8).join(' '), text, {
+          metadata: {
+            type,
+            tags,
+          },
+        }),
+      );
+    }
+
+    if (removeInboxEntry && entry?.id != null) {
+      removeInboxEntry(String(entry.id));
+    }
+  });
+
+  addNotes(notesToSave);
+
+  return {
+    processedCount: processedItems.length,
+    counts,
+    processedItems,
+    summary: [
+      `Processed ${processedItems.length} notes.`,
+      `${counts.idea + counts.training} teaching ideas`,
+      `${counts.reminder} reminders`,
+      `${counts.note + counts.personal} notes`,
+    ].join('\n'),
+  };
+};


### PR DESCRIPTION
## Summary
- Added `src/ai/inboxProcessor.js` with a new `processInbox(entries, options)` service.
- Implemented inbox classification for these categories: `note`, `reminder`, `idea`, `training`, and `personal`.
- Added lightweight tag inference (including `teaching` tag for lesson-related entries).
- Routed reminders through the existing `window.memoryCueCreateReminder` hook.
- Routed non-reminder items into notes storage via existing `notes-storage` helpers.
- Removed processed inbox entries via the existing capture service remove hook.
- Updated `js/entries.js` to use the new processing service instead of inline assistant-fetch classification logic.
- Added post-processing assistant summary alert after run (processed total + category counts).

## Why this approach
- The repo already had inbox processing in `js/entries.js` (`processInboxHandler`), so this keeps behavior centralized by extracting the logic into a dedicated service module while preserving the current command path (`executeCommand('processInbox', { handler })`).
- Reuses existing storage/reminder patterns rather than introducing new APIs.

## Notes
- Summary text is generated dynamically from processed items and shown after processing completes.
- Classification is deterministic and local (regex heuristics), so processing works without requiring backend AI classification for this flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3def75df48324baf0eea37a9a1f91)