### PR TITLE
Ensure reminders display in creation order by default

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -749,10 +749,14 @@ export async function initReminders(sel = {}) {
     if (Number.isFinite(createdAt) && createdAt > 0) {
       return createdAt;
     }
-    const updatedAt = Number(reminder?.updatedAt);
-    if (Number.isFinite(updatedAt) && updatedAt > 0) {
-      return updatedAt;
+
+    const createdAtFromApi = typeof reminder?.created_at === 'string'
+      ? Date.parse(reminder.created_at)
+      : Number(reminder?.created_at);
+    if (Number.isFinite(createdAtFromApi) && createdAtFromApi > 0) {
+      return createdAtFromApi;
     }
+
     return 0;
   }
 
@@ -781,7 +785,16 @@ export async function initReminders(sel = {}) {
       });
       return withTimeReferences.concat(withoutTimeReferences);
     }
-    return sorted;
+    return sorted
+      .map((reminder, index) => ({ reminder, index }))
+      .sort((a, b) => {
+        const diff = getReminderSortTimestamp(b.reminder) - getReminderSortTimestamp(a.reminder);
+        if (diff !== 0) {
+          return diff;
+        }
+        return a.index - b.index;
+      })
+      .map(({ reminder }) => reminder);
   }
 
   // Returns a short, user-facing label for "today", e.g. "Tue 18 Nov"


### PR DESCRIPTION
### Motivation
- Users prefer reminders shown in the order they were captured, so reminders must be displayed by `created_at`/`createdAt` timestamps by default.
- New reminders should appear at the top of the list without changing how reminders are created or stored.
- Ordering must be stable so adding new reminders preserves deterministic relative order for existing items.

### Description
- Update `getReminderSortTimestamp` to read `createdAt` and also accept `created_at` (API-style) rather than falling back to `updatedAt`, ensuring sort is based on creation time only.
- Change `sortReminderRows` to sort reminders newest-first by the creation timestamp and add a stable tie-breaker using the original array index so identical timestamps keep deterministic order.
- Keep the default sort mode as `REMINDER_SORT_OPTIONS.created` and do not modify reminder creation or storage structures.

### Testing
- Ran `npx jest js/__tests__/reminders.quick-add.test.js js/__tests__/reminders.save-click.test.js --runInBand`, which failed due to the repo test harness loading mode (`SyntaxError: Cannot use import statement outside a module`), so the targeted Jest suites could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5236b9c1c83249820279bea55292e)