### PR TITLE
Prefer redirect on mobile and add popup→redirect fallback for Google sign-in

### DIFF
--- a/js/supabase-auth.js
+++ b/js/supabase-auth.js
@@ -34,34 +34,46 @@ export function setAuthContext(ctx = {}) {
  */
 export async function startSignInFlow(options = {}) {
   try {
+    const prefersRedirect = Boolean(options?.preferRedirect)
+      || (typeof window !== 'undefined'
+        && typeof window.matchMedia === 'function'
+        && window.matchMedia('(max-width: 768px)').matches);
+
     // Prefer supplied handlers
     if (
       _externalAuthContext &&
-      typeof _externalAuthContext.signInWithPopup === 'function' &&
       _externalAuthContext.auth &&
       typeof _externalAuthContext.GoogleAuthProvider === 'function'
     ) {
-      return _externalAuthContext.signInWithPopup(
-        _externalAuthContext.auth,
-        new _externalAuthContext.GoogleAuthProvider()
-      );
-    }
-    if (
-      _externalAuthContext &&
-      typeof _externalAuthContext.signInWithRedirect === 'function' &&
-      _externalAuthContext.auth &&
-      typeof _externalAuthContext.GoogleAuthProvider === 'function'
-    ) {
-      return _externalAuthContext.signInWithRedirect(
-        _externalAuthContext.auth,
-        new _externalAuthContext.GoogleAuthProvider()
-      );
+      const provider = new _externalAuthContext.GoogleAuthProvider();
+      if (prefersRedirect && typeof _externalAuthContext.signInWithRedirect === 'function') {
+        return _externalAuthContext.signInWithRedirect(_externalAuthContext.auth, provider);
+      }
+
+      if (typeof _externalAuthContext.signInWithPopup === 'function') {
+        try {
+          return await _externalAuthContext.signInWithPopup(_externalAuthContext.auth, provider);
+        } catch (error) {
+          const popupIssue = typeof error?.code === 'string' && [
+            'auth/popup-closed-by-user',
+            'auth/popup-blocked',
+            'auth/cancelled-popup-request',
+          ].includes(error.code);
+          if (!popupIssue || typeof _externalAuthContext.signInWithRedirect !== 'function') {
+            throw error;
+          }
+        }
+      }
+
+      if (typeof _externalAuthContext.signInWithRedirect === 'function') {
+        return _externalAuthContext.signInWithRedirect(_externalAuthContext.auth, provider);
+      }
     }
     // Fallback to Supabase client if available
     const supabase = getSupabaseClient();
     if (supabase && supabase.auth) {
       if (typeof supabase.auth.signInWithOAuth === 'function') {
-        const redirectUrl = `${window.location.origin}/auth/callback`;
+        const redirectUrl = `${window.location.origin}${window.location.pathname}${window.location.search}`;
         return supabase.auth.signInWithOAuth({
           ...options,
           provider: 'google',


### PR DESCRIPTION
### Motivation
- Mobile browsers often block or immediately close popup-based OAuth flows, causing the sign-in popup to vanish; this change aims to route mobile users to a redirect flow and provide robust fallback behavior.

### Description
- Updated `startSignInFlow` in `js/supabase-auth.js` to detect mobile-sized viewports (or accept `options.preferRedirect`) and prefer redirect-based sign-in in those cases.
- Reworked external auth handling so it attempts a popup on non-mobile, catches common popup-related errors (`popup-closed-by-user`, `popup-blocked`, `cancelled-popup-request`) and falls back to a redirect when available.
- Changed Supabase OAuth `redirectTo` value from the hard-coded `/auth/callback` to the current page URL (`window.location.origin + window.location.pathname + window.location.search`) to better match deployments without a dedicated callback route.

### Testing
- Ran the build with `npm run build`, which completed successfully.
- Ran the unit tests for `js/__tests__/mobile.auth.test.js` and `js/__tests__/reminders.auth.test.js` with `npm test`, which failed due to the repository's existing module-format test harness error (`Cannot use import statement outside a module`), not caused by the auth change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b63239913c83248f5f36ec104b6236)