### PR TITLE
Convert capture screen into persistent chat conversation

### DIFF
--- a/css/capture.css
+++ b/css/capture.css
@@ -23,17 +23,25 @@
   gap: 0.8rem;
 }
 
+#thinkingBarForm {
+  flex-direction: row;
+  align-items: flex-end;
+  gap: 0.65rem;
+}
+
 .capture-input {
   width: 100%;
-  min-height: 8.5rem;
-  padding: 1rem 1rem;
+  min-height: 2.75rem;
+  max-height: 7.5rem;
+  padding: 0.72rem 0.9rem;
   border-radius: 0.85rem;
   border: 1px solid color-mix(in srgb, var(--card-border, #d1d5db) 80%, #ffffff 20%);
   background: var(--surface-elevated, #f9fafb);
   color: var(--text-main, #1f2937);
   font-size: 1rem;
-  line-height: 1.45;
-  resize: vertical;
+  line-height: 1.35;
+  resize: none;
+  overflow-y: auto;
 }
 
 .capture-input::placeholder {
@@ -48,8 +56,68 @@
 }
 
 .capture-save-btn {
-  align-self: flex-start;
-  min-width: 7rem;
+  align-self: flex-end;
+  min-width: 5.5rem;
+  height: 2.75rem;
+}
+
+.thinking-conversation {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  max-height: 20rem;
+  overflow-y: auto;
+  padding: 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--card-border, #d1d5db) 78%, #ffffff 22%);
+  border-radius: 0.85rem;
+  background: var(--surface-elevated, #f9fafb);
+}
+
+.thinking-message {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.thinking-message-user {
+  align-items: flex-end;
+}
+
+.thinking-message-assistant {
+  align-items: flex-start;
+}
+
+.thinking-message-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-muted, #6b7280);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.thinking-message-bubble {
+  max-width: 92%;
+  padding: 0.52rem 0.72rem;
+  border-radius: 0.72rem;
+  font-size: 0.92rem;
+  line-height: 1.35;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.thinking-message-user .thinking-message-bubble {
+  background: var(--accent-color, #512663);
+  color: #ffffff;
+}
+
+.thinking-message-assistant .thinking-message-bubble {
+  background: var(--card-bg, #ffffff);
+  border: 1px solid color-mix(in srgb, var(--card-border, #d1d5db) 80%, #ffffff 20%);
+  color: var(--text-main, #1f2937);
+}
+
+.thinking-message-typing .thinking-message-bubble {
+  color: var(--text-muted, #6b7280);
 }
 
 .capture-recent {

--- a/mobile.html
+++ b/mobile.html
@@ -245,27 +245,8 @@ Legacy shells remain for reference only.
       margin-top: 0.35rem;
     }
 
-    #thinkingBarResults {
+    #thinkingConversation {
       margin-top: 0.4rem;
-      display: grid;
-      gap: 0.45rem;
-    }
-
-    .thinking-result-item {
-      background: var(--surface-elevated);
-      border: 1px solid var(--border-subtle);
-      border-radius: 0.65rem;
-      padding: 0.55rem 0.65rem;
-      font-size: 0.84rem;
-      width: 100%;
-      text-align: left;
-      cursor: pointer;
-      color: inherit;
-    }
-
-    .thinking-result-title {
-      font-weight: 600;
-      margin-bottom: 0.12rem;
     }
 
     .swipe-container {
@@ -4846,7 +4827,7 @@ body, main, section, div, p, span, li {
             <button id="thinkingBarSubmit" type="submit" class="btn btn-primary capture-save-btn" aria-label="Send">Send</button>
           </form>
           <div id="thinkingBarStatus" class="hidden" aria-live="polite"></div>
-          <div id="thinkingBarResults" aria-live="polite"></div>
+          <div id="thinkingConversation" class="thinking-conversation" aria-live="polite"></div>
         </section>
     <!-- BEGIN GPT CHANGE: create form moved to bottom sheet -->
     <!-- END GPT CHANGE -->
@@ -6022,17 +6003,22 @@ body, main, section, div, p, span, li {
       renderInboxEntries();
     })();
   </script>
-  <script>
-    (function () {
-      const form = document.getElementById('thinkingBarForm');
-      const input = document.getElementById('thinkingBarInput');
-      const status = document.getElementById('thinkingBarStatus');
-      const results = document.getElementById('thinkingBarResults');
-      const processInboxButton = document.getElementById('processInboxButton');
+  <script type="module">
+    import { handleMessage } from './src/chat/chatManager.js';
+    import { getMessages } from './src/chat/messageStore.js';
 
-      if (!(form instanceof HTMLFormElement) || !(input instanceof HTMLTextAreaElement)) {
-        return;
-      }
+    const form = document.getElementById('thinkingBarForm');
+    const input = document.getElementById('thinkingBarInput');
+    const status = document.getElementById('thinkingBarStatus');
+    const conversation = document.getElementById('thinkingConversation');
+
+    if (!(form instanceof HTMLFormElement) || !(input instanceof HTMLTextAreaElement) || !(conversation instanceof HTMLElement)) {
+      // Keep the page usable if the chat capture elements are unavailable.
+    } else {
+      const autoResizeInput = () => {
+        input.style.height = 'auto';
+        input.style.height = `${Math.min(input.scrollHeight, 120)}px`;
+      };
 
       const setStatus = (text) => {
         if (!(status instanceof HTMLElement)) return;
@@ -6041,70 +6027,83 @@ body, main, section, div, p, span, li {
         status.classList.toggle('hidden', !msg);
       };
 
+      const createMessageBubble = (role, content) => {
+        const row = document.createElement('div');
+        row.className = `thinking-message thinking-message-${role}`;
 
-      const addResult = (title, body) => {
-        if (!(results instanceof HTMLElement)) return;
-        const item = document.createElement('div');
-        item.className = 'thinking-result-item';
-        const heading = document.createElement('div');
-        heading.className = 'thinking-result-title';
-        heading.textContent = title;
-        const detail = document.createElement('div');
-        detail.textContent = body;
-        item.append(heading, detail);
-        results.prepend(item);
+        const label = document.createElement('div');
+        label.className = 'thinking-message-label';
+        label.textContent = role === 'user' ? 'You' : 'Memory Cue';
+
+        const bubble = document.createElement('div');
+        bubble.className = 'thinking-message-bubble';
+        bubble.textContent = content;
+
+        row.append(label, bubble);
+        return row;
       };
 
-      const navigateTo = (view) => {
-        window.dispatchEvent(new CustomEvent('app:navigate', { detail: { view } }));
+      const appendMessage = (role, content) => {
+        if (!content) return;
+        conversation.appendChild(createMessageBubble(role, content));
+        conversation.scrollTop = conversation.scrollHeight;
       };
 
-      const isAssistantQuery = (text) => /\?$/.test(text) || /^(what|how|why|when|where|who|can|could|should|do|does|did)\b/i.test(text);
+      const renderHistory = () => {
+        const history = getMessages();
+        conversation.innerHTML = '';
+        history.forEach((message) => {
+          appendMessage(message.role === 'user' ? 'user' : 'assistant', message.content);
+        });
+      };
+
+      const createTypingIndicator = () => {
+        const row = document.createElement('div');
+        row.className = 'thinking-message thinking-message-assistant thinking-message-typing';
+
+        const label = document.createElement('div');
+        label.className = 'thinking-message-label';
+        label.textContent = 'Memory Cue';
+
+        const bubble = document.createElement('div');
+        bubble.className = 'thinking-message-bubble';
+        bubble.textContent = 'Memory Cue is thinking…';
+
+        row.append(label, bubble);
+        return row;
+      };
+
+      input.addEventListener('input', autoResizeInput);
+      autoResizeInput();
+      renderHistory();
 
       form.addEventListener('submit', async (event) => {
         event.preventDefault();
-        const text = (input.value || '').trim();
+        const text = input.value.trim();
         if (!text) return;
 
+        appendMessage('user', text);
         input.value = '';
-        setStatus('Working...');
+        autoResizeInput();
+
+        const typingIndicator = createTypingIndicator();
+        conversation.appendChild(typingIndicator);
+        conversation.scrollTop = conversation.scrollHeight;
+        setStatus('');
 
         try {
-          if (/^process\s+(today'?s\s+)?(notes|inbox)\b/i.test(text)) {
-            navigateTo('inbox');
-            processInboxButton?.click();
-            addResult('Inbox', 'Processing inbox notes.');
-            setStatus('Done');
-            return;
-          }
-
-          if (/^remind\s+me\b/i.test(text)) {
-            navigateTo('reminders');
-            const reminder = await window.memoryCueQuickAddNow?.({ forceText: text, source: 'thinking-bar' });
-            if (reminder) {
-              addResult('Reminder', 'Reminder added.');
-              setStatus('Done');
-              return;
-            }
-          }
-
-          if (isAssistantQuery(text)) {
-            navigateTo('assistant');
-            await window.memoryCueAskAssistant?.(text);
-            addResult('Assistant', 'Sent to assistant.');
-            setStatus('Done');
-            return;
-          }
-
-          await window.MemoryCueCaptureService?.captureInput?.(text, 'capture');
-          addResult('Capture', 'Saved to inbox.');
-          setStatus('Done');
+          const assistantReply = await handleMessage(text);
+          typingIndicator.remove();
+          appendMessage('assistant', assistantReply?.message || 'Saved to Inbox.');
+          setStatus('');
         } catch (error) {
+          typingIndicator.remove();
           console.error('Thinking bar request failed', error);
+          appendMessage('assistant', 'Unable to complete that request right now.');
           setStatus('Unable to complete that request right now.');
         }
       });
-    })();
+    }
   </script>
 
   <!-- build-marker: mobile.html / runs mobile.js / EXPECTED LIVE -->

--- a/src/components/ChatConversation.js
+++ b/src/components/ChatConversation.js
@@ -1,0 +1,171 @@
+import { handleMessage } from '../chat/chatManager.js';
+import { getMessages } from '../chat/messageStore.js';
+
+const bubbleStyles = {
+  user: {
+    alignSelf: 'flex-end',
+    background: 'var(--accent)',
+    color: 'var(--accent-contrast)',
+  },
+  assistant: {
+    alignSelf: 'flex-start',
+    background: 'var(--card)',
+    color: 'var(--fg)',
+    border: '1px solid color-mix(in srgb, var(--fg) 15%, transparent)',
+  },
+};
+
+const createNode = (tag, styles = {}) => {
+  const node = document.createElement(tag);
+  Object.assign(node.style, styles);
+  return node;
+};
+
+const createMessageBubble = (message) => {
+  const role = message?.role === 'user' ? 'user' : 'assistant';
+  const row = createNode('div', {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: role === 'user' ? 'flex-end' : 'flex-start',
+    gap: '0.2rem',
+  });
+
+  const label = createNode('div', {
+    fontSize: '0.7rem',
+    opacity: '0.75',
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: '0.02em',
+  });
+  label.textContent = role === 'user' ? 'You' : 'Memory Cue';
+
+  const bubble = createNode('div', {
+    maxWidth: '82%',
+    padding: '0.5rem 0.75rem',
+    borderRadius: '0.75rem',
+    fontSize: '0.95rem',
+    lineHeight: '1.35',
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+    ...bubbleStyles[role],
+  });
+  bubble.textContent = typeof message?.content === 'string' ? message.content : '';
+
+  row.append(label, bubble);
+  return row;
+};
+
+export const createChatConversation = () => {
+  const container = createNode('section', {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.75rem',
+    background: 'var(--bg)',
+    border: '1px solid color-mix(in srgb, var(--fg) 10%, transparent)',
+    borderRadius: '0.75rem',
+    padding: '0.75rem',
+  });
+
+  const messageList = createNode('div', {
+    minHeight: '220px',
+    maxHeight: '360px',
+    overflowY: 'auto',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+  });
+
+  const inputBar = createNode('form', {
+    display: 'flex',
+    gap: '0.5rem',
+    alignItems: 'flex-end',
+  });
+
+  const input = createNode('textarea', {
+    flex: '1',
+    border: '1px solid color-mix(in srgb, var(--fg) 15%, transparent)',
+    borderRadius: '0.5rem',
+    background: 'var(--card)',
+    color: 'var(--fg)',
+    padding: '0.55rem 0.75rem',
+    minHeight: '2.5rem',
+    maxHeight: '7.5rem',
+    resize: 'none',
+    lineHeight: '1.35',
+  });
+  input.rows = 1;
+  input.placeholder = 'Think or ask anything…';
+
+  const sendButton = createNode('button', {
+    border: 'none',
+    borderRadius: '0.5rem',
+    background: 'var(--accent)',
+    color: 'var(--accent-contrast)',
+    padding: '0.5rem 0.9rem',
+    cursor: 'pointer',
+    height: '2.5rem',
+  });
+  sendButton.type = 'submit';
+  sendButton.textContent = 'Send';
+
+  const resizeInput = () => {
+    input.style.height = 'auto';
+    input.style.height = `${Math.min(input.scrollHeight, 120)}px`;
+  };
+
+  const appendMessage = (role, content) => {
+    if (!content) return;
+    messageList.appendChild(createMessageBubble({ role, content }));
+    messageList.scrollTop = messageList.scrollHeight;
+  };
+
+  const renderMessages = () => {
+    messageList.innerHTML = '';
+    getMessages().forEach((message) => {
+      appendMessage(message.role, message.content);
+    });
+  };
+
+  const createTypingIndicator = () => createMessageBubble({ role: 'assistant', content: 'Memory Cue is thinking…' });
+
+  input.addEventListener('input', resizeInput);
+  resizeInput();
+  renderMessages();
+
+  inputBar.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const userInput = input.value.trim();
+    if (!userInput) {
+      return;
+    }
+
+    appendMessage('user', userInput);
+    input.value = '';
+    resizeInput();
+
+    const typingIndicator = createTypingIndicator();
+    messageList.appendChild(typingIndicator);
+    messageList.scrollTop = messageList.scrollHeight;
+
+    try {
+      const assistantReply = await handleMessage(userInput);
+      typingIndicator.remove();
+      appendMessage('assistant', assistantReply?.message || 'Saved to Inbox.');
+    } catch (error) {
+      typingIndicator.remove();
+      console.error('Failed to handle chat message', error);
+      appendMessage('assistant', 'Unable to complete that request right now.');
+    }
+  });
+
+  inputBar.append(input, sendButton);
+  container.append(messageList, inputBar);
+
+  return {
+    container,
+    messageList,
+    input,
+    sendButton,
+    inputBar,
+  };
+};


### PR DESCRIPTION
### Motivation
- Replace the old thinking-bar results list with a conversation-style chat UI so captures feel like a chat flow.
- Persist messages across reloads using the existing `messageStore` so users can revisit prior captures and assistant replies.
- Make the capture input a single-line auto-expanding control and add an assistant typing indicator to improve perceived responsiveness.

### Description
- Added a reusable chat component at `src/components/ChatConversation.js` that renders stored messages from `getMessages()`, submits via `handleMessage()`, and shows a typing indicator while awaiting responses.
- Replaced the capture results area in `mobile.html` with a conversation container (`#thinkingConversation`) and wired a module script to render history, append user/assistant bubbles, and call `chatManager.handleMessage()` on submit.
- Updated `css/capture.css` to switch the capture input to a compact single-line expanding textarea, resize the send button, and add conversation / bubble styles for user, assistant, and typing states.
- Kept changes minimal and consistent with existing runtime utilities (`chatManager`, `messageStore`) rather than introducing new storage or backend APIs.

### Testing
- Ran `npm run verify` and the build verification succeeded (`verify` passed).
- Ran `npm test -- chat-system.prompt12.test.js` and the test suite failed; failure is due to a pre-existing ESM/CommonJS test harness error in the test environment (import/`module` handling), not from the UI changes introduced here.
- Manual runtime smoke check performed by starting the dev server and capturing a browser screenshot of the updated capture view (UI rendering validated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3e72e91348324a60344b3ddf60655)