### PR TITLE
Add OpenAI-based embedding service with capped local storage index

### DIFF
--- a/src/services/embeddingService.js
+++ b/src/services/embeddingService.js
@@ -1,0 +1,147 @@
+const EMBEDDING_STORAGE_KEY = 'memoryCue:embeddings';
+const MAX_STORED_EMBEDDINGS = 200;
+const OPENAI_EMBEDDING_MODEL = 'text-embedding-3-small';
+
+const normalizeText = (value) => (typeof value === 'string' ? value.trim() : '');
+
+const normalizeEmbedding = (embedding) => {
+  if (!Array.isArray(embedding)) {
+    return [];
+  }
+
+  return embedding
+    .map((value) => Number(value))
+    .filter((value) => Number.isFinite(value));
+};
+
+const getStoredEmbeddings = () => {
+  if (typeof localStorage === 'undefined') {
+    return [];
+  }
+
+  try {
+    const raw = localStorage.getItem(EMBEDDING_STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.warn('[embedding-service] Failed to read stored embeddings', error);
+    return [];
+  }
+};
+
+const persistEmbeddings = (records) => {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+
+  try {
+    localStorage.setItem(EMBEDDING_STORAGE_KEY, JSON.stringify(records));
+  } catch (error) {
+    console.warn('[embedding-service] Failed to persist embeddings', error);
+  }
+};
+
+const cosineSimilarity = (left, right) => {
+  if (!Array.isArray(left) || !Array.isArray(right) || !left.length || !right.length) {
+    return 0;
+  }
+
+  const dimensions = Math.min(left.length, right.length);
+  let dotProduct = 0;
+  let leftMagnitude = 0;
+  let rightMagnitude = 0;
+
+  for (let index = 0; index < dimensions; index += 1) {
+    const leftValue = Number(left[index]);
+    const rightValue = Number(right[index]);
+
+    if (!Number.isFinite(leftValue) || !Number.isFinite(rightValue)) {
+      continue;
+    }
+
+    dotProduct += leftValue * rightValue;
+    leftMagnitude += leftValue * leftValue;
+    rightMagnitude += rightValue * rightValue;
+  }
+
+  if (leftMagnitude <= 0 || rightMagnitude <= 0) {
+    return 0;
+  }
+
+  return dotProduct / (Math.sqrt(leftMagnitude) * Math.sqrt(rightMagnitude));
+};
+
+export const createEmbedding = async (text) => {
+  const normalizedText = normalizeText(text);
+  if (!normalizedText) {
+    return [];
+  }
+
+  const openAiApiKey = typeof process !== 'undefined' ? process.env?.OPENAI_API_KEY : '';
+  if (!openAiApiKey) {
+    console.warn('[embedding-service] OPENAI_API_KEY is not configured');
+    return [];
+  }
+
+  const response = await fetch('https://api.openai.com/v1/embeddings', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${openAiApiKey}`,
+    },
+    body: JSON.stringify({
+      model: OPENAI_EMBEDDING_MODEL,
+      input: normalizedText,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Embedding request failed (${response.status})`);
+  }
+
+  const data = await response.json();
+  const embedding = data?.data?.[0]?.embedding;
+  return normalizeEmbedding(embedding);
+};
+
+export const storeEmbedding = (memoryId, embedding) => {
+  const normalizedMemoryId = normalizeText(memoryId);
+  const normalizedEmbedding = normalizeEmbedding(embedding);
+
+  if (!normalizedMemoryId || !normalizedEmbedding.length) {
+    return null;
+  }
+
+  const timestamp = Date.now();
+  const records = getStoredEmbeddings().filter((record) => normalizeText(record?.memoryId) !== normalizedMemoryId);
+
+  records.unshift({
+    memoryId: normalizedMemoryId,
+    embedding: normalizedEmbedding,
+    createdAt: timestamp,
+  });
+
+  const limitedRecords = records.slice(0, MAX_STORED_EMBEDDINGS);
+  persistEmbeddings(limitedRecords);
+
+  return limitedRecords[0];
+};
+
+export const searchEmbeddings = (queryEmbedding) => {
+  const normalizedQuery = normalizeEmbedding(queryEmbedding);
+  if (!normalizedQuery.length) {
+    return [];
+  }
+
+  return getStoredEmbeddings()
+    .map((record) => ({
+      memoryId: normalizeText(record?.memoryId),
+      score: cosineSimilarity(normalizedQuery, normalizeEmbedding(record?.embedding)),
+    }))
+    .filter((result) => result.memoryId)
+    .sort((left, right) => right.score - left.score);
+};


### PR DESCRIPTION
### Motivation

- Provide a small, local embedding index using the same OpenAI provider approach used elsewhere in the codebase so memories can be semantically searched without introducing a new vendor or backend.
- Persist embeddings client-side with a bounded size to avoid unbounded growth in localStorage.

### Description

- Add `src/services/embeddingService.js` which exposes `createEmbedding(text)`, `storeEmbedding(memoryId, embedding)`, and `searchEmbeddings(queryEmbedding)`.
- Implement `createEmbedding` to call OpenAI `/v1/embeddings` with model `text-embedding-3-small` and API key access pattern aligned to other OpenAI calls (`process.env.OPENAI_API_KEY`), returning a normalized vector or empty array on missing input/key.
- Implement `storeEmbedding` to normalize inputs, replace any existing record for the same `memoryId`, persist entries under `memoryCue:embeddings` in `localStorage`, and cap the stored set to the newest `MAX_STORED_EMBEDDINGS = 200` records.
- Implement `searchEmbeddings` to compute cosine similarity between a query embedding and stored vectors, returning ranked matches as `{ memoryId, score }`, and include defensive parsing/persisting and input normalization throughout.

### Testing

- Ran the project test suite with `npm test -- --runInBand`; the test run completed but reported test suite failures (15 failed, 11 passed; overall 33 failed, 51 passed) that are pre-existing and related to ESM/import issues in multiple test suites rather than this new file.
- No new automated tests were added for the embedding service in this change. 
- The embedding service code includes runtime guards and logs for missing `localStorage` and missing `OPENAI_API_KEY` to allow safe execution during local development and test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b631dd61f48324ab725b7745adb9d2)