### PR TITLE
Add keyword extraction and recall support for captured reminder ideas

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -35,6 +35,43 @@ const SEEDED_CATEGORIES = Object.freeze([
 ]);
 const OFFLINE_REMINDERS_KEY = 'memoryCue:offlineReminders';
 const ORDER_INDEX_GAP = 1024;
+const REMINDER_KEYWORD_STOP_WORDS = new Set([
+  'a', 'an', 'and', 'are', 'at', 'be', 'for', 'from', 'have', 'idea', 'ideas', 'in', 'is', 'it', 'lesson', 'meeting', 'my', 'of', 'on', 'or', 'reminder', 'reminders', 'shopping', 'that', 'the', 'this', 'to', 'with', 'write', 'wrote'
+]);
+
+function normalizeReminderKeywords(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const deduped = new Set();
+  value.forEach((entry) => {
+    if (typeof entry !== 'string') {
+      return;
+    }
+    const normalized = entry.trim().toLowerCase();
+    if (normalized) {
+      deduped.add(normalized);
+    }
+  });
+  return Array.from(deduped).slice(0, 12);
+}
+
+function extractReminderKeywords(text) {
+  const normalized = typeof text === 'string' ? text.toLowerCase() : '';
+  const terms = normalized
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .split(/\s+/)
+    .map((term) => term.trim())
+    .filter((term) => term.length > 2 && !REMINDER_KEYWORD_STOP_WORDS.has(term));
+
+  if (/\bdrills?\b/.test(normalized)) terms.push('drill');
+  if (/\blesson(s|\sideas?)?\b/.test(normalized)) terms.push('lesson');
+  if (/\bideas?\b/.test(normalized)) terms.push('idea');
+  if (/\bmeetings?\b/.test(normalized)) terms.push('meeting');
+  if (/\bshopping\b/.test(normalized)) terms.push('shopping');
+
+  return normalizeReminderKeywords(terms);
+}
 
 function normalizeSemanticEmbedding(value) {
   if (!Array.isArray(value)) {
@@ -3622,6 +3659,12 @@ export async function initReminders(sel = {}) {
                 : null,
             pinToToday: entry.pinToToday === true,
             semanticEmbedding: normalizeSemanticEmbedding(entry.semanticEmbedding),
+            metadata: entry.metadata && typeof entry.metadata === 'object' ? entry.metadata : null,
+            keywords: normalizeReminderKeywords(
+              entry.keywords
+              || entry?.metadata?.keywords
+              || extractReminderKeywords(`${entry.title || ''} ${entry.notes || ''}`),
+            ),
           };
         })
         .filter(Boolean);
