### PR TITLE
Unify assistant/chat orchestration into shared orchestrator

### DIFF
--- a/src/chat/chatManager.js
+++ b/src/chat/chatManager.js
@@ -7,6 +7,7 @@ import { semanticSearch } from '../services/semanticSearchService.js';
 import { ensureFolderExistsByName } from '../../js/modules/ai-capture-save.js';
 import { saveNote } from '../services/adapters/notePersistenceAdapter.js';
 import { generateDailyPlan, renderDailyPlan } from '../services/planningService.js';
+import { buildMemoryAssistantRequest, requestAssistantChat } from '../services/assistantOrchestrator.js';
 
 export const ENABLE_CHAT_INTERFACE = true;
 
@@ -73,72 +74,20 @@ const parseEntry = async (text) => {
 
 const askAssistant = async (text, uid) => {
   const MAX_MEMORY_SNIPPETS = 5;
-  const MAX_MEMORY_CHARS = 240;
-  const MAX_USER_QUESTION_CHARS = 500;
-  const MAX_MESSAGE_CHARS = 2600;
-
-  const toTrimmedText = (value, maxChars) => {
-    if (typeof value !== 'string') {
-      return '';
-    }
-    const normalized = value.trim();
-    if (!normalized) {
-      return '';
-    }
-    return normalized.length <= maxChars ? normalized : `${normalized.slice(0, maxChars - 1)}…`;
-  };
-
-  const safeQuestion = toTrimmedText(text, MAX_USER_QUESTION_CHARS);
+  const safeQuestion = typeof text === 'string' ? text.trim() : '';
   let memorySnippets = [];
   try {
     const memories = await semanticSearch(safeQuestion, uid);
     memorySnippets = memories
       .slice(0, MAX_MEMORY_SNIPPETS)
-      .map((memory, index) => {
-        const snippet = toTrimmedText(memory?.text, MAX_MEMORY_CHARS);
-        return snippet ? `${index + 1}. ${snippet}` : '';
-      })
+      .map((memory) => memory?.text)
       .filter(Boolean);
   } catch (error) {
     console.warn('[chat-manager] failed to retrieve relevant memories for assistant context', error);
   }
 
-  const memoryBlock = memorySnippets.length
-    ? memorySnippets.join('\n')
-    : 'No relevant memories found.';
-
-  const assembledUserContent = [
-    `User asked: "${safeQuestion}"`,
-    '',
-    'Relevant memories:',
-    memoryBlock,
-  ].join('\n').slice(0, MAX_MESSAGE_CHARS);
-
-  const messages = [
-    {
-      role: 'system',
-      content: 'You are Memory Cue, a personal assistant. Use provided memories when they are relevant, and be concise.',
-    },
-    {
-      role: 'user',
-      content: assembledUserContent,
-    },
-  ];
-
-  const response = await fetch('/api/assistant-chat', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ message: safeQuestion, messages }),
-  });
-
-  if (!response.ok) {
-    throw new Error(`Assistant request failed (${response.status})`);
-  }
-
-  const payload = await response.json();
-  return typeof payload?.reply === 'string' && payload.reply.trim()
-    ? payload.reply.trim()
-    : 'Here is what I found.';
+  const requestBody = buildMemoryAssistantRequest(safeQuestion, memorySnippets);
+  return requestAssistantChat(requestBody, { fallbackReply: 'Here is what I found.' });
 };
 
 const OFFLINE_REMINDERS_KEY = 'memoryCue:offlineReminders';

--- a/src/reminders/reminderController.js
+++ b/src/reminders/reminderController.js
@@ -7,6 +7,7 @@ import { renderReminderList, renderReminderItem, renderTodayReminders } from './
 import { setupSyncHandlers, loadRemindersFromFirestore, saveReminderToFirestore, listenForReminderUpdates } from './reminderSync.js';
 import { setupNotificationHandlers, startReminderScheduler, sendReminderNotification, requestNotificationPermission } from './reminderNotifications.js';
 import { saveNote } from '../services/adapters/notePersistenceAdapter.js';
+import { buildRagAssistantRequest, requestAssistantChat } from '../services/assistantOrchestrator.js';
 
 // Shared reminder logic used by both the mobile and desktop pages.
 // This module wires up Firebase/Firestore and all reminder UI handlers.
@@ -1924,33 +1925,17 @@ export async function initReminders(sel = {}) {
         updatedAt: entry.updatedAt,
       }));
 
+    const requestBody = buildRagAssistantRequest({
+      question: query,
+      contextText: context,
+      entries: selectedEntries,
+      schemaVersion: 2,
+    });
+
     try {
-      const response = await fetch('/api/assistant-chat', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          question: query,
-          contextText: context,
-          entries: selectedEntries,
-          schemaVersion: 2,
-        }),
+      return await requestAssistantChat(requestBody, {
+        fallbackReply: 'I could not read an assistant response.',
       });
