### PR TITLE
Route note writes through a canonical notes-storage helper

### DIFF
--- a/js/modules/notes-storage.js
+++ b/js/modules/notes-storage.js
@@ -151,7 +151,51 @@ const sanitizeMetadata = (value) => {
     metadata.aiFollowUpQuestion = value.aiFollowUpQuestion.trim();
   }
 
+  if (typeof value.source === 'string' && value.source.trim()) {
+    metadata.source = value.source.trim();
+  }
+
   return Object.keys(metadata).length ? metadata : null;
+};
+
+const sanitizeCanonicalTags = (value) => sanitizeTags(value);
+
+export const createAndSaveNote = (payload = {}, options = {}) => {
+  const normalizedPayload = payload && typeof payload === 'object' ? payload : {};
+  const text = typeof normalizedPayload.text === 'string' ? normalizedPayload.text.trim() : '';
+  if (!text) {
+    return null;
+  }
+
+  const title =
+    typeof normalizedPayload.title === 'string' && normalizedPayload.title.trim()
+      ? normalizedPayload.title.trim()
+      : text.split(/\s+/).slice(0, 8).join(' ') || 'Captured note';
+
+  const parsedType =
+    typeof normalizedPayload.parsedType === 'string' && normalizedPayload.parsedType.trim()
+      ? normalizedPayload.parsedType.trim()
+      : 'note';
+
+  const note = createNote(title, text, {
+    bodyText: text,
+    folderId:
+      typeof normalizedPayload.folderId === 'string' && normalizedPayload.folderId.trim()
+        ? normalizedPayload.folderId.trim()
+        : null,
+    metadata: {
+      type: parsedType,
+      tags: sanitizeCanonicalTags(normalizedPayload.tags),
+      source:
+        typeof normalizedPayload.source === 'string' && normalizedPayload.source.trim()
+          ? normalizedPayload.source.trim()
+          : undefined,
+    },
+  });
+
+  const notes = loadAllNotes();
+  const saved = saveAllNotes([note, ...notes], options);
+  return saved ? note : null;
 };
 
 export const createNote = (title, bodyHtml, overrides = {}) => {

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -2,6 +2,7 @@ import { setAuthContext, startSignInFlow, startSignOutFlow } from './supabase-au
 import { captureInput, getInboxEntries } from './services/capture-service.js';
 import { getSupabaseClient } from './supabase-client.js';
 import { deleteReminder, syncReminders, upsertReminder } from '../src/services/supabaseSyncService.js';
+import { createAndSaveNote } from './modules/notes-storage.js';
 
 // Shared reminder logic used by both the mobile and desktop pages.
 // This module wires up Firebase/Firestore and all reminder UI handlers.
@@ -1318,15 +1319,23 @@ export async function initReminders(sel = {}) {
       semanticEmbedding: null,
     };
 
-    const notes = readJsonArrayStorage(NOTES_STORAGE_KEY, []);
-    notes.unshift(smartEntry);
+    const savedEntry = createAndSaveNote({
+      text: normalizedText,
+      title: smartEntry.title,
+      tags: smartEntry.tags,
+      folderId: smartEntry.folderId,
+      source: 'reminder',
+      parsedType: smartEntry.type,
+    });
 
-    try {
-      localStorage.setItem(NOTES_STORAGE_KEY, JSON.stringify(notes));
-    } catch (error) {
-      console.error('Failed to save smart entry', error);
+    if (!savedEntry) {
+      console.error('Failed to save smart entry');
       return null;
     }
+
+    smartEntry.id = savedEntry.id;
+    smartEntry.createdAt = savedEntry.createdAt;
+    smartEntry.updatedAt = savedEntry.updatedAt;
 
     try {
       if (typeof document !== 'undefined' && typeof CustomEvent === 'function') {

--- a/js/services/capture-service.js
+++ b/js/services/capture-service.js
@@ -1,4 +1,4 @@
-import { createNote, loadAllNotes, saveAllNotes } from '../modules/notes-storage.js';
+import { createAndSaveNote } from '../modules/notes-storage.js';
 import { generateTags } from '../../src/ai/tagGenerator.js';
 import { syncInbox, upsertInboxEntry } from '../../src/services/supabaseSyncService.js';
 
@@ -175,16 +175,17 @@ export const convertInboxToNote = (entryId) => {
   }
 
   const title = text.split(/\s+/).slice(0, 8).join(' ') || 'Captured note';
-  const note = createNote(title, text, {
-    bodyText: text,
-    metadata: {
-      type: entry.parsedType || 'note',
-      source: 'inbox',
-    },
+  const note = createAndSaveNote({
+    text,
+    title,
+    tags: Array.isArray(entry.tags) ? entry.tags : [],
+    folderId: entry.folderId,
+    source: 'inbox',
+    parsedType: entry.parsedType || 'note',
   });
-
-  const notes = Array.isArray(loadAllNotes()) ? loadAllNotes() : [];
-  saveAllNotes([note, ...notes]);
+  if (!note) {
+    return null;
+  }
   removeInboxEntry(targetId);
 
   if (typeof document !== 'undefined' && typeof CustomEvent === 'function') {

--- a/src/chat/chatManager.js
+++ b/src/chat/chatManager.js
@@ -1,6 +1,6 @@
 import { addMessage } from './messageStore.js';
 import { executeCommand } from '../core/commandEngine.js';
-import { createNote, loadAllNotes, saveAllNotes } from '../../js/modules/notes-storage.js';
+import { createAndSaveNote } from '../../js/modules/notes-storage.js';
 import { saveToInbox } from '../services/inboxService.js';
 import { suggestNotebookAndTags } from '../services/taggingEngine.js';
 import { ensureFolderExistsByName } from '../../js/modules/ai-capture-save.js';
@@ -127,21 +127,18 @@ const createNotebookNote = async (parsed, text) => {
     : null;
   const folderId = folderName ? ensureFolderExistsByName(folderName) : null;
 
-  const note = createNote(title, text, {
-    bodyText: text,
+  const note = createAndSaveNote({
+    text,
+    title,
+    tags: Array.isArray(notebookSuggestion?.tags)
+      ? notebookSuggestion.tags
+      : Array.isArray(parsed?.tags)
+        ? parsed.tags
+        : [],
     folderId,
-    metadata: {
-      type: 'note',
-      tags: Array.isArray(notebookSuggestion?.tags)
-        ? notebookSuggestion.tags
-        : Array.isArray(parsed?.tags)
-          ? parsed.tags
-          : [],
-    },
+    source: 'chat',
+    parsedType: 'note',
   });
-
-  const notes = Array.isArray(loadAllNotes()) ? loadAllNotes() : [];
-  saveAllNotes([note, ...notes]);
   return { note, notebookName: folderName || 'Unsorted' };
 };
 


### PR DESCRIPTION
### Motivation
- Centralize all note creation/writes behind a single helper so different capture flows use consistent normalization and persistence.
- Preserve existing UI behavior and metadata (including note `source`) when routing writes through a canonical API.

### Description
- Added `createAndSaveNote(payload, options)` to `js/modules/notes-storage.js`; it accepts a normalized payload (`text`, `title`, `tags`, `folderId`, `source`, `parsedType`), builds a normalized note via existing helpers, and persists it with `saveAllNotes` while returning the saved note or `null` on failure. (F: `js/modules/notes-storage.js`)
- Extended `sanitizeMetadata` to retain a `source` field when present so origin metadata is preserved. (F: `js/modules/notes-storage.js`)
- Refactored `createNotebookNote` in `src/chat/chatManager.js` to call `createAndSaveNote` instead of manually calling `createNote` + `saveAllNotes`, preserving the returned note and notebook naming behavior. (F: `src/chat/chatManager.js`)
- Refactored `convertInboxToNote` in `js/services/capture-service.js` to call `createAndSaveNote` and preserved the existing event dispatch (`memoryCue:notesUpdated`) and inbox removal behavior. (F: `js/services/capture-service.js`)
- Replaced the direct initial note write in `createSmartEntry` (`js/reminders.js`) with `createAndSaveNote` and continued to dispatch update events and run the asynchronous AI enrichment flow unchanged. (F: `js/reminders.js`)

### Testing
- Ran the repository test suite with `npm test -- --runInBand`; the full suite reported existing unrelated failures and did not pass end-to-end. (Failures are unrelated to the note-storage changes.)
- Ran the focused notes storage test with `npx jest js/tests/notes-storage.links.test.js --runInBand`; this test passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b482df0dac8324b395e9ddfe54da3f)