### PR TITLE
Standardize authentication on Firebase and remove Supabase auth layer

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -1,7 +1,6 @@
 import { setAuthContext, startSignInFlow, startSignOutFlow } from './supabase-auth.js';
 import { captureInput, getInboxEntries } from './services/capture-service.js';
 import { createReminder as createReminderViaService, setReminderCreationHandler, buildReminderPayload } from '../src/services/reminderService.js';
-import { getSupabaseClient } from './supabase-client.js';
 import { deleteReminder, syncReminders, upsertReminder } from '../src/services/supabaseSyncService.js';
 import { createAndSaveNote } from './modules/notes-storage.js';
 
@@ -4190,6 +4189,7 @@ export async function initReminders(sel = {}) {
     authReady,
     auth,
     GoogleAuthProvider,
+    onAuthStateChanged,
     signInWithPopup,
     signInWithRedirect,
     signOut,
@@ -4229,12 +4229,13 @@ export async function initReminders(sel = {}) {
     googleSignOutBtns.forEach((btn) => wireAuthButton(btn, startSignOutFlow));
   }
 
-  const supabase = getSupabaseClient();
-  if (supabase && supabase.auth && typeof supabase.auth.onAuthStateChange === 'function') {
-    supabase.auth.onAuthStateChange(async (_event, session) => {
-      const user = session?.user || null;
+  if (authReady && typeof onAuthStateChanged === 'function') {
+    onAuthStateChanged(auth, async (user) => {
       if (user) {
-        userId = user.id;
+        userId = user.uid;
+        if (typeof window !== 'undefined') {
+          window.__MEMORY_CUE_AUTH_USER_ID = user.uid;
+        }
         renderSyncIndicator('online');
         googleSignInBtns.forEach((btn) => btn.classList.add('hidden'));
         googleSignOutBtns.forEach((btn) => btn.classList.remove('hidden'));
@@ -4242,17 +4243,21 @@ export async function initReminders(sel = {}) {
         await setupSupabaseSync();
         await migrateOfflineRemindersIfNeeded();
       } else {
+        if (typeof window !== 'undefined') {
+          window.__MEMORY_CUE_AUTH_USER_ID = '';
+        }
         applySignedOutState();
       }
     });
-    supabase.auth.getSession().then(async ({ data }) => {
-      const user = data?.session?.user || null;
-      if (user) {
-        userId = user.id;
-        renderSyncIndicator('online');
-        await setupSupabaseSync();
+    const initialUser = auth?.currentUser || null;
+    if (initialUser) {
+      userId = initialUser.uid;
+      if (typeof window !== 'undefined') {
+        window.__MEMORY_CUE_AUTH_USER_ID = initialUser.uid;
       }
-    }).catch(() => {});
+      renderSyncIndicator('online');
+      await setupSupabaseSync();
+    }
   } else {
     applySignedOutState();
   }

--- a/js/supabase-auth.js
+++ b/js/supabase-auth.js
@@ -1,5 +1,3 @@
-import { getSupabaseClient } from './supabase-client.js';
-
 // Module-level external auth context (populated by callers such as reminders.js)
 let _externalAuthContext = {
   authReady: false,
@@ -9,6 +7,7 @@ let _externalAuthContext = {
   signInWithRedirect: null,
   signOut: null,
   toast: null,
+  onAuthStateChanged: null,
 };
 
 /**
@@ -29,7 +28,6 @@ export function setAuthContext(ctx = {}) {
  * Start a sign-in flow.
  * Preference order:
  * - If an external handler (signInWithPopup or signInWithRedirect) was supplied via setAuthContext, use it.
- * - Fallback to the Supabase client (getSupabaseClient()) when available.
  * - Resolves null when no auth facilities are available.
  */
 export async function startSignInFlow(options = {}) {
@@ -69,25 +67,6 @@ export async function startSignInFlow(options = {}) {
         return _externalAuthContext.signInWithRedirect(_externalAuthContext.auth, provider);
       }
     }
-    // Fallback to Supabase client if available
-    const supabase = getSupabaseClient();
-    if (supabase && supabase.auth) {
-      if (typeof supabase.auth.signInWithOAuth === 'function') {
-        const redirectUrl = `${window.location.origin}${window.location.pathname}${window.location.search}`;
-        return supabase.auth.signInWithOAuth({
-          ...options,
-          provider: 'google',
-          options: {
-            ...(options?.options || {}),
-            redirectTo: redirectUrl,
-          },
-        });
-      }
-      if (typeof supabase.auth.signIn === 'function') {
-        // legacy support
-        return supabase.auth.signIn({ provider: 'google' });
-      }
-    }
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error('[supabase-auth] startSignInFlow error', err);
@@ -103,16 +82,12 @@ export async function startSignInFlow(options = {}) {
 }
 
 /**
- * Start sign-out flow. Prefer supplied handler, otherwise try supabase.auth.signOut().
+ * Start sign-out flow using the supplied Firebase signOut handler.
  */
 export async function startSignOutFlow() {
   try {
     if (_externalAuthContext && typeof _externalAuthContext.signOut === 'function') {
       return _externalAuthContext.signOut(_externalAuthContext.auth);
-    }
-    const supabase = getSupabaseClient();
-    if (supabase && supabase.auth && typeof supabase.auth.signOut === 'function') {
-      return supabase.auth.signOut();
     }
   } catch (err) {
     // eslint-disable-next-line no-console
@@ -301,64 +276,13 @@ export function applyAuthState(elements, { user, messages } = {}) {
   setFeedback(elements.feedbackEls, '');
 }
 
-function bindAuthForms(supabase, elements) {
-  elements.authForms.forEach((form) => {
-    if (!(form instanceof HTMLFormElement) || form.dataset.supabaseAuthBound === 'true') {
-      return;
-    }
-
-    form.dataset.supabaseAuthBound = 'true';
-
-    form.addEventListener('submit', async (event) => {
-      event.preventDefault();
-      const emailInput = elements.emailInputs.find((input) => form.contains(input))
-        || form.querySelector('input[type="email"]');
-      const email = typeof emailInput?.value === 'string' ? emailInput.value.trim() : '';
-
-      if (!email) {
-        setFeedback(elements.feedbackEls, 'Enter an email address to continue.');
-        return;
-      }
-
-      try {
-        const { error } = await supabase.auth.signInWithOtp({ email });
-        if (error) {
-          setFeedback(elements.feedbackEls, error.message || 'Unable to send magic link.');
-        } else {
-          setFeedback(elements.feedbackEls, 'Magic link sent. Check your email.');
-        }
-      } catch (error) {
-        setFeedback(elements.feedbackEls, error?.message || 'Unable to send magic link.');
-      }
-    });
-  });
-}
-
-function bindSignOutButtons(supabase, elements) {
-  elements.signOutButtons.forEach((button) => {
-    if (!(button instanceof HTMLElement) || button.dataset.supabaseAuthBound === 'true') {
-      return;
-    }
-
-    button.dataset.supabaseAuthBound = 'true';
-
-    button.addEventListener('click', async () => {
-      try {
-        await supabase.auth.signOut();
-      } catch (error) {
-        console.error('[supabase] Sign-out failed.', error);
-      }
-    });
-  });
-}
-
 function bindSignInButtons(elements) {
   elements.signInButtons.forEach((button) => {
-    if (!(button instanceof HTMLElement) || button.dataset.supabaseAuthBound === 'true') {
+    if (!(button instanceof HTMLElement) || button.dataset.authBound === 'true') {
       return;
     }
 
-    button.dataset.supabaseAuthBound = 'true';
+    button.dataset.authBound = 'true';
 
     button.addEventListener('click', async () => {
       try {
@@ -370,9 +294,27 @@ function bindSignInButtons(elements) {
   });
 }
 
+function bindSignOutButtons(elements) {
+  elements.signOutButtons.forEach((button) => {
+    if (!(button instanceof HTMLElement) || button.dataset.authBound === 'true') {
+      return;
+    }
+
+    button.dataset.authBound = 'true';
+
+    button.addEventListener('click', async () => {
+      try {
+        await startSignOutFlow();
+      } catch (error) {
+        console.error('[auth] Sign-out failed.', error);
+      }
+    });
+  });
+}
+
 export function initSupabaseAuth(options = {}) {
   const {
-    supabase: suppliedSupabase,
+    auth: suppliedAuth,
     scope = document,
     selectors: selectorOverrides = {},
     messages: messageOverrides = {},
@@ -390,61 +332,49 @@ export function initSupabaseAuth(options = {}) {
 
   applyAuthState(elements, { user: null, messages });
 
-  const supabase = suppliedSupabase
-    || getSupabaseClient()
-    || (typeof window !== 'undefined' ? window.supabase : null);
+  const auth = suppliedAuth || _externalAuthContext?.auth || null;
 
-  if (!supabase) {
+  if (!disableButtonBinding) {
+    bindSignInButtons(elements);
+    bindSignOutButtons(elements);
+  }
+
+  const cleanupFns = [];
+
+  if (!auth || typeof _externalAuthContext?.onAuthStateChanged !== 'function') {
     return {
-      supabase: null,
+      auth: null,
       elements,
       applyAuthState: (state) => applyAuthState(elements, { ...state, messages }),
       destroy() {},
     };
   }
 
-  bindAuthForms(supabase, elements);
-  if (!disableButtonBinding) {
-    bindSignInButtons(elements);
-    bindSignOutButtons(supabase, elements);
-  }
-
-  const cleanupFns = [];
-
-  const { data } = supabase.auth.onAuthStateChange((_event, session) => {
-    applyAuthState(elements, { user: session?.user ?? null, messages });
+  const unsubscribe = _externalAuthContext.onAuthStateChanged(auth, (user) => {
+    applyAuthState(elements, { user: user ?? null, messages });
     if (typeof onSessionChange === 'function') {
       try {
-        onSessionChange(session?.user ?? null, session);
+        onSessionChange(user ?? null, user ? { user } : null);
       } catch (error) {
-        console.error('[supabase] onSessionChange handler failed.', error);
+        console.error('[auth] onSessionChange handler failed.', error);
       }
     }
   });
 
-  if (data?.subscription) {
+  if (typeof unsubscribe === 'function') {
     cleanupFns.push(() => {
       try {
-        data.subscription.unsubscribe();
+        unsubscribe();
       } catch {
         /* noop */
       }
     });
   }
 
-  supabase.auth
-    .getSession()
-    .then(({ data: sessionData, error }) => {
-      if (!error) {
-        applyAuthState(elements, { user: sessionData?.session?.user ?? null, messages });
-      }
-    })
-    .catch((error) => {
-      console.error('[supabase] getSession failed.', error);
-    });
+  applyAuthState(elements, { user: auth.currentUser ?? null, messages });
 
   return {
-    supabase,
+    auth,
     elements,
     applyAuthState: (state) => applyAuthState(elements, { ...state, messages }),
     destroy() {

--- a/mobile.js
+++ b/mobile.js
@@ -3804,8 +3804,8 @@ function wireMobileNotesSupabaseAuth() {
     };
   }
 
-  // 2. Initialise Supabase auth, binding to mobile sign-in / sign-out buttons
-  const supabaseAuth = initSupabaseAuth({
+  // 2. Initialise auth, binding to mobile sign-in / sign-out buttons
+  const authController = initSupabaseAuth({
     selectors: {
       // Main sign-in button in the UI, if present
       signInButtons: ['#googleSignInBtn', '#googleSignInBtnMenu'],
@@ -3820,38 +3820,26 @@ function wireMobileNotesSupabaseAuth() {
     },
     disableButtonBinding: false,
     onSessionChange(user, session) {
-      debugLog('[notes-sync] Mobile session change', { userId: user?.id || null });
+      const normalizedUser = user && typeof user.uid === 'string' ? { ...user, id: user.uid } : null;
+      debugLog('[notes-sync] Mobile session change', { userId: normalizedUser?.id || null });
       if (notesSync && typeof notesSync.handleSessionChange === 'function') {
-        notesSync.handleSessionChange(user ?? null, session ?? null);
+        notesSync.handleSessionChange(normalizedUser, session ?? null);
       }
     },
   });
 
-  const supabase = supabaseAuth?.supabase;
-  if (!supabase || !notesSync) {
-    // If Supabase is not configured, notes will stay local; nothing else to do.
+  const auth = authController?.auth;
+  if (!notesSync) {
     return;
   }
 
-  // 3. Hand the Supabase client to the notes sync controller
-  if (typeof notesSync.setSupabaseClient === 'function') {
-    notesSync.setSupabaseClient(supabase);
+  // 3. Prime notes sync with the current Firebase session (if there is one)
+  const initialUser = auth?.currentUser;
+  if (initialUser && typeof notesSync.handleSessionChange === 'function') {
+    const normalizedUser = { ...initialUser, id: initialUser.uid };
+    debugLog('[notes-sync] Mobile initial session', { userId: normalizedUser.id || null });
+    notesSync.handleSessionChange(normalizedUser, { user: initialUser });
   }
-
-  // 4. Prime notes sync with the current session (if there is one)
-  supabase.auth
-    .getSession()
-    .then(({ data }) => {
-      const session = data?.session ?? null;
-      const user = session?.user ?? null;
-      debugLog('[notes-sync] Mobile initial session', { userId: user?.id || null });
-      if (typeof notesSync.handleSessionChange === 'function') {
-        notesSync.handleSessionChange(user, session);
-      }
-    })
-    .catch((err) => {
-      console.warn('[notes-sync] Failed to get initial Supabase session on mobile:', err);
-    });
 
   const requestRemoteSync = () => {
     if (typeof notesSync.syncFromRemote === 'function') {

--- a/src/services/supabaseSyncService.js
+++ b/src/services/supabaseSyncService.js
@@ -60,14 +60,12 @@ const mergeByLatest = (localItems = [], remoteItems = []) => {
   return Array.from(merged.values());
 };
 
-const getCurrentUserId = async (supabase) => {
-  if (!supabase?.auth?.getSession) return null;
-  const { data, error } = await supabase.auth.getSession();
-  if (error) {
-    console.warn('[supabase-sync] getSession failed', error);
-    return null;
-  }
-  return data?.session?.user?.id || null;
+const getCurrentUserId = async () => {
+  if (typeof window === 'undefined') return null;
+  const userId = typeof window.__MEMORY_CUE_AUTH_USER_ID === 'string'
+    ? window.__MEMORY_CUE_AUTH_USER_ID.trim()
+    : '';
+  return userId || null;
 };
 
 const mapNoteToRow = (item, userId) => ({
@@ -125,7 +123,7 @@ async function syncDomain({ key, table, mapToRow, mapFromRow = (row) => row }) {
   const supabase = getSupabaseClient();
   if (!supabase) return readLocal(key);
 
-  const userId = await getCurrentUserId(supabase);
+  const userId = await getCurrentUserId();
   if (!userId) return readLocal(key);
 
   const localItems = readLocal(key);
@@ -245,7 +243,7 @@ export const upsertReminder = async (reminder) => {
 
 export const deleteReminder = async (id) => {
   const supabase = getSupabaseClient();
-  const userId = supabase ? await getCurrentUserId(supabase) : null;
+  const userId = supabase ? await getCurrentUserId() : null;
   const cached = readLocal(REMINDERS_KEY).filter((item) => String(item?.id) !== String(id));
   writeLocal(REMINDERS_KEY, cached);
   if (supabase && userId) {


### PR DESCRIPTION
### Motivation
- Consolidate authentication to Firebase Auth and remove Supabase-specific auth fallbacks while preserving existing data sync utilities that talk to Supabase tables.\
- Ensure login flow uses Firebase providers (popup/redirect) and that session state flows into the app user state and sync code.\

### Description
- Updated `js/supabase-auth.js` to remove Supabase OAuth/signIn fallbacks and to rely solely on an injected auth context (Firebase-style): `auth`, `GoogleAuthProvider`, `signInWithPopup`, `signInWithRedirect`, `signOut`, and `onAuthStateChanged`; `startSignInFlow` now prefers the injected popup/redirect handlers and no longer calls Supabase; `startSignOutFlow` uses the supplied `signOut` handler.\
- Reworked `initSupabaseAuth` to accept `auth` and `onAuthStateChanged` handlers from the external context, wire sign-in/sign-out buttons to `startSignInFlow`/`startSignOutFlow`, and apply auth UI state from `auth.currentUser`.\
- Replaced Supabase session wiring in `js/reminders.js` with Firebase equivalents: use `onAuthStateChanged(auth, cb)` and prime initial session from `auth.currentUser`, and propagate the Firebase user id into `window.__MEMORY_CUE_AUTH_USER_ID` for downstream consumers.\
- Adjusted mobile notes wiring in `mobile.js` to use the updated auth controller and normalize Firebase user objects for `initNotesSync` (no longer hands a Supabase client to notes sync).\
- Preserved Supabase data sync utilities in `src/services/supabaseSyncService.js` but removed direct Supabase auth session calls: `getCurrentUserId` now reads `window.__MEMORY_CUE_AUTH_USER_ID` (set from Firebase auth) and sync functions call that; push/pull logic remains intact.\
- Minor housekeeping: removed unused `getSupabaseClient` import from the reminders module and standardized button dataset attribute usage for auth wiring.\

### Testing
- Ran `npm run build`; build completed successfully.\
- Ran targeted Jest test invocation for auth-related tests: `npm test -- --runTestsByPath js/__tests__/reminders.auth.test.js js/__tests__/mobile.auth.test.js`; these tests failed to run in this environment due to ESM vs CommonJS module parsing constraints in the test harness (syntax errors from test runner loading modules), not from the applied auth change itself.\
- Ran repository searches (`rg`) to validate removal of Supabase auth API usage and to confirm replaced auth call sites; results show Supabase auth fallbacks removed from runtime auth flow and remaining references are limited to a test file expectation for a Supabase client mock.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6841c70fc8324845e1f6555872857)