### PR TITLE
Add local embeddingService with OpenAI embeddings, capped storage, and cosine search

### DIFF
--- a/src/services/embeddingService.js
+++ b/src/services/embeddingService.js
@@ -14,6 +14,8 @@ const normalizeEmbedding = (embedding) => {
     .filter((value) => Number.isFinite(value));
 };
 
+const getOpenAiApiKey = () => (typeof process !== 'undefined' ? process.env?.OPENAI_API_KEY : '');
+
 const getStoredEmbeddings = () => {
   if (typeof localStorage === 'undefined') {
     return [];
@@ -26,7 +28,17 @@ const getStoredEmbeddings = () => {
     }
 
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed
+      .map((record) => ({
+        memoryId: normalizeText(record?.memoryId),
+        embedding: normalizeEmbedding(record?.embedding),
+        createdAt: Number(record?.createdAt) || 0,
+      }))
+      .filter((record) => record.memoryId && record.embedding.length);
   } catch (error) {
     console.warn('[embedding-service] Failed to read stored embeddings', error);
     return [];
@@ -81,7 +93,7 @@ export const createEmbedding = async (text) => {
     return [];
   }
 
-  const openAiApiKey = typeof process !== 'undefined' ? process.env?.OPENAI_API_KEY : '';
+  const openAiApiKey = getOpenAiApiKey();
   if (!openAiApiKey) {
     console.warn('[embedding-service] OPENAI_API_KEY is not configured');
     return [];
@@ -125,7 +137,9 @@ export const storeEmbedding = (memoryId, embedding) => {
     createdAt: timestamp,
   });
 
-  const limitedRecords = records.slice(0, MAX_STORED_EMBEDDINGS);
+  const limitedRecords = records
+    .sort((left, right) => (Number(right?.createdAt) || 0) - (Number(left?.createdAt) || 0))
+    .slice(0, MAX_STORED_EMBEDDINGS);
   persistEmbeddings(limitedRecords);
 
   return limitedRecords[0];


### PR DESCRIPTION
### Motivation
- Provide a small client-side embedding helper set (`createEmbedding`, `storeEmbedding`, `searchEmbeddings`) that follows the existing OpenAI provider style used elsewhere and lets the app persist and query semantic vectors locally while preventing unbounded storage growth. 
- No AGENTS skills were used because this change is a focused code addition to implement the requested service.

### Description
- Added `createEmbedding(text)` which calls OpenAI `POST /v1/embeddings` with model `text-embedding-3-small` and returns a normalized embedding or an empty array when no API key is configured. 
- Added `storeEmbedding(memoryId, embedding)` which normalizes inputs, writes records to `localStorage` under key `memoryCue:embeddings`, and enforces a cap by sorting by `createdAt` and keeping the newest `MAX_STORED_EMBEDDINGS`. 
- Added `searchEmbeddings(queryEmbedding)` which computes cosine similarity against stored records and returns ranked results as `{ memoryId, score }` sorted highest-first. 
- Added storage sanitization and small helpers (`getOpenAiApiKey`, embedding/text normalizers) so only valid `{ memoryId, embedding, createdAt }` records are retained and used.

### Testing
- Ran `npm run build` which completed successfully. 
- Ran `npm test -- --runInBand` and observed failures unrelated to this change (pre-existing baseline test issues including ESM parsing errors across multiple suites), so unit tests did not pass end-to-end in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b684342b8c8324ac38fc4d13c34260)