### PR TITLE
Add scheduled reminder notifications with Notification API and service worker

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -189,6 +189,76 @@ function getTimestampTriggerCtor() {
   return typeof Trigger === 'function' ? Trigger : null;
 }
 
+async function ensureNotificationPermission() {
+  if (typeof Notification === 'undefined') {
+    return false;
+  }
+
+  if (Notification.permission === 'granted') return true;
+
+  if (Notification.permission !== 'denied') {
+    const permission = await Notification.requestPermission();
+    return permission === 'granted';
+  }
+
+  return false;
+}
+
+function scheduleReminderNotification(reminder) {
+  if (!reminder || typeof reminder !== 'object') {
+    return;
+  }
+
+  const dueAtValue = typeof reminder.dueAt === 'string' && reminder.dueAt
+    ? reminder.dueAt
+    : reminder.due;
+  if (!dueAtValue) {
+    return;
+  }
+
+  const notifyMinutesBefore = Number.isFinite(reminder.notifyMinutesBefore)
+    ? reminder.notifyMinutesBefore
+    : 0;
+  const notifyTime =
+    new Date(dueAtValue).getTime() -
+    notifyMinutesBefore * 60000;
+
+  const delay = notifyTime - Date.now();
+  if (delay <= 0) {
+    return;
+  }
+
+  console.log('[notifications] scheduled reminder', {
+    id: reminder.id,
+    dueAt: dueAtValue,
+  });
+
+  setTimeout(() => {
+    if (typeof Notification !== 'undefined' && Notification.permission === 'granted') {
+      new Notification('Reminder', {
+        body: reminder.text || reminder.title || '',
+        icon: '/icons/icon-192.png',
+        tag: reminder.id,
+      });
+    }
+  }, delay);
+
+  if (
+    typeof navigator !== 'undefined' &&
+    navigator.serviceWorker &&
+    typeof navigator.serviceWorker.ready?.then === 'function'
+  ) {
+    navigator.serviceWorker.ready.then((reg) => {
+      reg.active?.postMessage({
+        type: 'scheduleReminder',
+        title: 'Reminder',
+        body: reminder.text || reminder.title || '',
+        time: notifyTime,
+      });
+    });
+  }
+}
+
 function supportsNotificationTriggers() {
   if (typeof window === 'undefined') return false;
   if (!('Notification' in window)) return false;
@@ -4284,6 +4354,7 @@ export async function initReminders(sel = {}) {
         await setupSupabaseSync();
         await syncNotesFromFirestoreOnLogin();
         await migrateOfflineRemindersIfNeeded();
+        await ensureNotificationPermission();
       } else {
         notesMigrationComplete = false;
         notesMigrationUserId = null;
@@ -4308,6 +4379,7 @@ export async function initReminders(sel = {}) {
       renderSyncIndicator('online');
       await setupSupabaseSync();
       await syncNotesFromFirestoreOnLogin();
+      await ensureNotificationPermission();
     }
   } else {
     applySignedOutState();
@@ -4484,6 +4556,13 @@ export async function initReminders(sel = {}) {
         userId,
         category: normalizeCategory(item.category),
       })));
+      items.forEach((reminder) => {
+        scheduleReminderNotification({
+          ...reminder,
+          dueAt: reminder.due,
+          text: reminder.title,
+        });
+      });
       render();
       updateMobileRemindersHeaderSubtitle();
       persistItems();
@@ -4709,6 +4788,24 @@ export async function initReminders(sel = {}) {
     } else {
       saveToFirebase(item);
     }
+    const notifyMinutesBefore = (() => {
+      if (typeof item.notifyAt !== 'string' || !item.notifyAt || typeof item.due !== 'string' || !item.due) {
+        return 0;
+      }
+      const dueMs = new Date(item.due).getTime();
+      const notifyMs = new Date(item.notifyAt).getTime();
+      if (!Number.isFinite(dueMs) || !Number.isFinite(notifyMs)) {
+        return 0;
+      }
+      return Math.max(0, Math.round((dueMs - notifyMs) / 60000));
+    })();
+    scheduleReminderNotification({
+      id: item.id,
+      text: item.title,
+      dueAt: item.due,
+      notifyMinutesBefore,
+    });
+    ensureNotificationPermission();
     tryCalendarSync(item);
     scheduleReminder(item);
     rescheduleAllReminders();
