### PR TITLE
Mobile-first layout: app shell, composer, and bottom navigation

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -15,6 +15,12 @@ body.app-shell {
   gap: 0;
 }
 
+.mobile-app {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+}
+
 body.app-shell .app-header {
   height: var(--mobile-header-height);
   flex-shrink: 0;
@@ -26,7 +32,9 @@ body.app-shell .content {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: var(--space-2);
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 16px;
   padding-top: 8px;
   margin-top: 0;
   padding-bottom: 140px !important;
@@ -97,6 +105,10 @@ body.app-shell #mobile-nav-shell {
   z-index: 59;
 }
 
+#bottom-nav {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
 body.app-shell #mobile-nav-shell .floating-footer {
   width: 100%;
   display: grid;
@@ -109,6 +121,16 @@ body.app-shell #mobile-nav-shell .floating-card {
   min-height: 48px;
   min-width: 48px;
   border-radius: 12px;
+}
+
+#bottom-nav button {
+  display: flex;
+  flex-direction: column;
+  font-size: 12px;
+}
+
+#bottom-nav button.active {
+  color: #5e3a8c;
 }
 
 body.app-shell .reminders-quick-bar {

--- a/mobile.html
+++ b/mobile.html
@@ -226,42 +226,48 @@ Legacy shells remain for reference only.
       background-color: rgba(0, 0, 0, 0.04);
     }
 
-    #thinkingBarContainer {
+    #thinkingBarContainer,
+    .chat-composer {
       position: fixed;
       left: 0;
       right: 0;
       bottom: 64px;
       z-index: 120;
-      padding: 0.6rem 0.8rem calc(0.6rem + env(safe-area-inset-bottom, 0px));
-      background: color-mix(in srgb, var(--surface-main) 92%, white 8%);
-      border-top: 1px solid var(--border-subtle);
+      background: white;
+      border-top: 1px solid #ddd;
+      padding: 10px 12px;
+      padding-bottom: calc(10px + env(safe-area-inset-bottom, 0px));
       box-shadow: 0 -6px 22px rgba(16, 12, 24, 0.12);
       transition: padding 0.2s ease;
     }
 
-    #thinkingBarForm.capture-form {
+    #thinkingBarForm.capture-form,
+    .chat-composer .capture-form {
       display: flex;
       align-items: flex-end;
-      gap: 0.55rem;
+      gap: 8px;
       margin: 0;
     }
 
-    #thinkingBarInput {
+    #thinkingBarInput,
+    .chat-composer textarea {
+      flex: 1;
       width: 100%;
-      border-radius: 1rem;
+      border-radius: 20px;
       min-height: 2.6rem;
       max-height: 9rem;
       resize: none;
-      padding: 0.7rem 0.9rem;
+      padding: 10px 14px;
       box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.06);
     }
 
