### PR TITLE
Add built-in assistant help content, detection, and onboarding UX

### DIFF
--- a/api/assistant-chat.ts
+++ b/api/assistant-chat.ts
@@ -1,3 +1,5 @@
+import { helpContent } from '../src/assistant/help-content.js';
+
 const ALLOWED_ORIGINS = [
   'https://dmaher42.github.io',
   'https://memory-cue.vercel.app',
@@ -76,6 +78,60 @@ function gatherContext(body) {
   ].filter(Boolean);
 
   return contextEntries;
+}
+
+function isHelpRequest(message) {
+  const helpWords = [
+    'help',
+    'how do i use',
+    'how do i use memory cue',
+    'how do i use this',
+    'how does this work',
+    'how does memory cue work',
+    'what can i type',
+    'what can i type here',
+    'what does inbox mean',
+    'what is inbox',
+    'how do reminders work',
+  ];
+
+  const normalized = toText(message).toLowerCase();
+  return helpWords.some((word) => normalized.includes(word));
+}
+
+function buildHelpReply(message) {
+  const normalized = toText(message).toLowerCase();
+
+  if (normalized === 'help') {
+    return [
+      'How to use Memory Cue:',
+      '',
+      'Type anything into the message bar.',
+      '',
+      helpContent.examples,
+      '',
+      'I will automatically store it in reminders, notebooks, or inbox.',
+    ].join('\n');
+  }
+
+  if (normalized.includes('inbox')) {
+    return `${helpContent.sections.inbox}\n\n${helpContent.examples}`;
+  }
+
+  if (normalized.includes('reminder')) {
+    return `${helpContent.sections.reminders}\n\n${helpContent.examples}`;
+  }
+
+  return [
+    'Memory Cue works by capturing thoughts through the message bar.',
+    '',
+    helpContent.examples,
+    '',
+    'I will automatically store them in:',
+    'Reminders',
+    'Notebooks',
+    'Inbox',
+  ].join('\n');
 }
 
 function buildPrompt(message, history, selectedContext) {
@@ -159,6 +215,15 @@ export default async function handler(req, res) {
       return res.status(200).json(body.entries.map((entry) => classifyLegacyEntry(entry)));
     }
     return res.status(400).json({ error: 'Missing message' });
+  }
+
+  if (isHelpRequest(message)) {
+    return res.status(200).json({
+      success: true,
+      reply: buildHelpReply(message),
+      references: [],
+      contextUsed: [],
+    });
   }
 
   try {

--- a/js/services/assistant-service.js
+++ b/js/services/assistant-service.js
@@ -20,6 +20,23 @@ const readReminders = () => {
 
 const readConversation = () => getMessages();
 
+const hasStoredItems = () => {
+  const notes = Array.isArray(loadAllNotes()) ? loadAllNotes() : [];
+  const reminders = readReminders();
+  const inboxEntries = getInboxEntries();
+  return notes.length > 0 || reminders.length > 0 || inboxEntries.length > 0;
+};
+
+const buildWelcomeMessage = () => [
+  'Welcome to Memory Cue.',
+  '',
+  'Try typing something like:',
+  '',
+  'remind me to get milk tomorrow',
+  'lesson idea for year 7 volleyball',
+  'remember Archer scored 3 goals today',
+].join('\n');
+
 const createStoredMessage = (role, content) => ({
   id:
     typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
@@ -186,6 +203,17 @@ const askAssistant = async ({ message, assistantMessages, assistantLoading }) =>
 
   if (typeof window !== 'undefined') {
     window.memoryCueAskAssistant = async (message) => askAssistant({ message, assistantMessages, assistantLoading });
+  }
+
+  const assistantHelpBtn = document.getElementById('assistantHelpBtn');
+  assistantHelpBtn?.addEventListener('click', async () => {
+    await askAssistant({ message: 'help', assistantMessages, assistantLoading });
+  });
+
+  if (!readConversation().length && !hasStoredItems()) {
+    const welcomeMessage = buildWelcomeMessage();
+    appendMessage(assistantMessages, welcomeMessage, 'assistant-message assistant-message--reply');
+    addMessage(createStoredMessage('assistant', welcomeMessage));
   }
 
   assistantForm.addEventListener('submit', async (event) => {

--- a/mobile.html
+++ b/mobile.html
@@ -4857,6 +4857,7 @@ body, main, section, div, p, span, li {
   <!-- Unified Mobile Header -->
   <header id="reminders-slim-header" class="mobile-header app-header" role="banner">
       <h1 class="header-title title">Memory Cue</h1>
+      <button id="assistantHelpBtn" type="button" class="icon-button control-icon-button" aria-label="How do I use this?">?</button>
       <button id="openSavedNotesGlobal" type="button" class="search icon-button control-icon-button" aria-label="Search">
         🔍
       </button>

--- a/src/assistant/help-content.js
+++ b/src/assistant/help-content.js
@@ -1,0 +1,27 @@
+export const helpContent = {
+  overview: `Memory Cue is an AI memory assistant.
+
+You capture thoughts in the message bar at the bottom.
+The assistant automatically decides where to store them.
+
+There are four main sections:
+
+Capture – where you type messages to the assistant
+Reminders – tasks and scheduled items
+Notebooks – organised notes
+Inbox – temporary storage for uncategorised items`,
+
+  examples: `Examples you can type:
+
+remind me to get milk tomorrow
+lesson idea for year 7 volleyball
+remember Archer scored 3 goals today
+need to think about football drill for next week`,
+
+  sections: {
+    capture: 'Capture is the main input area where you type messages.',
+    reminders: 'Reminders are tasks with dates or times.',
+    notebooks: 'Notebooks store organised notes and ideas.',
+    inbox: 'Inbox holds items the assistant cannot categorise yet.',
+  },
+};


### PR DESCRIPTION
### Motivation
- Provide an in-app help system so users can ask simple usage questions and get clear instructions without invoking the LLM.
- Make the assistant self-documenting and give first-time users a short onboarding message when the app has no stored items.

### Description
- Add a help knowledge module at `src/assistant/help-content.js` containing `overview`, `examples`, and `sections` for Capture/Reminders/Notebooks/Inbox.
- Detect help-style queries in the server assistant endpoint by adding `isHelpRequest` and `buildHelpReply` to `api/assistant-chat.ts` and return an immediate instructional reply (bypasses the LLM path for these queries).
- Show a first-run onboarding message in the client by adding `hasStoredItems`/`buildWelcomeMessage` and wiring the logic in `js/services/assistant-service.js` to post a welcome assistant message when there is no chat history and no stored notes/reminders/inbox entries.
- Add a small `?` help button to the mobile header in `mobile.html` and wire it so clicking it sends `help` to the assistant flow via the existing client handler.

### Testing
- Ran `npm run build` and the build completed successfully (`build` ✅).
- Ran unit tests with `npm test -- --runInBand` and observed repository-wide failures unrelated to the help changes (several existing suites failed due to ESM/import and test harness issues) (`test` ⚠️).
- Launched a local server with `npm start` and verified the UI and header `?` button by taking a screenshot of `mobile.html` (screenshot saved at the artifact path shown in the PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b47b0ee1f88324a3c3a5e6dc2d4363)