### PR TITLE
Add background reminder notification scheduler

### DIFF
--- a/js/reminders.js
+++ b/js/reminders.js
@@ -2,6 +2,7 @@ import { setAuthContext, startSignInFlow, startSignOutFlow } from './supabase-au
 import { captureInput, getInboxEntries } from './services/capture-service.js';
 import { createReminder as createReminderViaService, setReminderCreationHandler, buildReminderPayload } from '../src/services/reminderService.js';
 import { createAndSaveNote, loadAllNotes, saveAllNotes, setRemoteSyncHandler } from './modules/notes-storage.js';
+import { requestNotificationPermission, startReminderScheduler } from '../src/services/reminderNotificationService.js';
 
 // Shared reminder logic used by both the mobile and desktop pages.
 // This module wires up Firebase/Firestore and all reminder UI handlers.
@@ -6590,6 +6591,8 @@ export async function initReminders(sel = {}) {
     }
   }
   setupDragAndDrop();
+  startReminderScheduler(() => items);
+  requestNotificationPermission();
   rescheduleAllReminders();
   render();
   persistItems();

--- a/src/services/reminderNotificationService.js
+++ b/src/services/reminderNotificationService.js
@@ -1,0 +1,53 @@
+let reminderSchedulerId = null;
+let notificationPermissionRequested = false;
+
+export async function requestNotificationPermission() {
+  if (notificationPermissionRequested) {
+    return typeof Notification !== 'undefined' && Notification.permission === 'granted';
+  }
+  notificationPermissionRequested = true;
+
+  if (typeof window === 'undefined' || !('Notification' in window)) return false;
+
+  const permission = await Notification.requestPermission();
+  return permission === 'granted';
+}
+
+export function sendReminderNotification(reminder) {
+  if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return;
+
+  new Notification('Memory Cue Reminder', {
+    body: reminder.title || reminder.text,
+    icon: '/icons/icon-192.png',
+  });
+
+  reminder._notified = true;
+  console.log('[reminder-engine] notification fired', { id: reminder.id });
+}
+
+export function startReminderScheduler(getReminders) {
+  if (typeof getReminders !== 'function' || reminderSchedulerId) {
+    return;
+  }
+
+  reminderSchedulerId = setInterval(() => {
+    const reminders = getReminders();
+    const now = Date.now();
+
+    reminders.forEach((reminder) => {
+      if (!reminder || reminder._notified) return;
+
+      const dueAtValue = reminder.dueAt || reminder.due;
+      if (!dueAtValue) return;
+
+      const due = new Date(dueAtValue).getTime();
+      if (!Number.isFinite(due)) return;
+
+      if (Math.abs(due - now) < 60000) {
+        sendReminderNotification(reminder);
+      }
+    });
+  }, 60000);
+
+  console.log('[reminder-engine] scheduler started');
+}


### PR DESCRIPTION
## Summary
- add `src/services/reminderNotificationService.js` with notification permission handling, minute-based reminder checks, and reminder notification firing
- include duplicate-notification prevention by setting `reminder._notified = true` when a notification is sent
- add required reminder engine logs for scheduler start and notification fire events
- wire scheduler startup and one-time notification permission request into `initReminders()` in `js/reminders.js`

## Details
- scheduler checks reminders every 60 seconds
- scheduler supports reminders using `dueAt` or existing `due` fields without changing persisted schema
- scheduler only fires when a reminder is due within a 60-second window and has not already been notified

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7d5374e108324b181f1947d0f3de6)