### PR TITLE
Hoist normalizeFirestoreNote to function declaration to prevent TDZ in auth flow

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -4470,7 +4470,7 @@ export async function initReminders(sel = {}) {
     return Date.now();
   }
 
-  const normalizeFirestoreNote = (noteId, payload = {}) => {
+  function normalizeFirestoreNote(noteId, payload = {}) {
     if (!payload || typeof payload !== 'object') {
       return null;
     }
@@ -4478,7 +4478,7 @@ export async function initReminders(sel = {}) {
       ...payload,
       id: typeof payload.id === 'string' && payload.id ? payload.id : noteId,
     };
-  };
+  }
 
   async function migrateLocalNotesToFirestore(localNotes = []) {
     if (notesMigrationComplete || !userId || !db || typeof setDoc !== 'function' || typeof doc !== 'function') {


### PR DESCRIPTION
### Motivation
- Remove the temporal-dead-zone risk by hoisting `normalizeFirestoreNote` so auth callbacks that run immediately can call it reliably during login.

### Description
- Replaced the `const` arrow `normalizeFirestoreNote = (noteId, payload = {}) => { ... }` with a hoisted `function normalizeFirestoreNote(noteId, payload = {}) { ... }` in `js/reminders.js` while preserving the exact normalization logic and leaving `syncNotesFromFirestoreOnLogin` unchanged.

### Testing
- Ran `rg -n "normalizeFirestoreNote" js/reminders.js` to verify a single definition and ran `npm test -- --runInBand`, where the test run completed but reported multiple pre-existing failing suites unrelated to this focused change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7928330a88324849766cb1eba980a)