### PR TITLE
Update mobile navigation to Capture / Reminders / Notebooks / Inbox workflow

### DIFF
--- a/js/services/navigation-service.js
+++ b/js/services/navigation-service.js
@@ -1,10 +1,11 @@
 (function () {
-  const VIEW_ORDER = ['capture', 'notes', 'notebooks', 'settings'];
+  const VIEW_ORDER = ['capture', 'reminders', 'notebooks', 'inbox'];
 
   const normalizeViewName = (name) => {
     if (!name) return 'capture';
     const value = String(name).toLowerCase();
-    if (value === 'notebook' || value === 'notebooks') return 'notes';
+    if (value === 'notebook') return 'notebooks';
+    if (value === 'notes') return 'notebooks';
     return value;
   };
 

--- a/mobile.css
+++ b/mobile.css
@@ -46,6 +46,10 @@ body.app-shell .content {
   justify-content: flex-start;
 }
 
+.main-content {
+  padding-bottom: 140px;
+}
+
 body.app-shell .content > * {
   margin-top: 0;
 }
@@ -99,8 +103,8 @@ body.app-shell #mobile-nav-shell {
   justify-content: space-around;
   align-items: center;
   background: #fff;
-  border-top: 1px solid var(--border-subtle, #e3d9f4);
-  padding: 0 var(--space-1);
+  border-top: 1px solid var(--border, var(--border-subtle, #e3d9f4));
+  padding: 0;
   pointer-events: auto;
   z-index: 59;
 }
@@ -111,16 +115,20 @@ body.app-shell #mobile-nav-shell {
 
 body.app-shell #mobile-nav-shell .floating-footer {
   width: 100%;
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: var(--space-1);
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  gap: 0;
   pointer-events: auto;
 }
 
 body.app-shell #mobile-nav-shell .floating-card {
-  min-height: 48px;
-  min-width: 48px;
-  border-radius: 12px;
+  min-height: 0;
+  min-width: 0;
+  border-radius: 0;
+  flex: 1;
+  border: 0;
+  background: transparent;
 }
 
 #bottom-nav button {
@@ -130,7 +138,12 @@ body.app-shell #mobile-nav-shell .floating-card {
 }
 
 #bottom-nav button.active {
-  color: #5e3a8c;
+  color: var(--primary);
+  font-weight: 600;
+}
+
+#bottom-nav button {
+  color: var(--muted);
 }
 
 body.app-shell .reminders-quick-bar {
@@ -139,7 +152,7 @@ body.app-shell .reminders-quick-bar {
 
 body.app-shell #mobile-nav-shell .floating-card.active,
 body.app-shell #mobile-nav-shell .floating-card[aria-current='page'] {
-  outline: 2px solid color-mix(in srgb, var(--accent-color, #512663) 40%, transparent);
+  outline: none;
 }
 
 

--- a/mobile.html
+++ b/mobile.html
@@ -3286,11 +3286,8 @@ body, main, section, div, p, span, li {
     justify-content: space-around;
     align-items: center;
     height: 64px;
-    background: var(--surface-elevated, rgba(255, 255, 255, 0.85));
-    backdrop-filter: blur(18px);
-    -webkit-backdrop-filter: blur(18px);
-    border-top: 1px solid rgba(0, 0, 0, 0.07);
-    box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.06);
+    background: white;
+    border-top: 1px solid var(--border);
     padding: 0;
   }
 
@@ -3367,15 +3364,16 @@ body, main, section, div, p, span, li {
     justify-content: center;
     background: transparent;
     border: none;
-    padding: 0.25rem;
+    padding: 0.25rem 0;
     border-radius: 0;
     cursor: pointer;
     flex: 1;
-    color: var(--icon-inactive);
+    color: var(--muted);
   }
 
   #mobile-nav-shell .floating-footer .floating-card.active {
-    color: var(--accent-color);
+    color: var(--primary);
+    font-weight: 600;
   }
 
   .icon {
@@ -4916,7 +4914,7 @@ body, main, section, div, p, span, li {
 
 
   <!-- quickAddBar is now integrated in the header -->
-  <main id="main" class="app-content content mx-auto w-full max-w-none"
+  <main id="main" class="app-content content main-content mx-auto w-full max-w-none"
         tabindex="-1"
         data-active-view="capture"
       >
@@ -4940,7 +4938,7 @@ body, main, section, div, p, span, li {
       </div>
     </section>
     <!-- BEGIN GPT CHANGE: reminders view -->
-    <section id="view-reminders" class="view-panel hidden" aria-hidden="true">
+    <section data-view="reminders" id="view-reminders" class="view-panel hidden" aria-hidden="true">
       <div class="reminders-mobile-flow reminders-content-shell">
         <section class="reminders-screen-controls" aria-label="Reminder controls">
           <div class="reminders-quick-add-form" aria-label="Quick add reminder">
@@ -4948,8 +4946,7 @@ body, main, section, div, p, span, li {
           </div>
           <div class="reminders-top-controls-row">
             <div class="reminders-tabs" role="tablist" aria-label="Filter reminders by status">
-              <button type="button" class="reminder-tab reminders-tab-active" data-reminders-tab="all" aria-pressed="true">All</button>
-              <button type="button" class="reminder-tab" data-reminders-tab="today" aria-pressed="false">Today</button>
+              <button type="button" class="reminder-tab reminders-tab-active" data-reminders-tab="today" aria-pressed="true">Today</button>
               <button type="button" class="reminder-tab" data-reminders-tab="upcoming" aria-pressed="false">Upcoming</button>
               <button type="button" class="reminder-tab" data-reminders-tab="completed" aria-pressed="false">Completed</button>
             </div>
@@ -5000,10 +4997,11 @@ body, main, section, div, p, span, li {
         <div id="categoryEntriesList" class="category-entry-list"></div>
       </div>
     </div>
-    <div id="view-inbox" class="view-panel hidden" aria-hidden="true">
+    <div data-view="inbox" id="view-inbox" class="view-panel hidden" aria-hidden="true">
       <div class="space-y-3">
         <h2 class="text-lg font-semibold">Inbox</h2>
         <button id="processInboxButton" type="button" class="btn btn-sm btn-primary">Process Notes</button>
+        <p class="text-xs text-base-content/70">Each entry can be converted to a note, turned into a reminder, tagged, or deleted.</p>
         <ul id="inboxEntriesList" class="category-entry-list list-disc pl-4" aria-live="polite"></ul>
       </div>
     </div>
@@ -5011,10 +5009,19 @@ body, main, section, div, p, span, li {
     <!-- BEGIN GPT CHANGE: notebook view -->
     <div id="notesView" class="view hidden" aria-hidden="true"></div>
 
-    <section data-view="notes" id="view-notebook" class="view-panel hidden mobile-panel--notes mobile-panel--notes-size-small">
+    <section data-view="notebooks" id="view-notebook" class="view-panel hidden mobile-panel--notes mobile-panel--notes-size-small">
         <div class="mobile-view-inner mx-auto w-full px-0 pt-2 pb-2 space-y-0" style="padding: 0 !important; max-width: 100%;">
         <section id="notesOverviewPanel" class="memory-glass-card-soft p-3 m-2">
-          <h2 class="text-lg font-semibold">Notes</h2>
+          <h2 class="text-lg font-semibold">Notebooks</h2>
+          <div class="mt-2">
+            <p class="text-xs text-base-content/70">Notebook browser</p>
+            <div id="notebookBrowserList" class="flex flex-wrap gap-2 mt-2" role="tablist" aria-label="Notebook browser">
+              <button type="button" class="btn btn-xs btn-outline" data-notebook-folder="School">School</button>
+              <button type="button" class="btn btn-xs btn-outline" data-notebook-folder="Personal">Personal</button>
+              <button type="button" class="btn btn-xs btn-outline" data-notebook-folder="Projects">Projects</button>
+              <button type="button" class="btn btn-xs btn-outline" data-notebook-folder="Unsorted">Unsorted</button>
+            </div>
+          </div>
           <div class="flex flex-col gap-2 mt-2">
             <input id="notesOverviewSearch" type="search" class="input input-sm input-bordered w-full" placeholder="Search notes" autocomplete="off" />
             <div class="flex gap-2">
@@ -5495,16 +5502,16 @@ body, main, section, div, p, span, li {
           <path d="M12 5.25v13.5" />
           <path d="M5.25 12h13.5" />
         </svg>
-        <span>📥 Capture</span>
+        <span>Capture</span>
       </button>
 
       <button
         type="button"
-        class="floating-card nav-item btn-notes"
-        id="mobile-footer-notes"
-        data-nav-target="notes"
-        data-tab="notes"
-        aria-label="Go to Notes"
+        class="floating-card nav-item btn-reminders"
+        id="mobile-footer-reminders"
+        data-nav-target="reminders"
+        data-tab="reminders"
+        aria-label="Go to Reminders"
       >
         <svg
           class="icon icon-clock"
@@ -5521,7 +5528,7 @@ body, main, section, div, p, span, li {
           <circle cx="12" cy="12" r="7" />
           <path d="M12 9v3.5l2 1.5" />
         </svg>
-        <span>📝 Notes</span>
+        <span>Reminders</span>
       </button>
 
       <button
@@ -5549,7 +5556,34 @@ body, main, section, div, p, span, li {
           <path d="M9 12h6" />
           <path d="M9 15.5h4" />
         </svg>
-        <span>📚 Notebooks</span>
+        <span>Notebooks</span>
+      </button>
+
+      <button
+        type="button"
+        class="floating-card nav-item btn-inbox"
+        id="mobile-footer-inbox"
+        data-nav-target="inbox"
+        data-tab="inbox"
+        aria-label="Go to Inbox"
+      >
+        <svg
+          class="icon icon-inbox"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.75"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M4 7.5h16" />
+          <path d="M5.5 7.5l1.2 9A2 2 0 0 0 8.7 18h6.6a2 2 0 0 0 2-1.5l1.2-9" />
+          <path d="M9 11.5h6" />
+        </svg>
+        <span>Inbox</span>
       </button>
     </div>
     </div>
@@ -5674,6 +5708,31 @@ body, main, section, div, p, span, li {
         status: 'archived',
         archivedAt: new Date().toISOString(),
       }));
+
+      const deleteInboxEntry = (entry) => {
+        const allEntries = readEntries();
+        const entryIndex = findEntryIndex(allEntries, entry);
+        if (entryIndex === -1) return false;
+        allEntries.splice(entryIndex, 1);
+        writeEntries(allEntries);
+        return true;
+      };
+
+      const addTagToInboxEntry = (entry) => {
+        const nextTagRaw = window.prompt('Add tag', '');
+        if (nextTagRaw === null) return false;
+        const nextTag = nextTagRaw.trim();
+        if (!nextTag) return false;
+        return updateInboxEntry(entry, (currentEntry) => {
+          const existingTags = Array.isArray(currentEntry?.tags) ? currentEntry.tags : [];
+          const alreadyPresent = existingTags.some((tag) => String(tag).toLowerCase() === nextTag.toLowerCase());
+          const tags = alreadyPresent ? existingTags : [...existingTags, nextTag];
+          return {
+            ...currentEntry,
+            tags,
+          };
+        });
+      };
 
       const convertInboxEntryToNote = (entry) => {
         const entryId = String(entry?.id || '');
@@ -5803,6 +5862,47 @@ body, main, section, div, p, span, li {
           createdAt.textContent = getEntryCreatedDate(entry);
 
           meta.append(categoryTag, createdAt);
+
+          const actions = document.createElement('div');
+          actions.className = 'flex flex-wrap gap-2';
+
+          const convertButton = document.createElement('button');
+          convertButton.type = 'button';
+          convertButton.className = 'btn btn-xs btn-outline';
+          convertButton.textContent = 'Convert to note';
+          convertButton.addEventListener('click', () => {
+            convertInboxEntryToNote(entry);
+            renderInboxEntries();
+          });
+
+          const reminderButton = document.createElement('button');
+          reminderButton.type = 'button';
+          reminderButton.className = 'btn btn-xs btn-outline';
+          reminderButton.textContent = 'Create reminder';
+          reminderButton.addEventListener('click', async () => {
+            await convertInboxEntryToReminder(entry);
+            renderInboxEntries();
+          });
+
+          const tagButton = document.createElement('button');
+          tagButton.type = 'button';
+          tagButton.className = 'btn btn-xs btn-outline';
+          tagButton.textContent = 'Add tag';
+          tagButton.addEventListener('click', () => {
+            addTagToInboxEntry(entry);
+            renderInboxEntries();
+          });
+
+          const deleteButton = document.createElement('button');
+          deleteButton.type = 'button';
+          deleteButton.className = 'btn btn-xs btn-outline';
+          deleteButton.textContent = 'Delete';
+          deleteButton.addEventListener('click', () => {
+            deleteInboxEntry(entry);
+            renderInboxEntries();
+          });
+
+          actions.append(convertButton, reminderButton, tagButton, deleteButton);
 
           text.addEventListener('click', () => {
             const updatedText = window.prompt('Edit entry text', getEntryText(entry));
@@ -5934,7 +6034,7 @@ body, main, section, div, p, span, li {
           card.addEventListener('mouseup', clearLongPress);
           card.addEventListener('mouseleave', clearLongPress);
 
-          swipeForeground.append(text, meta);
+          swipeForeground.append(text, meta, actions);
           card.append(swipeBackground, swipeForeground);
           inboxEntriesList.appendChild(card);
         });

--- a/mobile.js
+++ b/mobile.js
@@ -1275,6 +1275,7 @@ const initMobileNotes = () => {
   const folderFilterSelect = document.getElementById('folderFilterSelect');
   const folderFilterNewButton = document.getElementById('folderFilterNewFolder');
   const notesOverviewPanel = document.getElementById('notesOverviewPanel');
+  const notebookBrowserList = document.getElementById('notebookBrowserList');
   const notesOverviewList = document.getElementById('notesOverviewList');
   const notesOverviewSearch = document.getElementById('notesOverviewSearch');
   const notesOverviewSort = document.getElementById('notesOverviewSort');
@@ -3635,6 +3636,31 @@ const initMobileNotes = () => {
     notesOverviewState.addEventListener('change', () => {
       notesOverviewStateValue = notesOverviewState.value || 'all';
       renderNotesOverview();
+    });
+  }
+
+  if (notebookBrowserList instanceof HTMLElement) {
+    notebookBrowserList.addEventListener('click', (event) => {
+      const trigger = event.target instanceof HTMLElement ? event.target.closest('[data-notebook-folder]') : null;
+      if (!(trigger instanceof HTMLElement)) {
+        return;
+      }
+      const requestedName = String(trigger.dataset.notebookFolder || '').trim();
+      if (!requestedName) {
+        return;
+      }
+
+      const allFolderOptions = Array.isArray(getFolders()) ? getFolders() : [];
+      const normalizedName = requestedName.toLowerCase();
+      const folderMatch = allFolderOptions.find((folder) => {
+        const folderName = typeof folder?.name === 'string' ? folder.name.trim().toLowerCase() : '';
+        return folderName === normalizedName;
+      });
+
+      currentFolderId = folderMatch?.id || (normalizedName === 'unsorted' ? 'unsorted' : 'all');
+      setActiveFolderFilter(currentFolderId);
+      setActiveFolderChip(currentFolderId);
+      renderFilteredNotes();
     });
   }
 


### PR DESCRIPTION
### Motivation
- Replace the legacy bottom navigation with a four-tab workflow (`Capture`, `Reminders`, `Notebooks`, `Inbox`) to match the requested application flow and remove old labels/icons. 
- Ensure the chat composer and page content do not overlap the new fixed tab bar and that tabs behave like a traditional tab bar rather than rounded cards.

### Description
- Update the navigation routing in `js/services/navigation-service.js` to use `VIEW_ORDER = ['capture','reminders','notebooks','inbox']` and normalize legacy `notes`/`notebook` names to `notebooks` so view switching maps to the new tabs. 
- Replace bottom navigation markup in `mobile.html` with four tab buttons (`Capture`, `Reminders`, `Notebooks`, `Inbox`), remove emoji/old Notes labels, and add `data-view` attributes for `reminders`, `notebooks`, and `inbox` views. 
- Add a simple notebook browser UI to `mobile.html` (buttons: `School`, `Personal`, `Projects`, `Unsorted`) and wire selection behavior in `mobile.js` via a `notebookBrowserList` click handler that sets `currentFolderId` and refreshes the notebook list. 
- Extend Inbox UI and handlers in `mobile.html` to expose actions per entry: `Convert to note`, `Create reminder`, `Add tag`, and `Delete`, including helper functions to delete and tag inbox items and UI wiring to re-render after actions. 
- Apply styling changes in `mobile.css` and `mobile.html` to implement a fixed 64px tab bar, edge-to-edge layout, non-card tab buttons, active/inactive color states, `main-content` bottom padding, and ensure the chat composer sits above the nav (`bottom: 64px`).

### Testing
- Ran the full unit test suite with `npm test -- --runInBand`; the command executed but multiple pre-existing suites failed (ESM/vm import test harness and unrelated service worker/mobile-auth tests), and failures appear unrelated to the navigation changes. 
- Started a local server with `npx serve . -l 4173` and used a headless browser script to capture a mobile-width screenshot of `mobile.html` to verify the updated layout, which completed successfully. 
- Verified visually that the chat composer remains above the nav and that page content has increased bottom padding to avoid overlap after the styling changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f8cfbe548324a53b9ad990717472)