### PR TITLE
Guard renderItems against non-string selectors to avoid invalid querySelector calls

### DIFF
--- a/memory/memory.js
+++ b/memory/memory.js
@@ -338,11 +338,17 @@
     } = config;
 
     const list = Array.isArray(items) ? items : [];
+    const selectorHost =
+      typeof document === 'undefined'
+        ? null
+        : typeof selector === 'string' && selector
+          ? document.querySelector(selector)
+          : (typeof Element !== 'undefined' && selector instanceof Element)
+            ? selector
+            : null;
     const host = container
       || (typeof document !== 'undefined'
-        ? document.querySelector(
-            selector || `[data-section="${section}"]`
-          )
+        ? selectorHost || document.querySelector(`[data-section="${section}"]`)
         : null);
 
     if (!host) {


### PR DESCRIPTION
### Motivation
- Fix a runtime error where passing a DOM element into `document.querySelector` produced: "Failed to execute 'querySelectorAll': '[object HTMLSpanElement]' is not a valid selector" during memory/reminder rendering.

### Description
- Add a minimal guard in `memory/memory.js` `renderItems` so `selector` is treated as: a non-empty string (then `document.querySelector(selector)`), an `Element` instance (reused directly), or else fall back to the existing `[data-section="..."]` selector; this prevents forwarding an `Element` into `document.querySelector`.
- Use a safe `typeof Element !== 'undefined' && selector instanceof Element` check to avoid runtime errors in non-browser environments.
- Change is limited to `memory/memory.js`, is a small focused patch, and does not add new files or refactor other code.

### Testing
- Ran `npm test -- --runInBand`, which completed but showed unrelated existing test failures in mobile/auth and reminders tests that are not caused by this change.
- Performed a targeted sanity check by executing the module in a `vm`+`jsdom` context and calling `renderItems` with an `HTMLSpanElement` selector, which confirmed the flow no longer throws and returns the created items.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba2c9b8e808324b0664a1f20c98fb3)