### PR TITLE
Stabilize mobile runtime navigation and capture routing

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -600,11 +600,15 @@
   const remindersSection = document.querySelector('section[data-view="reminders"]');
   if (!remindersSection) return;
 
-  const header = remindersSection.querySelector('header');
+  const header = remindersSection.querySelector('header') || remindersSection.querySelector('.reminders-header');
   const scrollContainer =
     remindersSection.querySelector('.reminders-scroll-container') ||
     remindersSection.querySelector('#reminders-list') ||
     remindersSection;
+
+  if (!(header instanceof HTMLElement) || !(scrollContainer instanceof HTMLElement)) {
+    return;
+  }
 
   // SAFETY:
   // Do NOT rename elements. We check multiple fallbacks.

--- a/mobile.html
+++ b/mobile.html
@@ -514,26 +514,26 @@ Legacy shells remain for reference only.
     padding-bottom: 140px;
   }
 
-  body[data-active-view="notes"] .container {
+  body[data-active-view="notebooks"] .container {
     max-width: none;
     margin: 0;
     padding: 0;
   }
 
-  body[data-active-view="notes"] #main {
+  body[data-active-view="notebooks"] #main {
     max-width: none;
     margin: 0;
     padding-bottom: calc(var(--mobile-bottom-nav-height, 80px) + 8px);
   }
 
   /* Ensure notebook content sits comfortably beneath the header */
-  body[data-active-view="notes"] #main {
+  body[data-active-view="notebooks"] #main {
     /* Use the variable set by JS, with a safe fallback and extra breathing room */
     padding-top: calc(var(--mobile-header-height, 112px) + 18px) !important;
     margin-top: 0 !important;
   }
 
-  body[data-active-view="notes"] #view-notebook .card-body {
+  body[data-active-view="notebooks"] #view-notebook .card-body {
     margin-top: 0 !important;
   }
 
@@ -562,11 +562,11 @@ Legacy shells remain for reference only.
     display: none !important;
   }
 
-  body[data-active-view="notes"] #view-notebook {
+  body[data-active-view="notebooks"] #view-notebook {
     background: #ffffff;
   }
 
-  body[data-active-view="notes"] #view-notebook .card {
+  body[data-active-view="notebooks"] #view-notebook .card {
     margin: 0;
     border: none;
     border-radius: 0;
@@ -583,12 +583,12 @@ Legacy shells remain for reference only.
     background: #ffffff;
   }
 
