### PR TITLE
Smart tagging service + auto-notebook assignment for inbox processing

### DIFF
--- a/src/ai/inboxProcessor.js
+++ b/src/ai/inboxProcessor.js
@@ -1,4 +1,6 @@
 import { createNote, loadAllNotes, saveAllNotes } from '../../js/modules/notes-storage.js';
+import { ensureFolderExistsByName } from '../../js/modules/ai-capture-save.js';
+import { suggestNotebookAndTags } from '../services/taggingEngine.js';
 
 const normalizeText = (value) => {
   if (typeof value !== 'string') {
@@ -58,6 +60,7 @@ const addNotes = (notes) => {
 export const processInbox = async (entries = [], options = {}) => {
   const createReminder = typeof options.createReminder === 'function' ? options.createReminder : null;
   const removeInboxEntry = typeof options.removeInboxEntry === 'function' ? options.removeInboxEntry : null;
+  const aiClassifier = typeof options.aiClassifier === 'function' ? options.aiClassifier : null;
 
   const counts = {
     note: 0,
@@ -70,26 +73,31 @@ export const processInbox = async (entries = [], options = {}) => {
   const notesToSave = [];
   const processedItems = [];
 
-  entries.forEach((entry) => {
+  for (const entry of entries) {
     const text = getEntryText(entry);
     if (!text) {
-      return;
+      continue;
     }
 
     const { type, tags } = classifyEntry(text);
+    const organization = await suggestNotebookAndTags(text, { aiClassifier });
+    const combinedTags = Array.from(new Set([...(Array.isArray(tags) ? tags : []), ...organization.tags]));
+
     counts[type] += 1;
-    processedItems.push({ ...entry, type, tags, text });
+    processedItems.push({ ...entry, type, text, tags: combinedTags, notebook: organization.notebook });
 
     if (type === 'reminder') {
       if (createReminder) {
         createReminder({ title: text, notes: 'Created from Inbox processing.' });
       }
     } else {
+      const folderId = ensureFolderExistsByName(organization.notebook);
       notesToSave.push(
         createNote(text.split(/\s+/).slice(0, 8).join(' '), text, {
+          folderId,
           metadata: {
             type,
-            tags,
+            tags: combinedTags,
           },
         }),
       );
@@ -98,7 +106,7 @@ export const processInbox = async (entries = [], options = {}) => {
     if (removeInboxEntry && entry?.id != null) {
       removeInboxEntry(String(entry.id));
     }
-  });
+  }
 
   addNotes(notesToSave);
 

--- a/src/services/taggingEngine.js
+++ b/src/services/taggingEngine.js
@@ -1,0 +1,105 @@
+import { generateTags } from '../ai/tagGenerator.js';
+
+const DEFAULT_NOTEBOOKS = ['Teaching', 'Coaching', 'Family', 'Ideas', 'Tasks'];
+const FALLBACK_NOTEBOOK = 'Inbox';
+
+const KEYWORD_RULES = [
+  {
+    notebook: 'Teaching',
+    tags: ['teaching', 'lesson idea'],
+    pattern: /\b(lesson|teach|teaching|class|classroom|student|curriculum|assignment|pompeii|history)\b/i,
+  },
+  {
+    notebook: 'Coaching',
+    tags: ['coaching'],
+    pattern: /\b(coach|coaching|client|session|mentoring|mentor|1:1|one on one)\b/i,
+  },
+  {
+    notebook: 'Family',
+    tags: ['family'],
+    pattern: /\b(family|mom|dad|parent|kids|child|home)\b/i,
+  },
+  {
+    notebook: 'Ideas',
+    tags: ['idea'],
+    pattern: /\b(idea|brainstorm|concept|prototype|invent|explore)\b/i,
+  },
+  {
+    notebook: 'Tasks',
+    tags: ['task'],
+    pattern: /\b(buy|task|todo|to-do|errand|groceries|shopping|finish|complete|call)\b/i,
+  },
+];
+
+const normalizeText = (value) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.replace(/\s+/g, ' ').trim();
+};
+
+const dedupeTags = (tags = []) => tags
+  .map((tag) => (typeof tag === 'string' ? tag.trim().toLowerCase() : ''))
+  .filter((tag, index, list) => tag && list.indexOf(tag) === index);
+
+const hasKeywordMatch = (text) => KEYWORD_RULES.some((rule) => rule.pattern.test(text));
+
+const classifyWithKeywords = (text) => {
+  const matchedRule = KEYWORD_RULES.find((rule) => rule.pattern.test(text));
+  if (!matchedRule) {
+    return { notebook: null, tags: [] };
+  }
+
+  const generatedTags = generateTags(text);
+  return {
+    notebook: matchedRule.notebook,
+    tags: dedupeTags([...matchedRule.tags, ...generatedTags]),
+  };
+};
+
+const classifyWithAI = async (text, options = {}) => {
+  const classifier = typeof options.aiClassifier === 'function' ? options.aiClassifier : null;
+  if (!classifier) {
+    return { notebook: null, tags: generateTags(text) };
+  }
+
+  try {
+    const result = await classifier(text);
+    const notebook = typeof result?.notebook === 'string' ? result.notebook.trim() : '';
+    const tags = Array.isArray(result?.tags) ? result.tags : [];
+    return {
+      notebook: notebook || null,
+      tags: dedupeTags(tags),
+    };
+  } catch (error) {
+    console.warn('[tagging-engine] AI fallback classification failed', error);
+    return { notebook: null, tags: generateTags(text) };
+  }
+};
+
+export const suggestNotebookAndTags = async (text, options = {}) => {
+  const normalizedText = normalizeText(text);
+  if (!normalizedText) {
+    return { notebook: FALLBACK_NOTEBOOK, tags: [] };
+  }
+
+  const keywordResult = classifyWithKeywords(normalizedText);
+  if (keywordResult.notebook || keywordResult.tags.length) {
+    return {
+      notebook: keywordResult.notebook || FALLBACK_NOTEBOOK,
+      tags: dedupeTags(keywordResult.tags),
+    };
+  }
+
+  const aiResult = await classifyWithAI(normalizedText, options);
+  const notebook = DEFAULT_NOTEBOOKS.includes(aiResult.notebook) ? aiResult.notebook : FALLBACK_NOTEBOOK;
+
+  return {
+    notebook,
+    tags: dedupeTags(aiResult.tags),
+  };
+};
+
+export const TAGGING_DEFAULT_NOTEBOOKS = [...DEFAULT_NOTEBOOKS];
+export const TAGGING_FALLBACK_NOTEBOOK = FALLBACK_NOTEBOOK;
+export const TAGGING_KEYWORD_MATCHER = hasKeywordMatch;


### PR DESCRIPTION
### Motivation
- Automatically organize captured notes by assigning tags and a suggested notebook so users don't need to manually sort inbox items.
- Use keyword matching first with a safe AI fallback and avoid duplicate tags when merging classifier and rule-based tags.

### Description
- Add `src/services/taggingEngine.js` implementing keyword-first notebook/tag rules, deduplication, default notebooks (`Teaching`, `Coaching`, `Family`, `Ideas`, `Tasks`) and `Inbox` as a fallback, plus support for an optional `aiClassifier` fallback via `suggestNotebookAndTags`.
- Integrate tagging into inbox processing (`src/ai/inboxProcessor.js`) by calling `suggestNotebookAndTags`, merging deduplicated tags with existing classification tags, and annotating processed items with the suggested `notebook` and `tags`.
- Persist suggested notebook placement by resolving notebook name to a folder id via the existing `ensureFolderExistsByName` and passing `folderId` into `createNote` so notes are created in the suggested notebook.
- Preserve existing reminder behavior and provide an `aiClassifier` option (passed through `processInbox` `options`) for environments that provide an external classifier.

### Testing
- Ran `npm run build`, which completed successfully and produced the rebuilt `dist` assets.
- Ran `npm test -- --runInBand`, which failed due to multiple pre-existing test-suite issues (ESM/CJS harness mismatches and unrelated assertions); failures appear unrelated to the changes in tagging and inbox processing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3ee1e45a8832480f3c4f640ae8b40)