### PR TITLE
Polish reminders checklist styling to match Capture minimal design

### DIFF
--- a/css/reminders-ui.css
+++ b/css/reminders-ui.css
@@ -210,7 +210,7 @@
 #view-reminders .reminder-row {
   display: flex;
   align-items: center;
-  min-height: 2.8rem;
+  min-height: 48px;
   border: 0;
   border-bottom: 1px solid rgba(0, 0, 0, 0.06);
   border-radius: 0;
@@ -245,6 +245,8 @@
 }
 
 #view-reminders .reminder-row-main {
+  display: flex;
+  flex-direction: column;
   gap: 0.14rem;
   justify-content: center;
 }


### PR DESCRIPTION
### Motivation
- Improve the visual appearance and touch comfort of the reminders checklist so it matches the clean, minimal style used on the Capture screen.
- Preserve existing reminder behavior and avoid introducing visual clutter or changes to reminder logic or IDs.

### Description
- Increase checklist row vertical spacing by setting `#view-reminders .reminder-row { min-height: 48px; padding: 10px 14px; }` to provide a more comfortable tap target.
- Ensure the row layout remains a simple flex arrangement with centered alignment and consistent gap between checkbox and text by keeping `display: flex; align-items: center; gap: 0.75rem;` on `.reminder-row`.
- Make the row content block explicitly a column flex container with `#view-reminders .reminder-row-main { display: flex; flex-direction: column; }` for stable title/meta alignment.
- Maintain the subtle divider and hover feedback by retaining `border-bottom: 1px solid rgba(0,0,0,0.06)` and the light hover background, and avoid adding heavy containers, shadows, or borders.

### Testing
- Ran `npm run build` and the build completed successfully.
- Ran `npm test -- --runInBand js/__tests__/reminders.dom-sync.test.js` and the test suite failed due to an existing ESM/CommonJS module-loading mismatch unrelated to this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b522299838832499b0cb626e00a39a)