### PR TITLE
Update mobile bottom navigation to Capture / Reminders / Notebooks / Inbox

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -1,3 +1,3 @@
 /* Phase 3 layout shell */
 .view-panel.hidden { display: none !important; }
-#mobile-nav-shell .floating-footer { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+#mobile-nav-shell .floating-footer { grid-template-columns: repeat(4, minmax(0, 1fr)); }

--- a/css/navigation.css
+++ b/css/navigation.css
@@ -4,56 +4,41 @@
   right: 0;
   bottom: 0;
   z-index: 100;
+  height: 64px;
 }
 
 #mobile-nav-shell.bottom-nav .bottom-nav-list {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  align-items: stretch;
-  gap: 0.25rem;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
   width: 100%;
-  padding: 0.4rem 0.5rem calc(0.4rem + env(safe-area-inset-bottom, 0px));
-  background: var(--surface-elevated, rgba(255, 255, 255, 0.9));
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
-  border-top: 1px solid rgba(0, 0, 0, 0.07);
-  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.06);
+  height: 64px;
+  padding: 0 env(safe-area-inset-right, 0px) env(safe-area-inset-bottom, 0px) env(safe-area-inset-left, 0px);
+  background: #fff;
+  border-top: 1px solid #e5e5e5;
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
 #mobile-nav-shell.bottom-nav .bottom-nav-list .nav-item {
-  display: flex;
-  flex-direction: column;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.2rem;
-  min-height: 48px;
-  padding: 0.35rem 0.3rem;
+  min-height: 44px;
+  padding: 8px;
   border: none;
-  border-radius: 0.75rem;
-  background: transparent;
-  color: var(--icon-inactive);
-  line-height: 1.1;
-}
-
-#mobile-nav-shell.bottom-nav .bottom-nav-list .nav-item .icon {
-  width: 20px;
-  height: 20px;
-  stroke: currentColor;
-}
-
-#mobile-nav-shell.bottom-nav .bottom-nav-list .nav-item span {
-  font-size: 0.72rem;
+  border-radius: 0;
+  background: none;
+  color: #666;
+  font-size: 14px;
   font-weight: 500;
+  line-height: 1.2;
 }
 
 #mobile-nav-shell.bottom-nav .bottom-nav-list .nav-item.active,
 #mobile-nav-shell.bottom-nav .bottom-nav-list .nav-item.nav-active {
-  color: var(--accent-color);
-  background: color-mix(in srgb, var(--accent-color) 12%, transparent);
-  font-weight: 700;
-}
-
-#mobile-nav-shell.bottom-nav .bottom-nav-list .nav-item.active .icon,
-#mobile-nav-shell.bottom-nav .bottom-nav-list .nav-item.nav-active .icon {
-  stroke-width: 2;
+  color: #5e3a8c;
+  font-weight: 600;
+  background: none;
 }

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -405,7 +405,7 @@
       if (captureInput && typeof captureInput.focus === 'function') captureInput.focus();
     }
 
-    if (activeView === 'notes' && typeof window.renderNotebookList === 'function') {
+    if (activeView === 'notebooks' && typeof window.renderNotebookList === 'function') {
       window.renderNotebookList();
     }
   });
@@ -498,10 +498,10 @@
   const navigateToNotebook = () => {
     window.dispatchEvent(
       new CustomEvent('app:navigate', {
-        detail: { view: 'notes' }
+        detail: { view: 'notebooks' }
       })
     );
-    setActiveFooterIcon('mobile-footer-notes');
+    setActiveFooterIcon('mobile-footer-notebooks');
     focusNotebookInputs();
     closeSavedNotesSheet();
   };
@@ -579,18 +579,7 @@
     closeFabMenu();
     setActiveFooterIcon(button.id);
 
