### PR TITLE
Remove fake Supabase runtime defaults

### DIFF
--- a/js/init-env.js
+++ b/js/init-env.js
@@ -1,5 +1,5 @@
 if (typeof window !== 'undefined') {
   const env = (window.__ENV = window.__ENV || {});
-  env.SUPABASE_URL = env.SUPABASE_URL || 'https://xyzcompany.supabase.co';
-  env.SUPABASE_ANON_KEY = env.SUPABASE_ANON_KEY || 'public-anon-key';
+  env.SUPABASE_URL = env.SUPABASE_URL || '';
+  env.SUPABASE_ANON_KEY = env.SUPABASE_ANON_KEY || '';
 }


### PR DESCRIPTION
### Motivation
- Avoid shipping placeholder Supabase credentials in the browser and allow real deployment env injection by leaving values empty in `window.__ENV`.

### Description
- Update `js/init-env.js` to initialize `window.__ENV` but set `env.SUPABASE_URL` and `env.SUPABASE_ANON_KEY` to empty strings instead of fake defaults, while leaving `js/supabase-client.js` behavior unchanged so it still prefers `import.meta.env.VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` and then `ENV.SUPABASE_URL`/`ENV.SUPABASE_ANON_KEY`, preserving the existing `[supabase] Missing SUPABASE_URL or SUPABASE_ANON_KEY.` error log.

### Testing
- Ran `npm test -- --runInBand`, which executed the test suite but reported multiple pre-existing failures in this environment (ESM/CommonJS test harness issues) and did not surface any new failures directly attributable to this small change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d019547c832488472bd2f0ad56eb)