### PR TITLE
Mirror note saves into memory service, normalize reminder sync paths, remove duplicate memory write, and add storage audit doc

### DIFF
--- a/docs/STORAGE_WRITER_AUDIT_TASK5.md
+++ b/docs/STORAGE_WRITER_AUDIT_TASK5.md
@@ -1,0 +1,57 @@
+# Task 5 Internal Storage Writer/Reader Map
+
+## Local key: `memoryCueNotes`
+- **Writes**
+  - `js/modules/notes-storage.js` via `saveAllNotes()` and `createAndSaveNote()`.
+  - `js/entries.js` legacy capture bridge writes direct note list.
+  - `src/reminders/reminderController.js` AI enrichment path updates note fields in-place.
+  - `src/services/supabaseSyncService.js` remote pull/merge writes canonical local cache.
+- **Reads**
+  - `js/modules/notes-storage.js` (`loadAllNotes`).
+  - `src/reminders/reminderController.js` note sync/enrichment paths.
+  - `src/services/brainAgent.js` context loading.
+
+## Local key: `memoryCueInbox`
+- **Writes**
+  - `src/services/inboxService.js` (`saveInboxEntry`, `persistInboxEntries`) canonical writer.
+  - `js/entries.js` legacy inbox writer.
+  - `src/services/supabaseSyncService.js` remote pull/merge writes canonical local cache.
+- **Reads**
+  - `src/services/inboxService.js` (`getInboxEntries`).
+  - `js/modules/daily-log.js` and `js/entries.js` listeners/views.
+  - `src/services/supabaseSyncService.js` merge helpers.
+
+## Local key: `memoryCueCache`
+- **Writes**
+  - `src/services/memoryService.js` (`writeCacheToStorage`) through `saveMemory()` and sync merge.
+- **Reads**
+  - `src/services/memoryService.js` (`readCacheFromStorage`) and retrieval/search APIs.
+
+## Local key: `memoryCue:offlineReminders`
+- **Writes**
+  - `src/reminders/reminderStore.js` canonical reminder offline storage.
+  - `src/reminders/reminderController.js` one-time migration/flush helpers and offline fallback.
+  - `src/services/supabaseSyncService.js` remote pull/merge writes canonical local cache.
+- **Reads**
+  - `src/reminders/reminderStore.js` (`getReminders`, `loadReminders`).
+  - `src/reminders/reminderController.js` migration/offline upload paths.
+  - `src/chat/chatManager.js` reminder query response helper.
+
+## Firestore reminders/notes
+- **Writes**
+  - `src/reminders/reminderController.js` writes reminder docs and note docs (`users/{uid}/reminders`, `users/{uid}/notes`).
+  - `js/modules/notes-sync.js` writes `users/{uid}/notes` migration/sync updates.
+- **Reads**
+  - `src/reminders/reminderController.js` note/reminder hydration from Firestore.
+  - `js/modules/notes-sync.js` pulls note snapshots from Firestore.
+
+## Supabase `memories`
+- **Writes**
+  - `src/services/memoryService.js` (`triggerSync` upsert to `memories`) from `saveMemory()`.
+- **Reads**
+  - `src/services/memoryService.js` (`triggerSync` select from `memories`).
+
+## Safe duplicate/dead write cleanup applied
+- Removed duplicate `saveMemory()` write in `src/services/adapters/notePersistenceAdapter.js`.
+  - Notes now persist through `js/modules/notes-storage.js`, which mirrors successful note saves into `memoryService`.
+- Added compatibility bridge in `js/modules/notes-storage.js` so note saves still use existing note storage/migrations/UI while ensuring memory-layer visibility for retrieval/search.

--- a/js/modules/notes-storage.js
+++ b/js/modules/notes-storage.js
@@ -15,6 +15,7 @@ const normalizeSemanticEmbedding = (value) => {
 };
 
 let remoteSyncHandler = null;
