### PR TITLE
Add patternLearningService and wire intentRouter to use it

### DIFF
--- a/src/services/intentRouter.js
+++ b/src/services/intentRouter.js
@@ -1,101 +1,14 @@
+import { predictIntent, recordPattern } from './patternLearningService.js';
+
 const NOTEBOOK_CAPTURE_PATTERN = /(meeting notes|lesson idea|remember\b|notes?\s+from|journal|plan\b|scored\b)/i;
 const REMINDER_KEYWORDS = ['remind', 'tomorrow', 'tonight', 'later', 'buy', 'pick up'];
 const NOTE_KEYWORDS = ['idea', 'note', 'remember', 'lesson'];
 const DRILL_KEYWORDS = ['drill', 'training', 'coaching'];
 const QUESTION_PREFIXES = ['what', 'when', 'how', 'where'];
-const INTENT_PATTERNS_KEY = 'memoryCueIntentPatterns';
-const MAX_STORED_PATTERNS = 50;
-
-const getPatternStorage = () => (typeof localStorage !== 'undefined' ? localStorage : null);
-
-const tokenizeText = (rawText) => {
-  const normalized = typeof rawText === 'string' ? rawText.trim().toLowerCase() : '';
-  if (!normalized) {
-    return [];
-  }
-
-  return Array.from(new Set(
-    normalized
-      .replace(/[^a-z0-9\s]/g, ' ')
-      .split(/\s+/)
-      .map((token) => token.trim())
-      .filter((token) => token.length >= 3),
-  ));
-};
-
-const readIntentPatterns = () => {
-  const storage = getPatternStorage();
-  if (!storage) {
-    return [];
-  }
-
-  try {
-    const raw = storage.getItem(INTENT_PATTERNS_KEY);
-    const parsed = raw ? JSON.parse(raw) : [];
-    return Array.isArray(parsed) ? parsed : [];
-  } catch (error) {
-    console.warn('[intent-router] Unable to read intent patterns from localStorage.', error);
-    return [];
-  }
-};
-
-const writeIntentPatterns = (patterns) => {
-  const storage = getPatternStorage();
-  if (!storage) {
-    return;
-  }
-
-  try {
-    storage.setItem(INTENT_PATTERNS_KEY, JSON.stringify(patterns.slice(0, MAX_STORED_PATTERNS)));
-  } catch (error) {
-    console.warn('[intent-router] Unable to persist intent patterns to localStorage.', error);
-  }
-};
-
-const learnIntentPattern = (rawText, decisionType) => {
-  const tokens = tokenizeText(rawText).slice(0, 5);
-  if (!tokens.length || !decisionType) {
-    return;
-  }
-
-  const existing = readIntentPatterns();
-  const now = Date.now();
-  const updates = tokens.map((token) => ({ token, decisionType, capturedAt: now }));
-  writeIntentPatterns([...updates, ...existing]);
-};
 
 const countKeywordMatches = (normalizedText, keywords) => keywords.reduce((count, keyword) => (
   normalizedText.includes(keyword) ? count + 1 : count
 ), 0);
