### PR TITLE
Unify inbox writes behind canonical src inbox service

### DIFF
--- a/js/services/capture-service.js
+++ b/js/services/capture-service.js
@@ -1,9 +1,13 @@
 import { createAndSaveNote } from '../modules/notes-storage.js';
 import { generateTags } from '../../src/ai/tagGenerator.js';
-import { syncInbox, upsertInboxEntry } from '../../src/services/supabaseSyncService.js';
+import {
+  getInboxEntries,
+  saveInboxEntry as saveInboxEntryCanonical,
+  removeInboxEntry,
+  INBOX_STORAGE_KEY,
+} from '../../src/services/inboxService.js';
 
-export const INBOX_STORAGE_KEY = 'memoryCueInbox';
-const LEGACY_INBOX_STORAGE_KEYS = ['memoryEntries'];
+export { INBOX_STORAGE_KEY, getInboxEntries, removeInboxEntry };
 
 const PARSED_TYPE_VALUES = new Set(['note', 'reminder', 'unknown']);
 const SOURCE_VALUES = new Set(['capture', 'reminder', 'assistant', 'quick-add']);
@@ -32,84 +36,7 @@ const generateId = () => {
   return `capture-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
 };
 
-export const getInboxEntries = () => {
-  if (typeof localStorage === 'undefined') {
-    return [];
-  }
-
-  try {
-    const raw = localStorage.getItem(INBOX_STORAGE_KEY);
-    if (!raw) {
-      for (const legacyKey of LEGACY_INBOX_STORAGE_KEYS) {
-        const legacyRaw = localStorage.getItem(legacyKey);
-        if (!legacyRaw) continue;
-        const legacyParsed = JSON.parse(legacyRaw);
-        if (Array.isArray(legacyParsed) && legacyParsed.length) {
-          localStorage.setItem(INBOX_STORAGE_KEY, JSON.stringify(legacyParsed));
-          localStorage.removeItem(legacyKey);
-          return legacyParsed;
-        }
-      }
-      return [];
-    }
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch (error) {
-    console.warn('[capture-service] Failed to read inbox entries', error);
-    return [];
-  }
-};
-
-const persistInboxEntries = (entries) => {
-  if (typeof localStorage === 'undefined') {
-    return;
-  }
-
-  try {
-    localStorage.setItem(INBOX_STORAGE_KEY, JSON.stringify(entries));
-  } catch (error) {
-    console.warn('[capture-service] Failed to persist inbox entries', error);
-  }
-};
-
-const dispatchEntriesUpdated = () => {
-  if (typeof document === 'undefined' || typeof CustomEvent !== 'function') {
-    return;
-  }
-  document.dispatchEvent(new CustomEvent('memoryCue:entriesUpdated'));
-};
-
-export const saveInboxEntry = (entry) => {
-  const entries = getInboxEntries();
-  const nextEntry = { ...entry, pendingSync: true, updatedAt: Date.now() };
-  entries.unshift(nextEntry);
-  persistInboxEntries(entries);
-  dispatchEntriesUpdated();
-  upsertInboxEntry(nextEntry).catch((error) => {
-    console.warn('[capture-service] Failed to sync inbox entry to Supabase', error);
-  });
-  return nextEntry;
-};
-
-export const removeInboxEntry = (id) => {
-  const targetId = typeof id === 'string' ? id : '';
-  if (!targetId) {
-    return false;
-  }
-
-  const entries = getInboxEntries();
-  const nextEntries = entries.filter((entry) => String(entry?.id || '') !== targetId);
-  if (nextEntries.length === entries.length) {
-    return false;
-  }
-
-  persistInboxEntries(nextEntries);
-  dispatchEntriesUpdated();
-  syncInbox().catch((error) => {
-    console.warn('[capture-service] Failed to sync inbox deletions to Supabase', error);
-  });
-  return true;
-};
+export const saveInboxEntry = (entry) => saveInboxEntryCanonical(entry);
 
 const parseEntry = async (text) => {
   try {
@@ -151,10 +78,9 @@ export const captureInput = async (text, source = 'capture') => {
     source: normalizeSource(source),
     parsedType: parsed.parsedType,
     metadata: parsed.metadata,
-    pendingSync: true,
   };
 
-  return saveInboxEntry(entry);
+  return saveInboxEntryCanonical(entry);
 };
 
 export const convertInboxToNote = (entryId) => {

--- a/src/chat/chatManager.js
+++ b/src/chat/chatManager.js
@@ -1,7 +1,7 @@
 import { addMessage } from './messageStore.js';
 import { executeCommand } from '../core/commandEngine.js';
 import { createAndSaveNote } from '../../js/modules/notes-storage.js';
-import { saveToInbox } from '../services/inboxService.js';
+import { saveInboxEntry } from '../services/inboxService.js';
 import { suggestNotebookAndTags } from '../services/taggingEngine.js';
 import { ensureFolderExistsByName } from '../../js/modules/ai-capture-save.js';
 
@@ -185,7 +185,13 @@ const processParsedEntry = async (parsed, text, dependencies = {}) => {
     return { message: await askAssistant(text) };
   }
 
-  saveToInbox(text);
+  saveInboxEntry({
+    text,
+    source: 'assistant',
+    parsedType: normalizeType(parsed?.type, text),
+    tags: Array.isArray(parsed?.tags) ? parsed.tags : [],
+    metadata: parsed?.metadata && typeof parsed.metadata === 'object' ? parsed.metadata : {},
+  });
   return { message: 'Added to inbox for later review.' };
 };
 

--- a/src/services/inboxService.js
+++ b/src/services/inboxService.js
@@ -1,5 +1,9 @@
-import { upsertInboxEntry } from './supabaseSyncService.js';
-const INBOX_STORAGE_KEY = 'memoryCueInbox';
+import { syncInbox, upsertInboxEntry } from './supabaseSyncService.js';
+
+export const INBOX_STORAGE_KEY = 'memoryCueInbox';
+const LEGACY_INBOX_STORAGE_KEYS = ['memoryEntries'];
+const PARSED_TYPE_VALUES = new Set(['note', 'reminder', 'unknown']);
+const SOURCE_VALUES = new Set(['capture', 'reminder', 'assistant', 'quick-add']);
 
 const generateId = () => {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -16,6 +20,26 @@ const sanitizeText = (value) => {
   return value.replace(/\s+/g, ' ').trim();
 };
 
+const normalizeSource = (source) => {
+  const normalized = typeof source === 'string' ? source.trim().toLowerCase() : '';
+  return SOURCE_VALUES.has(normalized) ? normalized : 'capture';
+};
+
+const normalizeParsedType = (value) => {
+  const normalized = typeof value === 'string' ? value.trim().toLowerCase() : 'unknown';
+  return PARSED_TYPE_VALUES.has(normalized) ? normalized : 'unknown';
+};
+
+const normalizeTags = (tags) => {
+  if (!Array.isArray(tags)) {
+    return [];
+  }
+
+  return tags
+    .map((tag) => (typeof tag === 'string' ? tag.trim().toLowerCase() : ''))
+    .filter(Boolean);
+};
+
 export const getInboxEntries = () => {
   if (typeof localStorage === 'undefined') {
     return [];
@@ -23,7 +47,20 @@ export const getInboxEntries = () => {
 
   try {
     const raw = localStorage.getItem(INBOX_STORAGE_KEY);
-    const parsed = raw ? JSON.parse(raw) : [];
+    if (!raw) {
+      for (const legacyKey of LEGACY_INBOX_STORAGE_KEYS) {
+        const legacyRaw = localStorage.getItem(legacyKey);
+        if (!legacyRaw) continue;
+        const legacyParsed = JSON.parse(legacyRaw);
+        if (Array.isArray(legacyParsed) && legacyParsed.length) {
+          localStorage.setItem(INBOX_STORAGE_KEY, JSON.stringify(legacyParsed));
+          localStorage.removeItem(legacyKey);
+          return legacyParsed;
+        }
+      }
+      return [];
+    }
+    const parsed = JSON.parse(raw);
     return Array.isArray(parsed) ? parsed : [];
   } catch (error) {
     console.warn('[inbox-service] Failed to load inbox entries', error);
@@ -57,17 +94,30 @@ export const saveToInbox = (text) => {
     return null;
   }
 
+  return saveInboxEntry({ text: normalizedText });
+};
+
+export const saveInboxEntry = (entryInput = {}) => {
+  const normalizedText = sanitizeText(entryInput?.text);
+  if (!normalizedText) {
+    return null;
+  }
+
+  const timestamp = Date.now();
   const entry = {
-    id: generateId(),
+    id: typeof entryInput?.id === 'string' && entryInput.id.trim() ? entryInput.id.trim() : generateId(),
     text: normalizedText,
-    createdAt: Date.now(),
-    processed: false,
-    tags: [],
+    tags: normalizeTags(entryInput?.tags),
+    createdAt: Number.isFinite(entryInput?.createdAt) ? entryInput.createdAt : timestamp,
+    source: normalizeSource(entryInput?.source),
+    parsedType: normalizeParsedType(entryInput?.parsedType),
+    metadata: entryInput?.metadata && typeof entryInput.metadata === 'object' ? entryInput.metadata : {},
     pendingSync: true,
+    updatedAt: timestamp,
   };
 
   const entries = getInboxEntries();
-  entries.push(entry);
+  entries.unshift(entry);
   persistInboxEntries(entries);
   dispatchInboxUpdated();
   upsertInboxEntry(entry).catch((error) => {
@@ -91,5 +141,8 @@ export const removeInboxEntry = (id) => {
 
   persistInboxEntries(nextEntries);
   dispatchInboxUpdated();
+  syncInbox().catch((error) => {
+    console.warn('[inbox-service] Supabase inbox deletion sync failed', error);
+  });
   return true;
 };


### PR DESCRIPTION
### Motivation
- Consolidate inbox write behavior so all parts of the app use one canonical API and share schema, events, and sync behavior.
- Make the legacy `js` capture code a thin compatibility layer so parsing/tagging remains but actual persistence is centralized.

### Description
- Added `saveInboxEntry(entryInput)` to `src/services/inboxService.js` as the canonical write API and normalized schema fields (`id`, `text`, `tags`, `source`, `parsedType`, `metadata`, `pendingSync`, `createdAt`, `updatedAt`).
- Kept `saveToInbox(text)` as a backward-compatible wrapper that delegates to `saveInboxEntry` and added normalization helpers (`normalizeSource`, `normalizeParsedType`, `normalizeTags`).
- Updated `js/services/capture-service.js` to become a thin wrapper that imports/exports `getInboxEntries`, `removeInboxEntry`, and `INBOX_STORAGE_KEY` and delegates writes to the canonical `saveInboxEntry` while preserving parsing and tag generation logic.
- Updated `src/chat/chatManager.js` fallback path to call `saveInboxEntry` with `source: 'assistant'` and include `parsedType`, `tags`, and `metadata`, and ensured deletions trigger `syncInbox()` and writes dispatch the `memoryCue:entriesUpdated` event.

### Testing
- Ran `npm test -- --runInBand js/__tests__/reminders.quick-add.test.js`, which failed due to a test-harness/module-mode mismatch (`SyntaxError: Cannot use import statement outside a module`) rather than changes made in this PR, resulting in 8 failing tests.
- No other automated test suites were run; changes are focused on unifying inbox write paths and preserving existing read/parse behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b487f9628c832490473030126d7add)