### PR TITLE
Polish Capture screen styling with light premium mobile UI

### DIFF
--- a/css/capture.css
+++ b/css/capture.css
@@ -1,7 +1,8 @@
 #view-capture {
   display: flex;
   justify-content: center;
-  padding: 1rem 0.75rem 1.5rem;
+  padding: 1.25rem 0.85rem 2rem;
+  background: linear-gradient(180deg, #f7f8fc 0%, #f2f5fb 100%);
 }
 
 .capture-container {
@@ -9,12 +10,12 @@
   max-width: 38rem;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 1.1rem;
-  border-radius: 1rem;
+  gap: 1.2rem;
+  padding: 1.3rem;
+  border-radius: 1.15rem;
   background: var(--card-bg, #ffffff);
-  border: 1px solid var(--card-border, #e5e7eb);
-  box-shadow: 0 10px 26px rgba(35, 27, 46, 0.08);
+  border: 1px solid color-mix(in srgb, var(--card-border, #e5e7eb) 70%, #ffffff 30%);
+  box-shadow: 0 12px 32px rgba(35, 27, 46, 0.08);
 }
 
 .capture-form {
@@ -121,18 +122,24 @@
 }
 
 .capture-recent {
-  margin-top: 0.25rem;
-  padding-top: 0.4rem;
-  border-top: 1px solid color-mix(in srgb, var(--card-border, #e5e7eb) 75%, transparent);
+  margin-top: 0.1rem;
+  padding: 0.9rem 0.95rem;
+  border-radius: 0.95rem;
+  background: color-mix(in srgb, #f8fafd 82%, #ffffff 18%);
+  border: 1px solid color-mix(in srgb, var(--card-border, #e5e7eb) 68%, #ffffff 32%);
 }
 
 .capture-recent-list {
-  margin-top: 0.55rem;
+  margin-top: 0.65rem;
   padding-left: 1.1rem;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.55rem;
   color: var(--text-body, #4b5563);
+}
+
+#recentCapturesList {
+  min-height: 1.2rem;
 }
 
 .capture-recent-list li {
@@ -143,4 +150,24 @@
   list-style: none;
   color: var(--text-muted, #6b7280);
   margin-left: -1.1rem;
+}
+
+#chatConversationContainer {
+  gap: 0.85rem !important;
+  padding: 0.45rem 0.2rem 0.5rem !important;
+}
+
+#chatConversationContainer .chat-message {
+  max-width: 92% !important;
+  border-radius: 1rem !important;
+  padding: 0.78rem 0.92rem !important;
+  background: #ffffff !important;
+  border: 1px solid color-mix(in srgb, var(--card-border, #dbe2ed) 66%, #ffffff 34%) !important;
+  box-shadow: 0 7px 18px rgba(24, 30, 43, 0.08) !important;
+  line-height: 1.45 !important;
+}
+
+#chatConversationContainer .chat-message--user,
+#chatConversationContainer .chat-message--assistant {
+  background: #ffffff !important;
 }

--- a/mobile.css
+++ b/mobile.css
@@ -199,3 +199,47 @@ body.app-shell .content .card,
   margin-bottom: 12px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 }
+
+/* Capture view polish */
+#thinkingBarContainer {
+  background: color-mix(in srgb, #ffffff 94%, #f4f7fb 6%) !important;
+  border-top: 1px solid color-mix(in srgb, var(--border-subtle, #e3d9f4) 70%, #ffffff 30%) !important;
+  padding: 12px 14px !important;
+  padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px)) !important;
+  box-shadow: 0 -10px 28px rgba(16, 12, 24, 0.08) !important;
+}
+
+#thinkingBarInput {
+  border-radius: 16px !important;
+  min-height: 3rem !important;
+  max-height: 9rem !important;
+  padding: 12px 15px !important;
+  border: 1px solid color-mix(in srgb, var(--border-subtle, #d8dfea) 74%, #ffffff 26%) !important;
+  box-shadow: inset 0 1px 2px rgba(20, 27, 41, 0.04) !important;
+  background: #ffffff !important;
+}
+
+#thinkingBarSubmit {
+  width: 2.5rem !important;
+  height: 2.5rem !important;
+  min-height: 2.5rem !important;
+  border-radius: 999px !important;
+  border: 1px solid color-mix(in srgb, var(--accent-color, #512663) 25%, #ffffff 75%) !important;
+  box-shadow: 0 6px 14px rgba(44, 30, 64, 0.2) !important;
+}
+
+#bottom-nav {
+  background: color-mix(in srgb, #ffffff 96%, #f4f7fb 4%) !important;
+  border-top: 1px solid color-mix(in srgb, var(--border-subtle, #e3d9f4) 74%, #ffffff 26%) !important;
+  box-shadow: 0 -8px 20px rgba(17, 23, 37, 0.08) !important;
+}
+
+#bottom-nav button {
+  color: color-mix(in srgb, var(--muted, #6b7280) 88%, #a8b1bf 12%) !important;
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+#bottom-nav button.active {
+  color: var(--accent-color, #512663) !important;
+  font-weight: 600;
+}


### PR DESCRIPTION
### Motivation
- Refresh the Capture view to feel light, calm, and premium while preserving existing behavior and DOM structure. 
- Deliver a CSS-only redesign focused on better vertical rhythm, soft card surfaces, and a modern composer without touching JS or routing. 

### Description
- Updated `css/capture.css` to add a subtle background gradient for `#view-capture`, increase padding/spacing, and refine the `.capture-container` card radius, border, and shadow. 
- Restyled recent thoughts by turning `.capture-recent` into a rounded, lighter surface and improved list spacing while adding a small minimum height for `#recentCapturesList`. 
- Scoped chat improvements to `#chatConversationContainer` so `.chat-message` uses a white card surface with increased vertical spacing, rounded corners, comfortable padding, subtle border and shadow. 
- Added scoped overrides in `mobile.css` for `#thinkingBarContainer`, `#thinkingBarInput`, and `#thinkingBarSubmit` to create a rounded, taller input and a modern circular send button, and elevated `#bottom-nav` with softer inactive color and clearer active state. 
- Kept changes strictly CSS-only and scoped to capture-related selectors, using `!important` in a few overrides to avoid altering other views that have highly specific in-page rules. 
- Confirmed that no IDs, DOM elements, routing logic, capture logic, modals, or JS files were modified. 

### Testing
- Ran a targeted grep of selectors with `rg` to validate impacted selectors were updated and found expected matches (succeeded). 
- Verified diffs with `git diff` to confirm only `css/capture.css` and `mobile.css` changed (succeeded). 
- Served the app locally with `python -m http.server 4173` and inspected the capture view in-browser for visual verification (succeeded). 
- Captured a Playwright screenshot of `http://127.0.0.1:4173/mobile.html` to validate the redesign artifact (succeeded).

Notes on conflicts: existing in-page/mobile-specific capture styles in `mobile.html` are very specific, so a few scoped `!important` overrides were applied to ensure the redesign applies without changing HTML or JS; this minimizes cross-view impact but should be reviewed if further global theming is introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b48cc0081483248be016f925688ca5)