-
-const getLearnedBias = (tokens) => {
-  const bias = {
-    persist_reminder: 0,
-    persist_note: 0,
-    query: 0,
-  };
-
-  if (!tokens.length) {
-    return bias;
-  }
-
-  const patterns = readIntentPatterns();
-  patterns.forEach((pattern) => {
-    if (!tokens.includes(pattern?.token)) {
-      return;
-    }
-
-    if (pattern?.decisionType === 'persist_reminder') {
-      bias.persist_reminder += 1;
-    } else if (pattern?.decisionType === 'persist_note') {
-      bias.persist_note += 1;
-    } else if (pattern?.decisionType === 'query') {
-      bias.query += 1;
-    }
-  });
-
-  return bias;
-};
 
 const createHeuristicParsedEntry = (type, text, hints = {}) => ({
   type,
@@ -120,16 +33,44 @@ export const classifyIntentLocally = (rawText, hints = {}) => {
     return null;
   }
 
+  const patternMatch = predictIntent(text);
+  if (patternMatch?.predictedIntent === 'persist_reminder') {
+    return {
+      decisionType: 'persist_reminder',
+      parsedType: 'reminder',
+      text,
+      parsedEntry: createHeuristicParsedEntry('reminder', text, hints),
+      hints,
+    };
+  }
+
+  if (patternMatch?.predictedIntent === 'persist_note') {
+    return {
+      decisionType: 'persist_note',
+      parsedType: 'note',
+      text,
+      parsedEntry: createHeuristicParsedEntry('note', text, hints),
+      hints,
+    };
+  }
+
+  if (patternMatch?.predictedIntent === 'query') {
+    return {
+      decisionType: 'query',
+      parsedType: 'question',
+      text,
+      parsedEntry: createHeuristicParsedEntry('question', text, hints),
+      hints,
+    };
+  }
+
   const startsWithQuestion = QUESTION_PREFIXES
     .some((prefix) => normalized.startsWith(`${prefix} `));
 
-  const tokens = tokenizeText(normalized);
-  const learnedBias = getLearnedBias(tokens);
-
-  const reminderScore = countKeywordMatches(normalized, REMINDER_KEYWORDS) + learnedBias.persist_reminder;
-  const noteScore = countKeywordMatches(normalized, NOTE_KEYWORDS) + learnedBias.persist_note;
+  const reminderScore = countKeywordMatches(normalized, REMINDER_KEYWORDS);
+  const noteScore = countKeywordMatches(normalized, NOTE_KEYWORDS);
   const drillScore = countKeywordMatches(normalized, DRILL_KEYWORDS);
-  const questionScore = (text.endsWith('?') ? 2 : 0) + (startsWithQuestion ? 1 : 0) + learnedBias.query;
+  const questionScore = (text.endsWith('?') ? 2 : 0) + (startsWithQuestion ? 1 : 0);
 
   const scored = [
     { kind: 'reminder', score: reminderScore },
@@ -153,7 +94,6 @@ export const classifyIntentLocally = (rawText, hints = {}) => {
       parsedEntry,
       hints,
     };
-    learnIntentPattern(text, decision.decisionType);
     return decision;
   }
 
@@ -167,7 +107,6 @@ export const classifyIntentLocally = (rawText, hints = {}) => {
       parsedEntry,
       hints,
     };
-    learnIntentPattern(text, decision.decisionType);
     return decision;
   }
 
@@ -179,7 +118,6 @@ export const classifyIntentLocally = (rawText, hints = {}) => {
     parsedEntry,
     hints,
   };
-  learnIntentPattern(text, decision.decisionType);
   return decision;
 };
 
@@ -230,7 +168,7 @@ export const routeIntent = (parsedEntry, rawText, hints = {}) => {
       parsedEntry: parsed,
       hints,
     };
-    learnIntentPattern(text, decision.decisionType);
+    recordPattern(text, { predictedIntent: decision.decisionType, predictedNotebook: '' });
     return decision;
   }
 
@@ -249,7 +187,7 @@ export const routeIntent = (parsedEntry, rawText, hints = {}) => {
       notebookHeuristic,
       hints,
     };
-    learnIntentPattern(text, decision.decisionType);
+    recordPattern(text, { predictedIntent: decision.decisionType, predictedNotebook: '' });
     return decision;
   }
 
@@ -261,17 +199,19 @@ export const routeIntent = (parsedEntry, rawText, hints = {}) => {
       parsedEntry: parsed,
       hints,
     };
-    learnIntentPattern(text, decision.decisionType);
+    recordPattern(text, { predictedIntent: decision.decisionType, predictedNotebook: '' });
     return decision;
   }
 
