### PR TITLE
Smart Idea Capture: classify captures, extract keywords, and add assistant recall highlights

### DIFF
--- a/api.parse-entry.test.js
+++ b/api.parse-entry.test.js
@@ -40,7 +40,7 @@ describe('api/parse-entry parse fallbacks', () => {
     jest.restoreAllMocks();
   });
 
-  test('returns fallback with 422 for malformed output_text JSON', async () => {
+  test('returns structured fallback for malformed output_text JSON', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ output_text: '{"type":"note", bad json' })
@@ -55,13 +55,16 @@ describe('api/parse-entry parse fallbacks', () => {
 
     await handler(req, res);
 
-    expect(res.statusCode).toBe(422);
-    expect(res.body).toEqual({
-      type: 'unknown',
-      title: 'Plan trip to Rome and review flights next week.',
-      tags: [],
-      reminderDate: null,
-      metadata: { parseError: true }
+    expect(res.statusCode).toBe(200);
+    expect(res.body.type).toBe('idea');
+    expect(res.body.title).toBe('Plan trip to Rome and review flights next week.');
+    expect(Array.isArray(res.body.tags)).toBe(true);
+    expect(res.body.reminderDate).toBeNull();
+    expect(res.body.metadata).toMatchObject({
+      originalText: 'Plan trip to Rome and review flights next week.',
+      type: 'idea'
     });
+    expect(Array.isArray(res.body.metadata.keywords)).toBe(true);
+    expect(typeof res.body.metadata.timestamp).toBe('string');
   });
 });

--- a/api/assistant-chat.ts
+++ b/api/assistant-chat.ts
@@ -40,6 +40,10 @@ function normalizeEntry(entry, type) {
     title: title || body.slice(0, 64) || `${type} entry`,
     body,
     createdAt: toText(entry?.createdAt),
+    parsedType: toText(entry?.parsedType || entry?.metadata?.type || ''),
+    keywords: Array.isArray(entry?.metadata?.keywords)
+      ? entry.metadata.keywords.map((keyword) => toText(keyword).toLowerCase()).filter(Boolean)
+      : [],
   };
 }
 
@@ -143,6 +147,84 @@ function buildPrompt(message, history, selectedContext) {
   ].filter(Boolean).join('\n');
 }
 
