### PR TITLE
Simplify Reminders tab visuals for a minimal Capture-aligned list

### DIFF
--- a/css/reminders-ui.css
+++ b/css/reminders-ui.css
@@ -47,18 +47,18 @@
 #reminderList {
   display: grid;
   grid-template-columns: 1fr !important;
-  gap: 0.5rem !important;
+  gap: 0 !important;
 }
 
 .reminder-group-heading {
-  margin-top: 0.25rem;
+  margin-top: 0.6rem;
 }
 
 .reminder-group-heading-label {
   font-size: 0.78rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  font-weight: 700;
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: 600;
   color: var(--text-secondary);
 }
 
@@ -161,7 +161,7 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.45rem;
+  gap: 0.35rem;
   margin-top: 0.1rem;
   margin-bottom: 0.2rem;
   padding: 0;
@@ -170,14 +170,14 @@
 }
 
 #view-reminders .category-filter-bar .category-chip {
-  border: 0;
+  border: 1px solid color-mix(in srgb, var(--text-main) 10%, transparent);
   border-radius: 999px;
-  background: color-mix(in srgb, var(--text-main) 8%, transparent);
+  background: color-mix(in srgb, var(--text-main) 4%, transparent);
   color: var(--text-secondary);
   font-size: 0.76rem;
   font-weight: 600;
   line-height: 1.2;
-  padding: 0.32rem 0.72rem;
+  padding: 0.24rem 0.58rem;
   box-shadow: none;
 }
 
@@ -189,9 +189,9 @@
 
 #view-reminders .category-filter-bar .category-chip.active,
 #view-reminders .category-filter-bar .category-chip[aria-pressed='true'] {
-  background: var(--accent-color);
-  color: #fff;
-  border: 0;
+  background: color-mix(in srgb, var(--accent-color) 16%, transparent);
+  color: var(--accent-color);
+  border-color: color-mix(in srgb, var(--accent-color) 28%, transparent);
 }
 
 #view-reminders #reminderListSection,
@@ -203,17 +203,18 @@
 }
 
 #view-reminders #reminderList {
-  gap: 0.55rem !important;
+  gap: 0 !important;
   padding-top: 0;
 }
 
 #view-reminders .reminder-row {
   min-height: 2.8rem;
   border: 0;
-  border-radius: 0.9rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--text-main) 10%, transparent);
+  border-radius: 0;
   background: transparent;
   box-shadow: none;
-  padding: 0.52rem 0.3rem;
+  padding: 0.7rem 0.25rem;
   gap: 0.6rem;
   transform: none;
   transition: background-color 0.16s ease;
@@ -223,7 +224,11 @@
 #view-reminders .reminder-row:focus-within {
   transform: none;
   box-shadow: none;
-  background: color-mix(in srgb, var(--accent-color) 7%, transparent);
+  background: color-mix(in srgb, var(--accent-color) 4%, transparent);
+}
+
+#view-reminders .reminder-row:last-child {
+  border-bottom-color: transparent;
 }
 
 #view-reminders .reminder-row-complete {

--- a/mobile.html
+++ b/mobile.html
@@ -475,7 +475,7 @@ Legacy shells remain for reference only.
     #reminderList {
       display: flex !important;
       flex-direction: column;
-      gap: 0.5rem;
+      gap: 0;
       overflow: visible;
     }
     @media (max-width: 380px) {
@@ -1628,17 +1628,17 @@ body[data-active-view="notebooks"] #view-notebook .card-body {
     .reminder-row {
       display: flex;
       align-items: center;
-      padding: 0.6rem 0.9rem;
-      border-radius: 999px;
-      background: var(--surface-soft, rgba(255, 255, 255, 0.7));
-      box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.02);
+      padding: 0.7rem 0.25rem;
+      border-radius: 0;
+      border-bottom: 1px solid color-mix(in srgb, var(--text-main) 10%, transparent);
+      background: transparent;
+      box-shadow: none;
       gap: 0.6rem;
-      transition: box-shadow 0.15s ease, transform 0.12s ease;
+      transition: background-color 0.16s ease;
     }
 
     .reminder-row:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 8px 20px rgba(0, 0, 0, 0.06);
+      background: color-mix(in srgb, var(--accent-color) 4%, transparent);
     }
 
     .reminder-row-complete {
@@ -1701,6 +1701,10 @@ body[data-active-view="notebooks"] #view-notebook .card-body {
 
     .reminder-row.reminder-row-overdue .reminder-row-meta {
       color: var(--text-danger, #c62828);
+    }
+
+    .reminder-row:last-child {
+      border-bottom-color: transparent;
     }
 
       .priority-pill.priority-high {
@@ -6332,7 +6336,7 @@ body, main, section, div, p, span, li {
     .category-filter-bar {
       display: flex;
       align-items: center;
-      gap: 8px;
+      gap: 6px;
       overflow-x: auto;
       padding: 0 4px 2px;
       margin-bottom: 4px;
@@ -6345,20 +6349,20 @@ body, main, section, div, p, span, li {
 
     .category-chip {
       border-radius: 999px;
-      border: 1px solid rgba(47, 27, 63, 0.18);
-      background: rgba(255, 255, 255, 0.92);
-      padding: 6px 12px;
-      font-size: 0.82rem;
+      border: 1px solid color-mix(in srgb, var(--text-main) 10%, transparent);
+      background: color-mix(in srgb, var(--text-main) 4%, transparent);
+      padding: 4px 9px;
+      font-size: 0.78rem;
       line-height: 1;
-      color: var(--primary-dark);
+      color: var(--text-secondary);
       white-space: nowrap;
       transition: background-color 0.14s ease, border-color 0.14s ease, color 0.14s ease;
     }
 
     .category-chip.active {
-      background: #5c4b8a;
-      border-color: #5c4b8a;
-      color: #fff;
+      background: color-mix(in srgb, var(--accent-color) 16%, transparent);
+      border-color: color-mix(in srgb, var(--accent-color) 28%, transparent);
+      color: var(--accent-color);
     }
 
     .reminder-actions {


### PR DESCRIPTION
### Motivation
- Reduce visual noise in the Reminders tab so the reminder list is the clear focus and matches the Capture screen's minimal design language.
- Keep all reminder behavior, IDs, and filtering logic exactly as-is while only simplifying styling and layout.

### Description
- Adjusted `css/reminders-ui.css` to remove card/pill treatments on reminder rows and render items as simple list rows with a thin bottom divider, increased vertical padding for whitespace separation, and lighter hover tint (`background` and `border-bottom` changes). 
- Tone down the `UPCOMING`/group heading by changing `text-transform`, `letter-spacing`, and using `font-weight: 600` with slightly larger top spacing so headings appear as simple section labels (`.reminder-group-heading-label`).
- Reduced visual weight of the category filter chips by tightening padding, adding a very subtle border, lowering background contrast, and using a low-contrast accent tint for active chips (`.category-chip` and active state adjustments).
- Mirrored the same minimal styling in the inline mobile stylesheet in `mobile.html` so the mobile Reminders view remains consistent with external CSS; no JavaScript or reminder logic was modified.

### Testing
- Ran `npm test -- --runInBand`; the test suite execution completed but multiple existing unrelated suites fail in this environment (ESM/CommonJS and other pre-existing issues), and there were no test failures attributable to the styling-only changes.
- Attempted a headless visual check with Playwright to capture a screenshot of the Reminders view but the Chromium process crashed in this environment so no screenshot was produced.
- Confirmed that only CSS and inline style rules were modified and that no reminder logic, IDs, or filtering behavior were changed, preserving functionality.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b9925de4832499c7e292034b17e8)