@@ -4817,6 +4914,24 @@ export async function initReminders(sel = {}) {
     } else {
       saveToFirebase(item);
     }
+    const notifyMinutesBefore = (() => {
+      if (typeof item.notifyAt !== 'string' || !item.notifyAt || typeof item.due !== 'string' || !item.due) {
+        return 0;
+      }
+      const dueMs = new Date(item.due).getTime();
+      const notifyMs = new Date(item.notifyAt).getTime();
+      if (!Number.isFinite(dueMs) || !Number.isFinite(notifyMs)) {
+        return 0;
+      }
+      return Math.max(0, Math.round((dueMs - notifyMs) / 60000));
+    })();
+    scheduleReminderNotification({
+      id: item.id,
+      text: item.title,
+      dueAt: item.due,
+      notifyMinutesBefore,
+    });
+    ensureNotificationPermission();
     tryCalendarSync(item);
     emitReminderUpdates();
     dispatchCueEvent('memoryCue:remindersUpdated', { items });
@@ -6131,8 +6246,8 @@ export async function initReminders(sel = {}) {
       return;
     }
     try {
-      const perm = await Notification.requestPermission();
-      if(perm==='granted'){
+      const granted = await ensureNotificationPermission();
+      if(granted){
         toast('Notifications enabled');
         if(supportsNotificationTriggers()) {
           ensureServiceWorkerRegistration();

--- a/mobile.js
+++ b/mobile.js
@@ -39,6 +39,12 @@ const isNotesSyncDebugEnabled = (() => {
 
 initViewportHeight();
 
+
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/sw.js');
+}
+
+
 function initAssistant() {
     const isTextEntryElement = (value) => {
       if (typeof HTMLInputElement !== 'undefined' && value instanceof HTMLInputElement) {

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,16 @@
+self.addEventListener('message', (event) => {
+  if (!event?.data || event.data.type !== 'scheduleReminder') {
+    return;
+  }
+
+  const { title, body, time } = event.data;
+  const delay = time - Date.now();
+
+  if (delay <= 0) {
+    return;
+  }
+
+  setTimeout(() => {
+    self.registration.showNotification(title, { body });
+  }, delay);
+});


### PR DESCRIPTION
### Motivation
- Reminders sync correctly but do not currently trigger notifications, so add scheduling that uses the Web Notification API and a Service Worker while keeping existing Firestore and storage logic unchanged.

### Description
- Add `ensureNotificationPermission()` in `js/reminders.js` to centralize permission checking and requesting via the Notification API.
- Add `scheduleReminderNotification(reminder)` in `js/reminders.js` to compute the notify time from `dueAt`/`notifyMinutesBefore`, schedule a foreground `Notification` via `setTimeout`, post a `scheduleReminder` message to the active service worker, and log scheduling with `console.log('[notifications] scheduled reminder', ...)`.
- Wire permission requests and scheduling into the reminder lifecycle by calling `ensureNotificationPermission()` after login and when creating/restoring reminders, and by scheduling notifications when reminders are loaded from Firestore to restore schedules on startup.
- Register `/sw.js` in `mobile.js` so the app registers a service worker on mobile startup.
- Add a root `sw.js` service worker that listens for `message` events of type `scheduleReminder` and calls `self.registration.showNotification(...)` at the requested time.

### Testing
- Ran `git diff --check` which returned no issues.
- Ran `npm test -- reminders.notifications.test.js` which failed in this environment due to the test harness executing `js/reminders.js` as CommonJS while the file uses ESM imports, producing a `Cannot use import statement outside a module` error.
- Ran `node --check` which surfaced the same ESM/CJS import mismatch when checking files containing `import` statements.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b78b7c16808324ba091af8ce221ec1)