### PR TITLE
Establish canonical note persistence adapter for note creation flows

### DIFF
--- a/js/services/capture-service.js
+++ b/js/services/capture-service.js
@@ -1,4 +1,4 @@
-import { createAndSaveNote } from '../modules/notes-storage.js';
+import { saveNote } from '../../src/services/adapters/notePersistenceAdapter.js';
 import { generateTags } from '../../src/ai/tagGenerator.js';
 import { routeIntent } from '../../src/services/intentRouter.js';
 import * as reminderService from '../../src/services/reminderService.js';
@@ -112,7 +112,7 @@ const persistNoteDecision = (text, parsedEntry, context) => {
       ? parsedEntry.title.trim()
       : text.split(/\s+/).slice(0, 8).join(' ') || 'Captured note';
 
-  const note = createAndSaveNote({
+  const note = saveNote({
     text,
     title,
     tags: Array.isArray(parsedEntry?.tags) ? parsedEntry.tags : generateTags(text),
@@ -218,7 +218,7 @@ export const convertInboxToNote = (entryId) => {
   }
 
   const title = text.split(/\s+/).slice(0, 8).join(' ') || 'Captured note';
-  const note = createAndSaveNote({
+  const note = saveNote({
     text,
     title,
     tags: Array.isArray(entry.tags) ? entry.tags : [],

--- a/src/ai/inboxProcessor.js
+++ b/src/ai/inboxProcessor.js
@@ -1,4 +1,4 @@
-import { createNote, loadAllNotes, saveAllNotes } from '../../js/modules/notes-storage.js';
+import { saveNote } from '../services/adapters/notePersistenceAdapter.js';
 import { ensureFolderExistsByName } from '../../js/modules/ai-capture-save.js';
 import { suggestNotebookAndTags } from '../services/taggingEngine.js';
 import { routeIntent } from '../services/intentRouter.js';
@@ -83,14 +83,6 @@ const mapDecisionToCountType = (decision) => {
   return 'note';
 };
 
-const addNotes = (notes) => {
-  if (!Array.isArray(notes) || !notes.length) {
-    return;
-  }
-
-  const existing = Array.isArray(loadAllNotes()) ? loadAllNotes() : [];
-  saveAllNotes([...notes, ...existing]);
-};
 
 export const processInbox = async (entries = [], options = {}) => {
   const createReminder = typeof options.createReminder === 'function' ? options.createReminder : null;
@@ -105,7 +97,7 @@ export const processInbox = async (entries = [], options = {}) => {
     personal: 0,
   };
 
-  const notesToSave = [];
+  const notePayloads = [];
   const processedItems = [];
 
   for (const entry of entries) {
@@ -152,15 +144,14 @@ export const processInbox = async (entries = [], options = {}) => {
       }
     } else if (decision.decisionType === 'persist_note') {
       const folderId = ensureFolderExistsByName(organization.notebook);
-      notesToSave.push(
-        createNote(parsedEntry?.title || text.split(/\s+/).slice(0, 8).join(' '), text, {
-          folderId,
-          metadata: {
-            type: parsedEntry?.type || type,
-            tags: combinedTags,
-          },
-        }),
-      );
+      notePayloads.push({
+        text,
+        title: parsedEntry?.title || text.split(/\s+/).slice(0, 8).join(' '),
+        folderId,
+        tags: combinedTags,
+        parsedType: parsedEntry?.type || type,
+        source: typeof entry?.source === 'string' ? entry.source : 'inbox',
+      });
     }
 
     if (removeInboxEntry && entry?.id != null) {
@@ -168,7 +159,9 @@ export const processInbox = async (entries = [], options = {}) => {
     }
   }
 
-  addNotes(notesToSave);
+  for (let index = notePayloads.length - 1; index >= 0; index -= 1) {
+    saveNote(notePayloads[index]);
+  }
 
   return {
     processedCount: processedItems.length,

--- a/src/chat/chatManager.js
+++ b/src/chat/chatManager.js
@@ -1,10 +1,10 @@
 import { addMessage } from './messageStore.js';
 import { executeCommand } from '../core/commandEngine.js';
-import { createAndSaveNote } from '../../js/modules/notes-storage.js';
 import { saveInboxEntry } from '../services/inboxService.js';
 import { suggestNotebookAndTags } from '../services/taggingEngine.js';
 import { createChatIntentInput, routeIntent } from '../services/intentRouter.js';
 import { ensureFolderExistsByName } from '../../js/modules/ai-capture-save.js';
+import { saveNote } from '../services/adapters/notePersistenceAdapter.js';
 
 export const ENABLE_CHAT_INTERFACE = true;
 
@@ -253,7 +253,7 @@ const createNotebookNote = async (parsed, text) => {
     : null;
   const folderId = folderName ? ensureFolderExistsByName(folderName) : null;
 
-  const note = createAndSaveNote({
+  const note = saveNote({
     text,
     title,
     tags: Array.isArray(notebookSuggestion?.tags)

--- a/src/services/adapters/notePersistenceAdapter.js
+++ b/src/services/adapters/notePersistenceAdapter.js
@@ -1,0 +1,11 @@
+import { createAndSaveNote } from '../../../js/modules/notes-storage.js';
+
+export const saveNote = (notePayload = {}, metadata = {}) => {
+  const payload = notePayload && typeof notePayload === 'object' ? notePayload : {};
+  const normalizedMetadata = metadata && typeof metadata === 'object' ? metadata : {};
+
+  return createAndSaveNote({
+    ...payload,
+    ...normalizedMetadata,
+  });
+};


### PR DESCRIPTION
### Motivation

- Provide a single canonical adapter so new notes are always written through one interface while preserving existing normalization and storage behavior.  
- Keep legacy read/migration logic and notebooks editor write paths intact to avoid UI regressions.  
- Make the change minimal and localized to note-creation flows without touching the notebooks editor.

### Description

- Added `src/services/adapters/notePersistenceAdapter.js` exporting `saveNote(notePayload, metadata)` that delegates to the existing `createAndSaveNote` to preserve normalization and storage semantics.  
- Updated chat note creation in `src/chat/chatManager.js` to call `saveNote` for notebook saves instead of calling notes-storage directly.  
- Updated capture flows in `js/services/capture-service.js` to use `saveNote` for the `persist_note` path and for converting an inbox item to a note.  
- Updated inbox processing in `src/ai/inboxProcessor.js` to build note payloads and persist them through `saveNote`, and save in reverse order to preserve top-of-list ordering previously produced by batched prepends.

### Testing

- Ran the test suite via `npm test -- --runInBand` to validate changes were import-safe and to surface regressions.  
- Tests executed but several unrelated suites failed due to pre-existing ESM/CommonJS harness and other unrelated failures; notes-storage-related tests (folders/links) passed and there were no new failures directly attributable to the adapter change.  
- Confirmed that note creation still flows through the canonical notes-storage implementation because `saveNote` delegates to `createAndSaveNote`, preserving existing behavior and metadata handling.

Legacy write paths still present

- `js/reminders.js` still writes notes via `createAndSaveNote` (left intentionally).  
- The notebooks editor still writes `memory-cue-notes` directly via `localStorage.setItem` in `js/storage.js` (left intentionally).  
- `js/modules/notes-storage.js` still exposes `createAndSaveNote`, `createNote`, and `saveAllNotes` for migration/read compatibility.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b534a093ac83249c0708d6b535e6e4)