### PR TITLE
Add best-effort async memory save after capture decision persistence

### DIFF
--- a/js/services/capture-service.js
+++ b/js/services/capture-service.js
@@ -2,6 +2,7 @@ import { saveNote } from '../../src/services/adapters/notePersistenceAdapter.js'
 import { generateTags } from '../../src/ai/tagGenerator.js';
 import { routeIntent } from '../../src/services/intentRouter.js';
 import * as reminderService from '../../src/services/reminderService.js';
+import * as memoryService from '../../src/services/memoryService.js';
 import {
   getInboxEntries,
   saveInboxEntry as saveInboxEntryCanonical,
@@ -156,19 +157,58 @@ const persistReminderDecision = async (text, parsedEntry, context) => {
 };
 
 const executeDecision = async (decision, text, parsedEntry, context) => {
+  const intentType = typeof decision?.decisionType === 'string' ? decision.decisionType : 'persist_inbox';
+
+  const enqueueMemorySave = (savedEntry) => {
+    if (!savedEntry) {
+      return;
+    }
+
+    const resolvedType =
+      intentType === 'persist_reminder'
+        ? 'reminder'
+        : intentType === 'persist_note'
+          ? 'note'
+          : 'inbox';
+
+    Promise.resolve(memoryService.saveMemory({
+      text,
+      type: resolvedType,
+      tags: Array.isArray(parsedEntry?.tags) ? parsedEntry.tags : generateTags(text),
+      source: context.source,
+      entryPoint: context.entryPoint,
+      metadata: {
+        source: context.source,
+        entryPoint: context.entryPoint,
+        capturedAt: context.capturedAt,
+        intentType,
+      },
+    })).catch((error) => {
+      console.warn('[capture-service] async memory save failed', error);
+    });
+  };
+
   if (!decision || typeof decision !== 'object') {
-    return persistInboxDecision(text, parsedEntry, context);
+    const savedEntry = persistInboxDecision(text, parsedEntry, context);
+    enqueueMemorySave(savedEntry);
+    return savedEntry;
   }
 
   if (decision.decisionType === 'persist_reminder') {
-    return persistReminderDecision(text, parsedEntry, context);
+    const savedEntry = await persistReminderDecision(text, parsedEntry, context);
+    enqueueMemorySave(savedEntry);
+    return savedEntry;
   }
 
   if (decision.decisionType === 'persist_note') {
-    return persistNoteDecision(text, parsedEntry, context);
+    const savedEntry = persistNoteDecision(text, parsedEntry, context);
+    enqueueMemorySave(savedEntry);
+    return savedEntry;
   }
 
-  return persistInboxDecision(text, parsedEntry, context);
+  const savedEntry = persistInboxDecision(text, parsedEntry, context);
+  enqueueMemorySave(savedEntry);
+  return savedEntry;
 };
 
 export const captureInput = async (text, source = 'capture') => {


### PR DESCRIPTION
### Motivation
- Ensure captures that are routed/persisted also enqueue a best-effort memory index/save so memories can be surfaced by the memory service without blocking the capture UX. 
- Preserve existing persistence behavior and UX by making the memory save strictly non-blocking and best-effort.

### Description
- Import `memoryService` into `js/services/capture-service.js` and derive `intentType` from the routing decision inside `executeDecision`.
- Add an `enqueueMemorySave` helper that maps the decision to a memory `type` and calls `memoryService.saveMemory(...)` with a payload including `text`, `type`, `tags`, `source`, `entryPoint`, and `metadata` containing `source`, `entryPoint`, `capturedAt`, and `intentType`.
- Invoke `enqueueMemorySave` after each successful persistence path (note, reminder, inbox) and after the fallback inbox persistence, passing through the original saved value as the return value.
- Make the async call strictly fire-and-forget by wrapping it in `Promise.resolve(...).catch(...)` and logging failures with `console.warn`, leaving existing return values and failure behavior unchanged, and leaving `convertInboxToNote` untouched.

### Testing
- Ran the test command `npm test -- --runInBand` to validate behavior; test run completed but the suite has unrelated failures and is not green: `26` total suites with `11` passed and `15` failed, and `84` tests with `51` passed and `33` failed.
- The failures appear to be pre-existing unrelated issues (ESM/vm import handling and other assertions) and not specific to the capture change; no new test files were added or modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6328e54788324a65554916fde5b7b)