### PR TITLE
Add lightweight chat system status indicator

### DIFF
--- a/src/chat/actionRouter.js
+++ b/src/chat/actionRouter.js
@@ -9,9 +9,10 @@ const QUICK_ACTIONS_BY_INTENT = {
   processInbox: [{ label: 'View Notes', targetView: 'notes' }],
 };
 
-const createActionResult = (intent, message) => ({
+const createActionResult = (intent, message, status) => ({
   message,
   quickActions: QUICK_ACTIONS_BY_INTENT[intent] || [],
+  status,
 });
 
 const shouldProcessInbox = (text) => {
@@ -25,7 +26,7 @@ const shouldProcessInbox = (text) => {
 
 const routeCapture = async (text) => {
   const result = await executeCommand('capture', { text, source: 'capture' });
-  return createActionResult('capture', result.message);
+  return createActionResult('capture', result.message, result);
 };
 
 const routeReminder = async (text, dependencies = {}) => {
@@ -33,12 +34,12 @@ const routeReminder = async (text, dependencies = {}) => {
     text,
     handler: dependencies.createReminder,
   });
-  return createActionResult('reminder', result.message);
+  return createActionResult('reminder', result.message, result);
 };
 
 const routeAssistant = async (text) => {
   const result = await executeCommand('assistantQuery', { question: text });
-  return createActionResult('assistant', result.message);
+  return createActionResult('assistant', result.message, result);
 };
 
 const routeProcessInbox = async (dependencies = {}) => {
@@ -65,7 +66,7 @@ const routeProcessInbox = async (dependencies = {}) => {
     ? result.data.summary
     : result.message;
 
-  return createActionResult('processInbox', summary);
+  return createActionResult('processInbox', summary, { ...result, message: summary });
 };
 
 export const routeAction = async (intent, text, dependencies = {}) => {

--- a/src/chat/chatManager.js
+++ b/src/chat/chatManager.js
@@ -21,19 +21,20 @@ const createMessage = (role, content, quickActions = []) => ({
 
 const normalizeRouteResult = (result) => {
   if (typeof result === 'string') {
-    return { message: result, quickActions: [] };
+    return { message: result, quickActions: [], status: null };
   }
 
   return {
     message: typeof result?.message === 'string' ? result.message : '',
     quickActions: Array.isArray(result?.quickActions) ? result.quickActions : [],
+    status: result?.status && typeof result.status === 'object' ? result.status : null,
   };
 };
 
 export const handleChatMessage = async (text, dependencies = {}) => {
   const userText = typeof text === 'string' ? text.trim() : '';
   if (!userText) {
-    return { message: '', quickActions: [] };
+    return { message: '', quickActions: [], status: null };
   }
 
   addMessage(createMessage('user', userText));

--- a/src/components/ChatPanel.js
+++ b/src/components/ChatPanel.js
@@ -1,4 +1,5 @@
 import { handleMessage } from '../chat/chatManager.js';
+import { createSystemStatusIndicator } from './SystemStatusIndicator.js';
 
 const bubbleStyles = {
   user: {
@@ -118,6 +119,8 @@ export const createChatPanel = () => {
     gap: '0.5rem',
   });
 
+  const statusIndicator = createSystemStatusIndicator();
+
   const inputBar = createNode('form', {
     display: 'flex',
     gap: '0.5rem',
@@ -156,11 +159,14 @@ export const createChatPanel = () => {
     input.value = '';
 
     const assistantReply = await handleMessage(userInput);
+    if (assistantReply?.status) {
+      statusIndicator.show(assistantReply.status);
+    }
     appendMessage(messageList, 'assistant', assistantReply.message, assistantReply.quickActions);
   });
 
   inputBar.append(input, sendButton);
-  container.append(messageList, inputBar);
+  container.append(messageList, statusIndicator.container, inputBar);
 
   return {
     container,
@@ -168,5 +174,6 @@ export const createChatPanel = () => {
     input,
     sendButton,
     inputBar,
+    statusIndicator: statusIndicator.container,
   };
 };

--- a/src/components/SystemStatusIndicator.js
+++ b/src/components/SystemStatusIndicator.js
@@ -1,0 +1,61 @@
+const createNode = (tag, styles = {}) => {
+  const node = document.createElement(tag);
+  Object.assign(node.style, styles);
+  return node;
+};
+
+export const createSystemStatusIndicator = () => {
+  let hideTimer = null;
+
+  const container = createNode('div', {
+    alignSelf: 'flex-start',
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0.35rem',
+    fontSize: '0.78rem',
+    lineHeight: '1.2',
+    color: 'var(--fg)',
+    background: 'color-mix(in srgb, var(--fg) 8%, transparent)',
+    borderRadius: '999px',
+    padding: '0.25rem 0.55rem',
+    opacity: '0',
+    transform: 'translateY(4px)',
+    pointerEvents: 'none',
+    transition: 'opacity 180ms ease, transform 180ms ease',
+  });
+
+  const icon = createNode('span', {
+    fontWeight: '600',
+  });
+  icon.textContent = '✓';
+
+  const text = createNode('span');
+  text.textContent = '';
+
+  const hide = () => {
+    container.style.opacity = '0';
+    container.style.transform = 'translateY(4px)';
+  };
+
+  const show = (response) => {
+    const message = typeof response?.message === 'string' ? response.message.trim() : '';
+    if (!message) {
+      return;
+    }
+
+    text.textContent = message.replace(/[.!?]+$/, '');
+    container.style.opacity = '1';
+    container.style.transform = 'translateY(0)';
+
+    if (hideTimer) {
+      clearTimeout(hideTimer);
+    }
+
+    hideTimer = setTimeout(hide, 4000);
+  };
+
+  return {
+    container,
+    show,
+  };
+};


### PR DESCRIPTION
### Motivation
- Provide immediate, non-blocking feedback for the result of the most recent command executed from the chat so users get a subtle confirmation (e.g. “✓ Saved to Inbox”).
- Keep the UI lightweight and transient so it does not obstruct chat messages or change existing chat behavior.

### Description
- Add a new `SystemStatusIndicator` component at `src/components/SystemStatusIndicator.js` that renders a small, rounded pill with a check icon, subtle background, smooth fade/slide transitions, and a 4-second auto-hide timer.
- Render the indicator directly above the chat input bar by integrating `createSystemStatusIndicator()` into `src/components/ChatPanel.js` and appending `statusIndicator.container` between the message list and the input bar.
- Wire the chat flow so routed actions forward the raw `executeCommand()` result as `status` by updating `src/chat/actionRouter.js` to include `status` on action results (including the process inbox path which returns a summary).
- Preserve and return `status` metadata from routed results in `src/chat/chatManager.js` so the UI can call `statusIndicator.show(response.status)` immediately when a response is received.

### Testing
- Ran `npm run build` which completed successfully and produced the distribution assets.
- Ran `npm test -- --runInBand` which failed due to existing unrelated repository test-suite issues (numerous pre-existing ESM/vm loading errors and other baseline failures), so test failures are not caused by these UI changes.
- Attempted an automated Playwright screenshot of the running app to validate the UI, but the Playwright run could not interact with the chat input in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3e53a34948324bea9a605cc74ff67)