-  return {
+  const decision = {
     decisionType: 'persist_inbox',
     parsedType,
     text,
     parsedEntry: parsed,
     hints,
   };
+  recordPattern(text, { predictedIntent: decision.decisionType, predictedNotebook: 'Inbox' });
+  return decision;
 };
 
 export const createChatIntentInput = (parsedEntry, rawText, hints = {}) => ({

--- a/src/services/patternLearningService.js
+++ b/src/services/patternLearningService.js
@@ -1,0 +1,97 @@
+const PATTERN_STORAGE_KEY = 'memoryCuePatterns';
+
+const getPatternStorage = () => (typeof localStorage !== 'undefined' ? localStorage : null);
+
+const normalizeText = (value) => (typeof value === 'string' ? value.trim().toLowerCase() : '');
+
+const readPatterns = () => {
+  const storage = getPatternStorage();
+  if (!storage) {
+    return [];
+  }
+
+  try {
+    const raw = storage.getItem(PATTERN_STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.warn('[pattern-learning] Unable to read patterns from localStorage.', error);
+    return [];
+  }
+};
+
+const writePatterns = (patterns) => {
+  const storage = getPatternStorage();
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.setItem(PATTERN_STORAGE_KEY, JSON.stringify(patterns));
+  } catch (error) {
+    console.warn('[pattern-learning] Unable to write patterns to localStorage.', error);
+  }
+};
+
+export const recordPattern = (phrase, intent) => {
+  const normalizedPhrase = normalizeText(phrase);
+  if (!normalizedPhrase || !intent || typeof intent !== 'object') {
+    return;
+  }
+
+  const predictedIntent = normalizeText(intent.predictedIntent || intent.decisionType);
+  const predictedNotebook = typeof intent.predictedNotebook === 'string'
+    ? intent.predictedNotebook.trim()
+    : '';
+
+  if (!predictedIntent) {
+    return;
+  }
+
+  const patterns = readPatterns();
+  const existingIndex = patterns.findIndex((pattern) => (
+    normalizeText(pattern?.phrase) === normalizedPhrase
+    && normalizeText(pattern?.predictedIntent) === predictedIntent
+    && normalizeText(pattern?.predictedNotebook) === normalizeText(predictedNotebook)
+  ));
+
+  if (existingIndex >= 0) {
+    const existing = patterns[existingIndex];
+    patterns[existingIndex] = {
+      ...existing,
+      frequency: Number(existing?.frequency || 0) + 1,
+      phrase: normalizedPhrase,
+      predictedNotebook,
+      predictedIntent,
+    };
+  } else {
+    patterns.unshift({
+      phrase: normalizedPhrase,
+      predictedNotebook,
+      predictedIntent,
+      frequency: 1,
+    });
+  }
+
+  writePatterns(patterns);
+};
+
+export const predictIntent = (text) => {
+  const normalizedText = normalizeText(text);
+  if (!normalizedText) {
+    return null;
+  }
+
+  const patterns = readPatterns();
+  const exactMatch = patterns.find((pattern) => normalizeText(pattern?.phrase) === normalizedText);
+
+  if (!exactMatch) {
+    return null;
+  }
+
+  return {
+    predictedNotebook: typeof exactMatch?.predictedNotebook === 'string' ? exactMatch.predictedNotebook : '',
+    predictedIntent: normalizeText(exactMatch?.predictedIntent),
+    frequency: Number(exactMatch?.frequency || 0),
+  };
+};


### PR DESCRIPTION
### Motivation
- Introduce local pattern learning so the app can persist simple phrase→intent mappings and leverage them to short-circuit AI/heuristic routing for repeated phrases.
- Keep persistence lightweight and browser-local using `localStorage` so no external services or config are required.

### Description
- Add `src/services/patternLearningService.js` exporting `recordPattern(phrase, intent)` and `predictIntent(text)` which persist patterns under `localStorage` key `memoryCuePatterns` with fields `phrase`, `predictedNotebook`, `predictedIntent`, and `frequency`.
- Refactor `src/services/intentRouter.js` to call `predictIntent(text)` at the top of `classifyIntentLocally` and return a matched decision immediately when a stored pattern exists.
- Call `recordPattern(...)` from `routeIntent` after each finalized routing outcome (`persist_reminder`, `persist_note`, `query`, `persist_inbox`) to record/update pattern frequencies.
- Removed the previous tokenized/biased pattern storage logic and simplified the local heuristic scoring to avoid duplicative learning logic in favor of the new pattern service.

### Testing
- Ran the automated test suite with `npm test -- --runInBand`; this run reported numerous pre-existing/import-related test failures unrelated to these service changes (module import environment issues), so the failures are not indicative of the pattern-service integration.
- Ran the build with `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b68627610083248fe828217620fd18)