### PR TITLE
Standardize query intent routing to `query_memory`

### DIFF
--- a/src/ai/inboxProcessor.js
+++ b/src/ai/inboxProcessor.js
@@ -135,7 +135,7 @@ export const processInbox = async (entries = [], options = {}) => {
 
     const decision = routeIntent(parsedEntry, text, hints);
 
-    if (decision.decisionType === 'persist_inbox' || decision.decisionType === 'query') {
+    if (decision.decisionType === 'persist_inbox' || decision.decisionType === 'query_memory') {
       continue;
     }
 

--- a/src/chat/chatManager.js
+++ b/src/chat/chatManager.js
@@ -356,7 +356,8 @@ const processParsedEntry = async (parsed, text, dependencies = {}) => {
     return { message: renderDailyPlan(plan) };
   }
 
-  if (decision.decisionType === 'query') {
+  // Canonical intent decision types: query_memory, plan_day, persist_reminder, persist_note, persist_inbox.
+  if (decision.decisionType === 'query_memory') {
     const reminderSearchResponse = buildReminderSearchResponse(text);
     if (reminderSearchResponse) {
       return { message: reminderSearchResponse };

--- a/src/services/brainQueryService.js
+++ b/src/services/brainQueryService.js
@@ -135,16 +135,16 @@ export const queryBrain = async (question) => {
   if (!safeQuestion) {
     return {
       answer: '',
-      intent: { decisionType: 'query', parsedType: 'question' },
+      intent: { decisionType: 'query_memory', parsedType: 'question' },
       memories: [],
     };
   }
 
   const intent = classifyIntentLocally(safeQuestion, { source: 'brain-query-service' })
-    || { decisionType: 'query', parsedType: 'question' };
+    || { decisionType: 'query_memory', parsedType: 'question' };
   console.info('[brain] routing decision', {
     source: 'queryBrain',
-    decisionType: intent?.decisionType || 'query',
+    decisionType: intent?.decisionType || 'query_memory',
     parsedType: intent?.parsedType || 'question',
   });
 
@@ -171,7 +171,7 @@ export const queryBrain = async (question) => {
   return {
     answer,
     intent: {
-      decisionType: normalizeText(intent?.decisionType) || 'query',
+      decisionType: normalizeText(intent?.decisionType) || 'query_memory',
       parsedType: normalizeText(intent?.parsedType) || 'question',
     },
     memories,


### PR DESCRIPTION
### Motivation

- The intent router emits `decisionType: 'query_memory'` while `chatManager` and some consumers were checking for `'query'`, causing question-style inputs to fall through to inbox handling. 
- Aligning on a single canonical decision type prevents misrouting of assistant queries and preserves the intended assistant vs capture flow. 
- Keep changes minimal and focused on routing checks and a short in-code note about canonical decision types to avoid wider refactors.

### Description

- Updated `src/chat/chatManager.js` to handle query intents by checking `decision.decisionType === 'query_memory'` and added a short inline comment documenting the canonical decision types. 
- Updated `src/ai/inboxProcessor.js` to treat `decision.decisionType === 'query_memory'` as a non-persisting/query decision so inbox processing skips query items. 
- Normalized `src/services/brainQueryService.js` fallback/default intent and logging to use `query_memory` instead of `query` for consistent intent metadata. 
- No other behavioral changes or feature additions were made; changes are limited to intent decision-type checks and a small comment.

### Testing

- Ran the repository test suite with `npm test -- --runInBand`, which executed the Jest suites; the run showed multiple failures (15 failed, 11 passed, 26 total) but the failures are due to pre-existing ESM/dynamic import and test-harness issues unrelated to the routing changes. 
- Verified via repository search and file diffs that all modified routing checks now consistently reference `query_memory` and that the new inline comment is present. 
- No new unit tests were added or modified as the change is a small routing alignment consistent with existing behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b85ac96eb88324ada4d68cbb9ef392)