### PR TITLE
Ensure build emits root index shell

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -132,6 +132,27 @@ async function copyStatic() {
   }
 }
 
+async function ensureRootHtml() {
+  const rootIndexPath = path.join(distDir, 'index.html');
+  const mobileShellPath = path.join(distDir, 'mobile.html');
+
+  try {
+    await fs.access(rootIndexPath);
+    return;
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error;
+  }
+
+  try {
+    await fs.copyFile(mobileShellPath, rootIndexPath);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      throw new Error('Build failed: no root HTML entry was generated. Expected dist/index.html or dist/mobile.html.');
+    }
+    throw error;
+  }
+}
+
 async function rewriteHtml(assetMap, cssPath) {
   const htmlFiles = ['index.html', '404.html', 'mobile.html'];
   for (const file of htmlFiles) {
@@ -150,12 +171,27 @@ async function rewriteHtml(assetMap, cssPath) {
   }
 }
 
+async function validateBuildOutput() {
+  const rootIndexPath = path.join(distDir, 'index.html');
+
+  try {
+    await fs.access(rootIndexPath);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      throw new Error('Build failed: dist/index.html is required for the Cloudflare Pages root entry point.');
+    }
+    throw error;
+  }
+}
+
 async function main() {
   await cleanDist();
   const cssPath = await buildCss();
   const assetMap = await buildScripts();
   await copyStatic();
+  await ensureRootHtml();
   await rewriteHtml(assetMap, cssPath);
+  await validateBuildOutput();
 }
 
 main().catch((error) => {


### PR DESCRIPTION
### Motivation
- Cloudflare Pages requires a root `index.html` in `dist/`, and the build previously tolerated a missing root entry which led to inconsistent deploy behaviour.
- Make the mobile runtime (`mobile.html`) the primary app shell when the root HTML is absent so the site always has a valid entry point.

### Description
- Added `ensureRootHtml()` to `scripts/build.mjs` which copies `dist/mobile.html` to `dist/index.html` when the root index is missing and throws a clear error if neither file exists.
- Added `validateBuildOutput()` to `scripts/build.mjs` to explicitly fail the build when `dist/index.html` is not present.
- Updated the main build flow in `scripts/build.mjs` to invoke `ensureRootHtml()` before HTML rewriting and `validateBuildOutput()` before exiting the build.

### Testing
- Ran `npm run build`, which completed successfully and produced the `dist/` assets.
- Verified both `dist/index.html` and `dist/mobile.html` exist and that `dist/index.html` matches the mobile shell fallback when applicable.
- Ran `npm run verify`, which passed and confirmed required build artifacts are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba026ea5148324a9edbcd7b370a87e)