### PR TITLE
Migrate local offline reminders to Firestore on login

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -3691,12 +3691,55 @@ export async function initReminders(sel = {}) {
 
   ensureAllEmbeddings();
 
+  async function migrateLocalReminders(authInstance, firestoreDb) {
+    if (!authInstance?.currentUser || !firestoreDb) {
+      return;
+    }
+
+    const uid = authInstance.currentUser.uid;
+    let localReminders = [];
+
+    try {
+      localReminders = JSON.parse(localStorage.getItem('memoryCue:offlineReminders') || '[]');
+    } catch (error) {
+      console.warn('Failed to parse local reminders for migration', error);
+      localReminders = [];
+    }
+
+    if (!Array.isArray(localReminders)) {
+      localReminders = [];
+    }
+
+    console.log('[brain] local reminders found:', localReminders.length);
+
+    if (!localReminders.length) {
+      return;
+    }
+
+    for (const reminder of localReminders) {
+      const reminderRef = doc(
+        collection(firestoreDb, 'users', uid, 'reminders'),
+        reminder?.id || crypto.randomUUID(),
+      );
+
+      await setDoc(reminderRef, {
+        ...reminder,
+        userId: uid,
+        migratedAt: Date.now(),
+      });
+    }
+
+    console.log('[brain] migrated reminders:', localReminders.length);
+    console.log('[brain] reminders migrated to firestore');
+    localStorage.removeItem('memoryCue:offlineReminders');
+  }
+
   async function migrateOfflineRemindersIfNeeded() {
     if (!userId) {
       items = loadOfflineRemindersFromStorage();
       return;
     }
-    // Local reminders are merged/synced during Firestore login sync.
+    await migrateLocalReminders(auth, db);
   }
   try {
     scheduledReminders = JSON.parse(localStorage.getItem('scheduledReminders') || '{}');


### PR DESCRIPTION
### Motivation
- Migrate legacy reminders stored in `localStorage` under `memoryCue:offlineReminders` into Firestore once a Firebase user signs in so users retain their prior reminders.
- Ensure migration runs only once by clearing the local key after a successful upload and avoid changing reminder UI or creation logic.

### Description
- Added `migrateLocalReminders(authInstance, firestoreDb)` which reads `memoryCue:offlineReminders` from `localStorage`, logs the count, and exits if none exist.
- Each reminder is written to Firestore at `users/{uid}/reminders/{reminderId}` using the reminder `id` or `crypto.randomUUID()` as a fallback, and saved with `userId` and `migratedAt` metadata via `setDoc` and `doc`/`collection`.
- Added debug logs `console.log('[brain] local reminders found:', ...)`, `console.log('[brain] migrated reminders:', ...)`, and `console.log('[brain] reminders migrated to firestore')`, and remove the local key after upload so migration only runs once.
- Wired the migration into the existing flow by calling `await migrateLocalReminders(auth, db)` from `migrateOfflineRemindersIfNeeded()` when a signed-in user is present, preserving the signed-out behavior that loads offline reminders.

### Testing
- Ran `npm test -- --runInBand sample.test.js` and the test passed.
- Attempted `npm test -- --runInBand js/__tests__/reminders.auth.test.js js/__tests__/reminders.notes.test.js` and the suites failed due to the test harness encountering an existing ESM/import `vm.runInNewContext` error (`Cannot use import statement outside a module`), which is unrelated to this migration change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7061073b0832485845f4911a30a8c)