### PR TITLE
Fix Firebase authentication for Cloudflare deployment

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -3940,8 +3940,8 @@ export async function initReminders(sel = {}) {
       if (!firebaseConfig.projectId) {
         throw new Error('Firebase projectId missing from configuration');
       }
-      console.log('[auth] Firebase project:', firebaseConfig.projectId);
-      console.log('[auth] Current domain:', (typeof window !== 'undefined' && window.location)
+      console.log('[auth] firebase project:', firebaseConfig.projectId);
+      console.log('[auth] domain:', (typeof window !== 'undefined' && window.location)
         ? window.location.hostname
         : 'unknown');
       console.info('[Firebase] Initialising Memory Cue', firebaseConfig.projectId);
@@ -4000,7 +4000,7 @@ export async function initReminders(sel = {}) {
   }
 
   if (firebaseReady && typeof getAuth === 'function') {
-    auth = getAuth(app);
+    auth = getAuth();
   }
 
   // Formatting helpers

--- a/js/supabase-auth.js
+++ b/js/supabase-auth.js
@@ -25,33 +25,20 @@ export function setAuthContext(ctx = {}) {
 }
 
 /**
- * Start a sign-in flow.
+ * Start a sign-in flow via Firebase popup auth.
  * Uses Firebase auth handlers supplied via setAuthContext.
  * Resolves null when no auth facilities are available.
  */
-export async function startSignInFlow(options = {}) {
+export async function startSignInFlow() {
   try {
-    const prefersRedirect = Boolean(options?.preferRedirect)
-      || (typeof window !== 'undefined' && window.innerWidth < 768);
-
-    // Prefer supplied handlers
     if (
       _externalAuthContext &&
       _externalAuthContext.auth &&
-      typeof _externalAuthContext.GoogleAuthProvider === 'function'
+      typeof _externalAuthContext.GoogleAuthProvider === 'function' &&
+      typeof _externalAuthContext.signInWithPopup === 'function'
     ) {
       const provider = new _externalAuthContext.GoogleAuthProvider();
-      if (prefersRedirect && typeof _externalAuthContext.signInWithRedirect === 'function') {
-        return _externalAuthContext.signInWithRedirect(_externalAuthContext.auth, provider);
-      }
-
-      if (typeof _externalAuthContext.signInWithPopup === 'function') {
-        return _externalAuthContext.signInWithPopup(_externalAuthContext.auth, provider);
-      }
-
-      if (typeof _externalAuthContext.signInWithRedirect === 'function') {
-        return _externalAuthContext.signInWithRedirect(_externalAuthContext.auth, provider);
-      }
+      return _externalAuthContext.signInWithPopup(_externalAuthContext.auth, provider);
     }
   } catch (err) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
### Motivation
- Ensure Firebase auth is correctly initialized for the Cloudflare Pages deployment and add clear runtime debug logs for domain/project detection.
- Remove the redirect-based / Supabase fallback path for sign-in so the app consistently uses Firebase popup auth with Google.

### Description
- Updated `js/reminders.js` to add concise auth debug logs and report `firebase project` and `domain` at startup, and changed auth initialization to call `getAuth()` (no `app` argument). 
- Modified `js/supabase-auth.js` `startSignInFlow` to always prefer the Firebase `GoogleAuthProvider` + `signInWithPopup` path and removed the redirect-based fallback. 
- Verified `js/firebase-config.js` `DEFAULT_FIREBASE_CONFIG` matches the target Firebase project (`authDomain: 'ai-assistant-d546b.firebaseapp.com'`, `projectId: 'ai-assistant-d546b'`, `storageBucket: 'ai-assistant-d546b.appspot.com'`). 
- Changes are minimal and limited to `js/reminders.js` and `js/supabase-auth.js` to preserve existing behavior elsewhere.

### Testing
- Ran `npm run build` and the build completed successfully. 
- Ran the targeted unit tests with `npm test -- --runInBand js/__tests__/reminders.auth.test.js js/__tests__/mobile.auth.test.js` and the suites failed due to an existing ESM/VM test harness parsing issue (`Cannot use import statement outside a module`), which is unrelated to the auth logic changes. 
- Committed the changes with the message `Fix Firebase authentication for Cloudflare deployment`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b68b89e44483249ac4b33fd2e7c8b5)