+function normalizeTypeLabel(value) {
+  const normalized = toText(value).toLowerCase();
+  if (!normalized) return '';
+  if (normalized === 'coaching_drill') return 'coaching drill';
+  if (normalized === 'lesson_idea') return 'lesson idea';
+  return normalized;
+}
+
+function detectRecallType(message) {
+  const normalized = toText(message).toLowerCase();
+  if (!normalized) return null;
+  if (/\bdrills?\b|\bcoaching drill\b/.test(normalized)) return 'coaching_drill';
+  if (/\blesson ideas?\b|\blesson\b/.test(normalized)) return 'lesson_idea';
+  if (/\breminders?\b/.test(normalized)) return 'reminder';
+  if (/\bideas?\b/.test(normalized)) return 'idea';
+  if (/\bnotes?\b/.test(normalized)) return 'note';
+  return null;
+}
+
+function extractSearchTerms(message) {
+  const normalized = toText(message).toLowerCase();
+  const cleaned = normalized.replace(/[^a-z0-9\s]/g, ' ');
+  const stopWords = new Set(['what', 'did', 'i', 'write', 'down', 'save', 'saved', 'say', 'about', 'was', 'that', 'the', 'a', 'an', 'my']);
+  return cleaned
+    .split(/\s+/)
+    .map((term) => term.trim())
+    .filter((term) => term.length > 2 && !stopWords.has(term));
+}
+
+function buildIdeaHighlights(message, contextEntries) {
+  const requestedType = detectRecallType(message);
+  const searchTerms = extractSearchTerms(message);
+
+  let matches = contextEntries.filter((entry) => entry.type === 'inbox');
+
+  if (requestedType) {
+    matches = matches.filter((entry) => normalizeTypeLabel(entry.parsedType) === normalizeTypeLabel(requestedType));
+  }
+
+  if (searchTerms.length) {
+    matches = matches
+      .map((entry) => {
+        const haystack = `${entry.title} ${entry.body} ${(entry.keywords || []).join(' ')}`.toLowerCase();
+        const score = searchTerms.reduce((total, term) => total + (haystack.includes(term) ? 1 : 0), 0);
+        return { entry, score };
+      })
+      .filter((item) => item.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .map((item) => item.entry);
+  }
+
+  const unique = [];
+  const seen = new Set();
+  for (const match of matches) {
+    const key = `${match.id}:${match.body}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(match);
+    if (unique.length >= 8) break;
+  }
+
+  if (!unique.length) {
+    return null;
+  }
+
+  const typeLabel = requestedType ? normalizeTypeLabel(requestedType) : 'ideas';
+  const heading = requestedType
+    ? `You wrote these ${typeLabel}${typeLabel.endsWith('s') ? '' : 's'}:`
+    : 'Here are matching ideas you saved:';
+  const list = unique.map((entry) => `• ${entry.body || entry.title}`).join('\n');
+
+  return {
+    reply: `${heading}\n\n${list}`,
+    references: unique.map((entry) => ({ id: entry.id, type: entry.parsedType || entry.type, title: entry.title || entry.body })),
+    contextUsed: unique,
+  };
+}
+
 async function getOpenAiResponse(prompt) {
   if (!process.env.OPENAI_API_KEY) {
     return 'Assistant is configured without OPENAI_API_KEY. I can still show matching context references below.';
@@ -207,6 +289,16 @@ export default async function handler(req, res) {
 
   try {
     const contextEntries = gatherContext(body);
+    const ideaHighlights = buildIdeaHighlights(message, contextEntries);
+    if (ideaHighlights) {
+      return res.status(200).json({
+        success: true,
+        reply: ideaHighlights.reply,
+        references: ideaHighlights.references,
+        contextUsed: ideaHighlights.contextUsed,
+      });
+    }
+
     const selectedContext = contextEntries
       .map((entry) => ({ entry, score: keywordScore(message, `${entry.title} ${entry.body}`) }))
       .sort((a, b) => b.score - a.score)

--- a/api/parse-entry.js
+++ b/api/parse-entry.js
@@ -4,11 +4,24 @@ const PARSED_ENTRY_SCHEMA = {
   properties: {
     type: {
       type: 'string',
-      enum: ['note', 'reminder', 'question']
+      enum: ['note', 'reminder', 'idea', 'lesson_idea', 'coaching_drill', 'question']
     },
-    content: { type: 'string' }
+    title: { type: 'string' },
+    tags: { type: 'array', items: { type: 'string' } },
+    reminderDate: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+    metadata: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        originalText: { type: 'string' },
+        type: { type: 'string' },
+        keywords: { type: 'array', items: { type: 'string' } },
+        timestamp: { type: 'string' }
+      },
+      required: ['originalText', 'type', 'keywords', 'timestamp']
+    }
   },
-  required: ['type', 'content']
+  required: ['type', 'title', 'tags', 'reminderDate', 'metadata']
 };
 
 const ALLOWED_ORIGINS = [
@@ -20,7 +33,11 @@ const ALLOWED_ORIGINS = [
 
 const MAX_TEXT_LENGTH = 4000;
 const PARSE_FALLBACK_STATUS = 200;
-const ALLOWED_PARSED_TYPES = ['note', 'reminder', 'question'];
+const ALLOWED_PARSED_TYPES = ['note', 'reminder', 'idea', 'lesson_idea', 'coaching_drill', 'question'];
+
+const STOP_WORDS = new Set([
+  'a', 'an', 'and', 'are', 'at', 'be', 'for', 'from', 'how', 'i', 'in', 'is', 'it', 'me', 'my', 'of', 'on', 'or', 'that', 'the', 'this', 'to', 'was', 'what', 'with', 'you', 'did', 'do'
+]);
 
 function sanitizePreview(value) {
   return String(value)
@@ -36,15 +53,83 @@ function isValidParsedEntry(parsed) {
   }
 
   const hasValidType = typeof parsed.type === 'string' && ALLOWED_PARSED_TYPES.includes(parsed.type);
-  const hasValidContent = typeof parsed.content === 'string';
+  const hasValidTitle = typeof parsed.title === 'string';
+  const hasValidTags = Array.isArray(parsed.tags) && parsed.tags.every((tag) => typeof tag === 'string');
+  const hasValidReminderDate = typeof parsed.reminderDate === 'string' || parsed.reminderDate === null;
+  const metadata = parsed.metadata && typeof parsed.metadata === 'object' ? parsed.metadata : null;
+  const hasValidMetadata = Boolean(
+    metadata
+    && typeof metadata.originalText === 'string'
+    && typeof metadata.type === 'string'
+    && Array.isArray(metadata.keywords)
+    && metadata.keywords.every((keyword) => typeof keyword === 'string')
+    && typeof metadata.timestamp === 'string'
+  );
 
-  return hasValidType && hasValidContent;
+  return hasValidType && hasValidTitle && hasValidTags && hasValidReminderDate && hasValidMetadata;
+}
+
+function extractKeywords(text) {
+  const terms = String(text || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .split(/\s+/)
+    .map((term) => term.trim())
+    .filter((term) => term.length > 2 && !STOP_WORDS.has(term));
+
+  return Array.from(new Set(terms)).slice(0, 8);
+}
+
+function inferType(text) {
+  const normalized = String(text || '').toLowerCase();
+
+  if (/\b(remind|tomorrow|today|tonight|\d{1,2}(:\d{2})?\s?(am|pm))\b/.test(normalized)) {
+    return 'reminder';
+  }
+
+  if (/\b(drill|coaching|warmup|scrimmage|hb\b|kick|passing|defence|offense|football|soccer|netball|basketball)\b/.test(normalized)) {
+    return 'coaching_drill';
+  }
+
+  if (/\b(lesson|class|student|students|naplan|curriculum|sentence|writing|dependent clauses|activity)\b/.test(normalized)) {
+    return 'lesson_idea';
+  }
+
+  if (/\?$/.test(normalized)) {
+    return 'question';
+  }
+
+  if (/\b(idea|try|brainstorm|plan|could|should)\b/.test(normalized)) {
+    return 'idea';
+  }
+
+  return 'note';
+}
+
+function toTitle(text) {
+  return String(text || '').replace(/\s+/g, ' ').trim().slice(0, 120);
+}
+
+function buildStructuredEntry(text) {
+  const type = inferType(text);
+  const keywords = extractKeywords(text);
+  return {
+    type,
+    title: toTitle(text),
+    tags: keywords,
+    reminderDate: null,
+    metadata: {
+      originalText: text,
+      type,
+      keywords,
+      timestamp: new Date().toISOString()
+    }
+  };
 }
 
 function buildFallbackEntry(text) {
   return {
-    type: 'note',
-    content: text,
+    ...buildStructuredEntry(text),
     source: 'fallback'
   };
 }
@@ -86,7 +171,7 @@ module.exports = async function handler(req, res) {
   }
 
   if (!process.env.OPENAI_API_KEY) {
-    return res.status(500).json({ error: 'Server misconfiguration: missing OpenAI API key.' });
+    return res.status(PARSE_FALLBACK_STATUS).json(buildStructuredEntry(text));
   }
 
   let response;
@@ -107,7 +192,7 @@ module.exports = async function handler(req, res) {
             content: [
               {
                 type: 'input_text',
-                text: `Return ONLY JSON matching schema.\nExtract:\n- type (note, reminder, question)\n- content (cleaned user text)\nIf unsure, use note.`
+                text: `Return ONLY JSON matching schema.\nClassify the message as one of: note, reminder, idea, lesson_idea, coaching_drill, question.\nInclude metadata with originalText, type, keywords, and timestamp.\nIf unsure, use note.`
               }
             ]
           },
@@ -159,7 +244,7 @@ module.exports = async function handler(req, res) {
         outputTextLength,
         outputTextPreview
       });
-      return res.status(PARSE_FALLBACK_STATUS).json(buildFallbackEntry(text));
+      return res.status(PARSE_FALLBACK_STATUS).json(buildStructuredEntry(text));
     }
 
     let parsedOutput;
@@ -172,7 +257,7 @@ module.exports = async function handler(req, res) {
         outputTextPreview,
         message: error.message
       });
-      return res.status(PARSE_FALLBACK_STATUS).json(buildFallbackEntry(text));
+      return res.status(PARSE_FALLBACK_STATUS).json(buildStructuredEntry(text));
     }
 
     if (!isValidParsedEntry(parsedOutput)) {
@@ -180,7 +265,7 @@ module.exports = async function handler(req, res) {
         outputTextLength,
         outputTextPreview
       });
-      return res.status(PARSE_FALLBACK_STATUS).json(buildFallbackEntry(text));
+      return res.status(PARSE_FALLBACK_STATUS).json(buildStructuredEntry(text));
     }
 
     return res.status(200).json(parsedOutput);

--- a/js/services/capture-service.js
+++ b/js/services/capture-service.js
@@ -9,7 +9,7 @@ import {
 
 export { INBOX_STORAGE_KEY, getInboxEntries, removeInboxEntry };
 
-const PARSED_TYPE_VALUES = new Set(['note', 'reminder', 'unknown']);
+const PARSED_TYPE_VALUES = new Set(['note', 'reminder', 'idea', 'lesson_idea', 'coaching_drill', 'question', 'unknown']);
 const SOURCE_VALUES = new Set(['capture', 'reminder', 'assistant', 'quick-add']);
 
 const sanitizeText = (value) => {

--- a/src/services/inboxService.js
+++ b/src/services/inboxService.js
@@ -2,7 +2,7 @@ import { syncInbox, upsertInboxEntry } from './supabaseSyncService.js';
 
 export const INBOX_STORAGE_KEY = 'memoryCueInbox';
 const LEGACY_INBOX_STORAGE_KEYS = ['memoryEntries'];
-const PARSED_TYPE_VALUES = new Set(['note', 'reminder', 'unknown']);
+const PARSED_TYPE_VALUES = new Set(['note', 'reminder', 'idea', 'lesson_idea', 'coaching_drill', 'question', 'unknown']);
 const SOURCE_VALUES = new Set(['capture', 'reminder', 'assistant', 'quick-add']);
 
 const generateId = () => {


### PR DESCRIPTION
### Motivation
- Improve capture quality so free-form user inputs are automatically classified as `reminder`, `idea`, `lesson_idea`, `coaching_drill`, `note`, or `question` and stored with structured metadata for easier recall. 
- Ensure the system extracts keywords and timestamps so the assistant can answer natural-language retrieval requests like “What drills did I write down?” without requiring the user to categorize items. 
- Provide a robust fallback when the AI parser is unavailable or returns malformed output so existing capture behavior is not broken. 

### Description
- Expanded `/api/parse-entry` to return a structured schema with `type`, `title`, `tags`, `reminderDate`, and `metadata` containing `originalText`, `type`, `keywords`, and `timestamp`, and added local keyword extraction and `inferType` heuristics as a fallback when the LLM is not available or output is invalid. 
- Kept the capture pipeline and IDs intact and extended accepted parsed types in `js/services/capture-service.js` and `src/services/inboxService.js` to include `idea`, `lesson_idea`, and `coaching_drill` so new types are preserved when saved. 
- Added assistant-side recall logic in `api/assistant-chat` to detect recall intents (drills, lesson ideas, reminders, notes, ideas), match against inbox entries and extracted keywords, and return concise bullet-list highlights and references for matching items. 
- Updated the parse-entry test to validate the new structured fallback response shape and ensured the `parse-entry` fallback path returns structured metadata rather than failing. 

### Testing
- Ran `npm test -- api.parse-entry.test.js` and it passed, validating structured fallback behavior for malformed model output. 
- Ran `npm test -- js/__tests__/reminders.quick-add.test.js` which failed in the current environment due to an existing module-loading issue (`Cannot use import statement outside a module` in `js/reminders.js`) that is unrelated to these changes. 
- Confirmed reminder storage logic and capture submission flow were not modified and remain compatible with existing behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4bd67691483249dab4c7d2cf96ed2)