### PR TITLE
Stage 4: Polish mobile capture conversation UI styling

### DIFF
--- a/css/capture.css
+++ b/css/capture.css
@@ -159,21 +159,47 @@
 #chatConversationContainer {
   width: min(100%, 36rem);
   margin: 0 auto;
-  gap: 0.95rem !important;
-  padding: 0.5rem 0.3rem 0.75rem !important;
+  gap: 1.1rem !important;
+  padding: 0.7rem 0.35rem 0.95rem !important;
 }
 
 #chatConversationContainer .chat-message {
-  max-width: min(100%, 32rem) !important;
-  border-radius: 1rem !important;
-  padding: 0.78rem 0.95rem !important;
-  background: #ffffff !important;
-  border: 1px solid color-mix(in srgb, var(--card-border, #dbe2ed) 58%, #ffffff 42%) !important;
-  box-shadow: 0 6px 14px rgba(24, 30, 43, 0.06) !important;
-  line-height: 1.45 !important;
+  max-width: min(88%, 31.5rem) !important;
+  border-radius: 1.1rem !important;
+  padding: 0.92rem 1.05rem !important;
+  line-height: 1.5 !important;
+  white-space: pre-wrap !important;
+  word-break: break-word !important;
 }
 
-#chatConversationContainer .chat-message--user,
 #chatConversationContainer .chat-message--assistant {
-  background: #ffffff !important;
+  align-self: flex-start !important;
+  background: color-mix(in srgb, var(--surface-elevated, #f9fafb) 78%, #ffffff 22%) !important;
+  border: 1px solid color-mix(in srgb, var(--card-border, #dbe2ed) 60%, #ffffff 40%) !important;
+  box-shadow: 0 6px 16px rgba(24, 30, 43, 0.05) !important;
+}
+
+#chatConversationContainer .chat-message--user {
+  align-self: flex-end !important;
+  background: color-mix(in srgb, var(--accent-color, #512663) 15%, #ffffff 85%) !important;
+  border: 1px solid color-mix(in srgb, var(--accent-color, #512663) 28%, transparent) !important;
+  box-shadow: 0 6px 14px rgba(62, 36, 89, 0.08) !important;
+}
+
+#chatConversationContainer .chat-message .chat-quick-actions {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.2rem;
+}
+
+#chatConversationContainer .chat-message .chat-quick-actions span {
+  font-size: 0.74rem;
+  line-height: 1.3;
+  color: color-mix(in srgb, var(--text-muted, #6b7280) 90%, #ffffff 10%);
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
 }

--- a/mobile.html
+++ b/mobile.html
@@ -343,44 +343,50 @@ Legacy shells remain for reference only.
       display: flex;
       flex-direction: column;
       justify-content: flex-start;
-      gap: 0.85rem;
-      padding: 0.5rem 0.15rem 0.55rem;
+      gap: 1.05rem;
+      padding: 0.65rem 0.2rem 0.8rem;
     }
 
     .chat-message {
-      max-width: min(92%, 34rem);
-      border-radius: 1.05rem;
-      padding: 0.82rem 0.95rem;
+      max-width: min(88%, 34rem);
+      border-radius: 1.1rem;
+      padding: 0.92rem 1.05rem;
       font-size: 0.94rem;
-      line-height: 1.45;
+      line-height: 1.5;
       white-space: pre-wrap;
       word-break: break-word;
     }
 
     .chat-message--user {
       align-self: flex-end;
-      background: color-mix(in srgb, var(--accent-color) 18%, #ffffff);
-      border: 1px solid color-mix(in srgb, var(--accent-color) 22%, transparent);
+      background: color-mix(in srgb, var(--accent-color) 15%, #ffffff 85%);
+      border: 1px solid color-mix(in srgb, var(--accent-color) 28%, transparent);
+      box-shadow: 0 6px 14px rgba(62, 36, 89, 0.08);
     }
 
     .chat-message--assistant {
       align-self: flex-start;
-      background: var(--surface-elevated);
-      border: 1px solid var(--border-subtle);
+      background: color-mix(in srgb, var(--surface-elevated) 78%, #ffffff 22%);
+      border: 1px solid color-mix(in srgb, var(--border-subtle) 74%, #ffffff 26%);
+      box-shadow: 0 6px 16px rgba(24, 30, 43, 0.05);
     }
 
     .chat-quick-actions {
       display: flex;
-      flex-wrap: wrap;
-      gap: 0.35rem;
-      margin-top: 0.4rem;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0.18rem;
+      margin-top: 0.48rem;
     }
 
     .chat-quick-actions span {
-      border: 1px solid var(--border-subtle);
-      border-radius: 999px;
-      padding: 0.1rem 0.45rem;
-      font-size: 0.72rem;
+      border: 0;
+      border-radius: 0;
+      padding: 0;
+      font-size: 0.74rem;
+      line-height: 1.3;
+      color: color-mix(in srgb, var(--text-muted) 88%, #ffffff 12%);
+      background: transparent;
     }
 
     .swipe-container {


### PR DESCRIPTION
### Motivation
- Make the capture conversation feel like a modern chat UI with calmer, more readable bubbles and breathing space. 
- Increase bubble padding, vertical spacing, and constrain max width so messages don’t stretch edge-to-edge. 
- Surface assistant status/metadata beneath messages in a subtle, smaller style rather than as heavy chips. 
- Keep all existing IDs, `.chat-message` classes, capture submission, routing, and reminder/notebook/inbox logic unchanged.

### Description
- Adjusted conversation container rhythm by increasing `#chatConversationContainer` `gap` and `padding` for more breathable spacing. 
- Refined base bubble rules (`.chat-message`) to increase `padding`, `border-radius`, `line-height`, and set `max-width`, `white-space`, and `word-break` for comfortable reading. 
- Added role-specific styling under `#chatConversationContainer` so assistant bubbles are left-aligned with a soft neutral surface, subtle border and shadow, and user bubbles are right-aligned with an accent-tinted surface and subtle elevation. 
- Restyled quick-action / status metadata so it appears as smaller, subtle text beneath assistant messages (stacked layout and toned color), improving the visual hierarchy. 
- Files changed: `css/capture.css` and the capture style block in `mobile.html` (CSS-only changes; JavaScript message rendering logic was not modified).

### Testing
- Ran `npm run verify` and build verification passed. 
- Ran `npm test -- chat-system.prompt12.test.js --runInBand` and the test suite failed due to existing ESM/CommonJS loader mismatch (`Cannot use import statement outside a module`), which is unrelated to these CSS-only changes. 
- Started a local server and captured a visual screenshot of the updated mobile capture UI for visual verification (manual run via local serve/playwright succeeded). 
- Confirmed message rendering functions such as `appendConversationMessage()` and `renderConversationHistory()` remain untouched so runtime message behavior is preserved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4ae87a2e88324a4ae372ecac874b8)