-
-      if (!response.ok) {
-        throw new Error(`Assistant request failed (${response.status})`);
-      }
-
-      const payload = await response.json();
-      const reply = typeof payload?.reply === 'string'
-        ? payload.reply
-        : typeof payload?.text === 'string'
-          ? payload.text
-          : typeof payload?.message === 'string'
-            ? payload.message
-            : '';
-      return reply || 'I could not read an assistant response.';
     } catch (error) {
       console.error('[RAG assistant] request failed while calling /api/assistant-chat', {
         error,

--- a/src/services/assistantOrchestrator.js
+++ b/src/services/assistantOrchestrator.js
@@ -1,0 +1,87 @@
+const DEFAULT_SYSTEM_PROMPT = 'You are Memory Cue, a personal assistant. Use provided memories when they are relevant, and be concise.';
+
+const trimText = (value, maxChars) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const normalized = value.trim();
+  if (!normalized) {
+    return '';
+  }
+  if (!Number.isFinite(maxChars) || maxChars <= 0) {
+    return normalized;
+  }
+  return normalized.length <= maxChars ? normalized : `${normalized.slice(0, maxChars - 1)}…`;
+};
+
+export const buildMemoryAssistantRequest = (question, memorySnippets = [], options = {}) => {
+  const safeQuestion = trimText(question, options.maxQuestionChars ?? 500);
+  const normalizedSnippets = Array.isArray(memorySnippets)
+    ? memorySnippets
+      .map((snippet, index) => {
+        const value = trimText(snippet, options.maxSnippetChars ?? 240);
+        return value ? `${index + 1}. ${value}` : '';
+      })
+      .filter(Boolean)
+    : [];
+
+  const memoryBlock = normalizedSnippets.length
+    ? normalizedSnippets.join('\n')
+    : 'No relevant memories found.';
+
+  const assembledUserContent = [
+    `User asked: "${safeQuestion}"`,
+    '',
+    'Relevant memories:',
+    memoryBlock,
+  ].join('\n').slice(0, options.maxMessageChars ?? 2600);
+
+  return {
+    message: safeQuestion,
+    messages: [
+      {
+        role: 'system',
+        content: options.systemPrompt || DEFAULT_SYSTEM_PROMPT,
+      },
+      {
+        role: 'user',
+        content: assembledUserContent,
+      },
+    ],
+  };
+};
+
+export const buildRagAssistantRequest = ({ question, contextText, entries = [], schemaVersion = 2 } = {}) => ({
+  question: trimText(question),
+  contextText: trimText(contextText),
+  entries: Array.isArray(entries) ? entries : [],
+  schemaVersion,
+});
+
+export const formatAssistantReply = (payload, fallbackReply = 'Here is what I found.') => {
+  const reply = typeof payload?.reply === 'string'
+    ? payload.reply
+    : typeof payload?.text === 'string'
+      ? payload.text
+      : typeof payload?.message === 'string'
+        ? payload.message
+        : '';
+
+  const normalizedReply = trimText(reply);
+  return normalizedReply || fallbackReply;
+};
+
+export const requestAssistantChat = async (body, options = {}) => {
+  const response = await fetch('/api/assistant-chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(options.errorMessage || `Assistant request failed (${response.status})`);
+  }
+
+  const payload = await response.json();
+  return formatAssistantReply(payload, options.fallbackReply);
+};


### PR DESCRIPTION
### Motivation
- Reduce duplicated assistant request and response logic across chat and reminders flows by centralizing API transport and reply formatting. 
- Keep one canonical path for calling `/api/assistant-chat` while preserving existing UI-sensitive reminder search behavior.

### Description
- Added a new orchestration module `src/services/assistantOrchestrator.js` providing `buildMemoryAssistantRequest`, `buildRagAssistantRequest`, `requestAssistantChat`, and `formatAssistantReply` to centralize payload assembly, transport, and response normalization.
- Refactored `src/chat/chatManager.js` to remove inline assistant payload construction and `fetch` logic and to call `buildMemoryAssistantRequest` + `requestAssistantChat` instead, while leaving local memory-snippet assembly intact.
- Refactored `src/reminders/reminderController.js` to replace inline RAG assistant `fetch`/parsing with `buildRagAssistantRequest` + `requestAssistantChat`, preserving RAG context assembly and entry selection.
- Audit of assistant entry points (implemented): `chatManager.askAssistant` (chat flow), `reminderController.askAssistant` (RAG reminders flow), and the deterministic `buildReminderSearchResponse` (inbox/reminder local search) which is intentionally retained as a local shortcut prior to the assistant fallback.

### Testing
- Ran the full test suite with `npm test -- --runInBand`; the suite executed but several pre-existing test suites failed (module format / dynamic import test environment issues) and are unrelated to the orchestration refactor. The refactor is scoped to changed files and compiles in the environment used for testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8617be1f08324babb12c78e068a67)