### PR TITLE
Unify offline caches with Supabase sync service (notes, inbox, reminders, chat)

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -1,5 +1,7 @@
 import { setAuthContext, startSignInFlow, startSignOutFlow } from './supabase-auth.js';
 import { captureInput, getInboxEntries } from './services/capture-service.js';
+import { getSupabaseClient } from './supabase-client.js';
+import { deleteReminder, syncReminders, upsertReminder } from '../src/services/supabaseSyncService.js';
 
 // Shared reminder logic used by both the mobile and desktop pages.
 // This module wires up Firebase/Firestore and all reminder UI handlers.
@@ -4263,29 +4265,35 @@ export async function initReminders(sel = {}) {
     googleSignOutBtns.forEach((btn) => wireAuthButton(btn, startSignOutFlow));
   }
 
-  if (authReady && typeof onAuthStateChanged === 'function') {
-    onAuthStateChanged(auth, async (user) => {
+  const supabase = getSupabaseClient();
+  if (supabase && supabase.auth && typeof supabase.auth.onAuthStateChange === 'function') {
+    supabase.auth.onAuthStateChange(async (_event, session) => {
+      const user = session?.user || null;
       if (user) {
-        userId = user.uid;
+        userId = user.id;
         renderSyncIndicator('online');
         googleSignInBtns.forEach((btn) => btn.classList.add('hidden'));
         googleSignOutBtns.forEach((btn) => btn.classList.remove('hidden'));
-        if(googleUserName) googleUserName.textContent = user.displayName || user.email || '';
-        setupFirestoreSync();
+        if(googleUserName) googleUserName.textContent = user.email || '';
+        await setupSupabaseSync();
         await migrateOfflineRemindersIfNeeded();
       } else {
         applySignedOutState();
       }
     });
+    supabase.auth.getSession().then(async ({ data }) => {
+      const user = data?.session?.user || null;
+      if (user) {
+        userId = user.id;
+        renderSyncIndicator('online');
+        await setupSupabaseSync();
+      }
+    }).catch(() => {});
   } else {
     applySignedOutState();
   }
 
-  // Firestore sync
-  function setupFirestoreSync(){
-    if(!firebaseReady || !db || typeof collection !== 'function' || typeof query !== 'function' || typeof orderBy !== 'function' || typeof onSnapshot !== 'function'){
-      return;
-    }
+  async function setupSupabaseSync(){
     if(!userId){
       hydrateOfflineReminders();
       render();
@@ -4294,68 +4302,41 @@ export async function initReminders(sel = {}) {
       rescheduleAllReminders();
       return;
     }
-    if(unsubscribe) unsubscribe();
-    const userCollection = collection(db, 'users', userId, 'reminders');
-    const qSnap = query(userCollection, orderBy('updatedAt','desc'));
-    unsubscribe = onSnapshot(qSnap, (snapshot) => {
-      const remoteItems = [];
-      snapshot.forEach((d)=>{
-        const data = d.data();
-        const orderValue = Number(data.orderIndex);
-        const plannerLessonId = typeof data.plannerLessonId === 'string' && data.plannerLessonId ? data.plannerLessonId : null;
-        const pinToToday = data.pinToToday === true;
-        remoteItems.push({
-          id: d.id,
-          title:
-            typeof data.title === 'string' && data.title.trim()
-              ? data.title
-              : (typeof data.text === 'string' ? data.text : ''),
-          priority: data.priority,
-          notes: data.notes || '',
-          done: typeof data.done === 'boolean'
-            ? data.done
-            : Boolean(data.completed || data.isDone || data.status === 'done'),
-          due: data.due || data.dueAt || null,
-          category: normalizeCategory(data.category),
-          createdAt: data.createdAt?.toMillis?.() || 0,
-          updatedAt: data.updatedAt?.toMillis?.() || 0,
-          pendingSync: false,
-          orderIndex: Number.isFinite(orderValue) ? orderValue : null,
-          plannerLessonId,
-          pinToToday,
-        });
-      });
-      items = ensureOrderIndicesInitialized(remoteItems);
+    try {
+      const remoteItems = await syncReminders();
+      items = ensureOrderIndicesInitialized(Array.isArray(remoteItems) ? remoteItems.map((item) => ({ ...item, category: normalizeCategory(item.category) })) : []);
       render();
       updateMobileRemindersHeaderSubtitle();
       persistItems();
       rescheduleAllReminders();
-    }, (error)=>{
-      console.error('Firestore sync error:', error);
+    } catch (error){
+      console.error('Supabase reminders sync error:', error);
       if(syncStatus){
         renderSyncIndicator('error', 'Sync Error');
       }
-    });
+    }
   }
 
   async function saveToFirebase(item){
-    if(!firebaseReady || !userId || !db || typeof doc !== 'function' || typeof setDoc !== 'function' || typeof serverTimestamp !== 'function') return;
+    if(!userId) return;
     try {
-      await setDoc(doc(db, 'users', userId, 'reminders', item.id), {
-        ownerUid: userId,
-        title: item.title, priority: item.priority, notes: item.notes || '', done: !!item.done, due: item.due || null,
+      await upsertReminder({
+        ...item,
         category: item.category || DEFAULT_CATEGORY,
         orderIndex: Number.isFinite(item.orderIndex) ? item.orderIndex : null,
-        plannerLessonId: typeof item.plannerLessonId === 'string' && item.plannerLessonId ? item.plannerLessonId : null,
-        pinToToday: !!item.pinToToday,
-        createdAt: item.createdAt ? new Date(item.createdAt) : serverTimestamp(),
-        updatedAt: serverTimestamp()
-      }, { merge: true });
+      });
     } catch (error) {
       console.error('Save failed:', error); toast('Save queued (offline)');
     }
   }
-  async function deleteFromFirebase(id){ if(!firebaseReady || !userId || !db || typeof doc !== 'function' || typeof deleteDoc !== 'function') return; try { await deleteDoc(doc(db,'users',userId,'reminders',id)); } catch { toast('Delete queued (offline)'); } }
+  async function deleteFromFirebase(id){
+    if(!userId) return;
+    try {
+      await deleteReminder(id);
+    } catch {
+      toast('Delete queued (offline)');
+    }
+  }
 
   async function tryCalendarSync(task){ const url=(localStorage.getItem('syncUrl')||'').trim(); if(!url) return; const payload={ id: task.id, title: task.title, dueIso: task.due || null, priority: task.priority || 'Medium', category: task.category || DEFAULT_CATEGORY, done: !!task.done, source: 'memory-cue-mobile' }; try{ await fetch(url,{method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)}); }catch{} }
 

--- a/js/services/capture-service.js
+++ b/js/services/capture-service.js
@@ -1,5 +1,6 @@
 import { createNote, loadAllNotes, saveAllNotes } from '../modules/notes-storage.js';
 import { generateTags } from '../../src/ai/tagGenerator.js';
+import { syncInbox, upsertInboxEntry } from '../../src/services/supabaseSyncService.js';
 
 export const INBOX_STORAGE_KEY = 'memoryCueInbox';
 const LEGACY_INBOX_STORAGE_KEYS = ['memoryEntries'];
@@ -80,10 +81,14 @@ const dispatchEntriesUpdated = () => {
 
 export const saveInboxEntry = (entry) => {
   const entries = getInboxEntries();
-  entries.unshift(entry);
+  const nextEntry = { ...entry, pendingSync: true, updatedAt: Date.now() };
+  entries.unshift(nextEntry);
   persistInboxEntries(entries);
   dispatchEntriesUpdated();
-  return entry;
+  upsertInboxEntry(nextEntry).catch((error) => {
+    console.warn('[capture-service] Failed to sync inbox entry to Supabase', error);
+  });
+  return nextEntry;
 };
 
 export const removeInboxEntry = (id) => {
@@ -100,6 +105,9 @@ export const removeInboxEntry = (id) => {
 
   persistInboxEntries(nextEntries);
   dispatchEntriesUpdated();
+  syncInbox().catch((error) => {
+    console.warn('[capture-service] Failed to sync inbox deletions to Supabase', error);
+  });
   return true;
 };
 
@@ -143,6 +151,7 @@ export const captureInput = async (text, source = 'capture') => {
     source: normalizeSource(source),
     parsedType: parsed.parsedType,
     metadata: parsed.metadata,
+    pendingSync: true,
   };
 
   return saveInboxEntry(entry);

--- a/js/supabase-auth-init.js
+++ b/js/supabase-auth-init.js
@@ -1,3 +1,13 @@
 import { initSupabaseAuth } from './supabase-auth.js';
+import { pullChanges } from '../src/services/supabaseSyncService.js';
 
-initSupabaseAuth();
+initSupabaseAuth({
+  onSessionChange: (user) => {
+    if (!user) {
+      return;
+    }
+    pullChanges().catch((error) => {
+      console.warn('[supabase-sync] Initial pull failed', error);
+    });
+  },
+});

--- a/src/chat/messageStore.js
+++ b/src/chat/messageStore.js
@@ -1,3 +1,4 @@
+import { appendChatMessage, syncChatHistory } from '../services/supabaseSyncService.js';
 const CHAT_HISTORY_STORAGE_KEY = 'memoryCueChatHistory';
 
 const readMessages = () => {
@@ -29,9 +30,13 @@ const writeMessages = (messages) => {
 
 export const addMessage = (message) => {
   const messages = readMessages();
-  const nextMessages = [...messages, message];
+  const nextMessage = { ...message, pendingSync: true };
+  const nextMessages = [...messages, nextMessage];
   writeMessages(nextMessages);
-  return message;
+  appendChatMessage(nextMessage, message?.conversationId || 'default').catch((error) => {
+    console.warn('[chat/messageStore] Failed to sync chat message', error);
+  });
+  return nextMessage;
 };
 
 export const getMessages = () => readMessages();
@@ -43,6 +48,7 @@ export const clearMessages = () => {
 
   try {
     localStorage.removeItem(CHAT_HISTORY_STORAGE_KEY);
+    syncChatHistory().catch(() => {});
   } catch (error) {
     console.warn('[chat/messageStore] Failed to clear chat history', error);
   }

--- a/src/services/inboxService.js
+++ b/src/services/inboxService.js
@@ -1,3 +1,4 @@
+import { upsertInboxEntry } from './supabaseSyncService.js';
 const INBOX_STORAGE_KEY = 'memoryCueInbox';
 
 const generateId = () => {
@@ -62,12 +63,16 @@ export const saveToInbox = (text) => {
     createdAt: Date.now(),
     processed: false,
     tags: [],
+    pendingSync: true,
   };
 
   const entries = getInboxEntries();
   entries.push(entry);
   persistInboxEntries(entries);
   dispatchInboxUpdated();
+  upsertInboxEntry(entry).catch((error) => {
+    console.warn('[inbox-service] Supabase inbox sync failed', error);
+  });
 
   return entry;
 };

--- a/src/services/supabaseSyncService.js
+++ b/src/services/supabaseSyncService.js
@@ -1,0 +1,272 @@
+import { getSupabaseClient } from '../../js/supabase-client.js';
+
+const NOTES_KEY = 'memoryCueNotes';
+const INBOX_KEY = 'memoryCueInbox';
+const REMINDERS_KEY = 'memoryCue:offlineReminders';
+const CHAT_KEY = 'memoryCueChatHistory';
+
+const TABLES = {
+  notes: 'notes',
+  inbox: 'inbox',
+  reminders: 'reminders',
+  chat: 'chat_messages',
+};
+
+const readLocal = (key) => {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(key);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.warn('[supabase-sync] Failed reading local cache', key, error);
+    return [];
+  }
+};
+
+const writeLocal = (key, items) => {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(key, JSON.stringify(Array.isArray(items) ? items : []));
+  } catch (error) {
+    console.warn('[supabase-sync] Failed writing local cache', key, error);
+  }
+};
+
+const toMs = (value) => {
+  if (typeof value === 'number') return value;
+  if (typeof value !== 'string') return 0;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+const getUpdatedMs = (item = {}) => toMs(item.updated_at || item.updatedAt || item.created_at || item.createdAt);
+
+const markSynced = (item = {}) => ({ ...item, pendingSync: false });
+
+const mergeByLatest = (localItems = [], remoteItems = []) => {
+  const merged = new Map();
+  remoteItems.forEach((item) => {
+    if (item?.id) merged.set(String(item.id), item);
+  });
+  localItems.forEach((item) => {
+    if (!item?.id) return;
+    const id = String(item.id);
+    const existing = merged.get(id);
+    if (!existing || getUpdatedMs(item) >= getUpdatedMs(existing)) {
+      merged.set(id, item);
+    }
+  });
+  return Array.from(merged.values());
+};
+
+const getCurrentUserId = async (supabase) => {
+  if (!supabase?.auth?.getSession) return null;
+  const { data, error } = await supabase.auth.getSession();
+  if (error) {
+    console.warn('[supabase-sync] getSession failed', error);
+    return null;
+  }
+  return data?.session?.user?.id || null;
+};
+
+const mapNoteToRow = (item, userId) => ({
+  id: item.id,
+  user_id: userId,
+  title: item.title || 'Untitled note',
+  body: item.bodyHtml || item.body || '',
+  body_html: item.bodyHtml || item.body || '',
+  body_text: item.bodyText || '',
+  folder_id: item.folderId || null,
+  metadata: item.metadata || null,
+  links: item.links || [],
+  pinned: !!item.pinned,
+  created_at: item.createdAt || new Date().toISOString(),
+  updated_at: item.updatedAt || new Date().toISOString(),
+});
+
+const mapInboxToRow = (item, userId) => ({
+  id: item.id,
+  user_id: userId,
+  text: item.text || '',
+  tags: Array.isArray(item.tags) ? item.tags : [],
+  source: item.source || 'capture',
+  parsed_type: item.parsedType || 'unknown',
+  metadata: item.metadata || null,
+  created_at: item.createdAt ? new Date(item.createdAt).toISOString() : new Date().toISOString(),
+  updated_at: item.updatedAt ? new Date(item.updatedAt).toISOString() : new Date().toISOString(),
+});
+
+const mapReminderToRow = (item, userId) => ({
+  id: item.id,
+  user_id: userId,
+  title: item.title || '',
+  notes: item.notes || '',
+  priority: item.priority || 'Medium',
+  category: item.category || null,
+  done: !!item.done,
+  due: item.due || null,
+  created_at: item.createdAt ? new Date(item.createdAt).toISOString() : new Date().toISOString(),
+  updated_at: item.updatedAt ? new Date(item.updatedAt).toISOString() : new Date().toISOString(),
+  order_index: Number.isFinite(item.orderIndex) ? item.orderIndex : null,
+  metadata: item.metadata || null,
+});
+
+const mapChatToRow = (item, userId) => ({
+  id: item.id,
+  user_id: userId,
+  role: item.role || 'user',
+  content: item.content || '',
+  created_at: item.createdAt || new Date().toISOString(),
+  conversation_id: item.conversationId || 'default',
+});
+
+async function syncDomain({ key, table, mapToRow, mapFromRow = (row) => row }) {
+  const supabase = getSupabaseClient();
+  if (!supabase) return readLocal(key);
+
+  const userId = await getCurrentUserId(supabase);
+  if (!userId) return readLocal(key);
+
+  const localItems = readLocal(key);
+  const pendingItems = localItems.filter((item) => item?.id && item.pendingSync !== false);
+
+  if (pendingItems.length) {
+    const { error } = await supabase.from(table).upsert(pendingItems.map((item) => mapToRow(item, userId)));
+    if (!error) {
+      const syncedIds = new Set(pendingItems.map((item) => String(item.id)));
+      const nextItems = localItems.map((item) => (syncedIds.has(String(item?.id)) ? markSynced(item) : item));
+      writeLocal(key, nextItems);
+    } else {
+      console.warn(`[supabase-sync] Failed pushing ${table}`, error);
+    }
+  }
+
+  const { data, error } = await supabase.from(table).select('*').eq('user_id', userId);
+  if (error) {
+    console.warn(`[supabase-sync] Failed pulling ${table}`, error);
+    return readLocal(key);
+  }
+
+  const remoteItems = Array.isArray(data) ? data.map((row) => mapFromRow(row)).filter(Boolean) : [];
+  const merged = mergeByLatest(readLocal(key), remoteItems).map(markSynced);
+  writeLocal(key, merged);
+  return merged;
+}
+
+
+const mapNoteFromRow = (row = {}) => ({
+  id: row.id,
+  title: row.title || 'Untitled note',
+  body: row.body_html || row.body || '',
+  bodyHtml: row.body_html || row.body || '',
+  bodyText: row.body_text || '',
+  folderId: row.folder_id || null,
+  metadata: row.metadata || null,
+  links: Array.isArray(row.links) ? row.links : [],
+  pinned: !!row.pinned,
+  createdAt: row.created_at || new Date().toISOString(),
+  updatedAt: row.updated_at || row.created_at || new Date().toISOString(),
+});
+
+const mapInboxFromRow = (row = {}) => ({
+  id: row.id,
+  text: row.text || '',
+  tags: Array.isArray(row.tags) ? row.tags : [],
+  source: row.source || 'capture',
+  parsedType: row.parsed_type || 'unknown',
+  metadata: row.metadata || {},
+  createdAt: row.created_at ? Date.parse(row.created_at) || Date.now() : Date.now(),
+  updatedAt: row.updated_at ? Date.parse(row.updated_at) || Date.now() : Date.now(),
+  pendingSync: false,
+});
+
+const mapReminderFromRow = (row = {}) => ({
+  id: row.id,
+  title: row.title || '',
+  notes: row.notes || '',
+  priority: row.priority || 'Medium',
+  category: row.category || null,
+  done: !!row.done,
+  due: row.due || null,
+  createdAt: row.created_at ? Date.parse(row.created_at) || Date.now() : Date.now(),
+  updatedAt: row.updated_at ? Date.parse(row.updated_at) || Date.now() : Date.now(),
+  orderIndex: Number.isFinite(row.order_index) ? row.order_index : null,
+  metadata: row.metadata || null,
+  pendingSync: false,
+});
+
+const mapChatFromRow = (row = {}) => ({
+  id: row.id,
+  role: row.role || 'user',
+  content: row.content || '',
+  conversationId: row.conversation_id || 'default',
+  createdAt: row.created_at || new Date().toISOString(),
+  pendingSync: false,
+});
+
+export const syncNotes = () => syncDomain({ key: NOTES_KEY, table: TABLES.notes, mapToRow: mapNoteToRow, mapFromRow: mapNoteFromRow });
+export const syncInbox = () => syncDomain({ key: INBOX_KEY, table: TABLES.inbox, mapToRow: mapInboxToRow, mapFromRow: mapInboxFromRow });
+export const syncReminders = () => syncDomain({ key: REMINDERS_KEY, table: TABLES.reminders, mapToRow: mapReminderToRow, mapFromRow: mapReminderFromRow });
+export const syncChatHistory = () => syncDomain({ key: CHAT_KEY, table: TABLES.chat, mapToRow: mapChatToRow, mapFromRow: mapChatFromRow });
+
+export const pushChanges = async () => {
+  await Promise.allSettled([syncNotes(), syncInbox(), syncReminders(), syncChatHistory()]);
+};
+
+export const pullChanges = async () => {
+  await Promise.allSettled([syncNotes(), syncInbox(), syncReminders(), syncChatHistory()]);
+};
+
+export const upsertInboxEntry = async (entry) => {
+  if (!entry?.id) return;
+  const cached = readLocal(INBOX_KEY);
+  const existingIndex = cached.findIndex((item) => String(item?.id) === String(entry.id));
+  const nextEntry = { ...entry, pendingSync: true, updatedAt: Date.now() };
+  if (existingIndex >= 0) {
+    cached[existingIndex] = { ...cached[existingIndex], ...nextEntry };
+  } else {
+    cached.unshift(nextEntry);
+  }
+  writeLocal(INBOX_KEY, cached);
+  await syncInbox();
+};
+
+export const upsertReminder = async (reminder) => {
+  if (!reminder?.id) return;
+  const cached = readLocal(REMINDERS_KEY);
+  const existingIndex = cached.findIndex((item) => String(item?.id) === String(reminder.id));
+  const nextReminder = { ...reminder, pendingSync: true, updatedAt: Date.now() };
+  if (existingIndex >= 0) cached[existingIndex] = { ...cached[existingIndex], ...nextReminder };
+  else cached.unshift(nextReminder);
+  writeLocal(REMINDERS_KEY, cached);
+  await syncReminders();
+};
+
+export const deleteReminder = async (id) => {
+  const supabase = getSupabaseClient();
+  const userId = supabase ? await getCurrentUserId(supabase) : null;
+  const cached = readLocal(REMINDERS_KEY).filter((item) => String(item?.id) !== String(id));
+  writeLocal(REMINDERS_KEY, cached);
+  if (supabase && userId) {
+    await supabase.from(TABLES.reminders).delete().eq('id', id).eq('user_id', userId);
+  }
+};
+
+export const appendChatMessage = async (message, conversationId = 'default') => {
+  const entry = {
+    id: message?.id || (typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `chat-${Date.now()}`),
+    role: message?.role || 'user',
+    content: message?.content || '',
+    conversationId,
+    createdAt: message?.createdAt || new Date().toISOString(),
+    pendingSync: true,
+  };
+  const cached = readLocal(CHAT_KEY);
+  const exists = cached.some((item) => String(item?.id) === String(entry.id));
+  if (!exists) {
+    cached.push(entry);
+    writeLocal(CHAT_KEY, cached);
+  }
+  await syncChatHistory();
+};

--- a/supabase/unified_sync_tables.sql
+++ b/supabase/unified_sync_tables.sql
@@ -1,0 +1,36 @@
+-- Memory Cue unified Supabase sync tables
+create table if not exists public.inbox (
+  id uuid primary key,
+  user_id uuid,
+  text text,
+  tags text[],
+  source text,
+  parsed_type text,
+  metadata jsonb,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create table if not exists public.reminders (
+  id uuid primary key,
+  user_id uuid,
+  title text,
+  notes text,
+  priority text,
+  category text,
+  done boolean default false,
+  due timestamptz,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  order_index integer,
+  metadata jsonb
+);
+
+create table if not exists public.chat_messages (
+  id uuid primary key,
+  user_id uuid,
+  role text,
+  content text,
+  created_at timestamptz default now(),
+  conversation_id text
+);


### PR DESCRIPTION
### Motivation
- Centralise persistence so notes, inbox, reminders and chat history all sync through Supabase while keeping `localStorage` as an offline cache. 
- Preserve existing offline-first flows and avoid breaking local caching while providing a single backend for cross-device sync. 
- Provide a simple pending-queue (`pendingSync`) and merge-by-latest strategy to safely reconcile local and remote data. 

### Description
- Add a new sync service at `src/services/supabaseSyncService.js` that exposes `syncNotes()`, `syncInbox()`, `syncReminders()`, `syncChatHistory()`, `pushChanges()`, `pullChanges()`, `upsertInboxEntry()`, `upsertReminder()`, `deleteReminder()`, and `appendChatMessage()` and implements push/pull + merge logic. 
- Treat `localStorage` keys (`memoryCueNotes`, `memoryCueInbox`, `memoryCue:offlineReminders`, `memoryCueChatHistory`) as offline caches, adding `pendingSync` markers when items are created/edited and marking items synced after successful upserts. 
- Wire inbox flows so both `src/services/inboxService.js` and `js/services/capture-service.js` persist locally and call `upsertInboxEntry()` (and call `syncInbox()` after deletes) to ensure Supabase receives new/updated inbox items. 
- Migrate reminders from Firestore plumbing to Supabase helpers by updating `js/reminders.js` to use `syncReminders()`, `upsertReminder()` and `deleteReminder()` and to perform an initial pull when a Supabase session is available. 
- Update chat persistence in `src/chat/messageStore.js` to append messages locally and call `appendChatMessage()` so chat rows are synced to the Supabase `chat_messages` table. 
- Trigger an initial pull after authentication by wiring the `initSupabaseAuth` session change handler to call `pullChanges()` in `js/supabase-auth-init.js`. 
- Add DDL scaffolding `supabase/unified_sync_tables.sql` for the `inbox`, `reminders`, and `chat_messages` tables to document expected schemas. 

### Testing
- Ran `npm run build` successfully to ensure the changes bundle (`npm run build` ✅). 
- Ran the test suite with `npm test -- --runInBand`; the run exposed existing repo test/environment failures (module-format / test harness errors across multiple suites) that are unrelated to the sync logic, so tests did not all pass (test run ⚠️). 
- Per-file smoke checks were performed by invoking the new sync helpers from inbox/capture/chat/reminders code paths and verifying local cache writes and calls to the sync functions (manual assertions during development).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f146d42883248a2d7b0584c778e1)