+let memoryServiceModulePromise = null;
 
 export const setRemoteSyncHandler = (handler) => {
   remoteSyncHandler = typeof handler === 'function' ? handler : null;
@@ -187,6 +188,44 @@ const deriveKeywords = (title = '', bodyText = '', provided = null) => {
   return extractKeywordsFromText(`${title} ${bodyText}`);
 };
 
+const syncNoteToMemoryService = (note, payload = {}) => {
+  if (!note || typeof note !== 'object' || typeof note.bodyText !== 'string' || !note.bodyText.trim()) {
+    return;
+  }
+
+  if (!memoryServiceModulePromise) {
+    memoryServiceModulePromise = import('../../src/services/memoryService.js').catch((error) => {
+      console.warn('[notes-storage] Failed to load memory service bridge', error);
+      return null;
+    });
+  }
+
+  memoryServiceModulePromise
+    .then((memoryServiceModule) => {
+      const saveMemory = memoryServiceModule?.saveMemory;
+      if (typeof saveMemory !== 'function') {
+        return;
+      }
+
+      return saveMemory({
+        id: note.id,
+        text: note.bodyText,
+        type: payload.parsedType || payload.type || 'note',
+        createdAt: Date.parse(note.createdAt),
+        updatedAt: Date.parse(note.updatedAt),
+        source: typeof payload.source === 'string' ? payload.source : 'capture',
+        entryPoint:
+          typeof payload.entryPoint === 'string'
+            ? payload.entryPoint
+            : 'notes-storage.createAndSaveNote',
+        tags: Array.isArray(payload.tags) ? payload.tags : note.keywords,
+      });
+    })
+    .catch((error) => {
+      console.warn('[memory-service] Failed to mirror note save', error);
+    });
+};
+
 export const createAndSaveNote = (payload = {}, options = {}) => {
   const normalizedPayload = payload && typeof payload === 'object' ? payload : {};
   const text = typeof normalizedPayload.text === 'string' ? normalizedPayload.text.trim() : '';
@@ -222,6 +261,9 @@ export const createAndSaveNote = (payload = {}, options = {}) => {
 
   const notes = loadAllNotes();
   const saved = saveAllNotes([note, ...notes], options);
+  if (saved) {
+    syncNoteToMemoryService(note, normalizedPayload);
+  }
   return saved ? note : null;
 };
 

--- a/js/reminders.js
+++ b/js/reminders.js
@@ -13,7 +13,9 @@ export async function initReminders(sel = {}) {
   if (typeof globalThis !== 'undefined') {
     globalThis.createReminderFromPayload = (...args) => controller.createReminderFromPayload(...args);
     globalThis.render = (...args) => controller.render(...args);
-    globalThis.setupSupabaseSync = (...args) => controller.setupSupabaseSync(...args);
+    globalThis.setupReminderFirestoreSync = (...args) => controller.setupReminderFirestoreSync(...args);
+    // Backward-compatible alias for legacy callers.
+    globalThis.setupSupabaseSync = (...args) => controller.setupReminderFirestoreSync(...args);
     globalThis.initReminders = (...args) => controller.initReminders(...args);
   }
 

--- a/src/reminders/reminderController.js
+++ b/src/reminders/reminderController.js
@@ -170,6 +170,16 @@ function normalizeReminderRecord(reminder = {}, options = {}) {
   return normalized;
 }
 
+function normalizeReminderList(list = []) {
+  if (!Array.isArray(list)) {
+    return [];
+  }
+
+  return list
+    .map((entry) => normalizeReminderRecord(entry, { fallbackId: uid() }))
+    .filter(Boolean);
+}
+
 function computeNextOccurrence(reminder) {
   if (!reminder?.due) {
     return null;
@@ -3759,6 +3769,7 @@ export async function initReminders(sel = {}) {
     rescheduleAllReminders();
   }
 
+  // Offline reminders in localStorage are the canonical local cache for reminder read/write/render.
   function loadOfflineRemindersFromStorage() {
     if (typeof localStorage === 'undefined') return [];
     try {
@@ -3766,18 +3777,14 @@ export async function initReminders(sel = {}) {
       if (!raw) return [];
       const parsed = JSON.parse(raw);
       if (!Array.isArray(parsed)) return [];
-      return parsed
-        .map((entry) => {
-          if (!entry || typeof entry !== 'object') return null;
-          return normalizeReminderRecord(entry, { fallbackId: uid() });
-        })
-        .filter(Boolean);
+      return normalizeReminderList(parsed);
     } catch (error) {
       console.warn('Failed to load offline reminders', error);
       return [];
     }
   }
 
+  // Persist using the same normalized reminder shape used by render and remote sync.
   function persistOfflineReminders(reminders = []) {
     if (typeof localStorage === 'undefined') return;
     try {
@@ -3785,9 +3792,7 @@ export async function initReminders(sel = {}) {
         localStorage.removeItem(OFFLINE_REMINDERS_KEY);
         return;
       }
-      const serialisable = reminders
-        .filter((entry) => entry && typeof entry === 'object')
-        .map((entry) => normalizeReminderRecord(entry, { fallbackId: uid() }));
+      const serialisable = normalizeReminderList(reminders);
       localStorage.setItem(OFFLINE_REMINDERS_KEY, JSON.stringify(serialisable));
     } catch (error) {
       console.warn('Failed to persist offline reminders', error);
@@ -4430,7 +4435,7 @@ export async function initReminders(sel = {}) {
         googleSignInBtns.forEach((btn) => btn.classList.add('hidden'));
         googleSignOutBtns.forEach((btn) => btn.classList.remove('hidden'));
         if(googleUserName) googleUserName.textContent = user.email || '';
-        await setupSupabaseSync();
+        await setupReminderFirestoreSync();
         await syncNotesFromFirestoreOnLogin();
         await migrateOfflineRemindersIfNeeded();
         await ensureNotificationPermission();
@@ -4456,7 +4461,7 @@ export async function initReminders(sel = {}) {
         window.__MEMORY_CUE_AUTH_USER_ID = initialUser.uid;
       }
       renderSyncIndicator('online');
-      await setupSupabaseSync();
+      await setupReminderFirestoreSync();
       await syncNotesFromFirestoreOnLogin();
       await ensureNotificationPermission();
     }
@@ -4563,7 +4568,8 @@ export async function initReminders(sel = {}) {
     }, { fallbackId: reminderId });
   }
 
-  async function setupSupabaseSync(){
+  // Historical name was setupSupabaseSync, but this flow reads/writes Firestore reminders.
+  async function setupReminderFirestoreSync(){
     if(!userId){
       hydrateOfflineReminders();
       render();
@@ -5730,7 +5736,7 @@ export async function initReminders(sel = {}) {
     const todayRange = { start: t0, end: t1 };
 
     clearDragHighlights();
-    items = items.map((entry) => normalizeReminderRecord(entry, { fallbackId: uid() }));
+    items = normalizeReminderList(items);
     sortItemsByOrder(items);
 
     if (countTotalEl) {
@@ -6530,7 +6536,7 @@ export async function initReminders(sel = {}) {
   activeReminderControllerApi = {
     createReminderFromPayload,
     render,
-    setupSupabaseSync,
+    setupReminderFirestoreSync,
   };
 
   return {
@@ -6543,9 +6549,7 @@ export async function initReminders(sel = {}) {
     askAssistant,
     __testing: {
       setItems(listItems = []) {
-        items = Array.isArray(listItems)
-          ? listItems.map((item) => normalizeReminderRecord(item, { fallbackId: uid() }))
-          : [];
+        items = normalizeReminderList(listItems);
         items = ensureOrderIndicesInitialized(items);
         sortItemsByOrder(items);
         render();
@@ -6568,6 +6572,11 @@ export function render() {
   return activeReminderControllerApi?.render?.();
 }
 
+export async function setupReminderFirestoreSync() {
+  return activeReminderControllerApi?.setupReminderFirestoreSync?.();
+}
+
+// Backward-compatible alias while callers migrate away from the old Supabase name.
 export async function setupSupabaseSync() {
-  return activeReminderControllerApi?.setupSupabaseSync?.();
+  return setupReminderFirestoreSync();
 }

--- a/src/reminders/reminderStore.js
+++ b/src/reminders/reminderStore.js
@@ -1,5 +1,8 @@
 const OFFLINE_REMINDERS_KEY = 'memoryCue:offlineReminders';
 
+// Reminder source of truth: this module owns the normalized local reminder cache
+// backed by localStorage. Remote sync layers should read/write through this shape.
+
 let reminders = [];
 
 

--- a/src/services/adapters/notePersistenceAdapter.js
+++ b/src/services/adapters/notePersistenceAdapter.js
@@ -1,6 +1,5 @@
 import { createAndSaveNote } from '../../../js/modules/notes-storage.js';
 import { indexSourceEmbedding } from '../embeddingService.js';
-import { saveMemory } from '../memoryService.js';
 
 export const saveNote = (notePayload = {}, metadata = {}) => {
   const payload = notePayload && typeof notePayload === 'object' ? notePayload : {};
@@ -18,19 +17,6 @@ export const saveNote = (notePayload = {}, metadata = {}) => {
       sourceId: note.id,
     }).catch((error) => {
       console.warn('[embedding] Failed to index note embedding', error);
-    });
-
-    saveMemory({
-      id: note.id,
-      text: note.bodyText,
-      type: payload.parsedType || 'note',
-      createdAt: Date.parse(note.createdAt),
-      updatedAt: Date.parse(note.updatedAt),
-      source: typeof payload.source === 'string' ? payload.source : 'capture',
-      entryPoint: typeof payload.entryPoint === 'string' ? payload.entryPoint : 'notes-storage.createAndSaveNote',
-      tags: Array.isArray(payload.tags) ? payload.tags : note.keywords,
-    }).catch((error) => {
-      console.warn('[memory-service] Failed to save note memory', error);
     });
   }
 


### PR DESCRIPTION
### Motivation
- Ensure notes saved via the legacy UI/storage layer are visible to the memory/search layer by mirroring saves into the `memoryService` bridge. 
- Clarify and modernize the reminders Firestore sync flow and local offline reminder normalization to provide a single canonical local cache shape. 
- Remove a duplicated `saveMemory()` call so memory writes are consolidated in one place and reduce risk of dead/duplicate writes.

### Description
- Added `syncNoteToMemoryService` and a dynamic import bridge in `js/modules/notes-storage.js` to mirror `createAndSaveNote` saves into `memoryService.saveMemory`. 
- Removed the duplicate `saveMemory()` invocation from `src/services/adapters/notePersistenceAdapter.js` and retained the canonical note save path via `createAndSaveNote`. 
- Normalized offline reminder handling in `src/reminders/reminderController.js` by introducing `normalizeReminderList`, updating `loadOfflineRemindersFromStorage`, `persistOfflineReminders`, `render`, and test helper paths to use the normalized shape. 
- Introduced a renamed and aliased sync entrypoint `setupReminderFirestoreSync` in place of the historical `setupSupabaseSync`, and kept a backward-compatible alias for existing callers. 
- Added documentation `docs/STORAGE_WRITER_AUDIT_TASK5.md` describing local storage keys and writer/reader mapping and noted the duplicate write cleanup. 
- Added clarifying comment in `src/reminders/reminderStore.js` documenting that the module is the local reminder source of truth.

### Testing
- Ran the project's unit test suite via `npm test` and linting via `npm run lint`, and both completed successfully. 
- Exercised note save and reminder sync flows (legacy UI path and Firestore sync) with automated smoke checks, and they behaved as expected with mirrored memory saves and normalized offline reminder persistence. 
- No new automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b863ec82988324a222cff95d67edc2)