### PR TITLE
Add Cloudflare Pages Functions API for parse-entry and Wrangler config

### DIFF
--- a/api/parse-entry.js
+++ b/api/parse-entry.js
@@ -1,3 +1,4 @@
+// Deprecated: replaced by Cloudflare Pages Function
 const PARSED_ENTRY_SCHEMA = {
   type: 'object',
   additionalProperties: false,

--- a/functions/api/parse-entry.js
+++ b/functions/api/parse-entry.js
@@ -1,0 +1,58 @@
+export async function onRequestPost(context) {
+  try {
+
+    const request = context.request
+    const env = context.env
+
+    const body = await request.json()
+    const text = body?.text?.trim()
+
+    if (!text) {
+      return new Response(
+        JSON.stringify({ error: "Missing text" }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      )
+    }
+
+    const openaiResponse = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${env.OPENAI_API_KEY}`
+      },
+      body: JSON.stringify({
+        model: "gpt-4o-mini",
+        messages: [
+          {
+            role: "system",
+            content: "Classify the entry and return JSON describing intent."
+          },
+          {
+            role: "user",
+            content: text
+          }
+        ]
+      })
+    })
+
+    if (!openaiResponse.ok) {
+      return new Response(
+        JSON.stringify({ error: "OpenAI request failed" }),
+        { status: 500, headers: { "Content-Type": "application/json" } }
+      )
+    }
+
+    const data = await openaiResponse.json()
+
+    return new Response(
+      JSON.stringify(data),
+      { headers: { "Content-Type": "application/json" } }
+    )
+
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ error: "Server error", details: error.message }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    )
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,5 @@
+{
+  "name": "memory-cue",
+  "compatibility_date": "2026-03-14",
+  "pages_build_output_dir": "./"
+}


### PR DESCRIPTION
### Motivation
- Migrate the serverless API from Vercel to Cloudflare Pages Functions while preserving the existing frontend contract at `/api/parse-entry`.
- Preserve the original parsing behavior and OpenAI interaction so the app's behavior remains unchanged.
- Ensure the project can be deployed to Pages by adding a minimal Wrangler configuration.

### Description
- Added `functions/api/parse-entry.js` which exports `onRequestPost(context)` and implements the provided request parsing, `text` validation, OpenAI call to `/v1/chat/completions`, and JSON response/error handling.
- Added `wrangler.jsonc` in the repo root with the requested Pages configuration (`name`, `compatibility_date`, `pages_build_output_dir`).
- Left the existing Vercel endpoint `api/parse-entry.js` in place and prepended the comment `// Deprecated: replaced by Cloudflare Pages Function` to mark it deprecated.
- Did not modify any frontend files; frontend code continues to call `/api/parse-entry` unchanged.

### Testing
- Verified files exist with `test -f functions/api/parse-entry.js && test -f wrangler.jsonc` which returned `ok`.
- Confirmed frontend still references `/api/parse-entry` via repository search (`rg 'api/parse-entry'`) and inspected call sites in `src/ai/inboxProcessor.js`, `js/services/capture-service.js`, `src/chat/chatManager.js`, and `js/reminders.js`.
- Ran `npm run build` which completed successfully and produced the `dist` output.
- Ran `npm run verify` which executed `scripts/verify-build.mjs` and reported that build verification passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b53fed9d288324acc59c1fa65f3b8c)