### PR TITLE
Make API CORS allowlists env-configurable and add Cloudflare Pages domain

### DIFF
--- a/api/assistant-chat.ts
+++ b/api/assistant-chat.ts
@@ -1,11 +1,32 @@
 import { helpContent } from '../src/assistant/help-content.js';
 
-const ALLOWED_ORIGINS = [
-  'https://dmaher42.github.io',
-  'https://memory-cue.vercel.app',
+const LOCALHOST_ORIGINS = [
   'http://localhost:3000',
   'http://localhost:5173'
 ];
+
+function buildAllowedOrigins() {
+  const envOrigins = [
+    process.env.CORS_ALLOWED_ORIGINS,
+    process.env.CLOUDFLARE_PAGES_URL,
+    process.env.CLOUDFLARE_APP_URL,
+    process.env.APP_URL,
+    process.env.PUBLIC_APP_URL
+  ]
+    .filter(Boolean)
+    .flatMap((value) => String(value).split(','))
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
+  return Array.from(new Set([
+    'https://dmaher42.github.io',
+    'https://memory-cue.pages.dev',
+    ...envOrigins,
+    ...LOCALHOST_ORIGINS
+  ]));
+}
+
+const ALLOWED_ORIGINS = buildAllowedOrigins();
 
 function applyCors(req, res) {
   const origin = req.headers.origin;

--- a/api/capture.js
+++ b/api/capture.js
@@ -1,12 +1,33 @@
 const { addRecord } = require('./memory-store');
 const { classifyMemoryType, createStructuredMemory } = require('./memory-utils');
 
-const ALLOWED_ORIGINS = [
-  'https://dmaher42.github.io',
-  'https://memory-cue.vercel.app',
+const LOCALHOST_ORIGINS = [
   'http://localhost:3000',
   'http://localhost:5173'
 ];
+
+function buildAllowedOrigins() {
+  const envOrigins = [
+    process.env.CORS_ALLOWED_ORIGINS,
+    process.env.CLOUDFLARE_PAGES_URL,
+    process.env.CLOUDFLARE_APP_URL,
+    process.env.APP_URL,
+    process.env.PUBLIC_APP_URL
+  ]
+    .filter(Boolean)
+    .flatMap((value) => String(value).split(','))
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
+  return Array.from(new Set([
+    'https://dmaher42.github.io',
+    'https://memory-cue.pages.dev',
+    ...envOrigins,
+    ...LOCALHOST_ORIGINS
+  ]));
+}
+
+const ALLOWED_ORIGINS = buildAllowedOrigins();
 
 const MAX_INPUT_CHARS = 6000;
 

--- a/api/parse-entry.js
+++ b/api/parse-entry.js
@@ -25,12 +25,33 @@ const PARSED_ENTRY_SCHEMA = {
   required: ['type', 'title', 'tags', 'reminderDate', 'metadata']
 };
 
-const ALLOWED_ORIGINS = [
-  'https://memory-cue.vercel.app',
-  'https://dmaher42.github.io',
+const LOCALHOST_ORIGINS = [
   'http://localhost:3000',
   'http://localhost:5173'
 ];
+
+function buildAllowedOrigins() {
+  const envOrigins = [
+    process.env.CORS_ALLOWED_ORIGINS,
+    process.env.CLOUDFLARE_PAGES_URL,
+    process.env.CLOUDFLARE_APP_URL,
+    process.env.APP_URL,
+    process.env.PUBLIC_APP_URL
+  ]
+    .filter(Boolean)
+    .flatMap((value) => String(value).split(','))
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
+  return Array.from(new Set([
+    'https://dmaher42.github.io',
+    'https://memory-cue.pages.dev',
+    ...envOrigins,
+    ...LOCALHOST_ORIGINS
+  ]));
+}
+
+const ALLOWED_ORIGINS = buildAllowedOrigins();
 
 const MAX_TEXT_LENGTH = 4000;
 const PARSE_FALLBACK_STATUS = 200;

--- a/api/search.ts
+++ b/api/search.ts
@@ -1,11 +1,32 @@
 const { getAllNotes } = require('./memory-store');
 
-const ALLOWED_ORIGINS = [
-  'https://dmaher42.github.io',
-  'https://memory-cue.vercel.app',
+const LOCALHOST_ORIGINS = [
   'http://localhost:3000',
   'http://localhost:5173'
 ];
+
+function buildAllowedOrigins() {
+  const envOrigins = [
+    process.env.CORS_ALLOWED_ORIGINS,
+    process.env.CLOUDFLARE_PAGES_URL,
+    process.env.CLOUDFLARE_APP_URL,
+    process.env.APP_URL,
+    process.env.PUBLIC_APP_URL
+  ]
+    .filter(Boolean)
+    .flatMap((value) => String(value).split(','))
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
+  return Array.from(new Set([
+    'https://dmaher42.github.io',
+    'https://memory-cue.pages.dev',
+    ...envOrigins,
+    ...LOCALHOST_ORIGINS
+  ]));
+}
+
+const ALLOWED_ORIGINS = buildAllowedOrigins();
 
 function applyCors(req, res) {
   const origin = req.headers.origin;


### PR DESCRIPTION
### Motivation
- Remove hard-coded Vercel origin entries and support the Cloudflare Pages/app domain used in production while keeping localhost dev origins intact.
- Allow origins to vary by environment so production domains can be provided via env vars without changing handler contracts.

### Description
- Updated `api/assistant-chat.ts`, `api/search.ts`, `api/capture.js`, and `api/parse-entry.js` to replace the static `ALLOWED_ORIGINS` arrays with a `buildAllowedOrigins()` helper and a `LOCALHOST_ORIGINS` constant.
- `buildAllowedOrigins()` collects origins from `CORS_ALLOWED_ORIGINS` (comma-separated), `CLOUDFLARE_PAGES_URL`, `CLOUDFLARE_APP_URL`, `APP_URL`, and `PUBLIC_APP_URL`, and also includes the defaults `https://dmaher42.github.io` and `https://memory-cue.pages.dev` plus localhost entries, with trimming and deduplication.
- Preserved the existing `applyCors` function signatures and the CORS response behavior (same headers, methods, and OPTIONS handling) so handlers behave identically at runtime.
- Kept localhost origins `http://localhost:3000` and `http://localhost:5173` unchanged.

### Testing
- Ran `npm run build` which completed successfully.
- Ran `npm test -- --runInBand` which failed due to pre-existing unrelated test-suite issues in this repository (ESM/CJS loader mismatches and other failing suites); the failures are not caused by these CORS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d2d6279483249b9ede50bd8e7324)