### PR TITLE
Stabilize runtime env bootstrap

### DIFF
--- a/js/init-env.js
+++ b/js/init-env.js
@@ -1,5 +1,20 @@
+const DEFAULT_ENV = {
+  GOOGLE_SCRIPT_ENDPOINT:
+    'https://script.google.com/macros/s/AKfycbylH5GmqeojNoZ-MA9WRg-w1S-ei9cv8Jo1M0qL7t5cn59LBRCCJ779WOyLi7qQwkSx/exec',
+};
+
 if (typeof window !== 'undefined') {
-  const env = window.__ENV || {};
+  const existingEnv =
+    window.__ENV && typeof window.__ENV === 'object' && !Array.isArray(window.__ENV)
+      ? window.__ENV
+      : {};
+
+  window.__ENV = {
+    ...DEFAULT_ENV,
+    ...existingEnv,
+  };
+
+  const env = window.__ENV;
   const hasFirebaseConfig = Boolean(
     env.FIREBASE_API_KEY && env.FIREBASE_AUTH_DOMAIN && env.FIREBASE_PROJECT_ID && env.FIREBASE_APP_ID
   );

--- a/js/storage.js
+++ b/js/storage.js
@@ -1,8 +1,3 @@
-window.__ENV = {
-  ...window.__ENV,
-  GOOGLE_SCRIPT_ENDPOINT: "https://script.google.com/macros/s/AKfycbylH5GmqeojNoZ-MA9WRg-w1S-ei9cv8Jo1M0qL7t5cn59LBRCCJ779WOyLi7qQwkSx/exec"
-};
-
 (function() {
   // Enhanced Notes Editor
   const notesEditor = document.getElementById('notes');


### PR DESCRIPTION
### Motivation
- Reduce duplicate environment initialization and make the mobile app boot deterministic by centralizing runtime env setup.
- Avoid accidental overwrites of deployment-injected values while keeping the existing build/deploy path intact.

### Description
- Make `js/init-env.js` the single mobile runtime initializer for `window.__ENV` by merging any existing injected env and backfilling a default `GOOGLE_SCRIPT_ENDPOINT` without overwriting provided values.
- Remove the `window.__ENV` write from `js/storage.js` so storage code only reads from the initialized runtime env.
- Keep the existing custom build flow (`npm run build` → `node scripts/build.mjs`) and Cloudflare Pages output (`wrangler.jsonc` → `pages_build_output_dir: ./dist`) rather than introducing Vite or changing deployment strategy.
- Confirmed there is no `js/config-supabase.js` and that Firebase runtime config is read from `window.__ENV` via `src/lib/firebase.js`; no behavioral changes to app logic were made.

### Testing
- Ran `npm run build` successfully which produced `dist/` and hashed assets.
- Ran `npm run verify` which executed `node scripts/verify-build.mjs` and passed build verification.
- Committed the changes (`js/init-env.js`, `js/storage.js`) with a descriptive message and validated the repo status; no automated tests failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba70dae9e883249d14088fb21df26b)