### PR TITLE
Unify capture intent classification on /api/parse-entry

### DIFF
--- a/api/assistant-chat.ts
+++ b/api/assistant-chat.ts
@@ -44,24 +44,6 @@ function normalizeEntry(entry, type) {
 }
 
 
-function classifyLegacyEntry(entry) {
-  const text = toText(entry?.text || entry?.body || entry?.title);
-  const lower = text.toLowerCase();
-  let type = 'note';
-  if (lower.includes('remind') || lower.includes('due')) type = 'task';
-  else if (lower.includes('idea')) type = 'idea';
-  else if (lower.includes('memory')) type = 'memory';
-
-  return {
-    id: toText(entry?.id),
-    type,
-    context: toText(entry?.context) || 'general',
-    person: toText(entry?.person) || null,
-    rewrite: text,
-    category: toText(entry?.category) || type,
-  };
-}
-
 function gatherContext(body) {
   const inboxEntries = Array.isArray(body?.inboxEntries) ? body.inboxEntries : [];
   const notes = Array.isArray(body?.notes) ? body.notes : [];
@@ -211,9 +193,6 @@ export default async function handler(req, res) {
   const message = toText(body.message || body.question || body.input);
 
   if (!message) {
-    if (Array.isArray(body.entries) && body.entries.length && toText(body.prompt)) {
-      return res.status(200).json(body.entries.map((entry) => classifyLegacyEntry(entry)));
-    }
     return res.status(400).json({ error: 'Missing message' });
   }
 

--- a/api/parse-entry.js
+++ b/api/parse-entry.js
@@ -9,7 +9,8 @@ const PARSED_ENTRY_SCHEMA = {
         'reminder',
         'drill',
         'idea',
-        'task'
+        'task',
+        'unknown'
       ]
     },
     title: { type: 'string' },
@@ -19,9 +20,13 @@ const PARSED_ENTRY_SCHEMA = {
     },
     reminderDate: {
       type: ['string', 'null']
+    },
+    metadata: {
+      type: 'object',
+      additionalProperties: true
     }
   },
