### PR TITLE
Connect assistant fallback routing to existing inbox capture flow

### DIFF
--- a/src/chat/chatManager.js
+++ b/src/chat/chatManager.js
@@ -1,7 +1,7 @@
 import { addMessage } from './messageStore.js';
 import { executeCommand } from '../core/commandEngine.js';
 import { createNote, loadAllNotes, saveAllNotes } from '../../js/modules/notes-storage.js';
-import { saveToInbox } from '../services/inboxService.js';
+import { captureInput } from '../../js/services/capture-service.js';
 
 export const ENABLE_CHAT_INTERFACE = true;
 
@@ -94,6 +94,7 @@ const processParsedEntry = async (parsed, text, dependencies = {}) => {
   const parsedType = normalizeType(parsed?.type, text);
 
   if (parsedType === 'reminder') {
+    console.log('Capture routed to:', 'reminder');
     await executeCommand('reminder', {
       text: typeof parsed?.title === 'string' && parsed.title.trim() ? parsed.title.trim() : text,
       handler: dependencies.createReminder,
@@ -102,16 +103,18 @@ const processParsedEntry = async (parsed, text, dependencies = {}) => {
   }
 
   if (parsedType === 'note' || parsedType === 'drill' || parsedType === 'idea' || parsedType === 'task') {
+    console.log('Capture routed to:', 'note');
     createNotebookNote(parsed, text);
-    return { message: 'Saved to notebook.' };
+    return { message: 'Saved as a notebook note.' };
   }
 
   if (parsedType === 'question' || text.endsWith('?')) {
     return { message: await askAssistant(text) };
   }
 
-  saveToInbox(text);
-  return { message: 'Added to inbox.' };
+  console.log('Capture routed to:', 'inbox');
+  await captureInput(text, 'assistant');
+  return { message: "I wasn't sure where this belongs, so I saved it to your Inbox." };
 };
 
 export const handleChatMessage = async (text, dependencies = {}) => {


### PR DESCRIPTION
### Motivation

- Ensure assistant-captured items that are uncertain use the canonical Inbox storage (`memoryCueInbox`) rather than introducing duplicate inbox paths.
- Keep capture routing consistent with the app's capture pipeline and surface clearer assistant feedback when items are routed.

### Description

- Replaced direct inbox write with the existing capture service by importing `captureInput` and using `captureInput(text, 'assistant')` for the assistant fallback path in `src/chat/chatManager.js`.
- Removed the previous `saveToInbox` usage and updated the assistant-facing message to: `I wasn't sure where this belongs, so I saved it to your Inbox.`
- Added temporary `console.log('Capture routed to:', ...)` debug lines for `reminder`, `note`, and `inbox` routing decisions.
- Adjusted notebook response wording to `Saved as a notebook note.` to match requested UX text.

### Testing

- Ran `npm run verify` which succeeded (`Build verification passed`).
- Ran `npm test -- chat-system.prompt12.test.js` which failed due to an existing ESM/CommonJS test harness mismatch (`SyntaxError: Cannot use import statement outside a module` in `src/chat/actionRouter.js`), which is unrelated to this change and prevented the prompt-specific tests from completing.
- No other automated tests were modified or added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b402e447b08324a76276828f898199)