-    if (view === 'notes') {
-      closeSavedNotesSheet();
-      window.dispatchEvent(new CustomEvent('memorycue:notes:mode', { detail: { mode: 'overview' } }));
-      window.dispatchEvent(
-        new CustomEvent('app:navigate', {
-          detail: { view: 'notes' }
-        })
-      );
-      return;
-    }
-
-    if (view === 'notebooks') {
+        if (view === 'notebooks') {
       window.dispatchEvent(new CustomEvent('memorycue:notes:mode', { detail: { mode: 'notebooks' } }));
       navigateToNotebook();
       setActiveFooterIcon('mobile-footer-notebooks');

--- a/mobile.html
+++ b/mobile.html
@@ -3277,7 +3277,7 @@ body, main, section, div, p, span, li {
     bottom: 0;
     height: 64px;
     background: white;
-    border-top: 1px solid #ddd;
+    border-top: 1px solid #e5e5e5;
     z-index: 50;
   }
 
@@ -3287,7 +3287,7 @@ body, main, section, div, p, span, li {
     align-items: center;
     height: 64px;
     background: white;
-    border-top: 1px solid var(--border);
+    border-top: 1px solid #e5e5e5;
     padding: 0;
   }
 
@@ -3358,21 +3358,22 @@ body, main, section, div, p, span, li {
   }
 
   #mobile-nav-shell .floating-footer .floating-card {
-    display: flex;
-    flex-direction: column;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     background: transparent;
     border: none;
-    padding: 0.25rem 0;
+    padding: 8px;
     border-radius: 0;
     cursor: pointer;
     flex: 1;
-    color: var(--muted);
+    color: #666;
+    font-size: 14px;
+    font-weight: 500;
   }
 
   #mobile-nav-shell .floating-footer .floating-card.active {
-    color: var(--primary);
+    color: #5e3a8c;
     font-weight: 600;
   }
 
@@ -5486,24 +5487,7 @@ body, main, section, div, p, span, li {
         data-nav-target="capture"
         data-tab="capture"
         aria-label="Go to Capture"
-      >
-        <svg
-          class="icon icon-capture"
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.75"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M12 5.25v13.5" />
-          <path d="M5.25 12h13.5" />
-        </svg>
-        <span>Capture</span>
-      </button>
+      >Capture</button>
 
       <button
         type="button"
@@ -5512,24 +5496,7 @@ body, main, section, div, p, span, li {
         data-nav-target="reminders"
         data-tab="reminders"
         aria-label="Go to Reminders"
-      >
-        <svg
-          class="icon icon-clock"
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.75"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          aria-hidden="true"
-        >
-          <circle cx="12" cy="12" r="7" />
-          <path d="M12 9v3.5l2 1.5" />
-        </svg>
-        <span>Reminders</span>
-      </button>
+      >Reminders</button>
 
       <button
         type="button"
@@ -5538,26 +5505,7 @@ body, main, section, div, p, span, li {
         data-nav-target="notebooks"
         data-tab="notebooks"
         aria-label="Go to Notebooks"
-      >
-        <svg
-          class="icon icon-notes"
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.75"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          aria-hidden="true"
-        >
-          <rect x="5" y="4.5" width="14" height="15" rx="2" />
-          <path d="M9 8.5h6" />
-          <path d="M9 12h6" />
-          <path d="M9 15.5h4" />
-        </svg>
-        <span>Notebooks</span>
-      </button>
+      >Notebooks</button>
 
       <button
         type="button"
@@ -5566,25 +5514,7 @@ body, main, section, div, p, span, li {
         data-nav-target="inbox"
         data-tab="inbox"
         aria-label="Go to Inbox"
-      >
-        <svg
-          class="icon icon-inbox"
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.75"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M4 7.5h16" />
-          <path d="M5.5 7.5l1.2 9A2 2 0 0 0 8.7 18h6.6a2 2 0 0 0 2-1.5l1.2-9" />
-          <path d="M9 11.5h6" />
-        </svg>
-        <span>Inbox</span>
-      </button>
+      >Inbox</button>
     </div>
     </div>
   </nav>


### PR DESCRIPTION
### Motivation
- Replace the previous rounded, icon-heavy mobile footer with a clean, minimal, text-first tab bar that matches modern productivity app patterns. 
- Keep routing and view behavior intact while removing old "Notes"/emoji-style buttons and making the footer consistent with the four primary app surfaces. 

### Description
- Replaced the bottom-nav markup in `mobile.html` to four text-only buttons exactly labeled `Capture`, `Reminders`, `Notebooks`, and `Inbox`, removing the SVG icon markup and large rounded card styling. 
- Updated visual rules in `css/navigation.css` to implement a minimal tab bar (fixed 64px height, subtle top border `#e5e5e5`, neutral inactive text `#666`, and active state `#5e3a8c`), removed heavy blur/shadow and rounded button styles. 
- Adjusted layout grid in `css/layout.css` to match four footer items (`repeat(4, ...)`). 
- Aligned navigation routing/behavior in `js/navigation.js` so notebook navigation consistently targets the `notebooks` view and footer active-state handling maps to the renamed notebook button id. 

### Testing
- Ran the targeted unit test with `npm test -- --runTestsByPath js/__tests__/mobile.footer-nav.test.js`, which passed. 
- Ran repository verification with `npm run verify` (build verification passed). 
- Started a local static server and captured a Playwright screenshot of `/mobile.html` to validate layout rendering (screenshot captured successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3fb3809648324ae70aea75ab621e9)