### PR TITLE
Restore Firebase popup sign-in redirect fallback

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -4196,6 +4196,7 @@ export async function initReminders(sel = {}) {
     onAuthStateChanged,
     signInWithPopup,
     signInWithRedirect,
+    getRedirectResult,
     signOut,
     toast,
   });

--- a/js/supabase-auth.js
+++ b/js/supabase-auth.js
@@ -5,6 +5,7 @@ let _externalAuthContext = {
   GoogleAuthProvider: null,
   signInWithPopup: null,
   signInWithRedirect: null,
+  getRedirectResult: null,
   signOut: null,
   toast: null,
   onAuthStateChanged: null,
@@ -38,7 +39,29 @@ export async function startSignInFlow() {
       typeof _externalAuthContext.signInWithPopup === 'function'
     ) {
       const provider = new _externalAuthContext.GoogleAuthProvider();
-      return _externalAuthContext.signInWithPopup(_externalAuthContext.auth, provider);
+      // eslint-disable-next-line no-console
+      console.log('[auth] popup login attempt');
+      try {
+        return await _externalAuthContext.signInWithPopup(_externalAuthContext.auth, provider);
+      } catch (error) {
+        const popupErrorCode = error?.code;
+        const shouldFallbackToRedirect = (
+          popupErrorCode === 'auth/popup-blocked'
+          || popupErrorCode === 'auth/popup-closed-by-user'
+          || popupErrorCode === 'auth/cancelled-popup-request'
+        );
+
+        if (
+          shouldFallbackToRedirect
+          && typeof _externalAuthContext.signInWithRedirect === 'function'
+        ) {
+          // eslint-disable-next-line no-console
+          console.log('[auth] redirect fallback triggered');
+          return _externalAuthContext.signInWithRedirect(_externalAuthContext.auth, provider);
+        }
+
+        throw error;
+      }
     }
   } catch (err) {
     // eslint-disable-next-line no-console
@@ -306,6 +329,12 @@ export function initSupabaseAuth(options = {}) {
   applyAuthState(elements, { user: null, messages });
 
   const auth = suppliedAuth || _externalAuthContext?.auth || null;
+
+  if (auth && typeof _externalAuthContext?.getRedirectResult === 'function') {
+    _externalAuthContext.getRedirectResult(auth).catch((error) => {
+      console.warn('[auth] Redirect sign-in result handling failed.', error);
+    });
+  }
 
   if (!disableButtonBinding) {
     bindSignInButtons(elements);


### PR DESCRIPTION
### Motivation
- Restore a robust Firebase login flow that attempts `signInWithPopup` first and falls back to `signInWithRedirect` for popup-specific failures so sign-in works on localhost, Vercel, and Cloudflare Pages.
- Ensure redirect-based sign-ins complete by invoking redirect result handling during app startup without changing `firebaseConfig` or the existing `GoogleAuthProvider` setup.

### Description
- Updated `js/supabase-auth.js` to add `getRedirectResult` to the shared auth context and to call `getRedirectResult(auth)` from `initSupabaseAuth` when available.
- Rewrote `startSignInFlow` to log `console.log("[auth] popup login attempt")`, try `signInWithPopup`, and on popup errors with codes `auth/popup-blocked`, `auth/popup-closed-by-user`, or `auth/cancelled-popup-request` fall back to `signInWithRedirect` while logging `console.log("[auth] redirect fallback triggered")`.
- Wired `getRedirectResult` into the shared auth context from `js/reminders.js` so startup redirect handling is available via existing plumbing.
- Preserved existing Firebase authentication, the `GoogleAuthProvider` setup, and did not modify `firebaseConfig` or unrelated files.

### Testing
- Ran targeted Jest tests: `npm test -- --runTestsByPath js/__tests__/reminders.auth.test.js js/__tests__/mobile.auth.test.js` which executed but failed due to the test harness reporting `SyntaxError: Cannot use import statement outside a module`, an existing ESM/CommonJS test environment issue unrelated to the auth logic changes.
- No new unit tests were added or modified and the change is limited to `js/supabase-auth.js` and `js/reminders.js` only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6998a98dc8324a6c0844b175f0d47)