### PR TITLE
Add AI Daily Planning Assistant (planner service, intent, chat UI)

### DIFF
--- a/src/chat/chatManager.js
+++ b/src/chat/chatManager.js
@@ -6,6 +6,7 @@ import { classifyIntentLocally, createChatIntentInput, routeIntent } from '../se
 import { retrieveRelevantMemories } from '../services/brainQueryService.js';
 import { ensureFolderExistsByName } from '../../js/modules/ai-capture-save.js';
 import { saveNote } from '../services/adapters/notePersistenceAdapter.js';
+import { generateDailyPlan, renderDailyPlan } from '../services/planningService.js';
 
 export const ENABLE_CHAT_INTERFACE = true;
 
@@ -348,6 +349,11 @@ const processParsedEntry = async (parsed, text, dependencies = {}) => {
   if (decision.decisionType === 'persist_note') {
     const { notebookName } = await createNotebookNote(parsed, text);
     return { message: `Saved to notebook (${notebookName}).` };
+  }
+
+  if (decision.decisionType === 'plan_day') {
+    const plan = await generateDailyPlan(dependencies.uid);
+    return { message: renderDailyPlan(plan) };
   }
 
   if (decision.decisionType === 'query') {

--- a/src/components/ChatPanel.js
+++ b/src/components/ChatPanel.js
@@ -35,6 +35,17 @@ const runQuickAction = (targetView) => {
   window.dispatchEvent(new CustomEvent('app:navigate', { detail: { view: targetView } }));
 };
 
+const resolveCurrentUid = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const scopedUid = typeof window.__MEMORY_CUE_AUTH_USER_ID === 'string'
+    ? window.__MEMORY_CUE_AUTH_USER_ID.trim()
+    : '';
+  return scopedUid || null;
+};
+
 const createQuickActionBar = (quickActions = []) => {
   if (!Array.isArray(quickActions) || quickActions.length === 0) {
     return null;
@@ -149,6 +160,17 @@ export const createChatPanel = () => {
   sendButton.type = 'submit';
   sendButton.textContent = 'Send';
 
+  const planButton = createNode('button', {
+    border: '1px solid color-mix(in srgb, var(--fg) 20%, transparent)',
+    borderRadius: '0.5rem',
+    background: 'var(--card)',
+    color: 'var(--fg)',
+    padding: '0.5rem 0.9rem',
+    cursor: 'pointer',
+  });
+  planButton.type = 'button';
+  planButton.textContent = 'Plan My Day';
+
   inputBar.addEventListener('submit', async (event) => {
     event.preventDefault();
     const userInput = input.value.trim();
@@ -159,14 +181,28 @@ export const createChatPanel = () => {
     appendMessage(messageList, 'user', userInput);
     input.value = '';
 
-    const assistantReply = await handleMessage(userInput, { createReminder });
+    const assistantReply = await handleMessage(userInput, {
+      createReminder,
+      uid: resolveCurrentUid(),
+    });
     if (assistantReply?.status) {
       statusIndicator.show(assistantReply.status);
     }
     appendMessage(messageList, 'assistant', assistantReply.message, assistantReply.quickActions);
   });
 
-  inputBar.append(input, sendButton);
+  planButton.addEventListener('click', async () => {
+    const assistantReply = await handleMessage('plan my day', {
+      createReminder,
+      uid: resolveCurrentUid(),
+    });
+    if (assistantReply?.status) {
+      statusIndicator.show(assistantReply.status);
+    }
+    appendMessage(messageList, 'assistant', assistantReply.message, assistantReply.quickActions);
+  });
+
+  inputBar.append(input, sendButton, planButton);
   container.append(messageList, statusIndicator.container, inputBar);
 
   return {

--- a/src/services/intentRouter.js
+++ b/src/services/intentRouter.js
@@ -5,6 +5,7 @@ const REMINDER_KEYWORDS = ['remind', 'tomorrow', 'tonight', 'later', 'buy', 'pic
 const NOTE_KEYWORDS = ['idea', 'note', 'remember', 'lesson'];
 const DRILL_KEYWORDS = ['drill', 'training', 'coaching'];
 const QUESTION_PREFIXES = ['what', 'when', 'how', 'where'];
+const PLAN_DAY_PHRASES = ['plan my day', 'what should i do today', 'daily plan', 'schedule my day'];
 
 export const DECISION_TYPES = ['query_memory', 'learn_pattern', 'plan_day', 'persist_reminder', 'persist_note', 'persist_inbox'];
 
@@ -23,6 +24,9 @@ const createHeuristicParsedEntry = (type, text, hints = {}) => ({
     capturedAt: hints?.capturedAt,
   },
 });
+
+const isPlanDayPhrase = (normalizedText) => PLAN_DAY_PHRASES
+  .some((phrase) => normalizedText.includes(phrase));
 
 const logRoutingDecision = (source, text, decision, details = {}) => {
   console.info('[brain] routing decision', {
@@ -48,6 +52,16 @@ export const classifyIntentLocally = (rawText, hints = {}) => {
   }
 
   const patternMatch = predictIntent(text);
+  if (isPlanDayPhrase(normalized)) {
+    return logRoutingDecision('classifyIntentLocally.phrase', text, {
+      decisionType: 'plan_day',
+      parsedType: 'plan_day',
+      text,
+      parsedEntry: createHeuristicParsedEntry('plan_day', text, hints),
+      hints,
+    });
+  }
+
   if (patternMatch?.predictedIntent === 'persist_reminder') {
     return logRoutingDecision('classifyIntentLocally.pattern', text, {
       decisionType: 'persist_reminder',
@@ -190,6 +204,7 @@ const looksLikeNotebookCapture = (rawText) => {
  */
 export const routeIntent = (parsedEntry, rawText, hints = {}) => {
   const text = typeof rawText === 'string' ? rawText.trim() : '';
+  const normalizedText = text.toLowerCase();
   const parsed = parsedEntry && typeof parsedEntry === 'object' ? parsedEntry : {};
   const parsedType = normalizeType(parsed?.type, text);
   const notebookHeuristic = looksLikeNotebookCapture(text);
@@ -215,6 +230,17 @@ export const routeIntent = (parsedEntry, rawText, hints = {}) => {
       hints,
     };
     return logRoutingDecision('routeIntent', text, decision);
+  }
+
+  if (isPlanDayPhrase(normalizedText)) {
+    const decision = {
+      decisionType: 'plan_day',
+      parsedType: 'plan_day',
+      text,
+      parsedEntry: parsed,
+      hints,
+    };
+    return logRoutingDecision('routeIntent.phrase', text, decision);
   }
 
   if (parsedType === 'reminder') {

--- a/src/services/planningService.js
+++ b/src/services/planningService.js
@@ -1,0 +1,229 @@
+const FIREBASE_VERSION = '12.2.1';
+const FIREBASE_APP_URL = `https://www.gstatic.com/firebasejs/${FIREBASE_VERSION}/firebase-app.js`;
+const FIREBASE_AUTH_URL = `https://www.gstatic.com/firebasejs/${FIREBASE_VERSION}/firebase-auth.js`;
+const FIREBASE_FIRESTORE_URL = `https://www.gstatic.com/firebasejs/${FIREBASE_VERSION}/firebase-firestore.js`;
+
+let plannerContextPromise = null;
+
+const resolveFirebaseConfig = () => {
+  if (typeof globalThis === 'undefined') {
+    return null;
+  }
+
+  return globalThis?.memoryCueFirebase?.getFirebaseConfig?.() || null;
+};
+
+const ensurePlannerContext = async () => {
+  if (plannerContextPromise) {
+    return plannerContextPromise;
+  }
+
+  plannerContextPromise = (async () => {
+    const config = resolveFirebaseConfig();
+    if (!config?.projectId) {
+      console.warn('[planner] Firebase config unavailable.');
+      return null;
+    }
+
+    const appModule = await import(FIREBASE_APP_URL);
+    const authModule = await import(FIREBASE_AUTH_URL);
+    const firestoreModule = await import(FIREBASE_FIRESTORE_URL);
+
+    const app = appModule.getApps().length ? appModule.getApp() : appModule.initializeApp(config);
+    const auth = authModule.getAuth(app);
+    const db = firestoreModule.getFirestore(app);
+
+    return {
+      auth,
+      db,
+      collection: firestoreModule.collection,
+      getDocs: firestoreModule.getDocs,
+    };
+  })();
+
+  return plannerContextPromise;
+};
+
+const resolveUid = async (uid) => {
+  if (typeof uid === 'string' && uid.trim()) {
+    return uid.trim();
+  }
+
+  if (typeof globalThis !== 'undefined' && typeof globalThis.__MEMORY_CUE_AUTH_USER_ID === 'string') {
+    const scopedUid = globalThis.__MEMORY_CUE_AUTH_USER_ID.trim();
+    if (scopedUid) {
+      return scopedUid;
+    }
+  }
+
+  const context = await ensurePlannerContext();
+  return context?.auth?.currentUser?.uid || null;
+};
+
+const normalizeItemTitle = (item = {}, fallback = 'Untitled') => {
+  if (typeof item?.title === 'string' && item.title.trim()) {
+    return item.title.trim();
+  }
+
+  if (typeof item?.text === 'string' && item.text.trim()) {
+    return item.text.trim();
+  }
+
+  if (typeof item?.body === 'string' && item.body.trim()) {
+    return item.body.trim();
+  }
+
+  return fallback;
+};
+
+const parseDueDate = (item = {}) => {
+  const rawDue = item?.dueAt || item?.due || item?.reminderDate || item?.metadata?.dueAt || item?.metadata?.due || null;
+  if (!rawDue) {
+    return null;
+  }
+
+  const dueDate = new Date(rawDue);
+  return Number.isNaN(dueDate.getTime()) ? null : dueDate;
+};
+
+const isToday = (date) => {
+  const now = new Date();
+  return date.getFullYear() === now.getFullYear()
+    && date.getMonth() === now.getMonth()
+    && date.getDate() === now.getDate();
+};
+
+const loadCollection = async (uid, collectionName) => {
+  const context = await ensurePlannerContext();
+  if (!context || !uid) {
+    return [];
+  }
+
+  const snapshot = await context.getDocs(context.collection(context.db, 'users', uid, collectionName));
+  return snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+};
+
+export const loadReminders = async (uid) => {
+  const resolvedUid = await resolveUid(uid);
+  return loadCollection(resolvedUid, 'reminders');
+};
+
+export const loadNotes = async (uid) => {
+  const resolvedUid = await resolveUid(uid);
+  return loadCollection(resolvedUid, 'notes');
+};
+
+export const loadInbox = async (uid) => {
+  const resolvedUid = await resolveUid(uid);
+  return loadCollection(resolvedUid, 'inbox');
+};
+
+const toPlanItem = (entry, dueDate = null) => ({
+  id: entry?.id || null,
+  title: normalizeItemTitle(entry),
+  dueAt: dueDate ? dueDate.toISOString() : null,
+  dueLabel: dueDate
+    ? dueDate.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+    : null,
+});
+
+export const generateDailyPlan = async (uid) => {
+  console.debug('[planner] generating daily plan');
+
+  const resolvedUid = await resolveUid(uid);
+  if (!resolvedUid) {
+    return {
+      morning: [],
+      afternoon: [],
+      evening: [],
+      suggestedTasks: [],
+    };
+  }
+
+  const [reminders, inbox, notes] = await Promise.all([
+    loadReminders(resolvedUid),
+    loadInbox(resolvedUid),
+    loadNotes(resolvedUid),
+  ]);
+
+  console.debug('[planner] reminders loaded', { count: reminders.length });
+
+  const todayReminders = reminders
+    .map((reminder) => ({ reminder, dueDate: parseDueDate(reminder) }))
+    .filter(({ dueDate }) => dueDate && isToday(dueDate))
+    .sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime());
+
+  const plan = {
+    morning: [],
+    afternoon: [],
+    evening: [],
+    suggestedTasks: [],
+  };
+
+  todayReminders.forEach(({ reminder, dueDate }) => {
+    const hour = dueDate.getHours();
+    const planItem = toPlanItem(reminder, dueDate);
+
+    if (hour < 12) {
+      plan.morning.push(planItem);
+      return;
+    }
+
+    if (hour < 17) {
+      plan.afternoon.push(planItem);
+      return;
+    }
+
+    plan.evening.push(planItem);
+  });
+
+  const inboxSuggestions = inbox
+    .filter((item) => !parseDueDate(item))
+    .map((item) => toPlanItem(item));
+
+  const noteSuggestions = notes
+    .slice(0, 3)
+    .map((item) => toPlanItem(item));
+
+  plan.suggestedTasks = [...inboxSuggestions, ...noteSuggestions]
+    .filter((item, index, list) => list.findIndex((candidate) => candidate.title === item.title) === index)
+    .slice(0, 8);
+
+  if (inboxSuggestions.length) {
+    console.debug('[planner] inbox suggestions added', { count: inboxSuggestions.length });
+  }
+
+  return plan;
+};
+
+export const renderDailyPlan = (plan = {}) => {
+  const sections = [
+    ['Morning', plan?.morning],
+    ['Afternoon', plan?.afternoon],
+    ['Evening', plan?.evening],
+  ];
+
+  const lines = ['Today\'s Plan', ''];
+
+  sections.forEach(([label, items]) => {
+    lines.push(label);
+    if (Array.isArray(items) && items.length) {
+      items.forEach((item) => {
+        const duePart = item?.dueLabel ? ` ${item.dueLabel}` : '';
+        lines.push(`• ${normalizeItemTitle(item)}${duePart}`);
+      });
+    } else {
+      lines.push('• No scheduled items');
+    }
+    lines.push('');
+  });
+
+  if (Array.isArray(plan?.suggestedTasks) && plan.suggestedTasks.length) {
+    lines.push('Suggested Tasks');
+    plan.suggestedTasks.forEach((item) => {
+      lines.push(`• ${normalizeItemTitle(item)}`);
+    });
+  }
+
+  return lines.join('\n').trim();
+};


### PR DESCRIPTION
### Motivation

- Provide a non-destructive planning layer that reads existing user data (`users/{uid}/reminders`, `users/{uid}/notes`, `users/{uid}/inbox`) and returns a suggested plan for the day without changing storage schema or write paths. 
- Allow users to request a daily plan via chat triggers and a UI button so the assistant can surface a quick, time-bucketed agenda and suggested tasks.

### Description

- Added a new planner service at `src/services/planningService.js` with `loadReminders`, `loadNotes`, `loadInbox`, `generateDailyPlan(uid)`, and `renderDailyPlan(plan)`; the planner only reads Firestore collections for the provided `uid` and builds `morning`, `afternoon`, `evening`, and `suggestedTasks` buckets, while emitting debug logs like `[planner] generating daily plan` and `[planner] reminders loaded`.
- Extended intent routing in `src/services/intentRouter.js` to detect planning trigger phrases (`plan my day`, `what should i do today`, `daily plan`, `schedule my day`) and return `decisionType: "plan_day"` via both local classification and routing fallbacks.
- Wired the planner into chat handling in `src/chat/chatManager.js` so when `decision.decisionType === 'plan_day'` the code calls `generateDailyPlan(uid)` and returns `renderDailyPlan(plan)` as the assistant message.
- Added a `Plan My Day` button to the chat UI in `src/components/ChatPanel.js` which invokes the same flow via `handleMessage('plan my day', { uid, createReminder })` and appends the rendered plan to the conversation, using the existing resolved UID pattern; no Firestore schema/storage logic was modified.

### Testing

- Ran unit test suite with `npm test -- --runInBand`, which failed due to many existing unrelated test/environment issues (pre-existing ESM/VM harness errors in the repository) and not because of planner code changes. 
- Ran `npm run verify`, which completed successfully and reported build verification passed. 
- Served the app locally with `npx serve` and performed a visual smoke check using a Playwright script to confirm the `Plan My Day` button is visible and triggers the chat flow (screenshot artifact captured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b791c11b0083249b721b7993c76d6b)