### PR TITLE
Refine reminders checklist styling to match Capture design

### DIFF
--- a/css/reminders-ui.css
+++ b/css/reminders-ui.css
@@ -208,14 +208,16 @@
 }
 
 #view-reminders .reminder-row {
+  display: flex;
+  align-items: center;
   min-height: 2.8rem;
   border: 0;
-  border-bottom: 1px solid color-mix(in srgb, var(--text-main) 10%, transparent);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
   border-radius: 0;
   background: transparent;
   box-shadow: none;
-  padding: 0.7rem 0.25rem;
-  gap: 0.6rem;
+  padding: 10px 14px;
+  gap: 0.75rem;
   transform: none;
   transition: background-color 0.16s ease;
 }
@@ -224,7 +226,7 @@
 #view-reminders .reminder-row:focus-within {
   transform: none;
   box-shadow: none;
-  background: color-mix(in srgb, var(--accent-color) 4%, transparent);
+  background: color-mix(in srgb, var(--text-main) 4%, transparent);
 }
 
 #view-reminders .reminder-row:last-child {
@@ -248,7 +250,8 @@
 }
 
 #view-reminders .reminder-row-title {
-  font-size: 0.95rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
   font-weight: 500;
   color: var(--text-main);
 }


### PR DESCRIPTION
### Motivation
- Improve the Reminders list visual design so it reads as a clean, minimal checklist consistent with the Capture screen while leaving reminder logic and storage untouched.

### Description
- Updated `css/reminders-ui.css` to make `.reminder-row` a flex row with `display: flex` and `align-items: center`, reduced divider weight to `border-bottom: 1px solid rgba(0,0,0,0.06)`, adjusted padding to `10px 14px`, increased checkbox/text `gap` to `0.75rem`, added a subtle hover highlight, and aligned reminder title typography (`font-size: 0.88rem`, `line-height: 1.45`).

### Testing
- Ran `npm run verify` which completed successfully.
- Ran the targeted unit test `npm test -- reminders.dom-sync.test.js --runInBand` which failed with a test harness `SyntaxError: Cannot use import statement outside a module` unrelated to the CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b50f48a44c8324867efda5e0079e80)