### PR TITLE
Simplify notebooks and add keyword-backed assistant search

### DIFF
--- a/js/modules/memory-index.js
+++ b/js/modules/memory-index.js
@@ -69,6 +69,7 @@ const buildIndexEntry = (note) => {
     summary: body.slice(0, 180),
     type,
     tags: normalizeTags(metadata.tags),
+    keywords: normalizeTags(note.keywords),
     folder: getFolderNameById(note.folderId),
     createdAt,
     updatedAt,
@@ -85,6 +86,9 @@ const scoreMemoryMatch = (entry, normalizedQuery) => {
   const lowerTitle = entry.title.toLowerCase();
   const lowerBody = entry.body.toLowerCase();
   const lowerTags = entry.tags.map((tag) => tag.toLowerCase());
+  const lowerKeywords = Array.isArray(entry.keywords)
+    ? entry.keywords.map((keyword) => String(keyword).toLowerCase())
+    : [];
 
   let score = 0;
   let matched = false;
@@ -97,6 +101,11 @@ const scoreMemoryMatch = (entry, normalizedQuery) => {
 
     if (lowerTags.some((tag) => tag.includes(token))) {
       score += 500;
+      matched = true;
+    }
+
+    if (lowerKeywords.some((keyword) => keyword.includes(token))) {
+      score += 450;
       matched = true;
     }
 

--- a/js/modules/notes-storage.js
+++ b/js/modules/notes-storage.js
@@ -160,6 +160,33 @@ const sanitizeMetadata = (value) => {
 
 const sanitizeCanonicalTags = (value) => sanitizeTags(value);
 
+const KEYWORD_STOP_WORDS = new Set([
+  'the', 'and', 'for', 'that', 'with', 'this', 'from', 'have', 'what', 'about', 'your', 'into',
+  'not', 'are', 'was', 'were', 'you', 'they', 'their', 'there', 'then', 'them', 'just', 'also',
+]);
+
+const extractKeywordsFromText = (value) => {
+  if (typeof value !== 'string') {
+    return [];
+  }
+
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter((token, index, list) => token.length > 2 && !KEYWORD_STOP_WORDS.has(token) && list.indexOf(token) === index)
+    .slice(0, 15);
+};
+
+const deriveKeywords = (title = '', bodyText = '', provided = null) => {
+  if (Array.isArray(provided) && provided.length) {
+    return sanitizeTags(provided).map((keyword) => keyword.toLowerCase());
+  }
+
+  return extractKeywordsFromText(`${title} ${bodyText}`);
+};
+
 export const createAndSaveNote = (payload = {}, options = {}) => {
   const normalizedPayload = payload && typeof payload === 'object' ? payload : {};
   const text = typeof normalizedPayload.text === 'string' ? normalizedPayload.text.trim() : '';
@@ -208,6 +235,7 @@ export const createNote = (title, bodyHtml, overrides = {}) => {
   const providedBodyText = typeof overrides.bodyText === 'string' ? overrides.bodyText : null;
   const normalizedBodyText =
     providedBodyText !== null ? providedBodyText.trim() : deriveBodyText(normalizedBodyHtml);
+  const keywords = deriveKeywords(trimmedTitle, normalizedBodyText, overrides.keywords);
   return {
     id: overrides.id && typeof overrides.id === 'string' ? overrides.id : generateId(),
     title: trimmedTitle || 'Untitled note',
@@ -225,6 +253,7 @@ export const createNote = (title, bodyHtml, overrides = {}) => {
         : new Date().toISOString(),
     folderId: overrides.folderId && typeof overrides.folderId === 'string' ? overrides.folderId : null,
     semanticEmbedding: normalizeSemanticEmbedding(overrides.semanticEmbedding),
+    keywords,
     metadata: sanitizeMetadata(overrides.metadata),
     links: sanitizeLinks(overrides.links),
   };
@@ -264,6 +293,7 @@ const normalizeNotes = (value) => {
           bodyText,
           pinned,
           semanticEmbedding: normalizeSemanticEmbedding(note.semanticEmbedding),
+          keywords: deriveKeywords(title, bodyText, note.keywords),
           metadata: sanitizeMetadata(note.metadata),
           links: sanitizeLinks(note.links),
         });
@@ -297,6 +327,7 @@ const normalizeNotes = (value) => {
         bodyText,
         pinned,
         semanticEmbedding: normalizeSemanticEmbedding(value.semanticEmbedding),
+        keywords: deriveKeywords(title, bodyText, value.keywords),
         metadata: sanitizeMetadata(value.metadata),
         links: sanitizeLinks(value.links),
       }),
@@ -384,6 +415,7 @@ export const saveAllNotes = (notes, options = {}) => {
       out.pinned = typeof note.pinned === 'boolean' ? note.pinned : Boolean(out.pinned);
       out.createdAt = isValidDateString(note.createdAt) ? note.createdAt : out.createdAt;
       out.semanticEmbedding = normalizeSemanticEmbedding(note.semanticEmbedding);
+      out.keywords = deriveKeywords(out.title, out.bodyText, note.keywords || out.keywords);
       out.metadata = sanitizeMetadata(note.metadata);
       out.links = sanitizeLinks(note.links);
     }
@@ -413,8 +445,12 @@ export const saveAllNotes = (notes, options = {}) => {
 export { NOTES_STORAGE_KEY };
 
 // Folders API
-const REFLECTIONS_FOLDER_NAME = 'Lesson – Reflections';
-const REFLECTIONS_FOLDER_ID = 'lesson-reflections';
+const CORE_NOTEBOOKS = [
+  { id: 'school', name: 'School' },
+  { id: 'coaching', name: 'Coaching' },
+  { id: 'everyday', name: 'Everyday' },
+  { id: 'archive', name: 'Archive' },
+];
 
 const ensureRequiredFolders = (folders = []) => {
   const normalized = Array.isArray(folders)
@@ -429,22 +465,12 @@ const ensureRequiredFolders = (folders = []) => {
 
   let changed = false;
 
-  if (!normalized.some((folder) => folder.id === 'unsorted')) {
-    normalized.unshift({ id: 'unsorted', name: 'Unsorted', order: 0 });
-    changed = true;
-  }
-
-  if (!normalized.some((folder) => folder.name === REFLECTIONS_FOLDER_NAME)) {
-    const usedIds = new Set(normalized.map((folder) => folder.id));
-    let folderId = REFLECTIONS_FOLDER_ID;
-    let suffix = 1;
-    while (usedIds.has(folderId)) {
-      suffix += 1;
-      folderId = `${REFLECTIONS_FOLDER_ID}-${suffix}`;
+  CORE_NOTEBOOKS.forEach((requiredFolder) => {
+    if (!normalized.some((folder) => folder.id === requiredFolder.id)) {
+      normalized.push({ ...requiredFolder, order: normalized.length });
+      changed = true;
     }
-    normalized.push({ id: folderId, name: REFLECTIONS_FOLDER_NAME, order: normalized.length });
-    changed = true;
-  }
+  });
 
   const withOrder = normalized.map((folder, index) => {
     if (folder.order !== index) {
@@ -456,7 +482,7 @@ const ensureRequiredFolders = (folders = []) => {
   return { folders: withOrder, changed };
 };
 
-const defaultFolders = () => ensureRequiredFolders([{ id: 'unsorted', name: 'Unsorted', order: 0 }]).folders;
+const defaultFolders = () => ensureRequiredFolders(CORE_NOTEBOOKS).folders;
 
 export const getFolders = () => {
   if (!hasLocalStorage()) {
@@ -494,7 +520,7 @@ export const getFolders = () => {
 export const getFolderNameById = (id) => {
   const folders = getFolders();
   const found = folders.find((f) => f && String(f.id) === String(id));
-  return found ? String(found.name) : 'Unsorted';
+  return found ? String(found.name) : 'Everyday';
 };
 
 export const saveFolders = (folders) => {
@@ -521,7 +547,7 @@ export const assignNoteToFolder = (noteId, folderId) => {
       changed = true;
       return {
         ...n,
-        folderId: folderId && typeof folderId === 'string' ? folderId : null,
+        folderId: folderId && typeof folderId === 'string' ? folderId : 'everyday',
         updatedAt: new Date().toISOString(),
       };
     }

--- a/js/tests/notes-storage.folders.test.js
+++ b/js/tests/notes-storage.folders.test.js
@@ -38,21 +38,27 @@ beforeEach(() => {
   localStorage.clear();
 });
 
-test('getFolders always includes Lesson – Reflections', () => {
+test('getFolders always includes the core notebooks', () => {
   const { getFolders } = loadNotesStorageModule();
 
   const folders = getFolders();
 
   expect(Array.isArray(folders)).toBe(true);
-  expect(folders.some((folder) => folder?.name === 'Lesson – Reflections')).toBe(true);
+  expect(folders.some((folder) => folder?.name === 'School')).toBe(true);
+  expect(folders.some((folder) => folder?.name === 'Coaching')).toBe(true);
+  expect(folders.some((folder) => folder?.name === 'Everyday')).toBe(true);
+  expect(folders.some((folder) => folder?.name === 'Archive')).toBe(true);
 });
 
-test('saveFolders keeps Lesson – Reflections in storage', () => {
+test('saveFolders keeps core notebooks in storage', () => {
   const { saveFolders, getFolders } = loadNotesStorageModule();
 
-  const saved = saveFolders([{ id: 'unsorted', name: 'Unsorted', order: 0 }]);
+  const saved = saveFolders([{ id: 'school', name: 'School', order: 0 }]);
 
   expect(saved).toBe(true);
   const folders = getFolders();
-  expect(folders.some((folder) => folder?.name === 'Lesson – Reflections')).toBe(true);
+  expect(folders.some((folder) => folder?.name === 'School')).toBe(true);
+  expect(folders.some((folder) => folder?.name === 'Coaching')).toBe(true);
+  expect(folders.some((folder) => folder?.name === 'Everyday')).toBe(true);
+  expect(folders.some((folder) => folder?.name === 'Archive')).toBe(true);
 });

--- a/mobile.js
+++ b/mobile.js
@@ -1705,7 +1705,7 @@ const initMobileNotes = () => {
     titleInput.dataset.noteOriginalTitle = isNew ? '' : nextTitle;
     scratchNotesEditorElement.dataset.noteOriginalBody = getEditorHTML();
     // set current editing folder for existing notes
-    currentEditingNoteFolderId = note.folderId && typeof note.folderId === 'string' ? note.folderId : 'unsorted';
+    currentEditingNoteFolderId = note.folderId && typeof note.folderId === 'string' ? note.folderId : 'everyday';
     const labelEl = document.getElementById('note-folder-label');
     if (labelEl) {
       labelEl.textContent = getFolderNameById(currentEditingNoteFolderId);
@@ -2263,7 +2263,7 @@ const initMobileNotes = () => {
         titleRow.appendChild(pinIcon);
       }
 
-      const folderId = note.folderId && typeof note.folderId === 'string' ? note.folderId : 'unsorted';
+      const folderId = note.folderId && typeof note.folderId === 'string' ? note.folderId : 'everyday';
       const folderName = getFolderNameById(folderId) || 'Unsorted';
       const timestamp = formatNoteTimestamp(note.updatedAt);
 
@@ -3535,7 +3535,7 @@ const initMobileNotes = () => {
   const openNoteEditorForNewNote = (note) => {
     if (!note) return;
     currentEditingNoteFolderId =
-      note.folderId && typeof note.folderId === 'string' ? note.folderId : 'unsorted';
+      note.folderId && typeof note.folderId === 'string' ? note.folderId : 'everyday';
     resetEditorScroll();
     setEditorValues(note, { isNew: true });
     updateListSelection();
@@ -3547,7 +3547,7 @@ const initMobileNotes = () => {
 
   const startNewNoteFromUI = () => {
     const timestamp = new Date().toISOString();
-    const activeFolderId = currentFolderId && currentFolderId !== 'all' ? currentFolderId : 'unsorted';
+    const activeFolderId = currentFolderId && currentFolderId !== 'all' ? currentFolderId : 'everyday';
     const draftNote = createNote('', '', { folderId: activeFolderId, updatedAt: timestamp });
     const newNote = {
       ...draftNote,
@@ -3575,7 +3575,7 @@ const initMobileNotes = () => {
     const normalizedFolderId =
       currentEditingNoteFolderId && currentEditingNoteFolderId !== 'all'
         ? currentEditingNoteFolderId
-        : 'unsorted';
+        : 'everyday';
 
     if (currentNoteId) {
       const noteIndex = notesArray.findIndex((note) => note.id === currentNoteId);

--- a/src/services/memorySearch.js
+++ b/src/services/memorySearch.js
@@ -73,6 +73,22 @@ const formatLineItems = (entries) => entries
   .map((entry) => `• ${entry.title}`)
   .join('\n');
 
+const formatNotebookHeading = (entries = []) => {
+  const folders = entries
+    .map((entry) => normalizeText(entry?.folder))
+    .filter((folder, index, list) => folder && list.indexOf(folder) === index);
+
+  if (!folders.length) {
+    return 'You wrote these notes:';
+  }
+
+  if (folders.length === 1) {
+    return `You wrote these ${folders[0].toLowerCase()} ideas:`;
+  }
+
+  return 'You wrote these notes:';
+};
+
 export const isMemorySearchQuery = (text) => {
   const normalized = normalizeToken(text);
   if (!normalized) {
@@ -111,6 +127,6 @@ export const formatMemorySearchResponse = (result) => {
     return 'I could not find any matching notes yet.';
   }
 
-  const heading = count === 1 ? 'You have 1 note saved:' : `You have ${count} notes saved:`;
+  const heading = formatNotebookHeading(items);
   return `${heading}\n\n${formatLineItems(items)}`;
 };


### PR DESCRIPTION
### Motivation
- Make the notebook system a minimal AI-assisted knowledge store by seeding the main life-context notebooks and keeping capture flow simple.
- Improve retrieval so the assistant can find relevant notes via natural language without requiring manual tagging or complex UI.
- Preserve existing reminder and capture behavior while keeping the Notebooks UI minimal.

### Description
- Add automatic keyword extraction and storage for notes via new helpers (`KEYWORD_STOP_WORDS`, `extractKeywordsFromText`, `deriveKeywords`) in `js/modules/notes-storage.js` and persist a `keywords` array on each note. 
- Ensure the core notebooks always exist by seeding `School`, `Coaching`, `Everyday`, and `Archive` via `CORE_NOTEBOOKS` in `js/modules/notes-storage.js` and adjust folder defaults so new/fallback notes target `Everyday` in `mobile.js`.
- Wire note `keywords` into the assistant index and ranking by indexing `keywords` and matching query tokens in `js/modules/memory-index.js` to improve relevance scoring alongside title/body/tags. 
- Tweak assistant response wording in `src/services/memorySearch.js` to produce concise, notebook-aware list responses, and update the folders unit test in `js/tests/notes-storage.folders.test.js` to validate the new required set.

### Testing
- Ran `npm test -- js/tests/notes-storage.folders.test.js`, which passed. 
- Ran `npm test -- js/__tests__/reminders.quick-add.test.js`, which failed in this environment due to an existing ESM/CJS import mismatch in `js/reminders.js` and not caused by these changes. 
- No other automated test suites were modified or added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5299a19848324914ee32de6d67dbf)