@@ -3658,6 +3701,12 @@ export async function initReminders(sel = {}) {
               : null,
           pinToToday: !!entry.pinToToday,
           semanticEmbedding: normalizeSemanticEmbedding(entry.semanticEmbedding),
+          metadata: entry.metadata && typeof entry.metadata === 'object' ? entry.metadata : null,
+          keywords: normalizeReminderKeywords(
+            entry.keywords
+            || entry?.metadata?.keywords
+            || extractReminderKeywords(`${entry.title || ''} ${entry.notes || ''}`),
+          ),
         }));
       localStorage.setItem(OFFLINE_REMINDERS_KEY, JSON.stringify(serialisable));
     } catch (error) {
@@ -4452,6 +4501,20 @@ export async function initReminders(sel = {}) {
       pinToToday: !!payload.pinToToday,
       notifyAt: notifyAtValue,
       semanticEmbedding: normalizeSemanticEmbedding(payload.semanticEmbedding),
+      metadata: payload.metadata && typeof payload.metadata === 'object' ? payload.metadata : null,
+    };
+
+    const derivedKeywords = normalizeReminderKeywords(
+      payload.keywords
+      || item?.metadata?.keywords
+      || extractReminderKeywords(`${titleText} ${note}`),
+    );
+    item.keywords = derivedKeywords;
+    item.metadata = {
+      ...(item.metadata || {}),
+      text: [titleText, note].filter(Boolean).join(' ').trim(),
+      keywords: derivedKeywords,
+      created_at: new Date(item.createdAt).toISOString(),
     };
 
     assignOrderIndexForNewItem(item, { position: 'start' });

--- a/src/chat/chatManager.js
+++ b/src/chat/chatManager.js
@@ -116,6 +116,17 @@ const REMINDER_QUERY_STOP_WORDS = new Set([
   'those',
   'reminder',
   'reminders',
+  'write',
+  'wrote',
+  'save',
+  'saved',
+  'lesson',
+  'lessons',
+  'idea',
+  'ideas',
+  'drill',
+  'drills',
+  'coaching',
 ]);
 
 const normalizeReminderQuery = (text) => (typeof text === 'string' ? text.trim().toLowerCase() : '');
@@ -133,7 +144,7 @@ const shouldSearchReminders = (text) => {
     return false;
   }
 
-  return /\b(reminder|reminders|meeting|meetings|shopping|list|idea|ideas|today|tonight|tomorrow)\b/.test(normalized);
+  return /\b(reminder|reminders|meeting|meetings|shopping|list|idea|ideas|lesson|lessons|drill|drills|coaching|today|tonight|tomorrow)\b/.test(normalized);
 };
 
 const readStoredReminders = () => {
@@ -192,7 +203,12 @@ const buildReminderSearchResponse = (queryText) => {
   const matches = reminders
     .filter((reminder) => !reminder?.done)
     .map((reminder) => {
-      const reminderText = `${reminder?.title || ''} ${reminder?.notes || ''}`.toLowerCase();
+      const reminderKeywords = Array.isArray(reminder?.keywords)
+        ? reminder.keywords
+        : Array.isArray(reminder?.metadata?.keywords)
+          ? reminder.metadata.keywords
+          : [];
+      const reminderText = `${reminder?.title || ''} ${reminder?.notes || ''} ${reminderKeywords.join(' ')}`.toLowerCase();
       const termScore = queryTerms.reduce((score, term) => score + (reminderText.includes(term) ? 1 : 0), 0);
       const todayScore = includesToday && isDueToday(reminder) ? 2 : 0;
       return { reminder, score: termScore + todayScore };
@@ -278,6 +294,8 @@ const processParsedEntry = async (parsed, text, dependencies = {}) => {
     console.log('Capture routed to:', 'reminder');
     await executeCommand('reminder', {
       text: typeof parsed?.title === 'string' && parsed.title.trim() ? parsed.title.trim() : text,
+      keywords: Array.isArray(parsed?.metadata?.keywords) ? parsed.metadata.keywords : [],
+      metadata: parsed?.metadata && typeof parsed.metadata === 'object' ? parsed.metadata : null,
       handler: dependencies.createReminder,
     });
     const scheduleLabel = getReminderScheduleLabel(parsed, text);


### PR DESCRIPTION
### Motivation
- Enable the assistant to recognise and retrieve captured ideas (drills, lesson ideas, coaching ideas, meetings, shopping, etc.) by extracting contextual keywords from captured text and making those keywords searchable with assistant queries.
- Preserve existing UI and reminder creation flows while attaching searchable metadata to reminders so stored ideas can be recalled without adding visible UI elements.

### Description
- Added keyword extraction helpers in `js/reminders.js`: `REMINDER_KEYWORD_STOP_WORDS`, `normalizeReminderKeywords`, and `extractReminderKeywords` to derive contextual keywords (including `drill`, `lesson`, `idea`, `meeting`, `shopping`).
- Persisted `keywords` and `metadata` for reminders during offline hydration and persistence in `js/reminders.js`, and attach derived `keywords` and `metadata` when creating reminders so entries include searchable context without changing UX.
- Updated assistant recall logic in `src/chat/chatManager.js` to broaden recall trigger terms (adds `lesson`, `drill`, `coaching`, etc.), include extra stop-words, and incorporate stored reminder `keywords` into scoring so queries like `What drills did I write` return matching entries.
- Passed parsed capture `keywords` and `metadata` through the capture->reminder route by including `keywords` and `metadata` in the `executeCommand('reminder', ...)` payload so assistant-captured reminders retain searchable keyword context.

### Testing
- Ran `npm test -- --runTestsByPath api.parse-entry.test.js` and it passed successfully.
- Ran `npm test -- --runTestsByPath js/__tests__/reminders.save-click.test.js` and it failed in this environment due to an existing ESM/CommonJS test harness mismatch (`Cannot use import statement outside a module`), which is unrelated to the changes made and prevented that specific test from executing here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b52860cc108324b2bf1905ae82d8d2)