### PR TITLE
Fix Firebase auth for Cloudflare (ai-assistant-d546b) and remove Supabase login fallback

### DIFF
--- a/js/__tests__/firebase-config.test.js
+++ b/js/__tests__/firebase-config.test.js
@@ -29,7 +29,7 @@ describe('firebase-config', () => {
     const config = getFirebaseConfig();
     expect(config).toEqual(DEFAULT_FIREBASE_CONFIG);
     expect(config).not.toBe(DEFAULT_FIREBASE_CONFIG);
-    expect(config.projectId).toBe('memory-cue-app');
+    expect(config.projectId).toBe('ai-assistant-d546b');
   });
 
   it('merges direct global overrides', () => {

--- a/js/firebase-config.js
+++ b/js/firebase-config.js
@@ -1,8 +1,8 @@
 const DEFAULT_FIREBASE_CONFIG = Object.freeze({
   apiKey: 'AIzaSyAmAMiz0zG3dAhZJhOy1DYj8fKVDObL36c',
-  authDomain: 'memory-cue-app.firebaseapp.com',
-  projectId: 'memory-cue-app',
-  storageBucket: 'memory-cue-app.firebasestorage.app',
+  authDomain: 'ai-assistant-d546b.firebaseapp.com',
+  projectId: 'ai-assistant-d546b',
+  storageBucket: 'ai-assistant-d546b.appspot.com',
   messagingSenderId: '751284466633',
   appId: '1:751284466633:web:3b10742970bef1a5d5ee18',
   measurementId: 'G-R0V4M7VCE6'

--- a/js/firebase-init.js
+++ b/js/firebase-init.js
@@ -1,9 +1,9 @@
 /* firebase-init.js */
 const FALLBACK_FIREBASE_CONFIG = Object.freeze({
   apiKey: 'AIzaSyAmAMiz0zG3dAhZJhOy1DYj8fKVDObL36c',
-  authDomain: 'memory-cue-app.firebaseapp.com',
-  projectId: 'memory-cue-app',
-  storageBucket: 'memory-cue-app.firebasestorage.app',
+  authDomain: 'ai-assistant-d546b.firebaseapp.com',
+  projectId: 'ai-assistant-d546b',
+  storageBucket: 'ai-assistant-d546b.appspot.com',
   messagingSenderId: '751284466633',
   appId: '1:751284466633:web:3b10742970bef1a5d5ee18',
   measurementId: 'G-R0V4M7VCE6'

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -3940,6 +3940,10 @@ export async function initReminders(sel = {}) {
       if (!firebaseConfig.projectId) {
         throw new Error('Firebase projectId missing from configuration');
       }
+      console.log('[auth] Firebase project:', firebaseConfig.projectId);
+      console.log('[auth] Current domain:', (typeof window !== 'undefined' && window.location)
+        ? window.location.hostname
+        : 'unknown');
       console.info('[Firebase] Initialising Memory Cue', firebaseConfig.projectId);
       app = initializeApp(firebaseConfig);
       db = getFirestore(app);
@@ -4222,7 +4226,9 @@ export async function initReminders(sel = {}) {
   }
 
   if (authReady && typeof getRedirectResult === 'function') {
-    getRedirectResult(auth).catch(()=>{});
+    getRedirectResult(auth).catch((error) => {
+      console.warn('[auth] Redirect sign-in result handling failed.', error);
+    });
   }
 
   if (shouldWireAuthButtons && googleSignOutBtns.length) {

--- a/js/storage.js
+++ b/js/storage.js
@@ -76,9 +76,9 @@ window.__ENV = {
 
   const FALLBACK_FIREBASE_CONFIG = Object.freeze({
     apiKey: 'AIzaSyAmAMiz0zG3dAhZJhOy1DYj8fKVDObL36c',
-    authDomain: 'memory-cue-app.firebaseapp.com',
-    projectId: 'memory-cue-app',
-    storageBucket: 'memory-cue-app.firebasestorage.app',
+    authDomain: 'ai-assistant-d546b.firebaseapp.com',
+    projectId: 'ai-assistant-d546b',
+    storageBucket: 'ai-assistant-d546b.appspot.com',
     messagingSenderId: '751284466633',
     appId: '1:751284466633:web:3b10742970bef1a5d5ee18',
     measurementId: 'G-R0V4M7VCE6'

--- a/js/supabase-auth.js
+++ b/js/supabase-auth.js
@@ -20,22 +20,19 @@ export function setAuthContext(ctx = {}) {
   } catch (err) {
     // non-fatal; keep module usable even if callers pass odd values
     // eslint-disable-next-line no-console
-    console.warn('[supabase-auth] setAuthContext failed', err);
+    console.warn('[auth] setAuthContext failed', err);
   }
 }
 
 /**
  * Start a sign-in flow.
- * Preference order:
- * - If an external handler (signInWithPopup or signInWithRedirect) was supplied via setAuthContext, use it.
- * - Resolves null when no auth facilities are available.
+ * Uses Firebase auth handlers supplied via setAuthContext.
+ * Resolves null when no auth facilities are available.
  */
 export async function startSignInFlow(options = {}) {
   try {
     const prefersRedirect = Boolean(options?.preferRedirect)
-      || (typeof window !== 'undefined'
-        && typeof window.matchMedia === 'function'
-        && window.matchMedia('(max-width: 768px)').matches);
+      || (typeof window !== 'undefined' && window.innerWidth < 768);
 
     // Prefer supplied handlers
     if (
@@ -49,18 +46,7 @@ export async function startSignInFlow(options = {}) {
       }
 
       if (typeof _externalAuthContext.signInWithPopup === 'function') {
-        try {
-          return await _externalAuthContext.signInWithPopup(_externalAuthContext.auth, provider);
-        } catch (error) {
-          const popupIssue = typeof error?.code === 'string' && [
-            'auth/popup-closed-by-user',
-            'auth/popup-blocked',
-            'auth/cancelled-popup-request',
-          ].includes(error.code);
-          if (!popupIssue || typeof _externalAuthContext.signInWithRedirect !== 'function') {
-            throw error;
-          }
-        }
+        return _externalAuthContext.signInWithPopup(_externalAuthContext.auth, provider);
       }
 
       if (typeof _externalAuthContext.signInWithRedirect === 'function') {
@@ -69,12 +55,12 @@ export async function startSignInFlow(options = {}) {
     }
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.error('[supabase-auth] startSignInFlow error', err);
+    console.error('[auth] startSignInFlow error', err);
     try {
       _externalAuthContext?.toast?.('Sign-in failed');
     } catch (toastErr) {
       // eslint-disable-next-line no-console
-      console.warn('[supabase-auth] toast handler failed', toastErr);
+      console.warn('[auth] toast handler failed', toastErr);
     }
     throw err;
   }
@@ -91,7 +77,7 @@ export async function startSignOutFlow() {
     }
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.error('[supabase-auth] startSignOutFlow error', err);
+    console.error('[auth] startSignOutFlow error', err);
     throw err;
   }
   return Promise.resolve(null);
@@ -288,7 +274,7 @@ function bindSignInButtons(elements) {
       try {
         await startSignInFlow();
       } catch (error) {
-        console.error('[supabase] Sign-in failed.', error);
+        console.error('[auth] Sign-in failed.', error);
       }
     });
   });

--- a/js/supabase-client.js
+++ b/js/supabase-client.js
@@ -37,7 +37,7 @@ export function getSupabaseClient() {
   );
 
   if (!supabaseUrl || !supabaseAnonKey) {
-    console.error('[supabase] Missing SUPABASE_URL or SUPABASE_ANON_KEY.');
+    console.info('[supabase] SUPABASE_URL or SUPABASE_ANON_KEY not set; sync remains local.');
     return null;
   }
 

--- a/mobile.js
+++ b/mobile.js
@@ -4090,7 +4090,7 @@ function wireMobileNotesSupabaseAuth() {
           primarySignInBtn.click();
         } else {
           startSignInFlow().catch((error) => {
-            console.error('[supabase] Sign-in failed.', error);
+            console.error('[auth] Sign-in failed.', error);
           });
         }
         break;
@@ -4100,13 +4100,6 @@ function wireMobileNotesSupabaseAuth() {
         const primarySignOutBtn = document.getElementById('googleSignOutBtn');
         if (primarySignOutBtn instanceof HTMLElement) {
           primarySignOutBtn.click();
-        } else if (
-          window.__supabaseAuth &&
-          window.__supabaseAuth.supabase &&
-          window.__supabaseAuth.supabase.auth &&
-          typeof window.__supabaseAuth.supabase.auth.signOut === 'function'
-        ) {
-          window.__supabaseAuth.supabase.auth.signOut().catch(() => {});
         }
         break;
       }


### PR DESCRIPTION
### Motivation
- The app was moved to Cloudflare Pages and Firebase sign-in was failing due to an incorrect default project configuration and Supabase fallback interfering with auth flows.
- Mobile popup sign-ins were unreliable, so the sign-in flow should prefer redirect on mobile to improve success rate.
- Add lightweight debug logs to diagnose domain / project mismatches during initialization.

### Description
- Updated the canonical default/fallback Firebase configuration to the Cloudflare project (`ai-assistant-d546b`) in `js/firebase-config.js`, and mirrored the same fallback values in `js/firebase-init.js` and `js/storage.js` so initialization targets `ai-assistant-d546b.firebaseapp.com` and `ai-assistant-d546b` project ID.
- Modified `js/supabase-auth.js` so `startSignInFlow` uses redirect on mobile (`window.innerWidth < 768`) and popup on desktop, removed the popup-error fallback path, and normalized log labels to `[auth]`.
- Removed the Supabase sign-out fallback from the mobile overflow handler in `mobile.js` so sign-out is handled via Firebase handlers only.
- Reduced noisy Supabase environment missing logging in `js/supabase-client.js` from `console.error` to `console.info` so absent Supabase env vars do not surface as an auth failure.
- Added debug logs in `js/reminders.js` to print `console.log('[auth] Firebase project:', ...)` and `console.log('[auth] Current domain:', ...)` during Firebase init, and added a `getRedirectResult` catch handler that logs redirect result failures.
- Updated `js/__tests__/firebase-config.test.js` expectation to match the new default `projectId` value.

### Testing
- Ran `npm test -- --runInBand js/__tests__/firebase-config.test.js` and the suite passed (3 tests passed).
- Ran `npm test -- --runInBand js/__tests__/firebase-config.test.js js/__tests__/reminders.auth.test.js` and `reminders.auth.test.js` failed due to the test harness attempting to load an ESM-style module with CJS `require` (existing environment issue), while `firebase-config.test.js` continued to pass.
- No other automated tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b68870a6948324a99a609d49f41325)