### PR TITLE
Add memory recall search routing for chat queries

### DIFF
--- a/src/chat/actionRouter.js
+++ b/src/chat/actionRouter.js
@@ -1,12 +1,14 @@
 import { processInbox } from '../ai/inboxProcessor.js';
 import { executeCommand } from '../core/commandEngine.js';
 import { getInboxEntries, removeInboxEntry } from '../services/inboxService.js';
+import { formatMemorySearchResponse, searchNotesMemory } from '../services/memorySearch.js';
 
 const QUICK_ACTIONS_BY_INTENT = {
   capture: [{ label: 'Open Inbox', targetView: 'inbox' }],
   reminder: [{ label: 'Edit Reminder', targetView: 'reminders' }],
   assistant: [{ label: 'View Notes', targetView: 'notes' }],
   processInbox: [{ label: 'View Notes', targetView: 'notes' }],
+  memorySearch: [{ label: 'View Notes', targetView: 'notes' }],
 };
 
 const createActionResult = (intent, message, status) => ({
@@ -40,6 +42,19 @@ const routeReminder = async (text, dependencies = {}) => {
 const routeAssistant = async (text) => {
   const result = await executeCommand('assistantQuery', { question: text });
   return createActionResult('assistant', result.message, result);
+};
+
+const routeMemorySearch = async (text) => {
+  const result = await executeCommand('search', {
+    query: text,
+    handler: ({ query }) => searchNotesMemory(query),
+  });
+
+  return createActionResult(
+    'memorySearch',
+    formatMemorySearchResponse(result.data),
+    { ...result, message: formatMemorySearchResponse(result.data) },
+  );
 };
 
 const routeProcessInbox = async (dependencies = {}) => {
@@ -80,6 +95,10 @@ export const routeAction = async (intent, text, dependencies = {}) => {
 
   if (intent === 'assistant') {
     return routeAssistant(text);
+  }
+
+  if (intent === 'memorySearch') {
+    return routeMemorySearch(text);
   }
 
   return routeCapture(text);

--- a/src/chat/intentParser.js
+++ b/src/chat/intentParser.js
@@ -1,8 +1,23 @@
+const MEMORY_SEARCH_PREFIXES = ['what', 'show', 'find', 'list'];
+
+const isMemorySearchQuery = (text) => {
+  const normalized = typeof text === 'string' ? text.trim().toLowerCase() : '';
+  if (!normalized) {
+    return false;
+  }
+
+  return MEMORY_SEARCH_PREFIXES.some((prefix) => normalized.startsWith(`${prefix} `));
+};
+
 export const parseIntent = (text) => {
   const normalized = typeof text === 'string' ? text.trim().toLowerCase() : '';
 
   if (normalized.includes('remind')) {
     return 'reminder';
+  }
+
+  if (isMemorySearchQuery(normalized)) {
+    return 'memorySearch';
   }
 
   if (normalized.includes('note')) {

--- a/src/services/memorySearch.js
+++ b/src/services/memorySearch.js
@@ -1,0 +1,116 @@
+import { searchMemoryIndex } from '../../js/modules/memory-index.js';
+
+const QUERY_PREFIXES = ['what', 'show', 'find', 'list'];
+
+const normalizeText = (value) => (typeof value === 'string' ? value.trim() : '');
+
+const normalizeToken = (value) => normalizeText(value).toLowerCase();
+
+const parseHashtagTags = (query) => {
+  const matches = typeof query === 'string' ? query.match(/#([a-z0-9_-]+)/gi) : null;
+  if (!matches) {
+    return [];
+  }
+
+  return matches
+    .map((tag) => normalizeToken(tag.replace(/^#/, '')))
+    .filter((tag, index, list) => tag && list.indexOf(tag) === index);
+};
+
+const parseExplicitTagTerms = (query) => {
+  if (typeof query !== 'string') {
+    return [];
+  }
+
+  const matches = [...query.matchAll(/tags?\s+([a-z0-9\s_-]+)/gi)];
+  if (!matches.length) {
+    return [];
+  }
+
+  return matches
+    .flatMap((match) => normalizeText(match[1]).split(/[,\s]+/))
+    .map((tag) => normalizeToken(tag))
+    .filter((tag, index, list) => tag && list.indexOf(tag) === index);
+};
+
+const parseNotebookTerm = (query) => {
+  if (typeof query !== 'string') {
+    return '';
+  }
+
+  const explicitMatch = query.match(/notebook\s+([a-z0-9\s_-]+)/i);
+  if (explicitMatch) {
+    return normalizeToken(explicitMatch[1]);
+  }
+
+  const inMatch = query.match(/in\s+([a-z0-9\s_-]+)\s+notebook/i);
+  if (inMatch) {
+    return normalizeToken(inMatch[1]);
+  }
+
+  return '';
+};
+
+const matchesTagTerms = (entry, tagTerms) => {
+  if (!tagTerms.length) {
+    return true;
+  }
+
+  const tags = Array.isArray(entry?.tags) ? entry.tags.map((tag) => normalizeToken(tag)) : [];
+  return tagTerms.every((tagTerm) => tags.some((tag) => tag.includes(tagTerm)));
+};
+
+const matchesNotebookTerm = (entry, notebookTerm) => {
+  if (!notebookTerm) {
+    return true;
+  }
+
+  const folderName = normalizeToken(entry?.folder);
+  return folderName.includes(notebookTerm);
+};
+
+const formatLineItems = (entries) => entries
+  .map((entry) => `• ${entry.title}`)
+  .join('\n');
+
+export const isMemorySearchQuery = (text) => {
+  const normalized = normalizeToken(text);
+  if (!normalized) {
+    return false;
+  }
+
+  return QUERY_PREFIXES.some((prefix) => normalized.startsWith(`${prefix} `));
+};
+
+export const searchNotesMemory = (query) => {
+  const normalizedQuery = normalizeText(query);
+  const tagTerms = [...parseHashtagTags(normalizedQuery), ...parseExplicitTagTerms(normalizedQuery)]
+    .filter((tag, index, list) => tag && list.indexOf(tag) === index);
+  const notebookTerm = parseNotebookTerm(normalizedQuery);
+
+  const filteredResults = searchMemoryIndex(normalizedQuery).filter((entry) => (
+    matchesTagTerms(entry, tagTerms) && matchesNotebookTerm(entry, notebookTerm)
+  ));
+
+  return {
+    query: normalizedQuery,
+    count: filteredResults.length,
+    items: filteredResults,
+    filters: {
+      tags: tagTerms,
+      notebook: notebookTerm,
+    },
+  };
+};
+
+export const formatMemorySearchResponse = (result) => {
+  const count = Number(result?.count) || 0;
+  const items = Array.isArray(result?.items) ? result.items : [];
+
+  if (!count || !items.length) {
+    return 'I could not find any matching notes yet.';
+  }
+
+  const heading = count === 1 ? 'You have 1 note saved:' : `You have ${count} notes saved:`;
+  return `${heading}\n\n${formatLineItems(items)}`;
+};


### PR DESCRIPTION
### Motivation
- Enable natural language recall of stored notes from the chat so users can ask questions like “what lesson ideas have I saved?”.
- Reuse the existing note index (`js/modules/memory-index.js`) rather than introducing a duplicate search implementation. 

### Description
- Added a new service `src/services/memorySearch.js` that layers keyword search, tag parsing (`#tag` and `tags ...`), and notebook filtering (`notebook ...` / `in ... notebook`) on top of the existing memory index and formats user-facing responses.
- Updated the chat intent parser (`src/chat/intentParser.js`) to detect memory-recall queries that begin with `what`, `show`, `find`, or `list` and return a new `memorySearch` intent.
- Updated the action router (`src/chat/actionRouter.js`) to handle the `memorySearch` intent by invoking the new service (via the existing `executeCommand('search')` hook) and returning a formatted response with the existing quick-action that navigates to Notes.
- Kept integration minimal and consistent with existing app navigation and indexing to avoid UI changes and duplicate storage logic.

### Testing
- Ran `npm run verify` and the build verification passed.
- Ran `npm test -- --runInBand js/tests/notes-storage.folders.test.js` and the suite passed.
- Ran `npm test -- --runInBand chat-system.prompt12.test.js` which failed because the legacy test harness executes source files via `vm.Script` without handling modern ESM `import` statements introduced by the routing changes, causing a parsing error in the test runner (this is a test-harness incompatibility rather than a runtime build failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3efceee30832499c1254205e28a9b)