### PR TITLE
Implement chat-first UI with 3-tab navigation (Capture / Notes / Notebooks)

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -580,7 +580,20 @@
     setActiveFooterIcon(button.id);
 
     if (view === 'notes') {
+      closeSavedNotesSheet();
+      window.dispatchEvent(new CustomEvent('memorycue:notes:mode', { detail: { mode: 'overview' } }));
+      window.dispatchEvent(
+        new CustomEvent('app:navigate', {
+          detail: { view: 'notes' }
+        })
+      );
+      return;
+    }
+
+    if (view === 'notebooks') {
+      window.dispatchEvent(new CustomEvent('memorycue:notes:mode', { detail: { mode: 'notebooks' } }));
       navigateToNotebook();
+      setActiveFooterIcon('mobile-footer-notebooks');
       return;
     }
 

--- a/js/services/navigation-service.js
+++ b/js/services/navigation-service.js
@@ -1,10 +1,10 @@
 (function () {
-  const VIEW_ORDER = ['capture', 'inbox', 'reminders', 'notes', 'assistant', 'settings'];
+  const VIEW_ORDER = ['capture', 'notes', 'notebooks', 'settings'];
 
   const normalizeViewName = (name) => {
     if (!name) return 'capture';
     const value = String(name).toLowerCase();
-    if (value === 'notebook') return 'notes';
+    if (value === 'notebook' || value === 'notebooks') return 'notes';
     return value;
   };
 

--- a/mobile.html
+++ b/mobile.html
@@ -4916,7 +4916,7 @@ body, main, section, div, p, span, li {
     <section data-view="capture" id="view-capture" class="view-panel">
       <div class="capture-container capture-chat-layout">
         <div>
-          <h2 class="text-lg font-semibold">Capture</h2>
+          <h2 class="text-lg font-semibold">Memory Cue</h2>
           <div class="capture-form">
           <p class="text-sm text-base-content/70">Use the chat capture bar to capture ideas, add reminders, ask questions, and process inbox notes.</p>
           </div>
@@ -4929,7 +4929,7 @@ body, main, section, div, p, span, li {
       </div>
     </section>
     <!-- BEGIN GPT CHANGE: reminders view -->
-    <section data-view="reminders" id="view-reminders" class="view-panel">
+    <section id="view-reminders" class="view-panel hidden" aria-hidden="true">
       <div class="reminders-mobile-flow reminders-content-shell">
         <section class="reminders-screen-controls" aria-label="Reminder controls">
           <div class="reminders-quick-add-form" aria-label="Quick add reminder">
@@ -4989,7 +4989,7 @@ body, main, section, div, p, span, li {
         <div id="categoryEntriesList" class="category-entry-list"></div>
       </div>
     </div>
-    <div id="view-inbox" data-view="inbox" class="view-panel hidden" aria-hidden="true">
+    <div id="view-inbox" class="view-panel hidden" aria-hidden="true">
       <div class="space-y-3">
         <h2 class="text-lg font-semibold">Inbox</h2>
         <button id="processInboxButton" type="button" class="btn btn-sm btn-primary">Process Notes</button>
@@ -5002,6 +5002,27 @@ body, main, section, div, p, span, li {
 
     <section data-view="notes" id="view-notebook" class="view-panel hidden mobile-panel--notes mobile-panel--notes-size-small">
         <div class="mobile-view-inner mx-auto w-full px-0 pt-2 pb-2 space-y-0" style="padding: 0 !important; max-width: 100%;">
+        <section id="notesOverviewPanel" class="memory-glass-card-soft p-3 m-2">
+          <h2 class="text-lg font-semibold">Notes</h2>
+          <div class="flex flex-col gap-2 mt-2">
+            <input id="notesOverviewSearch" type="search" class="input input-sm input-bordered w-full" placeholder="Search notes" autocomplete="off" />
+            <div class="flex gap-2">
+              <select id="notesOverviewSort" class="select select-sm select-bordered flex-1" aria-label="Sort notes">
+                <option value="recent">Recent</option>
+                <option value="tagged">Tagged</option>
+                <option value="notebook">Notebook</option>
+                <option value="priority">Priority</option>
+              </select>
+              <select id="notesOverviewState" class="select select-sm select-bordered flex-1" aria-label="Filter by note state">
+                <option value="all">All</option>
+                <option value="inbox">Inbox</option>
+                <option value="processed">Processed</option>
+                <option value="archived">Archived</option>
+              </select>
+            </div>
+          </div>
+          <div id="notesOverviewList" class="space-y-2 mt-3" aria-live="polite"></div>
+        </section>
         <!-- notebook view header removed to keep UI minimal -->
         <!-- Enhanced Notebook Card -->
         <div id="noteEditorSheet" class="note-sheet-wrapper scratch-notes-wrapper">
@@ -5377,7 +5398,7 @@ body, main, section, div, p, span, li {
                 <button type="button" class="note-action-btn note-action-delete">Delete note</button>
               </div>
             </div>
-    <section data-view="assistant" id="view-assistant" class="view hidden" aria-hidden="true">
+    <section id="view-assistant" class="view hidden" aria-hidden="true">
       <div class="assistant-panel">
         <div id="assistantMessages" class="assistant-messages" aria-live="polite" aria-label="Assistant conversation"></div>
         <div class="assistant-input">
@@ -5466,11 +5487,11 @@ body, main, section, div, p, span, li {
 
       <button
         type="button"
-        class="floating-card nav-item btn-reminders"
-        id="mobile-footer-reminders"
-        data-nav-target="reminders"
-        data-tab="reminders"
-        aria-label="Go to Reminders"
+        class="floating-card nav-item btn-notes"
+        id="mobile-footer-notes"
+        data-nav-target="notes"
+        data-tab="notes"
+        aria-label="Go to Notes"
       >
         <svg
           class="icon icon-clock"
@@ -5487,16 +5508,16 @@ body, main, section, div, p, span, li {
           <circle cx="12" cy="12" r="7" />
           <path d="M12 9v3.5l2 1.5" />
         </svg>
-        <span>Reminders</span>
+        <span>Notes</span>
       </button>
 
       <button
         type="button"
-        class="floating-card nav-item btn-notes"
-        id="mobile-footer-notes"
-        data-nav-target="notes"
-        data-tab="notes"
-        aria-label="Go to Notes"
+        class="floating-card nav-item btn-notebook"
+        id="mobile-footer-notebooks"
+        data-nav-target="notebooks"
+        data-tab="notebooks"
+        aria-label="Go to Notebooks"
       >
         <svg
           class="icon icon-notes"
@@ -5515,60 +5536,7 @@ body, main, section, div, p, span, li {
           <path d="M9 12h6" />
           <path d="M9 15.5h4" />
         </svg>
-        <span>Notes</span>
-      </button>
-
-
-
-      <button
-        type="button"
-        class="floating-card nav-item btn-inbox"
-        id="mobile-footer-inbox"
-        data-nav-target="inbox"
-        data-tab="inbox"
-        aria-label="Go to Inbox"
-      >
-        <svg
-          class="icon icon-inbox"
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.75"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M4.5 7.5h15v9a2 2 0 0 1-2 2h-11a2 2 0 0 1-2-2v-9Z" />
-          <path d="M4.5 12h4l1.5 2h4l1.5-2h4" />
-        </svg>
-        <span>Inbox</span>
-      </button>
-
-      <button
-        type="button"
-        class="floating-card nav-item btn-assistant"
-        id="mobile-footer-assistant"
-        data-nav-target="assistant"
-        data-tab="assistant"
-        aria-label="Go to Assistant"
-      >
-        <svg
-          class="icon icon-assistant"
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.75"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M12 3.5l1.58 3.24 3.57.52-2.58 2.52.61 3.56L12 11.78 8.82 13.34l.61-3.56-2.58-2.52 3.57-.52L12 3.5Z" />
-        </svg>
-        <span>Assistant</span>
+        <span>Notebooks</span>
       </button>
     </div>
   </nav>

--- a/mobile.js
+++ b/mobile.js
@@ -1274,6 +1274,12 @@ const initMobileNotes = () => {
   const filterInput = document.getElementById('notebook-search-input');
   const folderFilterSelect = document.getElementById('folderFilterSelect');
   const folderFilterNewButton = document.getElementById('folderFilterNewFolder');
+  const notesOverviewPanel = document.getElementById('notesOverviewPanel');
+  const notesOverviewList = document.getElementById('notesOverviewList');
+  const notesOverviewSearch = document.getElementById('notesOverviewSearch');
+  const notesOverviewSort = document.getElementById('notesOverviewSort');
+  const notesOverviewState = document.getElementById('notesOverviewState');
+  const noteEditorSheet = document.getElementById('noteEditorSheet');
   const savedNotesSheet = document.getElementById('savedNotesSheet');
   const openSavedNotesButton =
     document.getElementById('openSavedNotesGlobal') ||
@@ -1551,6 +1557,10 @@ const initMobileNotes = () => {
   let folderSelectorOnSelect = null;
   let activeFolderSheetOpener = null;
   let filterQuery = '';
+  let notesOverviewQuery = '';
+  let notesOverviewSortValue = 'recent';
+  let notesOverviewStateValue = 'all';
+  let notesMode = 'notebooks';
   let skipAutoSelectOnce = false;
   let savedNotesSheetHideTimeout = null;
 
@@ -1558,6 +1568,16 @@ const initMobileNotes = () => {
     filterQuery = '';
     if (filterInput) {
       filterInput.value = '';
+    }
+  };
+
+  const applyNotesMode = (mode = 'notebooks') => {
+    notesMode = mode === 'overview' ? 'overview' : 'notebooks';
+    if (notesOverviewPanel instanceof HTMLElement) {
+      notesOverviewPanel.classList.toggle('hidden', notesMode !== 'overview');
+    }
+    if (noteEditorSheet instanceof HTMLElement) {
+      noteEditorSheet.classList.toggle('hidden', notesMode === 'overview');
     }
   };
 
@@ -1702,6 +1722,82 @@ const initMobileNotes = () => {
     }
     // Then apply search filter
     return sortNotesForDisplay(getFilteredNotes(filteredByFolder));
+  };
+
+
+  const getNotesOverviewItems = () => {
+    const items = Array.isArray(allNotes) ? [...allNotes] : [];
+    const q = (notesOverviewQuery || '').trim().toLowerCase();
+    const stateFilter = (notesOverviewStateValue || 'all').toLowerCase();
+
+    const filtered = items.filter((note) => {
+      const title = typeof note?.title === 'string' ? note.title : '';
+      const body = getNoteBodyText(note);
+      const haystack = `${title} ${body}`.toLowerCase();
+      const noteState = typeof note?.state === 'string' ? note.state.toLowerCase() : 'processed';
+      const matchesQuery = !q || haystack.includes(q);
+      const matchesState = stateFilter === 'all' || noteState === stateFilter;
+      return matchesQuery && matchesState;
+    });
+
+    if (notesOverviewSortValue === 'notebook') {
+      filtered.sort((a, b) => {
+        const aFolder = getFolderNameById(a?.folderId || 'unsorted');
+        const bFolder = getFolderNameById(b?.folderId || 'unsorted');
+        return String(aFolder).localeCompare(String(bFolder));
+      });
+      return filtered;
+    }
+
+    if (notesOverviewSortValue === 'priority') {
+      filtered.sort((a, b) => Number(Boolean(b?.pinned)) - Number(Boolean(a?.pinned)) || getNoteTimestamp(b) - getNoteTimestamp(a));
+      return filtered;
+    }
+
+    if (notesOverviewSortValue === 'tagged') {
+      filtered.sort((a, b) => {
+        const aTags = Array.isArray(a?.tags) ? a.tags.length : 0;
+        const bTags = Array.isArray(b?.tags) ? b.tags.length : 0;
+        return bTags - aTags || getNoteTimestamp(b) - getNoteTimestamp(a);
+      });
+      return filtered;
+    }
+
+    return sortNotesForDisplay(filtered);
+  };
+
+  const renderNotesOverview = () => {
+    if (!(notesOverviewList instanceof HTMLElement)) {
+      return;
+    }
+    notesOverviewList.innerHTML = '';
+    const items = getNotesOverviewItems();
+    if (!items.length) {
+      const empty = document.createElement('p');
+      empty.className = 'text-sm text-base-content/70';
+      empty.textContent = 'No notes found.';
+      notesOverviewList.appendChild(empty);
+      return;
+    }
+
+    items.slice(0, 30).forEach((note) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'w-full text-left memory-glass-card-soft p-2';
+      const folder = getFolderNameById(note?.folderId || 'unsorted') || 'Unsorted';
+      const tags = Array.isArray(note?.tags) && note.tags.length ? note.tags.join(', ') : 'none';
+      button.innerHTML = `<div class="font-medium">${note?.title || 'Untitled note'}</div><div class="text-xs text-base-content/70">Notebook: ${folder}</div><div class="text-xs text-base-content/70">Tags: ${tags}</div><div class="text-xs text-base-content/70">Created: ${formatNoteTimestamp(note?.createdAt || note?.updatedAt)}</div>`;
+      button.addEventListener('click', () => {
+        setEditorValues(note);
+        updateListSelection();
+        applyNotesMode('notebooks');
+        const notebooksBtn = document.getElementById('mobile-footer-notebooks');
+        if (notebooksBtn instanceof HTMLElement) {
+          notebooksBtn.click();
+        }
+      });
+      notesOverviewList.appendChild(button);
+    });
   };
 
   const getNoteCountsByFolder = (allNotesArray = [], folders = []) => {
@@ -2056,6 +2152,7 @@ const initMobileNotes = () => {
 
     renderNotesList(visibleNotes);
     renderDashboardPanel();
+    renderNotesOverview();
 
     if (!hasAnyNotes) {
       if (!shouldPreserveEditor) {
@@ -2088,6 +2185,8 @@ const initMobileNotes = () => {
     updateStoredSnapshot();
     return visibleNotes;
   };
+
+  applyNotesMode('notebooks');
 
   const renderNotebookList = () => refreshFromStorage({ preserveDraft: true });
   window.renderNotebookList = renderNotebookList;
@@ -3517,6 +3616,34 @@ const initMobileNotes = () => {
     filterInput.addEventListener('input', handleFilterInput);
     filterInput.addEventListener('search', handleFilterInput);
   }
+
+  if (notesOverviewSearch instanceof HTMLElement) {
+    notesOverviewSearch.addEventListener('input', () => {
+      notesOverviewQuery = typeof notesOverviewSearch.value === 'string' ? notesOverviewSearch.value.trim() : '';
+      renderNotesOverview();
+    });
+  }
+
+  if (notesOverviewSort instanceof HTMLSelectElement) {
+    notesOverviewSort.addEventListener('change', () => {
+      notesOverviewSortValue = notesOverviewSort.value || 'recent';
+      renderNotesOverview();
+    });
+  }
+
+  if (notesOverviewState instanceof HTMLSelectElement) {
+    notesOverviewState.addEventListener('change', () => {
+      notesOverviewStateValue = notesOverviewState.value || 'all';
+      renderNotesOverview();
+    });
+  }
+
+  window.addEventListener('memorycue:notes:mode', (event) => {
+    applyNotesMode(event?.detail?.mode);
+    if (notesMode === 'overview') {
+      renderNotesOverview();
+    }
+  });
 
   if (folderFilterSelect) {
     folderFilterSelect.addEventListener('change', (event) => {


### PR DESCRIPTION
### Motivation
- Stabilize the mobile UI around a single chat-first Capture interface so all input flows through one composer and reduce duplication between Capture, Assistant and Inbox.
- Provide a simple three-screen navigation model (Capture, Notes, Notebooks) to reduce user confusion while keeping existing storage and processing intact.
- Surface a lightweight Notes overview so users can search, sort and filter note states (Inbox/Processed/Archived) without changing underlying note models.

### Description
- Reworked bottom navigation and mobile shell to expose only `Capture`, `Notes`, and `Notebooks` entries and updated the Capture header to `Memory Cue`. (changes in `mobile.html`).
- Introduced a Notes overview panel (search input, sort dropdown, state filter, and `#notesOverviewList`) rendered from existing note storage and wired to open notes into the editor. (UI markup + list container in `mobile.html`, rendering in `mobile.js`).
- Added notes-mode handling and overview rendering in `mobile.js` via `applyNotesMode`, `renderNotesOverview`, and `getNotesOverviewItems` while preserving all existing note storage and editor flows.
- Updated navigation wiring so `Notes` opens the overview and `Notebooks` opens the editor flow, and added a `memorycue:notes:mode` event; normalized view names and limited the `VIEW_ORDER` to `['capture','notes','notebooks','settings']` in `js/services/navigation-service.js`; adjusted `js/navigation.js` footer click behavior to dispatch the new mode events.

### Testing
- Ran targeted navigation test: `npx jest js/__tests__/mobile.footer-nav.test.js --runInBand` and it passed.
- Built and verified the site with `npm run verify` which passed the build verification step.
- Ran the full test suite via `npm test -- --runInBand` and observed unrelated pre-existing failures in `mobile.new-folder`, `mobile.auth`, and `reminders.categories` (these failures existed in this environment and are not regressions from the navigation work).
- Launched a local dev server and produced screenshots with Playwright to validate the new layout (artifacts available: final UI capture images).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3eb35be1483249e97a7df81aeb6e7)