### PR TITLE
Add heuristic and behavior-learning layer to intentRouter to reduce AI calls

### DIFF
--- a/src/ai/inboxProcessor.js
+++ b/src/ai/inboxProcessor.js
@@ -1,7 +1,7 @@
 import { saveNote } from '../services/adapters/notePersistenceAdapter.js';
 import { ensureFolderExistsByName } from '../../js/modules/ai-capture-save.js';
 import { suggestNotebookAndTags } from '../services/taggingEngine.js';
-import { routeIntent } from '../services/intentRouter.js';
+import { classifyIntentLocally, routeIntent } from '../services/intentRouter.js';
 
 const normalizeText = (value) => {
   if (typeof value !== 'string') {
@@ -106,20 +106,28 @@ export const processInbox = async (entries = [], options = {}) => {
       continue;
     }
 
-    let parsedEntry = getExistingParsedEntry(entry, text);
-    if (!parsedEntry) {
-      try {
-        parsedEntry = await parseEntry(text);
-      } catch (error) {
-        console.warn('[inbox-processor] parse-entry failed, leaving inbox item unchanged', error);
-        continue;
-      }
-    }
-
     const hints = {
       source: typeof entry?.source === 'string' ? entry.source : 'inbox',
       entryId: entry?.id != null ? String(entry.id) : '',
+      entryPoint: 'inbox.processInbox',
+      capturedAt: Date.now(),
     };
+
+    let parsedEntry = getExistingParsedEntry(entry, text);
+    if (!parsedEntry) {
+      const localDecision = classifyIntentLocally(text, hints);
+      if (localDecision) {
+        parsedEntry = localDecision.parsedEntry;
+      } else {
+        try {
+          parsedEntry = await parseEntry(text);
+        } catch (error) {
+          console.warn('[inbox-processor] parse-entry failed, leaving inbox item unchanged', error);
+          continue;
+        }
+      }
+    }
+
     const decision = routeIntent(parsedEntry, text, hints);
 
     if (decision.decisionType === 'persist_inbox' || decision.decisionType === 'query') {

--- a/src/chat/chatManager.js
+++ b/src/chat/chatManager.js
@@ -2,7 +2,7 @@ import { addMessage } from './messageStore.js';
 import { executeCommand } from '../core/commandEngine.js';
 import { saveInboxEntry } from '../services/inboxService.js';
 import { suggestNotebookAndTags } from '../services/taggingEngine.js';
-import { createChatIntentInput, routeIntent } from '../services/intentRouter.js';
+import { classifyIntentLocally, createChatIntentInput, routeIntent } from '../services/intentRouter.js';
 import { ensureFolderExistsByName } from '../../js/modules/ai-capture-save.js';
 import { saveNote } from '../services/adapters/notePersistenceAdapter.js';
 
@@ -323,7 +323,20 @@ export const handleChatMessage = async (text, dependencies = {}) => {
 
   addMessage(createMessage('user', userText));
 
-  const parsed = await parseEntry(userText);
+  // Run deterministic heuristics first so /api/parse-entry remains a fallback.
+  const localDecision = classifyIntentLocally(userText, {
+    source: 'chat',
+    entryPoint: 'chat.handleChatMessage',
+    capturedAt: Date.now(),
+  });
+
+  let parsed;
+  if (localDecision) {
+    parsed = localDecision.parsedEntry;
+  } else {
+    parsed = await parseEntry(userText);
+  }
+
   const routeResult = await processParsedEntry(parsed, userText, dependencies);
   const response = normalizeRouteResult(routeResult);
 

--- a/src/services/intentRouter.js
+++ b/src/services/intentRouter.js
@@ -1,4 +1,187 @@
 const NOTEBOOK_CAPTURE_PATTERN = /(meeting notes|lesson idea|remember\b|notes?\s+from|journal|plan\b|scored\b)/i;
+const REMINDER_KEYWORDS = ['remind', 'tomorrow', 'tonight', 'later', 'buy', 'pick up'];
+const NOTE_KEYWORDS = ['idea', 'note', 'remember', 'lesson'];
+const DRILL_KEYWORDS = ['drill', 'training', 'coaching'];
+const QUESTION_PREFIXES = ['what', 'when', 'how', 'where'];
+const INTENT_PATTERNS_KEY = 'memoryCueIntentPatterns';
+const MAX_STORED_PATTERNS = 50;
+
+const getPatternStorage = () => (typeof localStorage !== 'undefined' ? localStorage : null);
+
+const tokenizeText = (rawText) => {
+  const normalized = typeof rawText === 'string' ? rawText.trim().toLowerCase() : '';
+  if (!normalized) {
+    return [];
+  }
+
+  return Array.from(new Set(
+    normalized
+      .replace(/[^a-z0-9\s]/g, ' ')
+      .split(/\s+/)
+      .map((token) => token.trim())
+      .filter((token) => token.length >= 3),
+  ));
+};
+
+const readIntentPatterns = () => {
+  const storage = getPatternStorage();
+  if (!storage) {
+    return [];
+  }
+
+  try {
+    const raw = storage.getItem(INTENT_PATTERNS_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.warn('[intent-router] Unable to read intent patterns from localStorage.', error);
+    return [];
+  }
+};
+
+const writeIntentPatterns = (patterns) => {
+  const storage = getPatternStorage();
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.setItem(INTENT_PATTERNS_KEY, JSON.stringify(patterns.slice(0, MAX_STORED_PATTERNS)));
+  } catch (error) {
+    console.warn('[intent-router] Unable to persist intent patterns to localStorage.', error);
+  }
+};
+
+const learnIntentPattern = (rawText, decisionType) => {
+  const tokens = tokenizeText(rawText).slice(0, 5);
+  if (!tokens.length || !decisionType) {
+    return;
+  }
+
+  const existing = readIntentPatterns();
+  const now = Date.now();
+  const updates = tokens.map((token) => ({ token, decisionType, capturedAt: now }));
+  writeIntentPatterns([...updates, ...existing]);
+};
+
+const countKeywordMatches = (normalizedText, keywords) => keywords.reduce((count, keyword) => (
+  normalizedText.includes(keyword) ? count + 1 : count
+), 0);
+
+const getLearnedBias = (tokens) => {
+  const bias = {
+    persist_reminder: 0,
+    persist_note: 0,
+    query: 0,
+  };
+
+  if (!tokens.length) {
+    return bias;
+  }
+
+  const patterns = readIntentPatterns();
+  patterns.forEach((pattern) => {
+    if (!tokens.includes(pattern?.token)) {
+      return;
+    }
+
+    if (pattern?.decisionType === 'persist_reminder') {
+      bias.persist_reminder += 1;
+    } else if (pattern?.decisionType === 'persist_note') {
+      bias.persist_note += 1;
+    } else if (pattern?.decisionType === 'query') {
+      bias.query += 1;
+    }
+  });
+
+  return bias;
+};
+
+const createHeuristicParsedEntry = (type, text, hints = {}) => ({
+  type,
+  title: text,
+  tags: [],
+  reminderDate: null,
+  metadata: {
+    source: hints?.source,
+    entryPoint: hints?.entryPoint,
+    capturedAt: hints?.capturedAt,
+  },
+});
+
+/**
+ * Heuristic-first routing to reduce /api/parse-entry usage.
+ * If we can classify with high confidence locally, we skip AI parsing.
+ */
+export const classifyIntentLocally = (rawText, hints = {}) => {
+  const text = typeof rawText === 'string' ? rawText.trim() : '';
+  const normalized = text.toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+
+  const startsWithQuestion = QUESTION_PREFIXES
+    .some((prefix) => normalized.startsWith(`${prefix} `));
+
+  const tokens = tokenizeText(normalized);
+  const learnedBias = getLearnedBias(tokens);
+
+  const reminderScore = countKeywordMatches(normalized, REMINDER_KEYWORDS) + learnedBias.persist_reminder;
+  const noteScore = countKeywordMatches(normalized, NOTE_KEYWORDS) + learnedBias.persist_note;
+  const drillScore = countKeywordMatches(normalized, DRILL_KEYWORDS);
+  const questionScore = (text.endsWith('?') ? 2 : 0) + (startsWithQuestion ? 1 : 0) + learnedBias.query;
+
+  const scored = [
+    { kind: 'reminder', score: reminderScore },
+    { kind: 'drill', score: drillScore },
+    { kind: 'note', score: noteScore },
+    { kind: 'question', score: questionScore },
+  ].sort((a, b) => b.score - a.score);
+
+  const [top, next] = scored;
+  const isConfident = top.score >= 1 && top.score > (next?.score || 0);
+  if (!isConfident) {
+    return null;
+  }
+
+  if (top.kind === 'reminder') {
+    const parsedEntry = createHeuristicParsedEntry('reminder', text, hints);
+    const decision = {
+      decisionType: 'persist_reminder',
+      parsedType: 'reminder',
+      text,
+      parsedEntry,
+      hints,
+    };
+    learnIntentPattern(text, decision.decisionType);
+    return decision;
+  }
+
+  if (top.kind === 'drill' || top.kind === 'note') {
+    const parsedType = top.kind === 'drill' ? 'drill' : 'note';
+    const parsedEntry = createHeuristicParsedEntry(parsedType, text, hints);
+    const decision = {
+      decisionType: 'persist_note',
+      parsedType,
+      text,
+      parsedEntry,
+      hints,
+    };
+    learnIntentPattern(text, decision.decisionType);
+    return decision;
+  }
+
+  const parsedEntry = createHeuristicParsedEntry('question', text, hints);
+  const decision = {
+    decisionType: 'query',
+    parsedType: 'question',
+    text,
+    parsedEntry,
+    hints,
+  };
+  learnIntentPattern(text, decision.decisionType);
+  return decision;
+};
 
 const normalizeType = (parsedType, rawText) => {
   const normalizedType = typeof parsedType === 'string' ? parsedType.trim().toLowerCase() : '';
@@ -40,13 +223,15 @@ export const routeIntent = (parsedEntry, rawText, hints = {}) => {
   const isQuestion = parsedType === 'question' || text.endsWith('?');
 
   if (parsedType === 'reminder') {
-    return {
+    const decision = {
       decisionType: 'persist_reminder',
       parsedType,
       text,
       parsedEntry: parsed,
       hints,
     };
+    learnIntentPattern(text, decision.decisionType);
+    return decision;
   }
 
   if (
@@ -56,7 +241,7 @@ export const routeIntent = (parsedEntry, rawText, hints = {}) => {
     || parsedType === 'task'
     || notebookHeuristic
   ) {
-    return {
+    const decision = {
       decisionType: 'persist_note',
       parsedType,
       text,
@@ -64,16 +249,20 @@ export const routeIntent = (parsedEntry, rawText, hints = {}) => {
       notebookHeuristic,
       hints,
     };
+    learnIntentPattern(text, decision.decisionType);
+    return decision;
   }
 
   if (isQuestion) {
-    return {
+    const decision = {
       decisionType: 'query',
       parsedType,
       text,
       parsedEntry: parsed,
       hints,
     };
+    learnIntentPattern(text, decision.decisionType);
+    return decision;
   }
 
   return {


### PR DESCRIPTION
## Summary
- added a heuristic-first classifier in `src/services/intentRouter.js` that detects reminder/note/drill/question intents from keyword and question patterns before AI parsing
- added a lightweight behavior-learning layer backed by `localStorage` key `memoryCueIntentPatterns` to bias future local classifications
- preserved canonical routing outputs (`persist_reminder`, `persist_note`, `persist_inbox`, `query`) and kept metadata context (`source`, `entryPoint`, `capturedAt`) on heuristic parsed entries
- updated chat and inbox flows to call `/api/parse-entry` only when no confident local rule match is found

## Files changed
- `src/services/intentRouter.js`
- `src/chat/chatManager.js`
- `src/ai/inboxProcessor.js`

## Notes
- existing `routeIntent` behavior is preserved and now also feeds pattern learning for non-inbox decisions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5cbf165748324aca57de308e16fbc)