### PR TITLE
Fix capture bar submit-only behavior and assistant intent routing

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -5464,7 +5464,6 @@ body, main, section, div, p, span, li {
       <button id="thinkingBarSubmit" type="submit" class="btn btn-primary capture-save-btn" aria-label="Send">➤</button>
     </form>
     <div id="thinkingBarStatus" class="hidden" aria-live="polite"></div>
-    <div id="thinkingBarResults" aria-live="polite"></div>
   </section>
 
   <div class="move-to-folder-sheet hidden">

--- a/mobile.js
+++ b/mobile.js
@@ -67,7 +67,6 @@ function initAssistant() {
     const thinkingBarSubmit = document.getElementById('thinkingBarSubmit');
     const recentCapturesList = document.getElementById('recentCapturesList');
     const thinkingBarStatus = document.getElementById('thinkingBarStatus');
-    const thinkingBarResults = document.getElementById('thinkingBarResults');
     const chatConversationContainer = document.getElementById('chatConversationContainer');
     const weeklyReflectionCard = document.getElementById('weeklyReflectionCard');
     const weeklyReflectionButton = document.getElementById('weeklyReflectionButton');
@@ -77,7 +76,6 @@ function initAssistant() {
     const recallList = document.getElementById('memoryRecallList');
     let lastRecallNotificationKey = '';
     let isAssistantSending = false;
-    let latestThinkingSearchRequest = 0;
     const assistantConversationHistory = [];
 
     if (!isTextEntryElement(thinkingBarInput) || !(assistantThread instanceof HTMLElement)) {
@@ -157,69 +155,6 @@ function initAssistant() {
         thinkingBarStatus.classList.add('hidden');
       }
     };
-
-    const clearThinkingBarResults = () => {
-      if (thinkingBarResults instanceof HTMLElement) {
-        thinkingBarResults.innerHTML = '';
-      }
-    };
-
-
-    const renderSearchResults = async (query) => {
-      const requestId = ++latestThinkingSearchRequest;
-      clearThinkingBarResults();
-      setThinkingBarStatus('Search results');
-
-      const searchResponse = await executeCommand('search', { query });
-      const searchResults = (Array.isArray(searchResponse?.data) ? searchResponse.data : []).slice(0, 10);
-
-      if (requestId !== latestThinkingSearchRequest) {
-        return;
-      }
-
-      if (!(thinkingBarResults instanceof HTMLElement)) {
-        return;
-      }
-
-      if (!Array.isArray(searchResults) || !searchResults.length) {
-        const empty = document.createElement('div');
-        empty.className = 'thinking-result-item';
-        empty.textContent = 'No local matches found.';
-        thinkingBarResults.appendChild(empty);
-        return;
-      }
-
-      searchResults.forEach((entry) => {
-        const row = document.createElement('button');
-        row.type = 'button';
-        row.className = 'thinking-result-item';
-        row.setAttribute('aria-label', `Open note ${entry?.title || 'Untitled note'}`);
-
-        const title = document.createElement('div');
-        title.className = 'thinking-result-title';
-        title.textContent = typeof entry?.title === 'string' && entry.title.trim()
-          ? entry.title.trim()
-          : 'Untitled note';
-
-        const details = document.createElement('div');
-        const entryType = typeof entry?.type === 'string' && entry.type.trim() ? entry.type.trim() : 'Note';
-        const entryFolder = typeof entry?.folder === 'string' && entry.folder.trim() ? entry.folder.trim() : 'Unsorted';
-        details.textContent = `${entryType} • ${entryFolder}`;
-
-        row.addEventListener('click', () => {
-          const noteId = typeof entry?.id === 'string' ? entry.id : '';
-          if (!noteId) {
-            return;
-          }
-          document.dispatchEvent(new CustomEvent('thinkingBar:openNote', { detail: { noteId } }));
-        });
-
-        row.appendChild(title);
-        row.appendChild(details);
-        thinkingBarResults.appendChild(row);
-      });
-    };
-
 
     const readRemindersForRecall = () => {
       if (typeof localStorage === 'undefined') {
@@ -642,6 +577,7 @@ function initAssistant() {
           : 'Saved to Inbox';
         appendConversationMessage('assistant', replyMessage, reply?.quickActions);
         setThinkingBarStatus(replyMessage);
+        renderConversationHistory();
 
         thinkingBarInput.value = '';
         thinkingBarInput.focus();
@@ -652,24 +588,6 @@ function initAssistant() {
         isAssistantSending = false;
       }
     };
-
-    thinkingBarInput.addEventListener('input', () => {
-      const query = typeof thinkingBarInput.value === 'string' ? thinkingBarInput.value.trim() : '';
-
-      if (getActiveView() === 'inbox') {
-        syncInboxSearchInput();
-        return;
-      }
-
-      if (query.length <= 2) {
-        latestThinkingSearchRequest += 1;
-        clearThinkingBarResults();
-        setThinkingBarStatus('');
-        return;
-      }
-
-      renderSearchResults(query);
-    });
 
     createChatComposer({
       textarea: thinkingBarInput,
@@ -730,11 +648,15 @@ function initAssistant() {
 
       isAssistantSending = true;
       try {
+        appendConversationMessage('user', message);
         if (ENABLE_CHAT_INTERFACE) {
           const reply = await handleChatMessage(message);
-          if (typeof reply === 'string' && reply.trim()) {
-            setThinkingBarStatus(reply);
-          }
+          const replyMessage = typeof reply?.message === 'string' && reply.message.trim()
+            ? reply.message.trim()
+            : 'Added to inbox.';
+          appendConversationMessage('assistant', replyMessage, reply?.quickActions);
+          setThinkingBarStatus(replyMessage);
+          renderConversationHistory();
         } else {
           await executeCommand('capture', { text: message, source: 'capture' });
         }

--- a/src/chat/chatManager.js
+++ b/src/chat/chatManager.js
@@ -1,6 +1,7 @@
 import { addMessage } from './messageStore.js';
-import { parseIntent } from './intentParser.js';
-import { routeAction } from './actionRouter.js';
+import { executeCommand } from '../core/commandEngine.js';
+import { createNote, loadAllNotes, saveAllNotes } from '../../js/modules/notes-storage.js';
+import { saveToInbox } from '../services/inboxService.js';
 
 export const ENABLE_CHAT_INTERFACE = true;
 
@@ -31,6 +32,88 @@ const normalizeRouteResult = (result) => {
   };
 };
 
+const parseEntry = async (text) => {
+  const response = await fetch('/api/parse-entry', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to parse entry (${response.status})`);
+  }
+
+  return response.json();
+};
+
+const normalizeType = (parsedType, text) => {
+  const normalizedType = typeof parsedType === 'string' ? parsedType.trim().toLowerCase() : '';
+  if (normalizedType) {
+    return normalizedType;
+  }
+
+  return text.endsWith('?') ? 'question' : 'unknown';
+};
+
+const askAssistant = async (text) => {
+  const response = await fetch('/api/assistant-chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message: text }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Assistant request failed (${response.status})`);
+  }
+
+  const payload = await response.json();
+  return typeof payload?.reply === 'string' && payload.reply.trim()
+    ? payload.reply.trim()
+    : 'Here is what I found.';
+};
+
+const createNotebookNote = (parsed, text) => {
+  const title = typeof parsed?.title === 'string' && parsed.title.trim()
+    ? parsed.title.trim()
+    : text.split(/\s+/).slice(0, 8).join(' ') || 'Captured note';
+
+  const note = createNote(title, text, {
+    bodyText: text,
+    metadata: {
+      type: 'note',
+      tags: Array.isArray(parsed?.tags) ? parsed.tags : [],
+    },
+  });
+
+  const notes = Array.isArray(loadAllNotes()) ? loadAllNotes() : [];
+  saveAllNotes([note, ...notes]);
+  return note;
+};
+
+const processParsedEntry = async (parsed, text, dependencies = {}) => {
+  const parsedType = normalizeType(parsed?.type, text);
+
+  if (parsedType === 'reminder') {
+    await executeCommand('reminder', {
+      text: typeof parsed?.title === 'string' && parsed.title.trim() ? parsed.title.trim() : text,
+      handler: dependencies.createReminder,
+    });
+    return { message: 'Reminder created.' };
+  }
+
+  if (parsedType === 'note' || parsedType === 'drill' || parsedType === 'idea' || parsedType === 'task') {
+    createNotebookNote(parsed, text);
+    return { message: 'Saved to notebook.' };
+  }
+
+  if (parsedType === 'question' || text.endsWith('?')) {
+    return { message: await askAssistant(text) };
+  }
+
+  saveToInbox(text);
+  return { message: 'Added to inbox.' };
+};
+
 export const handleChatMessage = async (text, dependencies = {}) => {
   const userText = typeof text === 'string' ? text.trim() : '';
   if (!userText) {
@@ -39,8 +122,8 @@ export const handleChatMessage = async (text, dependencies = {}) => {
 
   addMessage(createMessage('user', userText));
 
-  const intent = parseIntent(userText);
-  const routeResult = await routeAction(intent, userText, dependencies);
+  const parsed = await parseEntry(userText);
+  const routeResult = await processParsedEntry(parsed, userText, dependencies);
   const response = normalizeRouteResult(routeResult);
 
   addMessage(createMessage('assistant', response.message, response.quickActions));


### PR DESCRIPTION
### Motivation
- Stop running assistant logic while the user types and make the capture bar behave like a chat composer that only triggers the assistant on submit.
- Route a submitted message to the correct action (reminder, notebook note, inbox fallback, or assistant Q&A) and always surface a short assistant response explaining what was done.

### Description
- Removed input-driven suggestion/search behavior and the `thinkingBarResults` suggestion container so no assistant work runs on `input` events and suggestions cannot collide with the composer UI (`mobile.js`, `mobile.html`).
- Reworked submit flows so Enter/Send triggers the assistant pipeline, user/assistant chat bubbles are appended in order, and the input is cleared after submission (`mobile.js`).
- Implemented a parsed-entry routing layer in `src/chat/chatManager.js` that calls the existing `/api/parse-entry`, maps the parsed type to actions (creates reminders via `executeCommand('reminder')`, saves notes via existing `createNote`/`saveAllNotes`, asks `/api/assistant-chat` for questions, or falls back to inbox via `saveToInbox`) and returns a short assistant message such as `Reminder created.`, `Saved to notebook.`, `Added to inbox.` or the assistant reply.

### Testing
- Ran the build with `npm run build` which completed successfully.
- Ran unit test suite with `npm test -- --runInBand` which exercised many suites but failed due to pre-existing module-format and unrelated baseline failures (several `Cannot use import statement outside a module` errors); failures appear unrelated to these focused UI changes.
- Started the local server with `npm start` and exercised the mobile composer in a headless Playwright script that submitted a capture and produced a screenshot at `browser:/tmp/codex_browser_invocations/82685ef639bb5fe9/artifacts/artifacts/capture-chat.png` to validate the chat flow visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b401299d748324af65c7eef8e4c5ae)