### PR TITLE
Add Created/Time relevance sort toggle for reminders (created default)

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -739,11 +739,10 @@ export async function initReminders(sel = {}) {
   let mobileRemindersCache = [];
   let mobileRemindersTemperatureLabel = '';
   const REMINDER_SORT_OPTIONS = Object.freeze({
-    newest: 'newest',
-    oldest: 'oldest',
-    category: 'category',
+    created: 'created',
+    timeRelevance: 'time-relevance',
   });
-  let reminderSortMode = REMINDER_SORT_OPTIONS.newest;
+  let reminderSortMode = REMINDER_SORT_OPTIONS.created;
 
   function getReminderSortTimestamp(reminder) {
     const createdAt = Number(reminder?.createdAt);
@@ -759,23 +758,29 @@ export async function initReminders(sel = {}) {
 
   function sortReminderRows(rows = []) {
     const sorted = Array.isArray(rows) ? rows.slice() : [];
-    if (reminderSortMode === REMINDER_SORT_OPTIONS.oldest) {
-      sorted.sort((a, b) => getReminderSortTimestamp(a) - getReminderSortTimestamp(b));
-      return sorted;
-    }
-    if (reminderSortMode === REMINDER_SORT_OPTIONS.category) {
-      sorted.sort((a, b) => {
-        const categoryDiff = normalizeCategory(a?.category).localeCompare(normalizeCategory(b?.category), undefined, {
-          sensitivity: 'base',
-        });
-        if (categoryDiff !== 0) {
-          return categoryDiff;
+    if (reminderSortMode === REMINDER_SORT_OPTIONS.timeRelevance) {
+      const hasTimeReference = (reminder) => {
+        if (!reminder || typeof reminder !== 'object') {
+          return false;
         }
-        return getReminderSortTimestamp(b) - getReminderSortTimestamp(a);
+        if (typeof reminder.due === 'string' && reminder.due.trim()) {
+          return true;
+        }
+        const sourceText = `${reminder.title || ''} ${reminder.notes || ''}`.toLowerCase();
+        return /(\btoday\b|\btomorrow\b|\btonight\b|\bthis\s+(week|month|year)\b|\bnext\s+(week|month|year|mon(day)?|tue(s|sday)?|wed(nesday)?|thu(r|rs|rsday)?|fri(day)?|sat(urday)?|sun(day)?)\b|\byesterday\b|\bdue\b|\bdeadline\b|\b\d{1,2}:\d{2}\b|\b\d{1,2}\s?(am|pm)\b)/i.test(sourceText);
+      };
+
+      const withTimeReferences = [];
+      const withoutTimeReferences = [];
+      sorted.forEach((reminder) => {
+        if (hasTimeReference(reminder)) {
+          withTimeReferences.push(reminder);
+        } else {
+          withoutTimeReferences.push(reminder);
+        }
       });
-      return sorted;
+      return withTimeReferences.concat(withoutTimeReferences);
     }
-    sorted.sort((a, b) => getReminderSortTimestamp(b) - getReminderSortTimestamp(a));
     return sorted;
   }
 
@@ -5101,7 +5106,7 @@ export async function initReminders(sel = {}) {
 
     const allowedModes = new Set(Object.values(REMINDER_SORT_OPTIONS));
     const initialMode = String(sortSelect.value || '').trim().toLowerCase();
-    reminderSortMode = allowedModes.has(initialMode) ? initialMode : REMINDER_SORT_OPTIONS.newest;
+    reminderSortMode = allowedModes.has(initialMode) ? initialMode : REMINDER_SORT_OPTIONS.created;
     sortSelect.value = reminderSortMode;
 
     if (setupReminderSortControl._wired) {
@@ -5119,22 +5124,27 @@ export async function initReminders(sel = {}) {
 
     const sortToggleBtn = document.getElementById('reminderSortToggle');
     if (sortToggleBtn instanceof HTMLElement) {
+      const updateSortToggleLabel = () => {
+        const label = reminderSortMode === REMINDER_SORT_OPTIONS.timeRelevance
+          ? 'Time relevance ▼'
+          : 'Created ▼';
+        sortToggleBtn.textContent = label;
+        sortToggleBtn.setAttribute('aria-label', `Sort reminders (${label.replace(' ▼', '')})`);
+        sortToggleBtn.title = `Sort reminders (${label.replace(' ▼', '')})`;
+      };
       sortToggleBtn.addEventListener('click', () => {
         const modes = [
-          REMINDER_SORT_OPTIONS.newest,
-          REMINDER_SORT_OPTIONS.oldest,
-          REMINDER_SORT_OPTIONS.category,
+          REMINDER_SORT_OPTIONS.created,
+          REMINDER_SORT_OPTIONS.timeRelevance,
         ];
         const currentIndex = modes.indexOf(reminderSortMode);
         const nextMode = modes[(currentIndex + 1) % modes.length];
         reminderSortMode = nextMode;
         sortSelect.value = nextMode;
-        sortToggleBtn.setAttribute('aria-label', `Sort reminders (${nextMode})`);
-        sortToggleBtn.title = `Sort reminders (${nextMode})`;
+        updateSortToggleLabel();
         render();
       });
-      sortToggleBtn.setAttribute('aria-label', `Sort reminders (${reminderSortMode})`);
-      sortToggleBtn.title = `Sort reminders (${reminderSortMode})`;
+      updateSortToggleLabel();
     }
 
     setupReminderSortControl._wired = true;

--- a/mobile.html
+++ b/mobile.html
@@ -4987,6 +4987,13 @@ body, main, section, div, p, span, li {
     <!-- BEGIN GPT CHANGE: reminders view -->
     <section data-view="reminders" id="view-reminders" class="view-panel hidden" aria-hidden="true">
       <div class="reminders-mobile-flow reminders-content-shell">
+        <div class="flex items-center justify-between">
+          <button id="reminderSortToggle" type="button" class="btn btn-xs btn-ghost" aria-haspopup="listbox" aria-label="Sort reminders (Created)">Created ▼</button>
+          <select id="reminderSort" class="sr-only" aria-label="Sort reminders">
+            <option value="created" selected>Created</option>
+            <option value="time-relevance">Time relevance</option>
+          </select>
+        </div>
         <p class="text-xs text-base-content/70">Use the chat capture bar to add reminders instantly.</p>
         <div id="inboxSearchResults"></div>
 


### PR DESCRIPTION
### Motivation
- Keep reminders displayed in stored creation order by default while providing an optional view that surfaces reminders with time references first.
- Provide a minimal, consistent header control so users can switch between the default "Created" view and a new "Time relevance" view without changing stored ordering or IDs.

### Description
- Introduces two sort modes in `js/reminders.js`: `created` (default) and `time-relevance`, and sets `created` as the initial mode so rendering preserves stored creation order. 
- Implements `time-relevance` sorting that groups reminders with detected time references (existing `due` value or simple natural-language patterns in title/notes) before reminders without time references while preserving each group’s original creation order. 
- Adds a minimal header toggle in `mobile.html` (a hidden `<select>` plus a compact `#reminderSortToggle` button labeled `Created ▼`) and wires the toggle to update the label and re-render the displayed order without mutating stored reminder order. 
- Keeps all reminder storage, creation, and ID semantics unchanged and follows existing UI styling patterns used on the Capture screen.

### Testing
- Ran `npm test -- --runInBand js/__tests__/reminders.quick-add.test.js js/__tests__/mobile.header.test.js`, where the `mobile.header.test.js` suite passed and the `reminders.quick-add.test.js` suite failed due to an existing ESM/CJS import parsing issue in the test loader unrelated to these changes. 
- Ran `npm run build`, which completed successfully and produced the build artifacts. 
- Attempted an automated headless browser screenshot run to verify the header toggle, but the Playwright/Chromium run failed in this environment with a browser crash (SIGSEGV), so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b50ed00b148324853f9e797f707a97)