### PR TITLE
Integrate inbox-processing into capture chat (process notes command)

### DIFF
--- a/src/chat/actionRouter.js
+++ b/src/chat/actionRouter.js
@@ -1,15 +1,27 @@
+import { processInbox } from '../ai/inboxProcessor.js';
 import { executeCommand } from '../core/commandEngine.js';
+import { getInboxEntries, removeInboxEntry } from '../services/inboxService.js';
 
 const QUICK_ACTIONS_BY_INTENT = {
   capture: [{ label: 'Open Inbox', targetView: 'inbox' }],
   reminder: [{ label: 'Edit Reminder', targetView: 'reminders' }],
   assistant: [{ label: 'View Notes', targetView: 'notes' }],
+  processInbox: [{ label: 'View Notes', targetView: 'notes' }],
 };
 
 const createActionResult = (intent, message) => ({
   message,
   quickActions: QUICK_ACTIONS_BY_INTENT[intent] || [],
 });
+
+const shouldProcessInbox = (text) => {
+  const normalized = typeof text === 'string' ? text.trim().toLowerCase() : '';
+  if (!normalized) {
+    return false;
+  }
+
+  return normalized.includes('process') && (normalized.includes('notes') || normalized.includes('inbox'));
+};
 
 const routeCapture = async (text) => {
   const result = await executeCommand('capture', { text, source: 'capture' });
@@ -29,7 +41,38 @@ const routeAssistant = async (text) => {
   return createActionResult('assistant', result.message);
 };
 
+const routeProcessInbox = async (dependencies = {}) => {
+  const result = await executeCommand('processInbox', {
+    handler: async () => {
+      const inboxEntries = getInboxEntries().filter((entry) => entry?.processed === false);
+      if (!inboxEntries.length) {
+        return {
+          processedCount: 0,
+          processedItems: [],
+          counts: { note: 0, reminder: 0, idea: 0, training: 0, personal: 0 },
+          summary: 'Processed 0 notes.',
+        };
+      }
+
+      return processInbox(inboxEntries, {
+        createReminder: dependencies.createReminder,
+        removeInboxEntry,
+      });
+    },
+  });
+
+  const summary = typeof result?.data?.summary === 'string' && result.data.summary.trim()
+    ? result.data.summary
+    : result.message;
+
+  return createActionResult('processInbox', summary);
+};
+
 export const routeAction = async (intent, text, dependencies = {}) => {
+  if (shouldProcessInbox(text)) {
+    return routeProcessInbox(dependencies);
+  }
+
   if (intent === 'reminder') {
     return routeReminder(text, dependencies);
   }

--- a/src/services/inboxService.js
+++ b/src/services/inboxService.js
@@ -71,3 +71,20 @@ export const saveToInbox = (text) => {
 
   return entry;
 };
+
+export const removeInboxEntry = (id) => {
+  const targetId = typeof id === 'string' ? id.trim() : String(id || '').trim();
+  if (!targetId) {
+    return false;
+  }
+
+  const entries = getInboxEntries();
+  const nextEntries = entries.filter((entry) => String(entry?.id || '') !== targetId);
+  if (nextEntries.length === entries.length) {
+    return false;
+  }
+
+  persistInboxEntries(nextEntries);
+  dispatchInboxUpdated();
+  return true;
+};


### PR DESCRIPTION
### Motivation
- Let users run inbox processing directly from the capture chat (e.g. "process today's notes") so the assistant replies with a processing summary instead of saving the prompt as a plain inbox entry.

### Description
- Added `shouldProcessInbox()` and `routeProcessInbox()` to `src/chat/actionRouter.js` to detect process-style chat input and run `processInbox`, returning the processing summary as the assistant reply.
- Imported `processInbox`, `getInboxEntries`, and `removeInboxEntry` in `src/chat/actionRouter.js` and wired `routeProcessInbox()` to use these to collect unprocessed entries and remove them as part of processing.
- Added `removeInboxEntry(id)` to `src/services/inboxService.js` to remove an inbox item, persist the updated list, and dispatch the existing `memoryCue:entriesUpdated` event, matching the existing storage/event pattern.
- Preserved existing `capture`, `reminder`, and `assistant` routing and quick-action behavior for non-processing chat inputs.

### Testing
- Ran `npm test -- --runInBand`, which executed the repository test suite and surfaced multiple pre-existing failing suites (including ESM/CommonJS test harness mismatches and unrelated failures); the failures are repository-wide and not specific to the small changes made here.
- Ran `node --input-type=module -e "import('./src/chat/actionRouter.js')"` to validate module loading, which failed due to the repo treating `.js` as CommonJS in `package.json`, indicating a repo-level ESM/CommonJS configuration mismatch rather than a functional regression from these edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3e21af8b0832483e5ace0dd3c7f45)