-    #thinkingBarSubmit {
+    #thinkingBarSubmit,
+    .chat-composer button {
       width: 2.2rem;
       height: 2.2rem;
       min-height: 2.2rem;
       padding: 0;
-      border-radius: 999px;
+      border-radius: 20px;
       font-size: 1rem;
       line-height: 1;
       display: inline-flex;
@@ -4848,6 +4854,7 @@ body, main, section, div, p, span, li {
 
 
 
+  <div class="mobile-app">
   <!-- Unified Mobile Header -->
   <header id="reminders-slim-header" class="mobile-header app-header" role="banner">
       <h1 class="header-title title">Memory Cue</h1>
@@ -5439,17 +5446,18 @@ body, main, section, div, p, span, li {
         <button id="closeWeeklyReflectionButton" type="button" class="btn btn-outline btn-sm close-reflection">Close</button>
       </div>
     </div>
-    <section id="thinkingBarContainer" aria-label="Chat capture bar">
-      <form id="thinkingBarForm" class="capture-form">
-        <label for="thinkingBarInput" class="sr-only">Think or ask anything</label>
-        <textarea id="thinkingBarInput" class="capture-input" placeholder="Think or ask anything…" autocomplete="off" rows="1"></textarea>
-        <button id="thinkingBarSubmit" type="submit" class="btn btn-primary capture-save-btn" aria-label="Send">➤</button>
-      </form>
-      <div id="thinkingBarStatus" class="hidden" aria-live="polite"></div>
-      <div id="thinkingBarResults" aria-live="polite"></div>
-    </section>
     </div>
 </main>
+
+  <section id="thinkingBarContainer" class="chat-composer" aria-label="Chat capture bar">
+    <form id="thinkingBarForm" class="capture-form">
+      <label for="thinkingBarInput" class="sr-only">Think or ask anything</label>
+      <textarea id="thinkingBarInput" class="capture-input" placeholder="Think or ask anything…" autocomplete="off" rows="1"></textarea>
+      <button id="thinkingBarSubmit" type="submit" class="btn btn-primary capture-save-btn" aria-label="Send">➤</button>
+    </form>
+    <div id="thinkingBarStatus" class="hidden" aria-live="polite"></div>
+    <div id="thinkingBarResults" aria-live="polite"></div>
+  </section>
 
   <div class="move-to-folder-sheet hidden">
     <div class="sheet-backdrop"></div>
@@ -5461,7 +5469,8 @@ body, main, section, div, p, span, li {
     </div>
   </div>
 
-  <nav id="mobile-nav-shell" class="bottom-nav inset-x-0 bottom-0 z-50 flex justify-center px-2 pb-3" aria-label="Bottom navigation">
+  <nav id="bottom-nav" aria-label="Bottom navigation">
+    <div id="mobile-nav-shell" class="bottom-nav inset-x-0 bottom-0 z-50 flex justify-center px-2 pb-3">
     <div class="floating-footer bottom-nav-list">
       <button
         type="button"
@@ -5486,7 +5495,7 @@ body, main, section, div, p, span, li {
           <path d="M12 5.25v13.5" />
           <path d="M5.25 12h13.5" />
         </svg>
-        <span>Capture</span>
+        <span>📥 Capture</span>
       </button>
 
       <button
@@ -5512,7 +5521,7 @@ body, main, section, div, p, span, li {
           <circle cx="12" cy="12" r="7" />
           <path d="M12 9v3.5l2 1.5" />
         </svg>
-        <span>Notes</span>
+        <span>📝 Notes</span>
       </button>
 
       <button
@@ -5540,10 +5549,12 @@ body, main, section, div, p, span, li {
           <path d="M9 12h6" />
           <path d="M9 15.5h4" />
         </svg>
-        <span>Notebooks</span>
+        <span>📚 Notebooks</span>
       </button>
     </div>
+    </div>
   </nav>
+  </div>
   <!-- Navigation/FAB behavior is centralized in js/navigation.js + js/services/navigation-service.js -->
   <script>
     (function () {


### PR DESCRIPTION
### Motivation
- Convert the mobile runtime into a clean mobile-first shell with explicit regions for header, content, composer, and bottom navigation to match modern productivity apps.
- Improve readability on narrow screens by centering and constraining the main content area for comfortable line-lengths.
- Ensure UI elements respect device safe areas and make the chat composer and bottom navigation ergonomically styled for touch.

### Description
- Added a new `.mobile-app` wrapper in `mobile.html` and restructured the page so the structure is header -> main `.app-content` -> composer (`#thinkingBarContainer` with `chat-composer`) -> bottom navigation (`#bottom-nav` + `#mobile-nav-shell`).
- Converted the composer into a dedicated `chat-composer` region and updated inline CSS in `mobile.html` to use a white background, top border, compact padding, rounded textarea and button, and safe-area-aware bottom padding.
- Introduced `#bottom-nav` around the existing footer nav and updated bottom nav labels to include icon+label text (`📥 Capture`, `📝 Notes`, `📚 Notebooks`).
- Applied mobile CSS updates in `mobile.css` to center content with `max-width: 640px`, `margin: 0 auto`, `padding: 16px`, added `env(safe-area-inset-bottom)` support for `#bottom-nav`, and added vertical button layout and active highlight color (`#5e3a8c`) for nav buttons.

### Testing
- Ran unit/ui tests with `npm test -- js/__tests__/mobile.footer-nav.test.js js/__tests__/mobile.header.test.js`, and both test suites passed.
- Executed an automated Playwright script to load the app at `/mobile` and capture a mobile viewport screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f4e6c68083249a58f9b2fb603a24)