### PR TITLE
Polish mobile capture layout for chat-first hierarchy

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -233,11 +233,11 @@ Legacy shells remain for reference only.
       right: 0;
       bottom: 64px;
       z-index: 120;
-      background: white;
-      border-top: 1px solid #ddd;
-      padding: 10px 12px;
-      padding-bottom: calc(10px + env(safe-area-inset-bottom, 0px));
-      box-shadow: 0 -6px 22px rgba(16, 12, 24, 0.12);
+      background: color-mix(in srgb, #ffffff 96%, #f4f7fb 4%);
+      border-top: 1px solid color-mix(in srgb, var(--border-subtle, #dbe2ef) 74%, #ffffff 26%);
+      padding: 12px 14px;
+      padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px));
+      box-shadow: 0 -10px 28px rgba(16, 12, 24, 0.1);
       transition: padding 0.2s ease;
     }
 
@@ -253,27 +253,38 @@ Legacy shells remain for reference only.
     .chat-composer textarea {
       flex: 1;
       width: 100%;
-      border-radius: 20px;
-      min-height: 2.6rem;
+      border-radius: 22px;
+      min-height: 3.15rem;
       max-height: 9rem;
       resize: none;
-      padding: 10px 14px;
-      box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.06);
+      padding: 13px 16px;
+      border: 1px solid color-mix(in srgb, var(--border-subtle, #d8dfea) 78%, #ffffff 22%);
+      background: #ffffff;
+      box-shadow: inset 0 1px 2px rgba(20, 27, 41, 0.04);
+    }
+
+    #thinkingBarInput:focus,
+    #thinkingBarInput:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--accent-color) 35%, transparent);
+      outline-offset: 1px;
+      border-color: color-mix(in srgb, var(--accent-color) 45%, #d8dfea);
     }
 
     #thinkingBarSubmit,
     .chat-composer button {
-      width: 2.2rem;
-      height: 2.2rem;
-      min-height: 2.2rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      min-height: 2.6rem;
       padding: 0;
-      border-radius: 20px;
+      border-radius: 999px;
       font-size: 1rem;
       line-height: 1;
       display: inline-flex;
       align-items: center;
       justify-content: center;
       flex-shrink: 0;
+      border: 1px solid color-mix(in srgb, var(--accent-color) 24%, #ffffff 76%);
+      box-shadow: 0 8px 18px rgba(44, 30, 64, 0.2);
     }
 
     #thinkingBarStatus {
@@ -291,12 +302,38 @@ Legacy shells remain for reference only.
       min-height: calc(100vh - var(--mobile-header-height));
       display: flex;
       flex-direction: column;
-      gap: 0.65rem;
+      gap: 0.5rem;
       padding-bottom: 8.4rem;
+    }
+
+    .capture-intro {
+      font-size: 0.8rem;
+      color: color-mix(in srgb, var(--text-muted) 88%, #ffffff 12%);
+      padding: 0.35rem 0.15rem 0.2rem;
     }
 
     .capture-recent {
       flex-shrink: 0;
+      padding: 0.6rem 0.75rem;
+      border-radius: 0.9rem;
+      background: color-mix(in srgb, var(--surface-elevated) 68%, #f4f7fb 32%);
+      border: 1px solid color-mix(in srgb, var(--border-subtle) 72%, #ffffff 28%);
+    }
+
+    .capture-recent h3 {
+      font-size: 0.75rem;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+    }
+
+    #recentCapturesList {
+      margin-top: 0.45rem;
+      font-size: 0.8rem;
+      line-height: 1.35;
+      gap: 0.35rem;
+      max-height: 4.75rem;
+      overflow-y: auto;
     }
 
     #chatConversationContainer {
@@ -305,17 +342,17 @@ Legacy shells remain for reference only.
       overflow-y: auto;
       display: flex;
       flex-direction: column;
-      justify-content: flex-end;
-      gap: 0.5rem;
-      padding: 0.2rem 0.15rem 0.35rem;
+      justify-content: flex-start;
+      gap: 0.85rem;
+      padding: 0.5rem 0.15rem 0.55rem;
     }
 
     .chat-message {
-      max-width: 86%;
-      border-radius: 0.85rem;
-      padding: 0.55rem 0.7rem;
-      font-size: 0.9rem;
-      line-height: 1.35;
+      max-width: min(92%, 34rem);
+      border-radius: 1.05rem;
+      padding: 0.82rem 0.95rem;
+      font-size: 0.94rem;
+      line-height: 1.45;
       white-space: pre-wrap;
       word-break: break-word;
     }
@@ -4927,10 +4964,8 @@ body, main, section, div, p, span, li {
     <section data-view="capture" id="view-capture" class="view-panel">
       <div class="capture-container capture-chat-layout">
         <div>
-          <h2 class="text-lg font-semibold">Memory Cue</h2>
-          <div class="capture-form">
-          <p class="text-sm text-base-content/70">Use the chat capture bar to capture ideas, add reminders, ask questions, and process inbox notes.</p>
-          </div>
+          <h2 class="text-base font-semibold">Memory Cue</h2>
+          <p class="capture-intro">Capture a thought, ask a question, or drop in something to organize.</p>
         </div>
         <section class="capture-recent" aria-labelledby="captureRecentHeading">
           <h3 id="captureRecentHeading" class="text-sm font-semibold">Recent Thoughts</h3>


### PR DESCRIPTION
### Motivation
- Make the mobile Capture view feel like a chat-first assistant by reducing top-card prominence, emphasizing the conversation, and making the composer more prominent and comfortable.
- Keep behavior, routing, and JS IDs unchanged so capture submission, navigation, and modal/reminder/notebook flows are preserved.

### Description
- Reworked composer styling and layout for `#thinkingBarContainer`, `#thinkingBarInput`, and `#thinkingBarSubmit` to provide a larger input height, softer rounded shapes, a clear focus state, subtle elevation, and a circular send button while preserving the existing IDs and form structure.
- Adjusted `#chatConversationContainer` to use top-led flow, increased message padding/spacing, widened message max-width, and made bubbles less pill-like for improved readability.
- Reduced intro prominence in `#view-capture` by replacing the larger helper block with a compact hint line and smaller heading to keep the conversation central.
- De-emphasized the Recent Thoughts area by updating `.capture-recent` styling and constraining `#recentCapturesList` height so it reads as secondary content.

### Testing
- Ran the repository test suite with `npm test -- --runInBand`; the run completed but reported pre-existing failures (Test Suites: 15 failed, 10 passed; Tests: 33 failed, 50 passed), which are unrelated to this CSS/HTML-only change (ESM/import test harness and baseline expectation mismatches observed). 
- Launched the local server (`npm start`) and captured a mobile viewport screenshot via a Playwright script to validate the visual layout; the render and screenshot completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4a327a5f883249211ef0cc1d1e0b6)