### PR TITLE
Add shared pure intent router and wire chatManager to use it

### DIFF
--- a/src/chat/chatManager.js
+++ b/src/chat/chatManager.js
@@ -3,6 +3,7 @@ import { executeCommand } from '../core/commandEngine.js';
 import { createAndSaveNote } from '../../js/modules/notes-storage.js';
 import { saveInboxEntry } from '../services/inboxService.js';
 import { suggestNotebookAndTags } from '../services/taggingEngine.js';
+import { createChatIntentInput, routeIntent } from '../services/intentRouter.js';
 import { ensureFolderExistsByName } from '../../js/modules/ai-capture-save.js';
 
 export const ENABLE_CHAT_INTERFACE = true;
@@ -66,15 +67,6 @@ const parseEntry = async (text) => {
 
   const parsed = await response.json();
   return normalizeParsedEntry(parsed, text);
-};
-
-const normalizeType = (parsedType, text) => {
-  const normalizedType = typeof parsedType === 'string' ? parsedType.trim().toLowerCase() : '';
-  if (normalizedType) {
-    return normalizedType;
-  }
-
-  return text.endsWith('?') ? 'question' : 'unknown';
 };
 
 const askAssistant = async (text) => {
@@ -276,21 +268,14 @@ const createNotebookNote = async (parsed, text) => {
   return { note, notebookName: folderName || 'Unsorted' };
 };
 
-const looksLikeNotebookCapture = (text) => {
-  const normalized = typeof text === 'string' ? text.trim().toLowerCase() : '';
-  if (!normalized) {
-    return false;
-  }
-  if (normalized.includes('?')) {
-    return false;
-  }
-  return /(meeting notes|lesson idea|remember\b|notes?\s+from|journal|plan\b|scored\b)/i.test(normalized);
-};
-
 const processParsedEntry = async (parsed, text, dependencies = {}) => {
-  const parsedType = normalizeType(parsed?.type, text);
+  const intentInput = createChatIntentInput(parsed, text, { channel: 'assistant_chat' });
+  const decision = routeIntent(intentInput.parsedEntry, intentInput.rawText, intentInput.hints);
+  const parsedType = typeof decision?.parsedType === 'string' && decision.parsedType
+    ? decision.parsedType
+    : 'unknown';
 
-  if (parsedType === 'reminder') {
+  if (decision.decisionType === 'persist_reminder') {
     console.log('Capture routed to:', 'reminder');
     await executeCommand('reminder', {
       text: typeof parsed?.title === 'string' && parsed.title.trim() ? parsed.title.trim() : text,
@@ -306,18 +291,12 @@ const processParsedEntry = async (parsed, text, dependencies = {}) => {
     return { message };
   }
 
-  if (
-    parsedType === 'note'
-    || parsedType === 'drill'
-    || parsedType === 'idea'
-    || parsedType === 'task'
-    || looksLikeNotebookCapture(text)
-  ) {
+  if (decision.decisionType === 'persist_note') {
     const { notebookName } = await createNotebookNote(parsed, text);
     return { message: `Saved to notebook (${notebookName}).` };
   }
 
-  if (parsedType === 'question' || text.endsWith('?')) {
+  if (decision.decisionType === 'query') {
     const reminderSearchResponse = buildReminderSearchResponse(text);
     if (reminderSearchResponse) {
       return { message: reminderSearchResponse };
@@ -329,7 +308,7 @@ const processParsedEntry = async (parsed, text, dependencies = {}) => {
   saveInboxEntry({
     text,
     source: 'assistant',
-    parsedType: normalizeType(parsed?.type, text),
+    parsedType,
     tags: Array.isArray(parsed?.tags) ? parsed.tags : [],
     metadata: parsed?.metadata && typeof parsed.metadata === 'object' ? parsed.metadata : {},
   });

--- a/src/services/intentRouter.js
+++ b/src/services/intentRouter.js
@@ -1,0 +1,104 @@
+const NOTEBOOK_CAPTURE_PATTERN = /(meeting notes|lesson idea|remember\b|notes?\s+from|journal|plan\b|scored\b)/i;
+
+const normalizeType = (parsedType, rawText) => {
+  const normalizedType = typeof parsedType === 'string' ? parsedType.trim().toLowerCase() : '';
+  if (normalizedType) {
+    return normalizedType;
+  }
+
+  const normalizedText = typeof rawText === 'string' ? rawText.trim() : '';
+  return normalizedText.endsWith('?') ? 'question' : 'unknown';
+};
+
+const looksLikeNotebookCapture = (rawText) => {
+  const normalized = typeof rawText === 'string' ? rawText.trim().toLowerCase() : '';
+  if (!normalized) {
+    return false;
+  }
+  if (normalized.includes('?')) {
+    return false;
+  }
+  return NOTEBOOK_CAPTURE_PATTERN.test(normalized);
+};
+
+/**
+ * Shared, pure routing decision for parsed captures.
+ *
+ * Inputs:
+ * - parsedEntry: parser payload (type/title/tags/metadata/reminderDate)
+ * - rawText: original user text
+ * - hints: optional metadata from caller context
+ *
+ * Output:
+ * - normalized decision object for caller-side handling
+ */
+export const routeIntent = (parsedEntry, rawText, hints = {}) => {
+  const text = typeof rawText === 'string' ? rawText.trim() : '';
+  const parsed = parsedEntry && typeof parsedEntry === 'object' ? parsedEntry : {};
+  const parsedType = normalizeType(parsed?.type, text);
+  const notebookHeuristic = looksLikeNotebookCapture(text);
+  const isQuestion = parsedType === 'question' || text.endsWith('?');
+
+  if (parsedType === 'reminder') {
+    return {
+      decisionType: 'persist_reminder',
+      parsedType,
+      text,
+      parsedEntry: parsed,
+      hints,
+    };
+  }
+
+  if (
+    parsedType === 'note'
+    || parsedType === 'drill'
+    || parsedType === 'idea'
+    || parsedType === 'task'
+    || notebookHeuristic
+  ) {
+    return {
+      decisionType: 'persist_note',
+      parsedType,
+      text,
+      parsedEntry: parsed,
+      notebookHeuristic,
+      hints,
+    };
+  }
+
+  if (isQuestion) {
+    return {
+      decisionType: 'query',
+      parsedType,
+      text,
+      parsedEntry: parsed,
+      hints,
+    };
+  }
+
+  return {
+    decisionType: 'persist_inbox',
+    parsedType,
+    text,
+    parsedEntry: parsed,
+    hints,
+  };
+};
+
+export const createChatIntentInput = (parsedEntry, rawText, hints = {}) => ({
+  parsedEntry,
+  rawText,
+  hints: { ...hints, source: 'chat' },
+});
+
+export const createCaptureIntentInput = (parsedEntry, rawText, hints = {}) => ({
+  parsedEntry,
+  rawText,
+  hints: { ...hints, source: 'capture' },
+});
+
+export const createInboxIntentInput = (parsedEntry, rawText, hints = {}) => ({
+  parsedEntry,
+  rawText,
+  hints: { ...hints, source: 'inbox_processor' },
+});


### PR DESCRIPTION
### Motivation
- Consolidate routing decisions into a single pure module so routing logic is no longer duplicated across callers. 
- Preserve existing chat capture behavior while enabling future reuse by `chatManager`, capture flows, and inbox processing.

### Description
- Added a new pure router at `src/services/intentRouter.js` that exports `routeIntent(parsedEntry, rawText, hints)` and returns normalized decisions (`decisionType`: `persist_reminder` / `persist_note` / `query` / `persist_inbox`) along with `parsedType`, `text`, `parsedEntry`, and `hints`.
- Implemented the same notebook-like heuristic and question detection used previously and preserved the reminder, note/drill/idea/task, question, and inbox fallback branches.
- Added thin adapter helpers `createChatIntentInput`, `createCaptureIntentInput`, and `createInboxIntentInput` so callers can build inputs consistently.
- Updated `src/chat/chatManager.js` to call the router (`createChatIntentInput` + `routeIntent`) in `processParsedEntry()` and kept all caller-side side effects (reminder creation, note saving, assistant query fallback, inbox save, and assistant UI rendering) in `chatManager` to preserve UX.

### Testing
- Ran the test suite with `npm test -- --runInBand`; the run completed but the repository has multiple pre-existing failing suites (15 failed, 11 passed) that are unrelated to the routing extraction.
- No new routing-specific failures were observed during the test run and chat manager behavior paths for reminders, notes, queries, and inbox fallback were preserved by inspection.
- Manual validation: ensured `chatManager` still performs assistant message rendering and persistence and that the router remains a pure function that does not touch DOM/UI code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b52eed400c8324a7c9ffe7707809cd)