### PR TITLE
Fix aria-hidden focus warning in saved notes sheet

### DIFF
--- a/mobile.js
+++ b/mobile.js
@@ -1440,6 +1440,7 @@ const initMobileNotes = () => {
     }
     savedNotesSheet.classList.remove('hidden');
     savedNotesSheet.dataset.open = 'true';
+    savedNotesSheet.removeAttribute('inert');
     savedNotesSheet.setAttribute('aria-hidden', 'false');
     document.body.dataset.savedNotesOpen = 'true';
     document.documentElement.dataset.savedNotesOpen = 'true';
@@ -1462,7 +1463,16 @@ const initMobileNotes = () => {
     if (!savedNotesSheet) {
       return;
     }
+    const activeElement = document.activeElement;
+    if (activeElement instanceof HTMLElement && savedNotesSheet.contains(activeElement)) {
+      if (openSavedNotesButton instanceof HTMLElement && typeof openSavedNotesButton.focus === 'function') {
+        openSavedNotesButton.focus();
+      } else if (typeof activeElement.blur === 'function') {
+        activeElement.blur();
+      }
+    }
     savedNotesSheet.dataset.open = 'false';
+    savedNotesSheet.setAttribute('inert', '');
     savedNotesSheet.setAttribute('aria-hidden', 'true');
     delete document.body.dataset.savedNotesOpen;
     delete document.documentElement.dataset.savedNotesOpen;


### PR DESCRIPTION
## Summary
- update `showSavedNotesSheet()` to remove `inert` when opening the saved notes dialog
- update `hideSavedNotesSheet()` to move focus out of the sheet before setting `aria-hidden="true"`
- set `inert` on the saved notes sheet while closed to prevent hidden descendants from retaining focus

## Why
Chrome warns when an element (or ancestor) is marked `aria-hidden="true"` while a focused descendant remains inside it. This patch ensures focus is redirected to the opener (or blurred) before hiding the sheet, and uses `inert` to keep hidden content unfocusable.

## Validation
- static inspection of `mobile.js` confirms focus handoff occurs before `aria-hidden` is applied on close
- verified only the saved notes sheet open/close logic was changed

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7725dfc6c832495e0b5e6aa9da757)