### PR TITLE
refactor(reminders): extract schema normalization/search helpers from controller

### DIFF
--- a/src/reminders/reminderController.js
+++ b/src/reminders/reminderController.js
@@ -8,6 +8,18 @@ import { setupSyncHandlers, loadRemindersFromFirestore, saveReminderToFirestore,
 import { setupNotificationHandlers, startReminderScheduler, sendReminderNotification, requestNotificationPermission } from './reminderNotifications.js';
 import { saveNote } from '../services/adapters/notePersistenceAdapter.js';
 import { buildRagAssistantRequest, requestAssistantChat } from '../services/assistantOrchestrator.js';
+import {
+  normalizeReminderKeywords,
+  extractReminderKeywords,
+  normalizeSemanticEmbedding,
+  normalizeRecurrence,
+  normalizeIsoString,
+  normalizeReminderRecord as normalizeReminderRecordHelper,
+  normalizeReminderList as normalizeReminderListHelper,
+  computeNextOccurrence,
+  getReminderScheduleIso,
+  cosineSimilarity,
+} from './reminderSchemaHelpers.js';
 
 // Shared reminder logic used by both the mobile and desktop pages.
 // This module wires up Firebase/Firestore and all reminder UI handlers.
@@ -38,173 +50,20 @@ const SEEDED_CATEGORIES = Object.freeze([
   'Wellbeing & Support',
 ]);
 const OFFLINE_REMINDERS_KEY = 'memoryCue:offlineReminders';
-const REMINDER_RECURRENCE_VALUES = new Set(['daily', 'weekly', 'monthly']);
 const ORDER_INDEX_GAP = 1024;
-const REMINDER_KEYWORD_STOP_WORDS = new Set([
-  'a', 'an', 'and', 'are', 'at', 'be', 'for', 'from', 'have', 'idea', 'ideas', 'in', 'is', 'it', 'lesson', 'meeting', 'my', 'of', 'on', 'or', 'reminder', 'reminders', 'shopping', 'that', 'the', 'this', 'to', 'with', 'write', 'wrote'
-]);
-
-function normalizeReminderKeywords(value) {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-  const deduped = new Set();
-  value.forEach((entry) => {
-    if (typeof entry !== 'string') {
-      return;
-    }
-    const normalized = entry.trim().toLowerCase();
-    if (normalized) {
-      deduped.add(normalized);
-    }
-  });
-  return Array.from(deduped).slice(0, 12);
-}
-
-function extractReminderKeywords(text) {
-  const normalized = typeof text === 'string' ? text.toLowerCase() : '';
-  const terms = normalized
-    .replace(/[^a-z0-9\s-]/g, ' ')
-    .split(/\s+/)
-    .map((term) => term.trim())
-    .filter((term) => term.length > 2 && !REMINDER_KEYWORD_STOP_WORDS.has(term));
-
-  if (/\bdrills?\b/.test(normalized)) terms.push('drill');
-  if (/\blesson(s|\sideas?)?\b/.test(normalized)) terms.push('lesson');
-  if (/\bideas?\b/.test(normalized)) terms.push('idea');
-  if (/\bmeetings?\b/.test(normalized)) terms.push('meeting');
-  if (/\bshopping\b/.test(normalized)) terms.push('shopping');
-
-  return normalizeReminderKeywords(terms);
-}
-
-function normalizeSemanticEmbedding(value) {
-  if (!Array.isArray(value)) {
-    return null;
-  }
-  const vector = value
-    .map((entry) => Number(entry))
-    .filter((entry) => Number.isFinite(entry));
-  return vector.length ? vector : null;
-}
-
-function normalizeRecurrence(value) {
-  if (typeof value !== 'string') {
-    return null;
-  }
-  const normalized = value.trim().toLowerCase();
-  return REMINDER_RECURRENCE_VALUES.has(normalized) ? normalized : null;
-}
-
-function normalizeIsoString(value) {
-  if (typeof value !== 'string' || !value.trim()) {
-    return null;
-  }
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) {
-    return null;
-  }
-  return parsed.toISOString();
-}
-
 function normalizeReminderRecord(reminder = {}, options = {}) {
-  const source = reminder && typeof reminder === 'object' ? reminder : {};
-  const now = Number.isFinite(options.now) ? options.now : Date.now();
-  const fallbackId = typeof options.fallbackId === 'string' && options.fallbackId ? options.fallbackId : uid();
-  const titleCandidates = [source.title, source.text, source.name];
-  const title = titleCandidates.find((value) => typeof value === 'string' && value.trim())?.trim() || '';
-  const dueCandidate = [source.due, source.dueAt, source.dueDate]
-    .find((value) => value instanceof Date || (typeof value === 'string' && value.trim()));
-  const due = dueCandidate instanceof Date
-    ? dueCandidate.toISOString()
-    : normalizeIsoString(dueCandidate);
-  const createdAt = Number.isFinite(Number(source.createdAt)) ? Number(source.createdAt) : now;
-  const updatedAt = Number.isFinite(Number(source.updatedAt)) ? Number(source.updatedAt) : createdAt;
-  const notes = typeof source.notes === 'string'
-    ? source.notes
-    : typeof source.bodyText === 'string'
-      ? source.bodyText
-      : typeof source.body === 'string'
-        ? source.body
-        : '';
-
-  const normalized = {
-    id: typeof source.id === 'string' && source.id ? source.id : fallbackId,
-    title,
-    notes,
-    due,
-    priority: source.priority || 'Medium',
-    category: normalizeCategory(source.category),
-    done: typeof source.done === 'boolean'
-      ? source.done
-      : Boolean(source.completed || source.isDone || source.status === 'done'),
-    createdAt,
-    updatedAt,
-    keywords: normalizeReminderKeywords(
-      source.keywords
-      || source?.metadata?.keywords
-      || extractReminderKeywords(`${title} ${notes}`),
-    ),
-    metadata: source.metadata && typeof source.metadata === 'object' ? source.metadata : null,
-    recurrence: normalizeRecurrence(source.recurrence),
-    snoozedUntil: normalizeIsoString(source.snoozedUntil),
-    notifyMinutesBefore: Number.isFinite(Number(source.notifyMinutesBefore)) ? Number(source.notifyMinutesBefore) : 0,
-    userId: typeof source.userId === 'string' && source.userId ? source.userId : null,
-    pendingSync: !!source.pendingSync,
-    orderIndex: Number.isFinite(Number(source.orderIndex)) ? Number(source.orderIndex) : null,
-    plannerLessonId:
-      typeof source.plannerLessonId === 'string' && source.plannerLessonId.trim()
-        ? source.plannerLessonId.trim()
-        : null,
-    pinToToday: source.pinToToday === true,
-    semanticEmbedding: normalizeSemanticEmbedding(source.semanticEmbedding),
-    notifyAt: normalizeIsoString(source.notifyAt),
-  };
-
-  normalized.metadata = {
-    ...(normalized.metadata || {}),
-    text: [normalized.title, normalized.notes].filter(Boolean).join(' ').trim(),
-    keywords: normalized.keywords,
-    created_at: new Date(normalized.createdAt).toISOString(),
-  };
-
-  return normalized;
+  return normalizeReminderRecordHelper(reminder, {
+    ...options,
+    createId: uid,
+    normalizeCategory,
+  });
 }
 
 function normalizeReminderList(list = []) {
-  if (!Array.isArray(list)) {
-    return [];
-  }
-
-  return list
-    .map((entry) => normalizeReminderRecord(entry, { fallbackId: uid() }))
-    .filter(Boolean);
-}
-
-function computeNextOccurrence(reminder) {
-  if (!reminder?.due) {
-    return null;
-  }
-  const recurrence = normalizeRecurrence(reminder.recurrence);
-  if (!recurrence) {
-    return null;
-  }
-  const date = new Date(reminder.due);
-  if (Number.isNaN(date.getTime())) {
-    return null;
-  }
-  if (recurrence === 'daily') date.setDate(date.getDate() + 1);
-  if (recurrence === 'weekly') date.setDate(date.getDate() + 7);
-  if (recurrence === 'monthly') date.setMonth(date.getMonth() + 1);
-  return date.toISOString();
-}
-
-function getReminderScheduleIso(reminder) {
-  const snoozed = normalizeIsoString(reminder?.snoozedUntil);
-  if (snoozed) {
-    return snoozed;
-  }
-  return normalizeIsoString(reminder?.due);
+  return normalizeReminderListHelper(list, {
+    createId: uid,
+    normalizeCategory,
+  });
 }
 
 async function generateEmbedding(text) {
@@ -214,26 +73,6 @@ async function generateEmbedding(text) {
   }
   // TODO: Replace this stub with a real embeddings API integration.
   return null;
-}
-
-function cosineSimilarity(vecA, vecB) {
-  const a = normalizeSemanticEmbedding(vecA);
-  const b = normalizeSemanticEmbedding(vecB);
-  if (!a || !b || a.length !== b.length) {
-    return 0;
-  }
-  let dot = 0;
-  let magA = 0;
-  let magB = 0;
-  for (let i = 0; i < a.length; i += 1) {
-    dot += a[i] * b[i];
-    magA += a[i] * a[i];
-    magB += b[i] * b[i];
-  }
-  if (!magA || !magB) {
-    return 0;
-  }
-  return dot / (Math.sqrt(magA) * Math.sqrt(magB));
 }
 
 async function ensureEmbeddingForItem(item) {

--- a/src/reminders/reminderSchemaHelpers.js
+++ b/src/reminders/reminderSchemaHelpers.js
@@ -1,0 +1,194 @@
+const REMINDER_RECURRENCE_VALUES = new Set(['daily', 'weekly', 'monthly']);
+const REMINDER_KEYWORD_STOP_WORDS = new Set([
+  'a', 'an', 'and', 'are', 'at', 'be', 'for', 'from', 'have', 'idea', 'ideas', 'in', 'is', 'it', 'lesson', 'meeting', 'my', 'of', 'on', 'or', 'reminder', 'reminders', 'shopping', 'that', 'the', 'this', 'to', 'with', 'write', 'wrote'
+]);
+
+export function normalizeReminderKeywords(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const deduped = new Set();
+  value.forEach((entry) => {
+    if (typeof entry !== 'string') {
+      return;
+    }
+    const normalized = entry.trim().toLowerCase();
+    if (normalized) {
+      deduped.add(normalized);
+    }
+  });
+  return Array.from(deduped).slice(0, 12);
+}
+
+export function extractReminderKeywords(text) {
+  const normalized = typeof text === 'string' ? text.toLowerCase() : '';
+  const terms = normalized
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .split(/\s+/)
+    .map((term) => term.trim())
+    .filter((term) => term.length > 2 && !REMINDER_KEYWORD_STOP_WORDS.has(term));
+
+  if (/\bdrills?\b/.test(normalized)) terms.push('drill');
+  if (/\blesson(s|\sideas?)?\b/.test(normalized)) terms.push('lesson');
+  if (/\bideas?\b/.test(normalized)) terms.push('idea');
+  if (/\bmeetings?\b/.test(normalized)) terms.push('meeting');
+  if (/\bshopping\b/.test(normalized)) terms.push('shopping');
+
+  return normalizeReminderKeywords(terms);
+}
+
+export function normalizeSemanticEmbedding(value) {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const vector = value
+    .map((entry) => Number(entry))
+    .filter((entry) => Number.isFinite(entry));
+  return vector.length ? vector : null;
+}
+
+export function normalizeRecurrence(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.trim().toLowerCase();
+  return REMINDER_RECURRENCE_VALUES.has(normalized) ? normalized : null;
+}
+
+export function normalizeIsoString(value) {
+  if (typeof value !== 'string' || !value.trim()) {
+    return null;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed.toISOString();
+}
+
+export function normalizeReminderRecord(reminder = {}, options = {}) {
+  const source = reminder && typeof reminder === 'object' ? reminder : {};
+  const now = Number.isFinite(options.now) ? options.now : Date.now();
+  const createId = typeof options.createId === 'function' ? options.createId : () => '';
+  const fallbackId = typeof options.fallbackId === 'string' && options.fallbackId ? options.fallbackId : createId();
+  const normalizeCategory = typeof options.normalizeCategory === 'function'
+    ? options.normalizeCategory
+    : (value) => value || 'General';
+  const titleCandidates = [source.title, source.text, source.name];
+  const title = titleCandidates.find((value) => typeof value === 'string' && value.trim())?.trim() || '';
+  const dueCandidate = [source.due, source.dueAt, source.dueDate]
+    .find((value) => value instanceof Date || (typeof value === 'string' && value.trim()));
+  const due = dueCandidate instanceof Date
+    ? dueCandidate.toISOString()
+    : normalizeIsoString(dueCandidate);
+  const createdAt = Number.isFinite(Number(source.createdAt)) ? Number(source.createdAt) : now;
+  const updatedAt = Number.isFinite(Number(source.updatedAt)) ? Number(source.updatedAt) : createdAt;
+  const notes = typeof source.notes === 'string'
+    ? source.notes
+    : typeof source.bodyText === 'string'
+      ? source.bodyText
+      : typeof source.body === 'string'
+        ? source.body
+        : '';
+
+  const normalized = {
+    id: typeof source.id === 'string' && source.id ? source.id : fallbackId,
+    title,
+    notes,
+    due,
+    priority: source.priority || 'Medium',
+    category: normalizeCategory(source.category),
+    done: typeof source.done === 'boolean'
+      ? source.done
+      : Boolean(source.completed || source.isDone || source.status === 'done'),
+    createdAt,
+    updatedAt,
+    keywords: normalizeReminderKeywords(
+      source.keywords
+      || source?.metadata?.keywords
+      || extractReminderKeywords(`${title} ${notes}`),
+    ),
+    metadata: source.metadata && typeof source.metadata === 'object' ? source.metadata : null,
+    recurrence: normalizeRecurrence(source.recurrence),
+    snoozedUntil: normalizeIsoString(source.snoozedUntil),
+    notifyMinutesBefore: Number.isFinite(Number(source.notifyMinutesBefore)) ? Number(source.notifyMinutesBefore) : 0,
+    userId: typeof source.userId === 'string' && source.userId ? source.userId : null,
+    pendingSync: !!source.pendingSync,
+    orderIndex: Number.isFinite(Number(source.orderIndex)) ? Number(source.orderIndex) : null,
+    plannerLessonId:
+      typeof source.plannerLessonId === 'string' && source.plannerLessonId.trim()
+        ? source.plannerLessonId.trim()
+        : null,
+    pinToToday: source.pinToToday === true,
+    semanticEmbedding: normalizeSemanticEmbedding(source.semanticEmbedding),
+    notifyAt: normalizeIsoString(source.notifyAt),
+  };
+
+  normalized.metadata = {
+    ...(normalized.metadata || {}),
+    text: [normalized.title, normalized.notes].filter(Boolean).join(' ').trim(),
+    keywords: normalized.keywords,
+    created_at: new Date(normalized.createdAt).toISOString(),
+  };
+
+  return normalized;
+}
+
+export function normalizeReminderList(list = [], options = {}) {
+  if (!Array.isArray(list)) {
+    return [];
+  }
+
+  return list
+    .map((entry) => normalizeReminderRecord(entry, {
+      ...options,
+      fallbackId: typeof options.createId === 'function' ? options.createId() : '',
+    }))
+    .filter(Boolean);
+}
+
+export function computeNextOccurrence(reminder) {
+  if (!reminder?.due) {
+    return null;
+  }
+  const recurrence = normalizeRecurrence(reminder.recurrence);
+  if (!recurrence) {
+    return null;
+  }
+  const date = new Date(reminder.due);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  if (recurrence === 'daily') date.setDate(date.getDate() + 1);
+  if (recurrence === 'weekly') date.setDate(date.getDate() + 7);
+  if (recurrence === 'monthly') date.setMonth(date.getMonth() + 1);
+  return date.toISOString();
+}
+
+export function getReminderScheduleIso(reminder) {
+  const snoozed = normalizeIsoString(reminder?.snoozedUntil);
+  if (snoozed) {
+    return snoozed;
+  }
+  return normalizeIsoString(reminder?.due);
+}
+
+export function cosineSimilarity(vecA, vecB) {
+  const a = normalizeSemanticEmbedding(vecA);
+  const b = normalizeSemanticEmbedding(vecB);
+  if (!a || !b || a.length !== b.length) {
+    return 0;
+  }
+  let dot = 0;
+  let magA = 0;
+  let magB = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    dot += a[i] * b[i];
+    magA += a[i] * a[i];
+    magB += b[i] * b[i];
+  }
+  if (!magA || !magB) {
+    return 0;
+  }
+  return dot / (Math.sqrt(magA) * Math.sqrt(magB));
+}


### PR DESCRIPTION
### Motivation
- Reduce the size and responsibilities of `reminderController.js` by extracting clearly separable pure/helper logic. 
- Make schema normalization, keyword/embedding handling and small search/scheduling helpers reusable and easier to test while preserving controller behavior.

### Description
- Added a new module `src/reminders/reminderSchemaHelpers.js` with exported helpers including `normalizeReminderKeywords`, `extractReminderKeywords`, `normalizeSemanticEmbedding`, `normalizeRecurrence`, `normalizeIsoString`, `normalizeReminderRecord`, `normalizeReminderList`, `computeNextOccurrence`, `getReminderScheduleIso`, and `cosineSimilarity`.
- Updated `src/reminders/reminderController.js` to import the new helpers and replaced the previous inline implementations with imports while keeping small local wrapper functions `normalizeReminderRecord` and `normalizeReminderList` that still inject `uid` and `normalizeCategory` to preserve prior behavior.
- Removed the duplicated in-file helper implementations from the controller, reducing file size and single-file responsibility.
- Preserved all existing public exports and external behavior of the controller (no public API changes).

### Testing
- Ran the build with `npm run build`, which completed successfully.
- Ran the test suite with `npm test -- --runInBand`, which produced failing suites: `Test Suites: 15 failed, 11 passed, 26 total` and `Tests: 33 failed, 51 passed, 84 total`; the failures are due to existing test-harness / ESM / dynamic-import errors surfaced across many tests and are not related to the small helper extraction performed in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b86763712083249bfb9d78c809f8f5)