### PR TITLE
Use runtime origin for Supabase OAuth redirect to /auth/callback

### DIFF
--- a/js/supabase-auth.js
+++ b/js/supabase-auth.js
@@ -61,7 +61,15 @@ export async function startSignInFlow(options = {}) {
     const supabase = getSupabaseClient();
     if (supabase && supabase.auth) {
       if (typeof supabase.auth.signInWithOAuth === 'function') {
-        return supabase.auth.signInWithOAuth({ provider: 'google', ...options });
+        const redirectUrl = `${window.location.origin}/auth/callback`;
+        return supabase.auth.signInWithOAuth({
+          ...options,
+          provider: 'google',
+          options: {
+            ...(options?.options || {}),
+            redirectTo: redirectUrl,
+          },
+        });
       }
       if (typeof supabase.auth.signIn === 'function') {
         // legacy support
@@ -428,4 +436,3 @@ export function getSupabaseAuthElements(selectors = {}, scope = document) {
     ...selectors,
   }, scope);
 }
-


### PR DESCRIPTION
### Motivation
- Avoid hardcoded Vercel URLs by computing the OAuth redirect at runtime using the current origin and preserve existing auth-provider behavior and options.

### Description
- In `startSignInFlow` (`js/supabase-auth.js`) construct `redirectUrl` as ``${window.location.origin}/auth/callback`` and pass it to Supabase via `options: { redirectTo: redirectUrl }` when calling `supabase.auth.signInWithOAuth`.
- Merge the new redirect into any existing `options` provided by the caller (preserving `options.options`), and keep the provider set to `'google'` and existing external-handler fallbacks unchanged.

### Testing
- Ran `npm test -- --runInBand js/__tests__/mobile.auth.test.js`; the test run failed due to an existing ESM/Jest module loading issue (`SyntaxError: Cannot use import statement outside a module` in `mobile.js`), not related to this small change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5cdfba5888324bdf13b98929ae18d)