-  [data-view="notes"] .textarea {
+  [data-view="notebooks"] .textarea {
     min-height: 0 !important;
   }
 
   /* Notebook: no extra top padding from card-body */
-body[data-active-view="notes"] #view-notebook .card-body {
+body[data-active-view="notebooks"] #view-notebook .card-body {
   padding: 0rem 0.75rem 0.6rem;
   margin-top: 0 !important;
   min-height: auto;
@@ -3968,13 +3968,13 @@ body, main, section, div, p, span, li {
   </style>
  <style>
   /* 1. Match the page padding to the header so content starts just below it */
-  body[data-active-view="notes"] #main {
+  body[data-active-view="notebooks"] #main {
     padding-top: calc(var(--mobile-header-height, 112px) + 18px) !important;
     margin-top: 0 !important; /* Keep content immediately below the header */
   }
 
   /* 2. Strip inner layout padding */
-  body[data-active-view="notes"] .mobile-view-inner {
+  body[data-active-view="notebooks"] .mobile-view-inner {
     padding: 0 !important;
     margin: 0 !important;
     width: 100% !important;
@@ -3982,7 +3982,7 @@ body, main, section, div, p, span, li {
   }
 
   /* 3. Card Reset: Full width, no shadow, no rounded corners */
-  body[data-active-view="notes"] #scratch-notes-card {
+  body[data-active-view="notebooks"] #scratch-notes-card {
     padding: 0 !important;
     margin: 0 !important;
     border-radius: 0 !important;
@@ -3992,7 +3992,7 @@ body, main, section, div, p, span, li {
   }
 
   /* 4. Remove internal card padding so Title touches the top */
-  body[data-active-view="notes"] .note-editor-card {
+  body[data-active-view="notebooks"] .note-editor-card {
     padding-top: 4px !important; /* Tiny breathing room only */
     padding-left: 16px !important;
     padding-right: 16px !important;
@@ -5417,27 +5417,7 @@ body, main, section, div, p, span, li {
                 <button type="button" class="note-action-btn note-action-delete">Delete note</button>
               </div>
             </div>
-    <section id="view-assistant" class="view hidden" aria-hidden="true">
-      <div class="assistant-panel">
-        <div id="assistantMessages" class="assistant-messages" aria-live="polite" aria-label="Assistant conversation"></div>
-        <div class="assistant-input">
-          <p class="text-xs text-base-content/70">Use the chat capture bar to ask the assistant.</p>
-        </div>
-        <div id="assistantLoading" class="hidden" aria-live="polite">Assistant is thinking…</div>
-        <div id="weeklyReflectionCard" class="insight-card" aria-live="polite">
-          <div class="insight-header"><span>Insights</span></div>
-          <p id="weeklyReflectionSummary" class="insight-summary">You captured items this week.</p>
-          <button id="weeklyReflectionButton" type="button" class="btn btn-outline btn-sm view-reflection-btn">Weekly Reflection</button>
-
-          <div class="memory-recall">
-            <h3>Memory Recall</h3>
-            <div id="memoryRecallList">
-              <div class="recall-item recall-item--empty">No recall suggestions yet.</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
+    
 
     <section data-view="settings" id="view-settings" class="view-panel hidden" aria-hidden="true">
       <div class="space-y-3">

--- a/mobile.js
+++ b/mobile.js
@@ -40,10 +40,6 @@ const isNotesSyncDebugEnabled = (() => {
 initViewportHeight();
 
 function initAssistant() {
-    const isFormElement = (value) =>
-      typeof HTMLFormElement !== 'undefined'
-        ? value instanceof HTMLFormElement
-        : value && value.tagName === 'FORM';
     const isTextEntryElement = (value) => {
       if (typeof HTMLInputElement !== 'undefined' && value instanceof HTMLInputElement) {
         return true;
@@ -78,16 +74,18 @@ function initAssistant() {
     let isAssistantSending = false;
     const assistantConversationHistory = [];
 
-    if (!isTextEntryElement(thinkingBarInput) || !(assistantThread instanceof HTMLElement)) {
+    if (!isTextEntryElement(thinkingBarInput)) {
       return;
     }
 
     const appendAssistantMessage = (text, className = 'assistant-message') => {
-      const message = document.createElement('div');
-      message.className = className;
-      message.textContent = text;
-      assistantThread.appendChild(message);
-      assistantThread.scrollTop = assistantThread.scrollHeight;
+      if (assistantThread instanceof HTMLElement) {
+        const message = document.createElement('div');
+        message.className = className;
+        message.textContent = text;
+        assistantThread.appendChild(message);
+        assistantThread.scrollTop = assistantThread.scrollHeight;
+      }
 
       if (chatConversationContainer instanceof HTMLElement) {
         const roleClass = className.includes('--error') ? 'chat-message--assistant' : 'chat-message--assistant';
@@ -476,81 +474,6 @@ function initAssistant() {
       ]);
     };
 
-
-    const getActiveView = () => document.body?.getAttribute('data-active-view') || '';
-
-    const syncInboxSearchInput = () => {
-      if (!isTextEntryElement(captureInputField)) {
-        return;
-      }
-      document.dispatchEvent(new CustomEvent('memoryCue:universalSearch', {
-        detail: { query: captureInputField.value },
-      }));
-    };
-
-    function detectIntent(text) {
-      const lower = text.toLowerCase();
-
-      const reminderKeywords = [
-        'today',
-        'tomorrow',
-        'tonight',
-        'monday',
-        'tuesday',
-        'wednesday',
-        'thursday',
-        'friday',
-        'saturday',
-        'sunday',
-        'next week',
-      ];
-
-      const assistantKeywords = [
-        'what',
-        'how',
-        'why',
-        'find',
-        'show',
-        'summarise',
-        'summarize',
-      ];
-
-      if (/\d{1,2}(:\d{2})?\s?(am|pm)/.test(lower)) {
-        return 'reminder';
-      }
-
-      if (reminderKeywords.some((keyword) => lower.includes(keyword))) {
-        return 'reminder';
-      }
-
-      if (assistantKeywords.some((keyword) => lower.startsWith(keyword))) {
-        return 'assistant';
-      }
-
-      return 'inbox';
-    }
-
-    const createReminderFromText = async (text) => {
-      if (typeof window.memoryCueQuickAddNow !== 'function') {
-        return false;
-      }
-
-      await window.memoryCueQuickAddNow({ forceText: text, source: 'smart-capture' });
-      return true;
-    };
-
-    const sendToAssistant = (text) => {
-      const assistantFormEl = document.getElementById('assistantForm');
-      const assistantInputEl = document.getElementById('assistantInput');
-      const isAssistantInput = assistantInputEl instanceof HTMLInputElement || assistantInputEl instanceof HTMLTextAreaElement;
-      if (!(assistantFormEl instanceof HTMLFormElement) || !isAssistantInput) {
-        return false;
-      }
-
-      assistantInputEl.value = text;
-      assistantFormEl.requestSubmit();
-      return true;
-    };
 
     const sendAssistantMessage = async (event) => {
       if (event) {
@@ -1887,7 +1810,7 @@ const initMobileNotes = () => {
       hideSavedNotesSheet();
     }
 
-    document.dispatchEvent(new CustomEvent('app:navigate', { detail: { view: 'notes' } }));
+    document.dispatchEvent(new CustomEvent('app:navigate', { detail: { view: 'notebooks' } }));
   };
 
   document.addEventListener('thinkingBar:openNote', (event) => {

--- a/src/chat/actionRouter.js
+++ b/src/chat/actionRouter.js
@@ -6,9 +6,9 @@ import { formatMemorySearchResponse, searchNotesMemory } from '../services/memor
 const QUICK_ACTIONS_BY_INTENT = {
   capture: [{ label: 'Open Inbox', targetView: 'inbox' }],
   reminder: [{ label: 'Edit Reminder', targetView: 'reminders' }],
-  assistant: [{ label: 'View Notes', targetView: 'notes' }],
-  processInbox: [{ label: 'View Notes', targetView: 'notes' }],
-  memorySearch: [{ label: 'View Notes', targetView: 'notes' }],
+  assistant: [{ label: 'View Notes', targetView: 'notebooks' }],
+  processInbox: [{ label: 'View Notes', targetView: 'notebooks' }],
+  memorySearch: [{ label: 'View Notes', targetView: 'notebooks' }],
 };
 
 const createActionResult = (intent, message, status) => ({

--- a/src/chat/chatManager.js
+++ b/src/chat/chatManager.js
@@ -2,6 +2,8 @@ import { addMessage } from './messageStore.js';
 import { executeCommand } from '../core/commandEngine.js';
 import { createNote, loadAllNotes, saveAllNotes } from '../../js/modules/notes-storage.js';
 import { saveToInbox } from '../services/inboxService.js';
+import { suggestNotebookAndTags } from '../services/taggingEngine.js';
+import { ensureFolderExistsByName } from '../../js/modules/ai-capture-save.js';
 
 export const ENABLE_CHAT_INTERFACE = true;
 
@@ -72,22 +74,68 @@ const askAssistant = async (text) => {
     : 'Here is what I found.';
 };
 
-const createNotebookNote = (parsed, text) => {
+const getReminderScheduleLabel = (parsed, text) => {
+  const metadata = parsed && typeof parsed === 'object' ? parsed.metadata || parsed : {};
+  const dueValue =
+    (typeof metadata?.due === 'string' && metadata.due.trim())
+    || (typeof metadata?.dueAt === 'string' && metadata.dueAt.trim())
+    || (typeof parsed?.due === 'string' && parsed.due.trim())
+    || (typeof parsed?.date === 'string' && parsed.date.trim())
+    || null;
+
+  if (dueValue) {
+    return dueValue;
+  }
+
+  const normalizedText = typeof text === 'string' ? text.toLowerCase() : '';
+  if (normalizedText.includes('tomorrow')) {
+    return 'tomorrow';
+  }
+  if (normalizedText.includes('today')) {
+    return 'today';
+  }
+
+  return null;
+};
+
+const createNotebookNote = async (parsed, text) => {
   const title = typeof parsed?.title === 'string' && parsed.title.trim()
     ? parsed.title.trim()
     : text.split(/\s+/).slice(0, 8).join(' ') || 'Captured note';
 
+  const notebookSuggestion = await suggestNotebookAndTags(text);
+  const folderName = notebookSuggestion?.notebook && notebookSuggestion.notebook !== 'Inbox'
+    ? notebookSuggestion.notebook
+    : null;
+  const folderId = folderName ? ensureFolderExistsByName(folderName) : null;
+
   const note = createNote(title, text, {
     bodyText: text,
+    folderId,
     metadata: {
       type: 'note',
-      tags: Array.isArray(parsed?.tags) ? parsed.tags : [],
+      tags: Array.isArray(notebookSuggestion?.tags)
+        ? notebookSuggestion.tags
+        : Array.isArray(parsed?.tags)
+          ? parsed.tags
+          : [],
     },
   });
 
   const notes = Array.isArray(loadAllNotes()) ? loadAllNotes() : [];
   saveAllNotes([note, ...notes]);
-  return note;
+  return { note, notebookName: folderName || 'Unsorted' };
+};
+
+const looksLikeNotebookCapture = (text) => {
+  const normalized = typeof text === 'string' ? text.trim().toLowerCase() : '';
+  if (!normalized) {
+    return false;
+  }
+  if (normalized.includes('?')) {
+    return false;
+  }
+  return /(meeting notes|lesson idea|remember\b|notes?\s+from|journal|plan\b|scored\b)/i.test(normalized);
 };
 
 const processParsedEntry = async (parsed, text, dependencies = {}) => {
@@ -98,12 +146,23 @@ const processParsedEntry = async (parsed, text, dependencies = {}) => {
       text: typeof parsed?.title === 'string' && parsed.title.trim() ? parsed.title.trim() : text,
       handler: dependencies.createReminder,
     });
-    return { message: 'Reminder created.' };
+    const scheduleLabel = getReminderScheduleLabel(parsed, text);
+    const title = typeof parsed?.title === 'string' && parsed.title.trim() ? parsed.title.trim() : text;
+    const message = scheduleLabel
+      ? `Reminder created for ${scheduleLabel}: ${title}`
+      : `Reminder created: ${title}`;
+    return { message };
   }
 
-  if (parsedType === 'note' || parsedType === 'drill' || parsedType === 'idea' || parsedType === 'task') {
-    createNotebookNote(parsed, text);
-    return { message: 'Saved to notebook.' };
+  if (
+    parsedType === 'note'
+    || parsedType === 'drill'
+    || parsedType === 'idea'
+    || parsedType === 'task'
+    || looksLikeNotebookCapture(text)
+  ) {
+    const { notebookName } = await createNotebookNote(parsed, text);
+    return { message: `Saved to notebook (${notebookName}).` };
   }
 
   if (parsedType === 'question' || text.endsWith('?')) {
@@ -111,7 +170,7 @@ const processParsedEntry = async (parsed, text, dependencies = {}) => {
   }
 
   saveToInbox(text);
-  return { message: 'Added to inbox.' };
+  return { message: 'Added to inbox for later review.' };
 };
 
 export const handleChatMessage = async (text, dependencies = {}) => {


### PR DESCRIPTION
### Motivation
- Consolidate and stabilize the mobile-first runtime so the bottom navigation is the single navigation surface for `capture`, `reminders`, `notebooks`, and `inbox`. 
- Fix capture/chat composer behaviour so captures only act on explicit submit (Enter / Send) and are routed by the assistant rather than by live typing. 
- Ensure notebook routing and storage wiring (notes, inbox, reminders) produce visible items and correct folder assignment without duplicate legacy surfaces.

### Description
- Harmonised view naming and layout by replacing legacy `notes` selectors with `notebooks` and removing the unused `assistant` section from `mobile.html` so the bottom nav controls the active view. 
- Hardened reminders header behaviour in `js/navigation.js` by adding fallbacks and guarding for missing header/scroll nodes before binding scroll listeners. 
- Simplified capture/assistant flow in `mobile.js` by removing dead duplicate intent helpers, keeping assistant send only on form submit/Enter, and ensuring conversation history renders safely when assistant DOM is absent. 
- Implemented clearer routing and notebook handling in `src/chat/chatManager.js` by adding: reminder schedule labels, notebook/tag suggestion integration via `taggingEngine`, automatic folder creation via `ai-capture-save`, a heuristic `looksLikeNotebookCapture` detector, and clearer assistant confirmation strings. 
- Updated quick-action navigation targets in `src/chat/actionRouter.js` from `notes` to `notebooks` to match the runtime navigation model. 
- Files changed: `mobile.html`, `mobile.js`, `js/navigation.js`, `src/chat/chatManager.js`, `src/chat/actionRouter.js`.

### Testing
- Ran the repository test suite with `npm test -- --runInBand`, which executed but reported failures due to existing CJS/ESM test-harness and unrelated legacy issues (tests failing are not regressions introduced by these focused runtime fixes). 
- Performed runtime validation by serving the app with `npm start` and running a Playwright navigation script to cycle `Capture → Reminders → Notebooks → Inbox` which completed successfully and produced a screenshot of the mobile runtime. 
- Verified changed code loads in the browser environment and that capture submit/assistant routing produces assistant confirmations and writes to chat history in the served runtime during manual/automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b403c054c48324ab6e0a329ea985b8)