### PR TITLE
Fix Firebase auth config and popup/redirect sign-in flow

### DIFF
--- a/js/__tests__/firebase-config.test.js
+++ b/js/__tests__/firebase-config.test.js
@@ -29,7 +29,7 @@ describe('firebase-config', () => {
     const config = getFirebaseConfig();
     expect(config).toEqual(DEFAULT_FIREBASE_CONFIG);
     expect(config).not.toBe(DEFAULT_FIREBASE_CONFIG);
-    expect(config.projectId).toBe('ai-assistant-d546b');
+    expect(config.projectId).toBe('memory-cue-app');
   });
 
   it('merges direct global overrides', () => {

--- a/js/firebase-config.js
+++ b/js/firebase-config.js
@@ -1,8 +1,8 @@
 const DEFAULT_FIREBASE_CONFIG = Object.freeze({
   apiKey: 'AIzaSyAmAMiz0zG3dAhZJhOy1DYj8fKVDObL36c',
-  authDomain: 'ai-assistant-d546b.firebaseapp.com',
-  projectId: 'ai-assistant-d546b',
-  storageBucket: 'ai-assistant-d546b.appspot.com',
+  authDomain: 'memory-cue-app.firebaseapp.com',
+  projectId: 'memory-cue-app',
+  storageBucket: 'memory-cue-app.appspot.com',
   messagingSenderId: '751284466633',
   appId: '1:751284466633:web:3b10742970bef1a5d5ee18',
   measurementId: 'G-R0V4M7VCE6'

--- a/js/firebase-init.js
+++ b/js/firebase-init.js
@@ -1,9 +1,9 @@
 /* firebase-init.js */
 const FALLBACK_FIREBASE_CONFIG = Object.freeze({
   apiKey: 'AIzaSyAmAMiz0zG3dAhZJhOy1DYj8fKVDObL36c',
-  authDomain: 'ai-assistant-d546b.firebaseapp.com',
-  projectId: 'ai-assistant-d546b',
-  storageBucket: 'ai-assistant-d546b.appspot.com',
+  authDomain: 'memory-cue-app.firebaseapp.com',
+  projectId: 'memory-cue-app',
+  storageBucket: 'memory-cue-app.appspot.com',
   messagingSenderId: '751284466633',
   appId: '1:751284466633:web:3b10742970bef1a5d5ee18',
   measurementId: 'G-R0V4M7VCE6'

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -2810,7 +2810,7 @@ export async function initReminders(sel = {}) {
   setupVoiceEnhancement();
 
   // Placeholder for Firebase modules loaded later
-  let initializeApp, getFirestore, enableMultiTabIndexedDbPersistence,
+  let initializeApp, getApps, getApp, getFirestore, enableMultiTabIndexedDbPersistence,
     enableIndexedDbPersistence, doc, setDoc, deleteDoc, onSnapshot, collection,
     query, orderBy, serverTimestamp, getAuth, onAuthStateChanged,
     GoogleAuthProvider, signInWithPopup, signInWithRedirect, getRedirectResult,
@@ -3915,11 +3915,11 @@ export async function initReminders(sel = {}) {
   saveBtn?.addEventListener('click', handleSaveAction);
 
   if (firebaseDeps) {
-    ({ initializeApp, getFirestore, enableMultiTabIndexedDbPersistence, enableIndexedDbPersistence, doc, setDoc, deleteDoc, onSnapshot, collection, query, orderBy, serverTimestamp, getAuth, onAuthStateChanged, GoogleAuthProvider, signInWithPopup, signInWithRedirect, getRedirectResult, signOut } = firebaseDeps);
+    ({ initializeApp, getApps, getApp, getFirestore, enableMultiTabIndexedDbPersistence, enableIndexedDbPersistence, doc, setDoc, deleteDoc, onSnapshot, collection, query, orderBy, serverTimestamp, getAuth, onAuthStateChanged, GoogleAuthProvider, signInWithPopup, signInWithRedirect, getRedirectResult, signOut } = firebaseDeps);
     firebaseModulesLoaded = true;
   } else {
     try {
-      ({ initializeApp } = await importModule('https://www.gstatic.com/firebasejs/12.2.1/firebase-app.js'));
+      ({ initializeApp, getApps, getApp } = await importModule('https://www.gstatic.com/firebasejs/12.2.1/firebase-app.js'));
       ({ getFirestore, enableMultiTabIndexedDbPersistence, enableIndexedDbPersistence, doc, setDoc, deleteDoc, onSnapshot, collection, query, orderBy, serverTimestamp } = await importModule('https://www.gstatic.com/firebasejs/12.2.1/firebase-firestore.js'));
       ({ getAuth, onAuthStateChanged, GoogleAuthProvider, signInWithPopup, signInWithRedirect, getRedirectResult, signOut } = await importModule('https://www.gstatic.com/firebasejs/12.2.1/firebase-auth.js'));
       firebaseModulesLoaded = true;
@@ -3945,7 +3945,9 @@ export async function initReminders(sel = {}) {
         ? window.location.hostname
         : 'unknown');
       console.info('[Firebase] Initialising Memory Cue', firebaseConfig.projectId);
-      app = initializeApp(firebaseConfig);
+      app = (typeof getApps === 'function' && getApps().length && typeof getApp === 'function')
+        ? getApp()
+        : initializeApp(firebaseConfig);
       db = getFirestore(app);
       firebaseReady = true;
       console.info('[Firebase] Firestore initialised', firebaseConfig.projectId);
@@ -4000,7 +4002,7 @@ export async function initReminders(sel = {}) {
   }
 
   if (firebaseReady && typeof getAuth === 'function') {
-    auth = getAuth();
+    auth = getAuth(app);
   }
 
   // Formatting helpers

--- a/js/storage.js
+++ b/js/storage.js
@@ -76,9 +76,9 @@ window.__ENV = {
 
   const FALLBACK_FIREBASE_CONFIG = Object.freeze({
     apiKey: 'AIzaSyAmAMiz0zG3dAhZJhOy1DYj8fKVDObL36c',
-    authDomain: 'ai-assistant-d546b.firebaseapp.com',
-    projectId: 'ai-assistant-d546b',
-    storageBucket: 'ai-assistant-d546b.appspot.com',
+    authDomain: 'memory-cue-app.firebaseapp.com',
+    projectId: 'memory-cue-app',
+    storageBucket: 'memory-cue-app.appspot.com',
     messagingSenderId: '751284466633',
     appId: '1:751284466633:web:3b10742970bef1a5d5ee18',
     measurementId: 'G-R0V4M7VCE6'

--- a/js/supabase-auth.js
+++ b/js/supabase-auth.js
@@ -43,24 +43,22 @@ export async function startSignInFlow() {
       console.log('[auth] popup login attempt');
       try {
         return await _externalAuthContext.signInWithPopup(_externalAuthContext.auth, provider);
-      } catch (error) {
-        const popupErrorCode = error?.code;
-        const shouldFallbackToRedirect = (
-          popupErrorCode === 'auth/popup-blocked'
-          || popupErrorCode === 'auth/popup-closed-by-user'
-          || popupErrorCode === 'auth/cancelled-popup-request'
-        );
-
+      } catch (err) {
         if (
-          shouldFallbackToRedirect
-          && typeof _externalAuthContext.signInWithRedirect === 'function'
+          err?.code === 'auth/popup-blocked'
+          || err?.code === 'auth/popup-closed-by-user'
+          || err?.code === 'auth/cancelled-popup-request'
         ) {
-          // eslint-disable-next-line no-console
-          console.log('[auth] redirect fallback triggered');
-          return _externalAuthContext.signInWithRedirect(_externalAuthContext.auth, provider);
+          if (typeof _externalAuthContext.signInWithRedirect === 'function') {
+            // eslint-disable-next-line no-console
+            console.log('[auth] redirect fallback triggered');
+            return await _externalAuthContext.signInWithRedirect(_externalAuthContext.auth, provider);
+          }
+        } else {
+          throw err;
         }
 
-        throw error;
+        throw err;
       }
     }
   } catch (err) {


### PR DESCRIPTION
### Motivation
- Align the app's Firebase defaults and fallbacks with the correct project to fix `auth/unauthorized-domain` errors. 
- Ensure Firebase is initialized once and `getAuth` is bound to the initialized app to avoid duplicate/incorrect initialization. 
- Use the recommended popup-first sign-in with a redirect fallback to handle popup-blocking cases reliably. 

### Description
- Updated default Firebase config values to the required project: `projectId: "memory-cue-app"`, `authDomain: "memory-cue-app.firebaseapp.com"`, and `storageBucket: "memory-cue-app.appspot.com"` in `js/firebase-config.js` and fallback spots (`js/firebase-init.js`, `js/storage.js`).
- Changed Firebase app initialization in `js/reminders.js` to reuse an existing app when present (`getApps`/`getApp`) and to call `getAuth(app)` so auth is always tied to the initialized app.
- Implemented the popup-first sign-in flow with redirect fallback in `js/supabase-auth.js` per the requested pattern and added console logs for popup attempt and redirect fallback.
- Ensured redirect-based sign-in completion is invoked on startup (`getRedirectResult(auth)`) and left/retained debug logs showing the active Firebase project and `window.location.hostname`.
- Files modified: `js/firebase-config.js`, `js/firebase-init.js`, `js/reminders.js`, `js/supabase-auth.js`, `js/storage.js`, and the updated test `js/__tests__/firebase-config.test.js`.
- Login flow summary: attempts `signInWithPopup(auth, provider)` first (logs `[auth] popup login attempt`) and falls back to `signInWithRedirect(auth, provider)` on popup interruption errors (`auth/popup-blocked`, `auth/popup-closed-by-user`, `auth/cancelled-popup-request`) (logs `[auth] redirect fallback triggered`).
- Confirmation: Firebase project used is `memory-cue-app` in defaults and fallbacks.

### Testing
- Ran `npm test -- --runInBand js/__tests__/firebase-config.test.js` and it passed (all assertions for `getFirebaseConfig` updated and succeeding). ✅
- Ran `npm test -- --runInBand js/__tests__/firebase-config.test.js js/__tests__/reminders.auth.test.js` which reported a failing `reminders.auth` suite caused by an ESM import/runtime mismatch in the test harness (parsing `import` in a VM context), which is unrelated to these auth config/login changes. ❌
- No changes were made to unrelated systems (reminders, notes storage, capture pipeline, AI services) as requested.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b69de21c8083249b54072804c4089a)