### PR TITLE
Restore mobile bottom nav visibility and adjust composer/FAB spacing

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -230,7 +230,7 @@ Legacy shells remain for reference only.
       position: fixed;
       left: 0;
       right: 0;
-      bottom: 0;
+      bottom: 64px;
       z-index: 120;
       padding: 0.6rem 0.8rem calc(0.6rem + env(safe-area-inset-bottom, 0px));
       background: color-mix(in srgb, var(--surface-main) 92%, white 8%);
@@ -505,6 +505,7 @@ Legacy shells remain for reference only.
     margin: 0;
     padding-left: 0;
     padding-right: 0;
+    padding-bottom: 140px;
   }
 
   body[data-active-view="notes"] .container {
@@ -3268,20 +3269,23 @@ body, main, section, div, p, span, li {
     left: 0;
     right: 0;
     bottom: 0;
-    z-index: 100;
+    height: 64px;
+    background: white;
+    border-top: 1px solid #ddd;
+    z-index: 50;
   }
 
   #mobile-nav-shell .floating-footer {
     display: flex;
     justify-content: space-around;
     align-items: center;
+    height: 64px;
     background: var(--surface-elevated, rgba(255, 255, 255, 0.85));
     backdrop-filter: blur(18px);
     -webkit-backdrop-filter: blur(18px);
     border-top: 1px solid rgba(0, 0, 0, 0.07);
     box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.06);
-    padding: 0.5rem 1rem;
-    padding-bottom: calc(0.5rem + env(safe-area-inset-bottom, 0px));
+    padding: 0;
   }
 
   #mobile-nav-shell .fab-container {
@@ -3434,7 +3438,7 @@ body, main, section, div, p, span, li {
   .brain-dump-fab {
     position: fixed;
     right: 1rem;
-    bottom: calc(var(--mobile-bottom-nav-height, 80px) + 0.75rem + env(safe-area-inset-bottom, 0px));
+    bottom: 120px;
     width: 3.5rem;
     height: 3.5rem;
     border: none;


### PR DESCRIPTION
### Motivation
- Restore the bottom navigation bar visibility on mobile and ensure the chat composer does not overlap or hide the nav while preserving existing navigation behavior.
- Keep navigation wiring unchanged and only adjust layout/CSS so content and floating actions remain accessible.

### Description
- Updated `mobile.html` layout/CSS to move the chat composer (`#thinkingBarContainer`) above the bottom nav by changing `bottom: 0` to `bottom: 64px`.
- Added bottom spacing to the main scroll container by adding `padding-bottom: 140px` to `body.mobile-shell #main` to prevent content from being hidden behind fixed layers.
- Enforced a consistent 64px footprint for the bottom nav by setting `#mobile-nav-shell` to `height: 64px`, `background: white`, `border-top: 1px solid #ddd`, and `z-index: 50`, and adjusted `.floating-footer` to match the height and remove extra padding.
- Repositioned the floating action button (`.brain-dump-fab`) to `bottom: 120px` so it floats above both the composer and bottom nav; no navigation logic or event wiring was changed (the existing `#mobile-nav-shell` was used).

### Testing
- Ran the unit test targeting footer/nav: `npm test -- --runInBand js/__tests__/mobile.footer-nav.test.js`, which passed.
- Attempted a visual verification via a local server + Playwright screenshot, but the browser request failed with `net::ERR_EMPTY_RESPONSE` so no screenshot artifact was produced; server start/logging was attempted during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f3986b9083248c5567a5c8e3ec1b)