-  required: ['type', 'title', 'tags', 'reminderDate']
+  required: ['type', 'title', 'tags', 'reminderDate', 'metadata']
 };
 
 const ALLOWED_ORIGINS = [
@@ -91,7 +96,7 @@ module.exports = async function handler(req, res) {
             content: [
               {
                 type: 'input_text',
-                text: `Return ONLY JSON matching schema.\nExtract:\n- type (note, reminder, drill, idea, task)\n- title (short summary under 60 chars)\n- tags (lowercase keywords)\n- reminderDate (ISO string if date/time mentioned, else null)\nIf unsure, use note.`
+                text: `Return ONLY JSON matching schema.\nExtract:\n- type (note, reminder, drill, idea, task, unknown)\n- title (short summary under 60 chars)\n- tags (lowercase keywords)\n- reminderDate (ISO string if date/time mentioned, else null)\nIf unsure, use unknown. Include metadata object with parse hints (or {}).`
               }
             ]
           },

--- a/docs/CAPTURE_FLOW.md
+++ b/docs/CAPTURE_FLOW.md
@@ -75,3 +75,5 @@ Use capture-service.js instead.
 ```
 
 These remain for compatibility scaffolding, but capture writes should use `captureInput()`.
+
+- `src/chat/intentParser.js` is deprecated. Use `/api/parse-entry` through `src/chat/chatManager.js` (or the same parse contract) and consume `{ type, title, tags, reminderDate, metadata }`.

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -1175,21 +1175,12 @@ export async function initReminders(sel = {}) {
     return note;
   }
 
-  function classifyInput(text) {
-    const normalized = typeof text === 'string' ? text.toLowerCase() : '';
-    if (normalized.includes('remind')) return 'reminder';
-    if (normalized.includes('drill') || normalized.includes('footy')) return 'drill';
-    if (normalized.includes('task') || normalized.includes('todo') || normalized.includes('to do')) return 'task';
-    if (normalized.includes('idea')) return 'idea';
-    return 'note';
-  }
-
   function normalizeMemoryEntryType(type) {
     const value = typeof type === 'string' ? type.trim().toLowerCase() : '';
-    if (value === 'note' || value === 'reminder' || value === 'drill' || value === 'idea' || value === 'task') {
+    if (value === 'note' || value === 'reminder' || value === 'drill' || value === 'idea' || value === 'task' || value === 'unknown') {
       return value;
     }
-    return 'note';
+    return 'unknown';
   }
 
   function inferRelevantEntryType(query) {
@@ -1249,7 +1240,7 @@ export async function initReminders(sel = {}) {
     const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
     const timeoutId = controller ? setTimeout(() => controller.abort(), 8000) : null;
 
-    const requestUrl = 'https://memory-cue-api.vercel.app/api/parse-entry';
+    const requestUrl = '/api/parse-entry';
 
     try {
       const response = await fetch(requestUrl, {
@@ -1274,10 +1265,11 @@ export async function initReminders(sel = {}) {
       }
       const data = await response.json();
       return {
-        type: data?.type,
-        title: typeof data?.title === 'string' ? data.title.trim() : '',
-        tags: sanitizeTags(data?.tags),
+        type: typeof data?.type === 'string' ? data.type.trim().toLowerCase() : 'unknown',
+        title: typeof data?.title === 'string' ? data.title.trim() : extractTitle(text),
+        tags: sanitizeTags(Array.isArray(data?.tags) ? data.tags : extractTags(text)),
         reminderDate: typeof data?.reminderDate === 'string' ? data.reminderDate : null,
+        metadata: data?.metadata && typeof data.metadata === 'object' ? data.metadata : {},
       };
     } finally {
       if (timeoutId) {
@@ -1288,10 +1280,11 @@ export async function initReminders(sel = {}) {
 
   function parseSmartEntryWithFallback(text) {
     return {
-      type: classifyInput(text),
+      type: 'unknown',
       title: extractTitle(text),
       tags: extractTags(text),
       reminderDate: null,
+      metadata: {},
     };
   }
 
@@ -1302,7 +1295,7 @@ export async function initReminders(sel = {}) {
     }
 
     const fallbackFields = parseSmartEntryWithFallback(normalizedText);
-    const resolvedType = fallbackFields.type;
+    const resolvedType = normalizeMemoryEntryType(fallbackFields.type);
     const resolvedTitle = fallbackFields.title;
     const resolvedTags = sanitizeTags(fallbackFields.tags);
     const resolvedReminderDate = null;

--- a/src/chat/chatManager.js
+++ b/src/chat/chatManager.js
@@ -34,6 +34,25 @@ const normalizeRouteResult = (result) => {
   };
 };
 
+const normalizeParsedEntry = (parsed, text = '') => {
+  const payload = parsed && typeof parsed === 'object' ? parsed : {};
+  const normalizedType = typeof payload.type === 'string' ? payload.type.trim().toLowerCase() : '';
+  const fallbackType = typeof text === 'string' && text.trim().endsWith('?') ? 'question' : 'unknown';
+
+  return {
+    type: normalizedType || fallbackType,
+    title: typeof payload.title === 'string' ? payload.title.trim() : '',
+    tags: Array.isArray(payload.tags)
+      ? payload.tags.map((tag) => (typeof tag === 'string' ? tag.trim().toLowerCase() : '')).filter(Boolean)
+      : [],
+    reminderDate:
+      typeof payload.reminderDate === 'string' && payload.reminderDate.trim()
+        ? payload.reminderDate.trim()
+        : null,
+    metadata: payload.metadata && typeof payload.metadata === 'object' ? payload.metadata : {},
+  };
+};
+
 const parseEntry = async (text) => {
   const response = await fetch('/api/parse-entry', {
     method: 'POST',
@@ -45,7 +64,8 @@ const parseEntry = async (text) => {
     throw new Error(`Failed to parse entry (${response.status})`);
   }
 
-  return response.json();
+  const parsed = await response.json();
+  return normalizeParsedEntry(parsed, text);
 };
 
 const normalizeType = (parsedType, text) => {
@@ -75,12 +95,10 @@ const askAssistant = async (text) => {
 };
 
 const getReminderScheduleLabel = (parsed, text) => {
-  const metadata = parsed && typeof parsed === 'object' ? parsed.metadata || parsed : {};
   const dueValue =
-    (typeof metadata?.due === 'string' && metadata.due.trim())
-    || (typeof metadata?.dueAt === 'string' && metadata.dueAt.trim())
-    || (typeof parsed?.due === 'string' && parsed.due.trim())
-    || (typeof parsed?.date === 'string' && parsed.date.trim())
+    (typeof parsed?.reminderDate === 'string' && parsed.reminderDate.trim())
+    || (typeof parsed?.metadata?.due === 'string' && parsed.metadata.due.trim())
+    || (typeof parsed?.metadata?.dueAt === 'string' && parsed.metadata.dueAt.trim())
     || null;
 
   if (dueValue) {

--- a/src/chat/intentParser.js
+++ b/src/chat/intentParser.js
@@ -1,3 +1,15 @@
+/*
+ * DEPRECATED MODULE
+ *
+ * Intent classification for capture messages has moved to the canonical
+ * /api/parse-entry contract consumed by src/chat/chatManager.js.
+ *
+ * Migration note: do not add new imports of parseIntent(). Route capture
+ * inputs through chatManager (or callers that use /api/parse-entry directly)
+ * and consume the canonical parsed shape:
+ * { type, title, tags, reminderDate, metadata }.
+ */
+
 const MEMORY_SEARCH_PREFIXES = ['what', 'show', 'find', 'list'];
 
 const isMemorySearchQuery = (text) => {


### PR DESCRIPTION
### Motivation
- Consolidate all capture intent classification behind a single parse contract so chat, quick-add, and capture flows consume one canonical parsed shape.
- Deprecate the old local intent classifier to avoid divergent classification logic and reduce maintenance burden.
- Keep the assistant API focused on help/assistant replies rather than doing capture-type classification.

### Description
- Added a module-level deprecation banner to `src/chat/intentParser.js` and documented the migration target in `docs/CAPTURE_FLOW.md` to direct future work to `/api/parse-entry` and `src/chat/chatManager.js`.
- Extended the `/api/parse-entry` schema to include `metadata` and an `unknown` type and updated its LLM prompt so the endpoint returns the canonical shape: `{ type, title, tags, reminderDate, metadata }`.
- Updated `src/chat/chatManager.js` to normalize responses from `/api/parse-entry` into the canonical parsed shape and to route captures using the normalized fields (including `reminderDate`/`metadata`).
- Replaced local quick-add classification in `js/reminders.js` by removing `classifyInput` and the older fallback, switching quick-add parsing to call the same `/api/parse-entry` contract and to consume the canonical parsed shape.
- Removed legacy classification behavior from `api/assistant-chat.ts` so it remains focused on assistant/help responses rather than capture-type inference.

### Testing
- Ran repository verification with `npm run verify` and it passed.
- Ran the focused test suite with `npm test -- --runInBand js/__tests__/reminders.quick-add.test.js`, which failed in this environment with `Cannot use import statement outside a module` from the test harness; this failure relates to the test runner/module format and was not caused by introducing new classification logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b480a5695883249a0bdeeb5f52b7d4)