### PR TITLE
Centralize query intent routing

### DIFF
--- a/src/brain/queryEngine.js
+++ b/src/brain/queryEngine.js
@@ -1,4 +1,4 @@
-import { classifyIntentLocally } from '../services/intentRouter.js';
+import { intentRouter } from '../services/intentRouter.js';
 import { getMemories } from '../services/memoryService.js';
 import { getReminderList } from '../reminders/reminderService.js';
 import { semanticSearch } from './semanticSearchService.js';
@@ -16,10 +16,13 @@ const normalizeReminderDate = (reminder) => {
 
 export function detectIntent(query) {
   const text = normalizeText(query);
+  const routedIntent = intentRouter(text, {
+    source: 'query_engine',
+    entryPoint: 'queryEngine.detectIntent',
+  });
   const q = text.toLowerCase();
-  const localIntent = classifyIntentLocally(text, { source: 'query_engine' });
 
-  if (localIntent?.decisionType === 'persist_reminder') {
+  if (routedIntent?.type === 'reminder') {
     return { type: 'reminder_query' };
   }
 
@@ -34,7 +37,7 @@ export function detectIntent(query) {
     return { type: 'reminder_query' };
   }
 
-  if (hasMemoryKeywords || localIntent?.decisionType === 'query_memory') {
+  if (hasMemoryKeywords || routedIntent?.type === 'query') {
     return { type: 'memory_query' };
   }
 

--- a/src/core/capturePipeline.js
+++ b/src/core/capturePipeline.js
@@ -1,4 +1,4 @@
-import { classifyIntentLocally, routeIntent } from '../services/intentRouter.js';
+import { intentRouter } from '../services/intentRouter.js';
 import { saveMemory } from '../services/memoryService.js';
 import { createReminder } from '../services/reminderService.js';
 import { semanticSearch } from '../services/semanticSearchService.js';
@@ -56,9 +56,15 @@ const parseEntry = async (text) => {
 };
 
 const resolveDecision = async (text, hints) => {
-  const localDecision = classifyIntentLocally(text, hints);
-  if (localDecision) {
-    return localDecision;
+  const initialIntent = intentRouter(text, hints);
+  if (initialIntent?.payload?.decisionType && initialIntent.payload.decisionType !== 'unresolved') {
+    return {
+      decisionType: initialIntent.payload.decisionType,
+      parsedType: initialIntent.payload.parsedType,
+      text,
+      parsedEntry: initialIntent.payload.parsedEntry,
+      hints,
+    };
   }
 
   let parsedEntry = null;
@@ -69,7 +75,14 @@ const resolveDecision = async (text, hints) => {
     parsedEntry = normalizeParsedEntry({ type: 'unknown', title: text }, text);
   }
 
-  return routeIntent(parsedEntry, text, hints);
+  const routedIntent = intentRouter(text, { ...hints, parsedEntry });
+  return {
+    decisionType: routedIntent?.payload?.decisionType || 'persist_inbox',
+    parsedType: routedIntent?.payload?.parsedType || 'unknown',
+    text,
+    parsedEntry: routedIntent?.payload?.parsedEntry || parsedEntry,
+    hints,
+  };
 };
 
 const saveNoteMemory = async (text, decision, context) => {

--- a/src/core/commandEngine.js
+++ b/src/core/commandEngine.js
@@ -2,6 +2,7 @@ import { captureInput } from './capturePipeline.js';
 import { loadAllNotes, saveAllNotes } from '../../js/modules/notes-storage.js';
 import { searchMemoryIndex } from '../../js/modules/memory-index.js';
 import { createReminder } from '../services/reminderService.js';
+import { handleQuery } from '../brain/queryEngine.js';
 
 const parseAssistantReply = (payload) => {
   if (typeof payload?.reply === 'string' && payload.reply.trim()) {
@@ -163,7 +164,9 @@ export const executeCommand = async (type, payload = {}) => {
           break;
         }
         const query = typeof payload?.query === 'string' ? payload.query : '';
-        const data = await searchMemoryIndex(query);
+        const data = query
+          ? await handleQuery(query)
+          : await searchMemoryIndex(query);
         result = {
           status: 'success',
           message: 'Search complete.',

--- a/src/services/intentRouter.js
+++ b/src/services/intentRouter.js
@@ -297,6 +297,64 @@ export const routeIntent = (parsedEntry, rawText, hints = {}) => {
   return logRoutingDecision('routeIntent', text, decision);
 };
 
+const mapDecisionTypeToIntentType = (decisionType) => {
+  switch (decisionType) {
+    case 'persist_reminder':
+      return 'reminder';
+    case 'persist_note':
+      return 'note';
+    case 'query_memory':
+    case 'assistant_query':
+      return 'query';
+    case 'plan_day':
+      return 'plan_day';
+    case 'learn_pattern':
+      return 'learn_pattern';
+    case 'persist_inbox':
+    default:
+      return 'inbox';
+  }
+};
+
+/**
+ * Canonical classification entry point for user text.
+ * This is intentionally pure routing metadata: callers decide how to execute.
+ */
+export const intentRouter = (query, context = {}) => {
+  const text = typeof query === 'string' ? query.trim() : '';
+  const hints = context && typeof context === 'object' ? context : {};
+  const parsedEntry = hints?.parsedEntry && typeof hints.parsedEntry === 'object'
+    ? hints.parsedEntry
+    : null;
+
+  const decision = parsedEntry
+    ? routeIntent(parsedEntry, text, hints)
+    : classifyIntentLocally(text, hints);
+
+  if (!decision) {
+    return {
+      type: 'unknown',
+      payload: {
+        query: text,
+        decisionType: 'unresolved',
+        parsedType: 'unknown',
+        hints,
+      },
+    };
+  }
+
+  return {
+    type: mapDecisionTypeToIntentType(decision.decisionType),
+    payload: {
+      query: text,
+      decisionType: decision.decisionType,
+      parsedType: decision.parsedType || 'unknown',
+      parsedEntry: decision.parsedEntry || null,
+      hints,
+    },
+  };
+};
+
 export const createChatIntentInput = (parsedEntry, rawText, hints = {}) => ({
   parsedEntry,
   rawText,


### PR DESCRIPTION
### Motivation
- Provide a single, pure intent classification entry so all user text (chat, quick-add, inbox, queries) can be routed consistently without executing handlers during classification. 
- Reduce duplicated inline parsing/keyword checks so downstream handlers receive a structured intent → payload shape and decide execution.

### Description
- Add `intentRouter(query, context)` in `src/services/intentRouter.js` which returns `{ type, payload }` and does not execute handlers, plus a small `mapDecisionTypeToIntentType` translator. 
- Update `src/core/capturePipeline.js` to call `intentRouter` first and only fall back to `/api/parse-entry` when local classification is unresolved, while keeping existing handler execution (persist_note, persist_reminder, query_memory, persist_inbox) unchanged. 
- Update `src/brain/queryEngine.js` to consult `intentRouter` when detecting query type before applying existing reminder/memory heuristics. 
- Update `src/core/commandEngine.js` so `executeCommand('search')` uses `handleQuery(query)` for non-handler search requests to converge search routing through the shared path.

### Testing
- Ran build verification with `npm run verify`, which passed. 
- Ran focused unit tests with `npm test -- --runInBand chat-system.prompt12.test.js reminders.categories.test.js`, which failed in the existing test harness due to ESM/dynamic import issues in the test environment (errors from dynamic `import()` and ESM `import` usage), not caused by these routing changes. 
- No new test files were added or modified and changes were kept minimal to avoid breaking unrelated systems.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba77d16c208324a386d80130feee15)