### PR TITLE
Guard selector helpers against DOM elements

### DIFF
--- a/js/supabase-auth.js
+++ b/js/supabase-auth.js
@@ -121,7 +121,7 @@ function uniqueElements(elements) {
 }
 
 function queryAll(root, selectorValue) {
-  const selectors = toArray(selectorValue).filter(Boolean);
+  const selectors = toArray(selectorValue).filter((selector) => typeof selector === 'string' && selector);
   if (!selectors.length) {
     return [];
   }

--- a/src/reminders/reminderController.js
+++ b/src/reminders/reminderController.js
@@ -428,8 +428,8 @@ let activeReminderControllerApi = null;
 
 export async function initReminders(sel = {}) {
   console.log('[reminder-controller] initialized');
-  const $ = (s) => (s ? document.querySelector(s) : null);
-  const $$ = (s) => (s ? Array.from(document.querySelectorAll(s)) : []);
+  const $ = (s) => (typeof s === 'string' && s ? document.querySelector(s) : null);
+  const $$ = (s) => (typeof s === 'string' && s ? Array.from(document.querySelectorAll(s)) : []);
 
   // Elements
   const title = $(sel.titleSel);


### PR DESCRIPTION
### Motivation
- Prevent runtime errors like "Failed to execute 'querySelectorAll': '[object HTMLSpanElement]' is not a valid selector'" by ensuring non-string selector inputs are not forwarded into `querySelector`/`querySelectorAll` calls.

### Description
- Add defensive checks so `initReminders` helper selectors use `const $ = (s) => (typeof s === 'string' && s ? document.querySelector(s) : null)` and `const $$ = (s) => (typeof s === 'string' && s ? Array.from(document.querySelectorAll(s)) : [])` in `src/reminders/reminderController.js`.
- Restrict `queryAll` to only treat string selectors by filtering with `filter((selector) => typeof selector === 'string' && selector)` in `js/supabase-auth.js` so non-string values are ignored before calling `root.querySelectorAll`.
- Keep changes minimal and local to the selector helper logic without refactoring call sites or adding new files.

### Testing
- Ran repository checks including `git diff --check` which reported no issues.
- Executed the reminder-related Jest tests via `npm test -- --runInBand js/__tests__/reminders.auth.test.js js/__tests__/reminders.save-click.test.js js/__tests__/reminders.quick-add.test.js`, which failed to run to completion due to the test environment raising `TypeError: A dynamic import callback was not specified.` before exercising the patched selector logic.
- No new tests were added and the change is limited to defensive input validation in the two modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba1d1329fc8324bad4688d0144b450)