### PR TITLE
Add embedding-based memory recall for brain queries

### DIFF
--- a/src/services/brainQueryService.js
+++ b/src/services/brainQueryService.js
@@ -1,6 +1,6 @@
 import { classifyIntentLocally } from './intentRouter.js';
-import { createEmbedding, searchEmbeddings } from './embeddingService.js';
-import { getMemoryById, searchMemories } from './memoryService.js';
+import { generateEmbedding, similaritySearch } from './embeddingService.js';
+import { getRecentMemories, searchMemories } from './memoryService.js';
 
 const OPENAI_MODEL = 'gpt-5-nano';
 const MAX_CONTEXT_MEMORIES = 5;
@@ -18,91 +18,41 @@ const truncateText = (text, maxLength) => {
   return `${normalized.slice(0, maxLength - 1)}…`;
 };
 
-const scoreByTermOverlap = (question, memory) => {
-  const tokens = normalizeText(question)
-    .toLowerCase()
-    .split(/\s+/)
-    .map((token) => token.replace(/[^a-z0-9]/g, ''))
-    .filter((token) => token.length > 2);
+const buildMemoryContext = (memories) => memories
+  .slice(0, MAX_CONTEXT_MEMORIES)
+  .map((memory, index) => {
+    const notebook = truncateText(memory?.notebook, 60);
+    const text = truncateText(memory?.text, MAX_MEMORY_TEXT_LENGTH);
+    const tags = Array.isArray(memory?.tags) ? memory.tags.slice(0, 4).join(', ') : '';
 
-  if (!tokens.length) {
-    return 0;
-  }
+    return [
+      `${index + 1}. ${text}`,
+      notebook ? `Notebook: ${notebook}` : '',
+      tags ? `Tags: ${tags}` : '',
+    ]
+      .filter(Boolean)
+      .join(' | ');
+  })
+  .filter(Boolean)
+  .join('\n');
 
-  const haystack = [memory?.text, memory?.notebook, ...(Array.isArray(memory?.tags) ? memory.tags : [])]
-    .join(' ')
-    .toLowerCase();
-
-  return tokens.reduce((score, token) => (haystack.includes(token) ? score + 1 : score), 0);
+const buildPrompt = (question, memories) => {
+  const snippets = buildMemoryContext(memories) || 'No relevant memories found.';
+  return [
+    'System:',
+    'You are the Memory Cue assistant.',
+    '',
+    'Relevant memories:',
+    snippets,
+    '',
+    'User question:',
+    question,
+    '',
+    'Return answer grounded in the memories.',
+  ].join('\n');
 };
 
-const selectTopMemories = (question, lexicalMemories, embeddingMatches) => {
-  const scored = new Map();
-
-  lexicalMemories.forEach((memory, index) => {
-    const memoryId = normalizeText(memory?.id);
-    if (!memoryId) {
-      return;
-    }
-
-    const overlapScore = scoreByTermOverlap(question, memory);
-    const rankBonus = Math.max(0, 8 - index) * 0.25;
-    scored.set(memoryId, {
-      memory,
-      score: overlapScore + rankBonus,
-    });
-  });
-
-  embeddingMatches.forEach((match, index) => {
-    const memoryId = normalizeText(match?.memoryId);
-    if (!memoryId) {
-      return;
-    }
-
-    const memory = getMemoryById(memoryId);
-    if (!memory) {
-      return;
-    }
-
-    const baseScore = Number(match?.score) || 0;
-    const rankBonus = Math.max(0, 10 - index) * 0.1;
-    const previous = scored.get(memoryId);
-
-    scored.set(memoryId, {
-      memory,
-      score: (previous?.score || 0) + baseScore + rankBonus,
-    });
-  });
-
-  return Array.from(scored.values())
-    .sort((left, right) => right.score - left.score)
-    .slice(0, MAX_CONTEXT_MEMORIES)
-    .map((item) => item.memory);
-};
-
-const buildStructuredContext = (question, intent, memories) => {
-  const safeQuestion = truncateText(question, MAX_QUESTION_LENGTH);
-  const memoryItems = memories.map((memory, index) => ({
-    index: index + 1,
-    id: normalizeText(memory?.id),
-    type: normalizeText(memory?.type) || 'note',
-    notebook: truncateText(memory?.notebook, 60),
-    tags: Array.isArray(memory?.tags) ? memory.tags.slice(0, 6) : [],
-    createdAt: normalizeText(memory?.createdAt),
-    text: truncateText(memory?.text, MAX_MEMORY_TEXT_LENGTH),
-  }));
-
-  return {
-    question: safeQuestion,
-    intent: {
-      decisionType: normalizeText(intent?.decisionType) || 'query',
-      parsedType: normalizeText(intent?.parsedType) || 'question',
-    },
-    memories: memoryItems,
-  };
-};
-
-const callAiSummary = async (contextPayload) => {
+const callAiSummary = async (question, memories) => {
   const openAiApiKey = typeof process !== 'undefined' ? process.env?.OPENAI_API_KEY : '';
   if (!openAiApiKey) {
     console.warn('[brain] AI fallback triggered', {
@@ -113,12 +63,7 @@ const callAiSummary = async (contextPayload) => {
   }
 
   const prompt = [
-    'You are Memory Cue, a concise personal memory assistant.',
-    'Use only the provided JSON context to answer the user question.',
-    'If context is incomplete, say what is missing in one short sentence.',
-    'Respond in 3-5 sentences and keep the response under 120 words.',
-    'JSON context:',
-    JSON.stringify(contextPayload),
+    buildPrompt(question, memories),
   ].join('\n');
 
   const response = await fetch('https://api.openai.com/v1/responses', {
@@ -157,32 +102,21 @@ export const retrieveRelevantMemories = async (question) => {
     return [];
   }
 
-  const lexicalMemories = searchMemories(safeQuestion);
-  console.debug('[brain] memory retrieved', {
-    source: 'retrieveRelevantMemories.lexical',
-    query: safeQuestion,
-    count: lexicalMemories.length,
-  });
+  const allMemories = getRecentMemories(200);
+  let selectedMemories = searchMemories(safeQuestion, MAX_CONTEXT_MEMORIES);
 
-  let embeddingMatches = [];
   try {
-    const questionEmbedding = await createEmbedding(safeQuestion);
-    const memoryMatches = searchMemories(questionEmbedding, 12);
-    embeddingMatches = memoryMatches.map((memory, index) => ({
-      memoryId: memory.id,
-      score: Math.max(0, 1 - (index * 0.05)),
-    }));
-
-    if (!embeddingMatches.length) {
-      embeddingMatches = searchEmbeddings(questionEmbedding).slice(0, 12);
+    const questionEmbedding = await generateEmbedding(safeQuestion);
+    if (questionEmbedding.length) {
+      selectedMemories = similaritySearch(questionEmbedding, allMemories)
+        .slice(0, MAX_CONTEXT_MEMORIES);
     }
   } catch (error) {
     console.warn('[brain-query-service] Embedding retrieval failed', error);
   }
 
-  const selectedMemories = selectTopMemories(safeQuestion, lexicalMemories, embeddingMatches);
-  console.info('[brain] memory retrieved', {
-    source: 'retrieveRelevantMemories.selected',
+  console.info('[brain] memory_retrieved', {
+    source: 'retrieveRelevantMemories',
     query: safeQuestion,
     count: selectedMemories.length,
   });
@@ -193,10 +127,7 @@ export const retrieveRelevantMemories = async (question) => {
 export const generateAnswer = async (question, context = {}) => {
   const safeQuestion = truncateText(question, MAX_QUESTION_LENGTH);
   const memories = Array.isArray(context?.memories) ? context.memories : [];
-  const intent = context?.intent && typeof context.intent === 'object' ? context.intent : {};
-
-  const structuredContext = buildStructuredContext(safeQuestion, intent, memories);
-  return callAiSummary(structuredContext);
+  return callAiSummary(safeQuestion, memories);
 };
 
 export const queryBrain = async (question) => {
@@ -230,6 +161,12 @@ export const queryBrain = async (question) => {
     });
     answer = 'I found relevant memories, but could not generate an AI summary right now.';
   }
+
+  console.info('[brain] query_answered', {
+    source: 'queryBrain',
+    question: safeQuestion,
+    memories: memories.length,
+  });
 
   return {
     answer,

--- a/src/services/embeddingService.js
+++ b/src/services/embeddingService.js
@@ -87,7 +87,7 @@ const cosineSimilarity = (left, right) => {
   return dotProduct / (Math.sqrt(leftMagnitude) * Math.sqrt(rightMagnitude));
 };
 
-export const createEmbedding = async (text) => {
+export const generateEmbedding = async (text) => {
   const normalizedText = normalizeText(text);
   if (!normalizedText) {
     return [];
@@ -145,10 +145,20 @@ export const storeEmbedding = (memoryId, embedding) => {
   return limitedRecords[0];
 };
 
-export const searchEmbeddings = (queryEmbedding) => {
+export const similaritySearch = (queryEmbedding, memories = []) => {
   const normalizedQuery = normalizeEmbedding(queryEmbedding);
   if (!normalizedQuery.length) {
     return [];
+  }
+
+  if (Array.isArray(memories) && memories.length) {
+    return memories
+      .map((memory) => ({
+        ...memory,
+        score: cosineSimilarity(normalizedQuery, normalizeEmbedding(memory?.embedding)),
+      }))
+      .filter((memory) => Number.isFinite(memory.score))
+      .sort((left, right) => right.score - left.score);
   }
 
   return getStoredEmbeddings()
@@ -159,3 +169,6 @@ export const searchEmbeddings = (queryEmbedding) => {
     .filter((result) => result.memoryId)
     .sort((left, right) => right.score - left.score);
 };
+
+export const createEmbedding = generateEmbedding;
+export const searchEmbeddings = similaritySearch;

--- a/src/services/memoryService.js
+++ b/src/services/memoryService.js
@@ -1,4 +1,5 @@
 import { getSupabaseClient } from '../../js/supabase-client.js';
+import { generateEmbedding, storeEmbedding } from './embeddingService.js';
 
 const MEMORY_CACHE_KEY = 'memoryCueCache';
 const LEGACY_KEYS = ['memoryCueNotes', 'mobileNotes', 'memory-cue-notes', 'memoryCueInbox'];
@@ -330,24 +331,40 @@ export const saveMemory = async (memory = {}) => {
     return null;
   }
 
+  let embedding = normalizeEmbedding(memory.embedding);
+  if (!embedding) {
+    try {
+      embedding = await generateEmbedding(nextMemory.text);
+    } catch (error) {
+      console.warn('[memory-service] Failed to generate embedding', error);
+    }
+  }
+
+  const memoryWithEmbedding = {
+    ...nextMemory,
+    embedding,
+    updatedAt: Date.now(),
+    pendingSync: true,
+  };
+
   memoryCache = mergeByLatest([
     ...memoryCache,
-    {
-      ...nextMemory,
-      updatedAt: Date.now(),
-      pendingSync: true,
-    },
+    memoryWithEmbedding,
   ]);
+
+  if (Array.isArray(embedding) && embedding.length) {
+    storeEmbedding(memoryWithEmbedding.id, embedding);
+  }
 
   writeCacheToStorage(memoryCache);
   console.info('[brain] memory_saved', {
-    id: nextMemory.id,
-    type: nextMemory.type,
-    source: nextMemory.source,
+    id: memoryWithEmbedding.id,
+    type: memoryWithEmbedding.type,
+    source: memoryWithEmbedding.source,
   });
 
   void triggerSync();
-  return nextMemory;
+  return memoryWithEmbedding;
 };
 
 export const getMemoryById = (id) => {


### PR DESCRIPTION
### Motivation

- Enable the assistant to ground answers using relevant past memories by adding embedding generation and similarity search support. 
- Attach embeddings to memories at save time so the system can perform fast semantic retrieval for question answering.

### Description

- Added `generateEmbedding(text)` and `similaritySearch(queryEmbedding, memories)` to `src/services/embeddingService.js`, and preserved backward-compatible aliases `createEmbedding` and `searchEmbeddings`.
- Updated `src/services/memoryService.js` so `saveMemory` will generate an embedding (if one is not provided), attach it to the saved memory object, and persist the vector via `storeEmbedding`.
- Reworked `src/services/brainQueryService.js` to generate an embedding for the question, retrieve the top context memories (up to `MAX_CONTEXT_MEMORIES`), build a prompt in the requested format (System + Relevant memories + User question + instruction to return an answer grounded in the memories), and forward that prompt to the LLM for a grounded response.
- Added debug logs `[brain] memory_retrieved` and `[brain] query_answered` to aid observability.

### Testing

- Ran `npm run verify`, which passed.
- Ran `npm test -- --runInBand`, which exercised the test suite but failed due to multiple baseline test/runtime issues (ESM/CommonJS harness mismatches and unrelated failures) that pre-existed outside the scope of these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6913005148324803638897db98082)