### PR TITLE
Add semantic search service and include relevant memories in assistant context

### DIFF
--- a/src/chat/chatManager.js
+++ b/src/chat/chatManager.js
@@ -3,7 +3,7 @@ import { executeCommand } from '../core/commandEngine.js';
 import { saveInboxEntry } from '../services/inboxService.js';
 import { suggestNotebookAndTags } from '../services/taggingEngine.js';
 import { classifyIntentLocally, createChatIntentInput, routeIntent } from '../services/intentRouter.js';
-import { retrieveRelevantMemories } from '../services/brainQueryService.js';
+import { semanticSearch } from '../services/semanticSearchService.js';
 import { ensureFolderExistsByName } from '../../js/modules/ai-capture-save.js';
 import { saveNote } from '../services/adapters/notePersistenceAdapter.js';
 import { generateDailyPlan, renderDailyPlan } from '../services/planningService.js';
@@ -71,7 +71,7 @@ const parseEntry = async (text) => {
   return normalizeParsedEntry(parsed, text);
 };
 
-const askAssistant = async (text) => {
+const askAssistant = async (text, uid) => {
   const MAX_MEMORY_SNIPPETS = 5;
   const MAX_MEMORY_CHARS = 240;
   const MAX_USER_QUESTION_CHARS = 500;
@@ -91,7 +91,7 @@ const askAssistant = async (text) => {
   const safeQuestion = toTrimmedText(text, MAX_USER_QUESTION_CHARS);
   let memorySnippets = [];
   try {
-    const memories = await retrieveRelevantMemories(safeQuestion);
+    const memories = await semanticSearch(safeQuestion, uid);
     memorySnippets = memories
       .slice(0, MAX_MEMORY_SNIPPETS)
       .map((memory, index) => {
@@ -108,10 +108,10 @@ const askAssistant = async (text) => {
     : 'No relevant memories found.';
 
   const assembledUserContent = [
-    'Relevant past memories:',
-    memoryBlock,
+    `User asked: "${safeQuestion}"`,
     '',
-    `User question: ${safeQuestion}`,
+    'Relevant memories:',
+    memoryBlock,
   ].join('\n').slice(0, MAX_MESSAGE_CHARS);
 
   const messages = [
@@ -362,7 +362,7 @@ const processParsedEntry = async (parsed, text, dependencies = {}) => {
       return { message: reminderSearchResponse };
     }
 
-    return { message: await askAssistant(text) };
+    return { message: await askAssistant(text, dependencies.uid) };
   }
 
   saveInboxEntry({

--- a/src/services/semanticSearchService.js
+++ b/src/services/semanticSearchService.js
@@ -1,0 +1,67 @@
+import { generateEmbedding, getEmbeddingsForUser } from './embeddingService.js';
+
+const MAX_MATCHES = 5;
+
+export function cosineSimilarity(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b) || !a.length || !b.length) {
+    return 0;
+  }
+
+  const dimensions = Math.min(a.length, b.length);
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+
+  for (let i = 0; i < dimensions; i += 1) {
+    const left = Number(a[i]);
+    const right = Number(b[i]);
+
+    if (!Number.isFinite(left) || !Number.isFinite(right)) {
+      continue;
+    }
+
+    dot += left * right;
+    normA += left * left;
+    normB += right * right;
+  }
+
+  if (!normA || !normB) {
+    return 0;
+  }
+
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+export const semanticSearch = async (query, uid) => {
+  const normalizedQuery = typeof query === 'string' ? query.trim() : '';
+  if (!normalizedQuery) {
+    return [];
+  }
+
+  const queryEmbedding = await generateEmbedding(normalizedQuery);
+  console.info('[semantic-search] query embedding generated');
+
+  if (!queryEmbedding.length) {
+    return [];
+  }
+
+  const storedEmbeddings = await getEmbeddingsForUser(uid);
+  console.info('[semantic-search] embeddings loaded');
+
+  const matches = storedEmbeddings
+    .map((item) => ({
+      ...item,
+      score: cosineSimilarity(queryEmbedding, item?.embedding),
+    }))
+    .filter((item) => Number.isFinite(item.score) && item.score > 0)
+    .sort((left, right) => right.score - left.score)
+    .slice(0, MAX_MATCHES)
+    .map((item) => ({
+      text: typeof item?.text === 'string' ? item.text : '',
+      score: item.score,
+    }))
+    .filter((item) => item.text);
+
+  console.info('[semantic-search] matches found', { count: matches.length });
+  return matches;
+};


### PR DESCRIPTION
### Motivation
- Provide semantic memory lookup so the assistant can ground answers in a user’s stored memories using embeddings.

### Description
- Added `src/services/semanticSearchService.js` which generates a query embedding via `generateEmbedding`, loads stored embeddings via `getEmbeddingsForUser` (from `users/{uid}/embeddings`), computes cosine similarity, and returns the top 5 `{ text, score }` matches with logs for lifecycle events.
- Implemented `cosineSimilarity` in the new service to compare embeddings and filter/sort matches by score.
- Wired semantic search into the assistant flow by updating `src/chat/chatManager.js` to call `semanticSearch(safeQuestion, uid)` and pass `dependencies.uid` when invoking the assistant helper.
- Adjusted the assistant prompt assembly to include `User asked: "..."` and a `Relevant memories:` block so the assistant receives memory context.

### Testing
- Ran build verification with `npm run verify` which passed successfully.
- Ran the test suite with `npm test -- --runInBand` and observed failures; these failures appear to be pre-existing ESM/vm and reminders/mobile/service-worker related issues and are not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7d9089eec8324aeaad73740640ddd)