### PR TITLE
Make pin toggle handler property TDZ-safe in reminders

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -5470,7 +5470,9 @@ export async function initReminders(sel = {}) {
     }
   }
 
-  const PIN_TOGGLE_HANDLER_PROP = '__mcPinToggleHandler';
+  function getPinToggleHandlerProp() {
+    return '__mcPinToggleHandler';
+  }
   var pinToggleSyncScheduled = false;
 
   function updatePinToggleVisualState(toggle, pinned) {
@@ -5487,7 +5489,7 @@ export async function initReminders(sel = {}) {
     if (!(element instanceof HTMLElement)) {
       return;
     }
-    if (element[PIN_TOGGLE_HANDLER_PROP]) {
+    if (element[getPinToggleHandlerProp()]) {
       return;
     }
     if (!element.hasAttribute('role')) {
@@ -5530,7 +5532,7 @@ export async function initReminders(sel = {}) {
     };
     element.addEventListener('click', handleToggle);
     element.addEventListener('keydown', handleKeyDown);
-    element[PIN_TOGGLE_HANDLER_PROP] = { click: handleToggle, keydown: handleKeyDown };
+    element[getPinToggleHandlerProp()] = { click: handleToggle, keydown: handleKeyDown };
   }
 
   function syncPinToggleStates() {


### PR DESCRIPTION
### Motivation
- Prevent a temporal-dead-zone crash when `render()` (or other early code) references the pin-toggle handler property before its `const` initializer runs.

### Description
- Replace `const PIN_TOGGLE_HANDLER_PROP = '__mcPinToggleHandler'` with a hoisted helper `getPinToggleHandlerProp()` that returns the same string and update `bindTodayToggleListener` to call `getPinToggleHandlerProp()` for both the existing-handler guard and the handler storage assignment, preserving identical runtime behavior.

### Testing
- Ran the test suite with `npm test -- --runInBand`; the runner executed but the repository has multiple pre-existing failing suites unrelated to this minimal change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7976836588324ab84cc564bac3b53)