### PR TITLE
Fix runtime Supabase env handling

### DIFF
--- a/js/config-supabase.js
+++ b/js/config-supabase.js
@@ -1,6 +1,5 @@
 import { getSupabaseClient, setSupabaseClient } from './supabase-client.js';
 
-window.__SUPABASE_ENV__ = typeof import.meta !== 'undefined' && import.meta ? import.meta.env : undefined;
 
 const supabase = getSupabaseClient();
 

--- a/js/init-env.js
+++ b/js/init-env.js
@@ -1,11 +1,12 @@
 if (typeof window !== 'undefined') {
-window.__ENV = window.__ENV || {};
+  const env = window.__ENV || {};
 
-window.__ENV = {
-...window.__ENV,
-SUPABASE_URL: window.__ENV.SUPABASE_URL || '',
-SUPABASE_ANON_KEY: window.__ENV.SUPABASE_ANON_KEY || ''
-};
+  if (!env.SUPABASE_URL || !env.SUPABASE_ANON_KEY) {
+    console.warn('[ENV INIT] Missing Supabase env values.', {
+      hasSupabaseUrl: Boolean(env.SUPABASE_URL),
+      hasSupabaseAnonKey: Boolean(env.SUPABASE_ANON_KEY)
+    });
+  }
 
-console.log('[ENV INIT]', window.__ENV);
+  console.log('[ENV INIT]', env);
 }

--- a/js/storage.js
+++ b/js/storage.js
@@ -1,4 +1,5 @@
 window.__ENV = {
+  ...window.__ENV,
   GOOGLE_SCRIPT_ENDPOINT: "https://script.google.com/macros/s/AKfycbylH5GmqeojNoZ-MA9WRg-w1S-ei9cv8Jo1M0qL7t5cn59LBRCCJ779WOyLi7qQwkSx/exec"
 };
 

--- a/js/supabase-client.js
+++ b/js/supabase-client.js
@@ -1,10 +1,3 @@
-if (!window.__ENV) {
-  window.__ENV = {
-    SUPABASE_URL: 'https://lycwdurbwdoacgsidfuk.supabase.co',
-    SUPABASE_ANON_KEY: 'sb_publishable_2y6z8d4_SCHbVIWPA3EI3Q_5As_3J_u',
-  };
-}
-
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
 let cachedClient = null;
@@ -33,9 +26,9 @@ export function getSupabaseClient() {
 
   attemptedInitialisation = true;
 
-  const SUPABASE_URL = normalise(window.__ENV?.SUPABASE_URL || import.meta.env?.VITE_SUPABASE_URL);
+  const SUPABASE_URL = normalise(window.__ENV?.SUPABASE_URL);
 
-  const SUPABASE_ANON_KEY = normalise(window.__ENV?.SUPABASE_ANON_KEY || import.meta.env?.VITE_SUPABASE_ANON_KEY);
+  const SUPABASE_ANON_KEY = normalise(window.__ENV?.SUPABASE_ANON_KEY);
 
   console.log('ENV URL:', SUPABASE_URL);
 


### PR DESCRIPTION
### Motivation
- Preserve runtime-provided `window.__ENV` values so Supabase credentials injected in the HTML are not overwritten by JS. 
- Stop the app from mutating missing Supabase values to empty strings; prefer validation-only so real browser runtime values remain intact. 
- Remove Vite/`import.meta.env` fallbacks and hardcoded defaults so the Supabase client uses only the browser runtime environment. 

### Description
- `js/storage.js`: merge into existing `window.__ENV` instead of replacing it by adding the spread: `window.__ENV = { ...window.__ENV, GOOGLE_SCRIPT_ENDPOINT: "..." };`. 
- `js/init-env.js`: stop writing empty-string fallbacks for `SUPABASE_URL`/`SUPABASE_ANON_KEY`; now only validates and logs a warning when values are missing without mutating `window.__ENV`. 
- `js/supabase-client.js`: removed hardcoded `window.__ENV` defaults and removed `import.meta.env` fallbacks so the client reads only `window.__ENV.SUPABASE_URL` and `window.__ENV.SUPABASE_ANON_KEY`. 
- `js/config-supabase.js`: remove the unused `import.meta.env` bridge (`window.__SUPABASE_ENV__`) so runtime env handling is consistently browser-driven. 
- Confirmed `mobile.html` remains the single place defining `window.__ENV` and is loaded before the app JS. 

### Testing
- Ran a repository search with `rg -n "import.meta|window\.__ENV = \{" mobile.html js` to confirm no remaining `import.meta.env` fallbacks; this check succeeded. 
- Ran the automated test suite with `npm test -- --runInBand`; the suite ran but the repository has pre-existing failures that persisted after these changes (summary from the run: `26` total suites, `11` passed, `15` failed; `84` total tests, `51` passed, `33` failed), and failures appear unrelated to these env-only edits (tests show CommonJS/ESM loading and dynamic import issues).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba00a7b520832480cb04c4dd475ae6)