### PR TITLE
Add automatic tag generation for captured inbox entries

### DIFF
--- a/js/services/capture-service.js
+++ b/js/services/capture-service.js
@@ -1,4 +1,5 @@
 import { createNote, loadAllNotes, saveAllNotes } from '../modules/notes-storage.js';
+import { generateTags } from '../../src/ai/tagGenerator.js';
 
 export const INBOX_STORAGE_KEY = 'memoryCueInbox';
 const LEGACY_INBOX_STORAGE_KEYS = ['memoryEntries'];
@@ -137,6 +138,7 @@ export const captureInput = async (text, source = 'capture') => {
   const entry = {
     id: generateId(),
     text: cleanedText,
+    tags: generateTags(cleanedText),
     createdAt: Date.now(),
     source: normalizeSource(source),
     parsedType: parsed.parsedType,

--- a/src/ai/tagGenerator.js
+++ b/src/ai/tagGenerator.js
@@ -1,0 +1,40 @@
+const MAX_TAGS = 5;
+
+const TAG_RULES = [
+  { tag: 'teaching', pattern: /\b(lesson|teach|teaching|class|classroom|student|curriculum)\b/i },
+  { tag: 'history', pattern: /\b(history|historical|ancient|rome|roman|pompeii)\b/i },
+  { tag: 'idea', pattern: /\b(idea|brainstorm|concept|plan|draft)\b/i },
+  { tag: 'reminder', pattern: /\b(remind|reminder|due|deadline|follow\s?up|schedule|appointment)\b/i },
+  { tag: 'task', pattern: /\b(todo|to-do|task|checklist|finish|complete)\b/i },
+  { tag: 'meeting', pattern: /\b(meeting|call|sync|standup)\b/i },
+  { tag: 'personal', pattern: /\b(personal|family|home|health)\b/i },
+];
+
+const normalizeText = (value) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.replace(/\s+/g, ' ').trim();
+};
+
+export const generateTags = (text) => {
+  const normalizedText = normalizeText(text);
+  if (!normalizedText) {
+    return [];
+  }
+
+  const tags = [];
+
+  TAG_RULES.forEach(({ tag, pattern }) => {
+    if (tags.length >= MAX_TAGS) {
+      return;
+    }
+
+    if (pattern.test(normalizedText) && !tags.includes(tag)) {
+      tags.push(tag);
+    }
+  });
+
+  return tags.slice(0, MAX_TAGS);
+};


### PR DESCRIPTION
### Motivation
- Improve search and organization by attaching inferred tags to captured inbox items so they can be filtered and surfaced more intelligently.

### Description
- Add a new tag generator module at `src/ai/tagGenerator.js` that exports `generateTags(text)` and returns up to `5` inferred tags using keyword rules (examples: `lesson idea pompeii` → `["teaching","history","idea"]`).
- Integrate tag generation into the capture flow by importing `generateTags` in `js/services/capture-service.js` and adding a `tags` array to inbox entries created by `captureInput` before they are persisted.
- Keep tagging logic local and rule-based to avoid adding dependencies or external services.

### Testing
- Ran `npm test -- sample.test.js` which passed.
- Ran `npm test -- chat-system.prompt12.test.js` which failed due to an existing ESM/Jest loader mismatch in `src/chat/actionRouter.js` that is unrelated to this change.
- Ran `npm test -- reminders.quick-add.test.js` which showed failures in existing quick-add/Firebase-dependent test paths unrelated to the tag generator integration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3e40f9018832484a2698e59b30762)