### PR TITLE
Use per-user Firestore subcollection for reminders

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -4345,9 +4345,8 @@ export async function initReminders(sel = {}) {
     }
     try {
       const localItems = ensureOrderIndicesInitialized(loadOfflineRemindersFromStorage());
-      const remindersCollection = collection(db, 'reminders');
-      const remindersQuery = query(remindersCollection, where('userId', '==', userId));
-      const remindersSnapshot = await getDocs(remindersQuery);
+      const remindersCollection = collection(db, 'users', userId, 'reminders');
+      const remindersSnapshot = await getDocs(remindersCollection);
       const remoteItems = remindersSnapshot.docs
         .map((reminderDoc) => mapFirestoreReminder(reminderDoc.id, reminderDoc.data()));
       console.log('[brain] reminders_loaded_from_firestore', { count: remoteItems.length });


### PR DESCRIPTION
### Motivation
- Switch the reminders fetch/sync to the per-user Firestore subcollection to align with the database structure and avoid client-side filtering by `userId`.

### Description
- Updated `js/reminders.js` in `setupSupabaseSync` to read from `collection(db, 'users', userId, 'reminders')` and removed the previous `query(..., where('userId', '==', userId))` usage so remote reminders are loaded directly from the user's subcollection.

### Testing
- Ran the existing reminder sync unit/integration tests and local sync scenario checks; all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b73b432a0c83248c351f5fe197a18b)