### PR TITLE
Simplify Reminders tab into active quick-check checklist

### DIFF
--- a/css/reminders-ui.css
+++ b/css/reminders-ui.css
@@ -210,14 +210,14 @@
 #view-reminders .reminder-row {
   display: flex;
   align-items: center;
-  min-height: 2.8rem;
+  min-height: 2.4rem;
   border: 0;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+  border-bottom: 1px solid color-mix(in srgb, var(--text-main) 9%, transparent);
   border-radius: 0;
   background: transparent;
   box-shadow: none;
-  padding: 10px 14px;
-  gap: 0.75rem;
+  padding: 0.45rem 0.25rem;
+  gap: 0.5rem;
   transform: none;
   transition: background-color 0.16s ease;
 }
@@ -234,14 +234,14 @@
 }
 
 #view-reminders .reminder-row-complete {
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 1.1rem;
+  height: 1.1rem;
   margin-top: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   border-radius: 999px;
-  flex: 0 0 1.5rem;
+  flex: 0 0 1.1rem;
 }
 
 #view-reminders .reminder-row-main {
@@ -250,9 +250,9 @@
 }
 
 #view-reminders .reminder-row-title {
-  font-size: 0.88rem;
-  line-height: 1.45;
-  font-weight: 500;
+  font-size: 0.9rem;
+  line-height: 1.35;
+  font-weight: 450;
   color: var(--text-main);
 }
 

--- a/mobile.html
+++ b/mobile.html
@@ -4987,14 +4987,6 @@ body, main, section, div, p, span, li {
     <!-- BEGIN GPT CHANGE: reminders view -->
     <section data-view="reminders" id="view-reminders" class="view-panel hidden" aria-hidden="true">
       <div class="reminders-mobile-flow reminders-content-shell">
-        <div class="flex items-center justify-between">
-          <button id="reminderSortToggle" type="button" class="btn btn-xs btn-ghost" aria-haspopup="listbox" aria-label="Sort reminders (Created)">Created ▼</button>
-          <select id="reminderSort" class="sr-only" aria-label="Sort reminders">
-            <option value="created" selected>Created</option>
-            <option value="time-relevance">Time relevance</option>
-          </select>
-        </div>
-        <p class="text-xs text-base-content/70">Use the chat capture bar to add reminders instantly.</p>
         <div id="inboxSearchResults"></div>
 
         <section id="remindersListMobile">
@@ -5007,7 +4999,7 @@ body, main, section, div, p, span, li {
               <p id="reminderReorderHint" class="sr-only">
                 Press, hold, and drag a reminder card to reorder your list. Screen reader users can double-tap and hold, then drag to move a reminder.
               </p>
-              <ul id="reminderList" class="w-full space-y-2 overflow-x-hidden reminder-list reminders-list" aria-describedby="reminderReorderHint"></ul>
+              <ul id="reminderList" class="w-full overflow-x-hidden reminder-list reminders-list" aria-describedby="reminderReorderHint"></ul>
             </div>
           </section>
         </section>


### PR DESCRIPTION
### Motivation
- Make the Reminders screen a minimal, quick-check checklist by removing non-essential chrome and tightening row styling so users see a compact list of actionable items.

### Description
- Removed the sort control and helper text from the mobile Reminders view in `mobile.html` so the screen focuses on the checklist only.
- Simplified the reminders list markup by removing extra spacing on the `#reminderList` element (removed `space-y-2`) so rows render as a single vertical list in `mobile.html`.
- Tightened visual styling in `css/reminders-ui.css`: reduced row height, subtler row divider color, smaller checkbox footprint, reduced padding/gap, and adjusted title typography so each reminder displays as a compact checkbox + text row.
- Did not change storage or ID logic and left the existing completion handler (`toggleDone`) and active-row filtering in `js/reminders.js` intact so completed reminders remain stored but are excluded from the visible list.

### Testing
- Ran `npm test -- reminders.categories.test.js`, which failed with a preexisting ESM/CommonJS harness error not introduced by these changes (baseline tests in this environment already fail on import style).
- Ran `npm run build` to validate the project builds successfully after the edits and the build completed.
- Served `mobile.html` locally and captured a screenshot of the reminders view to visually verify the compact checklist layout (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5204a63348324a412a6c52c4186da)