### PR TITLE
Simplify Reminders tab styling to a minimal layout

### DIFF
--- a/css/reminders-ui.css
+++ b/css/reminders-ui.css
@@ -99,3 +99,167 @@
 #view-reminders .reminder-upcoming {
   border-color: color-mix(in srgb, #94a3b8 30%, var(--card-border));
 }
+
+/* Reminders tab: minimal layout aligned with Capture spacing */
+#view-reminders .reminders-mobile-flow,
+#view-reminders .reminders-content-shell {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  padding: var(--space-2) var(--space-4) calc(var(--space-3) + 0.25rem);
+}
+
+#view-reminders .reminders-screen-controls {
+  gap: 0.75rem;
+  margin-bottom: 0.9rem;
+}
+
+#view-reminders .reminders-top-controls-row {
+  gap: 0.6rem;
+  align-items: center;
+}
+
+#view-reminders .reminders-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  border-radius: 999px;
+}
+
+#view-reminders .reminder-tab {
+  border: 0;
+  background: color-mix(in srgb, var(--text-main) 8%, transparent);
+  color: var(--text-secondary);
+  border-radius: 999px;
+  padding: 0.36rem 0.82rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  box-shadow: none;
+}
+
+#view-reminders .reminder-tab:hover,
+#view-reminders .reminder-tab:focus-visible {
+  background: color-mix(in srgb, var(--text-main) 12%, transparent);
+  color: var(--text-main);
+}
+
+#view-reminders .reminder-tab.reminders-tab-active,
+#view-reminders .reminder-tab.active,
+#view-reminders .reminder-tab[aria-pressed='true'] {
+  border: 0;
+  background: var(--accent-color);
+  color: #fff;
+  box-shadow: none;
+}
+
+#view-reminders .category-filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem;
+  margin-top: 0.1rem;
+  margin-bottom: 0.2rem;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+#view-reminders .category-filter-bar .category-chip {
+  border: 0;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-main) 8%, transparent);
+  color: var(--text-secondary);
+  font-size: 0.76rem;
+  font-weight: 600;
+  line-height: 1.2;
+  padding: 0.32rem 0.72rem;
+  box-shadow: none;
+}
+
+#view-reminders .category-filter-bar .category-chip:hover,
+#view-reminders .category-filter-bar .category-chip:focus-visible {
+  background: color-mix(in srgb, var(--text-main) 12%, transparent);
+  color: var(--text-main);
+}
+
+#view-reminders .category-filter-bar .category-chip.active,
+#view-reminders .category-filter-bar .category-chip[aria-pressed='true'] {
+  background: var(--accent-color);
+  color: #fff;
+  border: 0;
+}
+
+#view-reminders #reminderListSection,
+#view-reminders #remindersWrapper {
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  padding-inline: 0;
+}
+
+#view-reminders #reminderList {
+  gap: 0.55rem !important;
+  padding-top: 0;
+}
+
+#view-reminders .reminder-row {
+  min-height: 2.8rem;
+  border: 0;
+  border-radius: 0.9rem;
+  background: transparent;
+  box-shadow: none;
+  padding: 0.52rem 0.3rem;
+  gap: 0.6rem;
+  transform: none;
+  transition: background-color 0.16s ease;
+}
+
+#view-reminders .reminder-row:hover,
+#view-reminders .reminder-row:focus-within {
+  transform: none;
+  box-shadow: none;
+  background: color-mix(in srgb, var(--accent-color) 7%, transparent);
+}
+
+#view-reminders .reminder-row-complete {
+  width: 1.5rem;
+  height: 1.5rem;
+  margin-top: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  flex: 0 0 1.5rem;
+}
+
+#view-reminders .reminder-row-main {
+  gap: 0.14rem;
+  justify-content: center;
+}
+
+#view-reminders .reminder-row-title {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--text-main);
+}
+
+#view-reminders .reminder-row-meta {
+  margin-top: 0;
+  font-size: 0.77rem;
+  color: var(--text-secondary);
+}
+
+#view-reminders .reminder-row-overflow {
+  border-radius: 999px;
+  padding: 0.2rem;
+}
+
+#view-reminders .reminder-row-overflow:hover,
+#view-reminders .reminder-row-overflow:focus-visible {
+  background: color-mix(in srgb, var(--text-main) 10%, transparent);
+}


### PR DESCRIPTION
### Motivation
- Reduce visual noise in the Reminders screen by replacing boxed card treatments with a calm, spacing-first layout that matches the Capture screen.
- Make reminder rows simpler and more scannable while preserving existing behavior and DOM wiring.

### Description
- Added a focused stylesheet override in `css/reminders-ui.css` to remove heavy containers, borders, shadows, and elevated surfaces for the reminders shell and list.
- Restyled status tabs and category filter chips as flat pills with neutral inactive states and an accent-colored active state using existing design tokens (`--accent-color`, `--text-main`, etc.).
- Simplified reminder rows to a consistent-height row with subtle padding, soft hover/focus highlight, and cleaned checkbox alignment while avoiding input-like backgrounds.
- No HTML or JS changes were made and no IDs, creation, filtering, or sorting logic were modified.

### Testing
- Ran the targeted Jest test `js/__tests__/reminders.quick-add.test.js`, which failed due to the repository baseline ESM/CommonJS test harness mismatch when loading `js/reminders.js` (failure unrelated to these CSS-only changes).
- Executed the project build workflow (`npm run build`), which started the build and Tailwind/DaisyUI steps (process produced warnings and was observed but did not fully complete within the execution window).
- Performed a visual smoke-check by serving the site and capturing a Reminders screenshot using Playwright, producing an artifact for manual visual verification.
- Confirmed by inspection that no JS behavior or DOM IDs were altered and reminder functionality remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b6ecc774832495261a295b0faa29)