### PR TITLE
Wire mobile sign-in buttons through shared Supabase auth flow

### DIFF
--- a/js/supabase-auth.js
+++ b/js/supabase-auth.js
@@ -332,6 +332,24 @@ function bindSignOutButtons(supabase, elements) {
   });
 }
 
+function bindSignInButtons(elements) {
+  elements.signInButtons.forEach((button) => {
+    if (!(button instanceof HTMLElement) || button.dataset.supabaseAuthBound === 'true') {
+      return;
+    }
+
+    button.dataset.supabaseAuthBound = 'true';
+
+    button.addEventListener('click', async () => {
+      try {
+        await startSignInFlow();
+      } catch (error) {
+        console.error('[supabase] Sign-in failed.', error);
+      }
+    });
+  });
+}
+
 export function initSupabaseAuth(options = {}) {
   const {
     supabase: suppliedSupabase,
@@ -367,6 +385,7 @@ export function initSupabaseAuth(options = {}) {
 
   bindAuthForms(supabase, elements);
   if (!disableButtonBinding) {
+    bindSignInButtons(elements);
     bindSignOutButtons(supabase, elements);
   }
 
@@ -428,4 +447,3 @@ export function getSupabaseAuthElements(selectors = {}, scope = document) {
     ...selectors,
   }, scope);
 }
-

--- a/mobile.js
+++ b/mobile.js
@@ -1,6 +1,6 @@
 import { initViewportHeight } from './js/modules/viewport-height.js';
 import { initReminders } from './js/reminders.js';
-import { initSupabaseAuth } from './js/supabase-auth.js';
+import { initSupabaseAuth, startSignInFlow } from './js/supabase-auth.js';
 import {
   loadAllNotes,
   saveAllNotes,
@@ -4100,8 +4100,10 @@ function wireMobileNotesSupabaseAuth() {
         const primarySignInBtn = document.getElementById('googleSignInBtn');
         if (primarySignInBtn instanceof HTMLElement) {
           primarySignInBtn.click();
-        } else if (typeof window.startSignInFlow === 'function') {
-          window.startSignInFlow();
+        } else {
+          startSignInFlow().catch((error) => {
+            console.error('[supabase] Sign-in failed.', error);
+          });
         }
         break;
       }


### PR DESCRIPTION
### Motivation
- Ensure mobile sign-in buttons (`#googleSignInBtn`, `#googleSignInBtnMenu`) and the overflow-menu sign-in action all invoke the same shared Supabase sign-in flow instead of relying on a `window` fallback.

### Description
- Added `bindSignInButtons(elements)` to `js/supabase-auth.js` which iterates `elements.signInButtons`, uses the existing `dataset.supabaseAuthBound` guard, attaches click handlers that call `startSignInFlow()` and log failures with `console.error`, wired the helper into `initSupabaseAuth(...)`, and updated `mobile.js` to import `startSignInFlow` and call it from the overflow menu `case 'sign-in'` when a primary sign-in button is not present.

### Testing
- Ran `npm test -- --runInBand`; the test run executed but failed due to unrelated, pre-existing test-suite issues (ESM/CommonJS VM loading errors and multiple failing suites).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5cd05be50832490fcd066afb9ae6d)