### PR TITLE
Handle parse-entry JSON parse/shape failures with safe fallback

### DIFF
--- a/api.parse-entry.test.js
+++ b/api.parse-entry.test.js
@@ -1,0 +1,67 @@
+const handler = require('./api/parse-entry');
+
+function createRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: null,
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    send(payload) {
+      this.body = payload;
+      return this;
+    },
+    end() {
+      return this;
+    }
+  };
+}
+
+describe('api/parse-entry parse fallbacks', () => {
+  const originalFetch = global.fetch;
+  const originalApiKey = process.env.OPENAI_API_KEY;
+
+  beforeEach(() => {
+    process.env.OPENAI_API_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.OPENAI_API_KEY = originalApiKey;
+    jest.restoreAllMocks();
+  });
+
+  test('returns fallback with 422 for malformed output_text JSON', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ output_text: '{"type":"note", bad json' })
+    });
+
+    const req = {
+      method: 'POST',
+      headers: {},
+      body: { text: 'Plan trip to Rome and review flights next week.' }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(422);
+    expect(res.body).toEqual({
+      type: 'unknown',
+      title: 'Plan trip to Rome and review flights next week.',
+      tags: [],
+      reminderDate: null,
+      metadata: { parseError: true }
+    });
+  });
+});

--- a/api/parse-entry.js
+++ b/api/parse-entry.js
@@ -37,6 +37,42 @@ const ALLOWED_ORIGINS = [
 ];
 
 const MAX_TEXT_LENGTH = 4000;
+const PARSE_FALLBACK_STATUS = 422;
+
+function sanitizePreview(value) {
+  return String(value)
+    .replace(/[\r\n\t]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 200);
+}
+
+function isValidParsedEntry(parsed) {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return false;
+  }
+
+  const hasValidType = typeof parsed.type === 'string';
+  const hasValidTitle = typeof parsed.title === 'string';
+  const hasValidTags =
+    Array.isArray(parsed.tags) && parsed.tags.every((tag) => typeof tag === 'string');
+  const hasValidReminderDate =
+    parsed.reminderDate === null || typeof parsed.reminderDate === 'string';
+  const hasValidMetadata =
+    parsed.metadata && typeof parsed.metadata === 'object' && !Array.isArray(parsed.metadata);
+
+  return hasValidType && hasValidTitle && hasValidTags && hasValidReminderDate && hasValidMetadata;
+}
+
+function buildFallbackEntry(text) {
+  return {
+    type: 'unknown',
+    title: text.slice(0, 60),
+    tags: [],
+    reminderDate: null,
+    metadata: { parseError: true }
+  };
+}
 
 module.exports = async function handler(req, res) {
   const origin = req.headers.origin;
@@ -144,7 +180,30 @@ module.exports = async function handler(req, res) {
       return res.status(500).json({ error: 'Failed to parse entry.' });
     }
 
-    return res.status(200).json(JSON.parse(outputText));
+    const outputTextLength = typeof outputText === 'string' ? outputText.length : 0;
+    const outputTextPreview = sanitizePreview(outputText || '');
+
+    let parsedOutput;
+    try {
+      parsedOutput = JSON.parse(outputText);
+    } catch (error) {
+      console.warn('Failed to parse model output JSON', {
+        outputTextLength,
+        outputTextPreview,
+        message: error.message
+      });
+      return res.status(PARSE_FALLBACK_STATUS).json(buildFallbackEntry(text));
+    }
+
+    if (!isValidParsedEntry(parsedOutput)) {
+      console.warn('Model output failed schema shape validation', {
+        outputTextLength,
+        outputTextPreview
+      });
+      return res.status(PARSE_FALLBACK_STATUS).json(buildFallbackEntry(text));
+    }
+
+    return res.status(200).json(parsedOutput);
   } catch (error) {
     return res.status(500).json({ error: 'AI parse error', message: error.message });
   }


### PR DESCRIPTION
### Motivation
- Avoid server 500s caused by malformed AI model output when parsing `outputText` and provide a safe, predictable fallback for clients.
- Prevent leaking raw model output into client-facing errors while still logging useful diagnostics server-side.
- Ensure the parsed response conforms to the expected shape before returning to downstream code.

### Description
- Added a `PARSE_FALLBACK_STATUS` constant and helper `sanitizePreview()` to capture a safe preview and length of `outputText` for server-side logs.
- Added `isValidParsedEntry()` to validate the parsed object includes `type`, `title`, `tags`, `reminderDate`, and `metadata` with expected primitive/container types, and `buildFallbackEntry()` to produce the safe fallback object.
- Replaced the direct `JSON.parse(outputText)` return with a narrow try/catch that logs sanitized diagnostics on parse failure and returns the fallback object with HTTP `422`, and also returns the fallback on schema-shape validation failure.
- Preserved existing CORS/method checks and preserved upstream `429` pass-through behavior when the AI request itself fails.

### Testing
- Added `api.parse-entry.test.js` which mocks a malformed `output_text` and verifies the endpoint returns the safe fallback with HTTP `422` instead of a generic `500`.
- Ran `npm test -- api.parse-entry.test.js` and the test suite passed (test for malformed output JSON returned fallback + `422`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b099698c832498c60fd7b2536429)