### PR TITLE
Normalize Firebase authDomain overrides to hostnames

### DIFF
--- a/js/__tests__/firebase-config.test.js
+++ b/js/__tests__/firebase-config.test.js
@@ -46,4 +46,16 @@ describe('firebase-config', () => {
     expect(config.measurementId).toBe('G-TESTING1234');
     expect(config.projectId).toBe(DEFAULT_FIREBASE_CONFIG.projectId);
   });
+
+  it('normalizes authDomain when direct config includes protocol', () => {
+    globalThis.__FIREBASE_CONFIG = { authDomain: 'https://ai-assistant-d546b.firebaseapp.com/auth/callback' };
+    const config = getFirebaseConfig();
+    expect(config.authDomain).toBe('ai-assistant-d546b.firebaseapp.com');
+  });
+
+  it('normalizes FIREBASE_AUTH_DOMAIN from __ENV legacy values', () => {
+    globalThis.__ENV = { FIREBASE_AUTH_DOMAIN: 'https://custom-auth.example.com/path' };
+    const config = getFirebaseConfig();
+    expect(config.authDomain).toBe('custom-auth.example.com');
+  });
 });

--- a/js/firebase-config.js
+++ b/js/firebase-config.js
@@ -19,15 +19,47 @@ function normalizeConfigCandidate(candidate) {
   return Object.fromEntries(entries);
 }
 
+function normalizeAuthDomainValue(value) {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.hostname) {
+      return parsed.hostname;
+    }
+  } catch {
+    // keep original value when it is already a bare hostname
+  }
+  return trimmed.replace(/^https?:\/\//i, '').replace(/\/.*$/, '');
+}
+
+function normalizeFirebaseConfig(config) {
+  if (!config || typeof config !== 'object') {
+    return config;
+  }
+  if (typeof config.authDomain !== 'string') {
+    return config;
+  }
+  return {
+    ...config,
+    authDomain: normalizeAuthDomainValue(config.authDomain),
+  };
+}
+
 function readConfigFromGlobals() {
   const scope = typeof globalThis !== 'undefined' ? globalThis : (typeof window !== 'undefined' ? window : {});
   const direct = normalizeConfigCandidate(scope?.__FIREBASE_CONFIG);
   if (direct) {
-    return direct;
+    return normalizeFirebaseConfig(direct);
   }
   const env = normalizeConfigCandidate(scope?.__ENV?.FIREBASE_CONFIG);
   if (env) {
-    return env;
+    return normalizeFirebaseConfig(env);
   }
   const legacyMap = {
     FIREBASE_API_KEY: 'apiKey',
@@ -45,7 +77,7 @@ function readConfigFromGlobals() {
     }
     return acc;
   }, {});
-  return Object.keys(legacy).length ? legacy : null;
+  return Object.keys(legacy).length ? normalizeFirebaseConfig(legacy) : null;
 }
 
 function getFirebaseConfig() {


### PR DESCRIPTION
### Motivation

- Prevent malformed `authDomain` values (for example full URLs that include `https://` and path segments) from causing invalid redirect/continue URI errors during auth flows.
- Ensure any Firebase config override sources are normalized so the auth setup always receives a bare hostname.
- Cover legacy and environment-based configuration inputs so runtime overrides behave consistently.

### Description

- Add `normalizeAuthDomainValue` which strips protocol and path or extracts the hostname from a provided URL and falls back to a cleaned hostname when parsing fails in `js/firebase-config.js`.
- Add `normalizeFirebaseConfig` and apply it in `readConfigFromGlobals` for direct `__FIREBASE_CONFIG`, `__ENV.FIREBASE_CONFIG`, and legacy `FIREBASE_AUTH_DOMAIN` inputs to ensure `authDomain` is normalized before merging with defaults.
- Add tests in `js/__tests__/firebase-config.test.js` that validate normalization for direct and legacy env overrides.

### Testing

- Ran `npm test -- js/__tests__/firebase-config.test.js` and the suite passed.
- Test output: `5 passed, 5 total` for the modified test file.
- No other test suites were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6943767c48324a2237d09f4043839)