### PR TITLE
Standardize text routing through capture pipeline

### DIFF
--- a/js/services/assistant-service.js
+++ b/js/services/assistant-service.js
@@ -1,11 +1,6 @@
 import { loadAllNotes } from '../modules/notes-storage.js';
-import { getInboxEntries } from './capture-service.js';
+import { captureInput, getInboxEntries } from './capture-service.js';
 import { addMessage, clearMessages, getMessages } from '../../src/chat/messageStore.js';
-
-const toTimestamp = (value) => {
-  const parsed = Date.parse(typeof value === 'string' ? value : '');
-  return Number.isNaN(parsed) ? 0 : parsed;
-};
 
 const readReminders = () => {
   if (typeof localStorage === 'undefined') return [];
@@ -87,59 +82,53 @@ const appendReferences = (container, references) => {
   container.appendChild(list);
 };
 
-const buildPayload = (message, history) => {
-  const notes = (Array.isArray(loadAllNotes()) ? loadAllNotes() : [])
-    .sort((a, b) => toTimestamp(b?.updatedAt || b?.createdAt) - toTimestamp(a?.updatedAt || a?.createdAt))
-    .slice(0, 20)
-    .map((note) => ({
-      id: note?.id,
-      title: note?.title,
-      body: note?.bodyText || note?.body || '',
-      createdAt: note?.createdAt,
-      updatedAt: note?.updatedAt,
-    }));
-
-  const reminders = readReminders().slice(0, 20).map((reminder) => ({
-    id: reminder?.id,
-    title: reminder?.title,
-    body: reminder?.notes || reminder?.body || '',
-    due: reminder?.due,
-    createdAt: reminder?.createdAt,
-  }));
-
-  const inboxEntries = getInboxEntries().slice(0, 20).map((entry) => ({
-    id: entry?.id,
-    text: entry?.text,
-    createdAt: entry?.createdAt,
-    source: entry?.source,
-  }));
-
-  return {
-    message,
-    history,
-    notes,
-    reminders,
-    inboxEntries,
-  };
-};
-
-const sendAssistantRequest = async (payload) => {
-  const response = await fetch('/api/assistant-chat', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  });
-
-  if (!response.ok) {
-    throw new Error(`Assistant request failed (${response.status})`);
+const formatReminderItems = (items = []) => {
+  if (!Array.isArray(items) || !items.length) {
+    return 'I could not find any matching reminders.';
   }
 
-  const data = await response.json();
-  return {
-    reply: typeof data?.reply === 'string' ? data.reply : 'I could not read the assistant response.',
-    references: Array.isArray(data?.references) ? data.references : [],
-  };
+  return [
+    'Here are the matching reminders:',
+    '',
+    ...items.slice(0, 10).map((item) => `• ${item?.title || item?.text || item?.notes || 'Untitled reminder'}`),
+  ].join('\n');
 };
+
+const formatMemoryItems = (items = []) => {
+  if (!Array.isArray(items) || !items.length) {
+    return 'I could not find any matching memories.';
+  }
+
+  return [
+    'Here is what I found:',
+    '',
+    ...items.slice(0, 10).map((item) => `• ${item?.title || item?.text || 'Untitled memory'}`),
+  ].join('\n');
+};
+
+const formatQueryResponse = (data) => {
+  if (!data || typeof data !== 'object') {
+    return '';
+  }
+
+  if (data.type === 'reminder_results') {
+    return formatReminderItems(data.items);
+  }
+
+  if (data.type === 'memory_results') {
+    return formatMemoryItems(data.items);
+  }
+
+  if (data.type === 'mixed_results') {
+    const memories = formatMemoryItems(data.memories);
+    const reminders = formatReminderItems(data.reminders);
+    return [memories, '', reminders].join('\n');
+  }
+
+  return '';
+};
+
+const shouldUseAssistantApi = (result) => result?.decision?.decisionType === 'assistant_query';
 
 const askAssistant = async ({ message, assistantMessages, assistantLoading }) => {
   const trimmedMessage = typeof message === 'string' ? message.trim() : '';
@@ -156,17 +145,37 @@ const askAssistant = async ({ message, assistantMessages, assistantLoading }) =>
     assistantLoading.classList.remove('hidden');
   }
 
-  const history = readConversation();
-
   try {
-    const payload = buildPayload(trimmedMessage, history);
-    const result = await sendAssistantRequest(payload);
-    if (assistantMessages instanceof HTMLElement) {
-      const replyNode = appendMessage(assistantMessages, result.reply, 'assistant-message assistant-message--reply');
-      appendReferences(replyNode, result.references);
+    const routed = await captureInput({
+      text: trimmedMessage,
+      source: 'assistant_service',
+      metadata: {
+        entryPoint: 'assistant-service.askAssistant',
+      },
+    });
+
+    let reply = typeof routed?.message === 'string' ? routed.message.trim() : '';
+    let references = [];
+
+    if (!reply) {
+      reply = formatQueryResponse(routed?.data);
     }
-    addMessage(createStoredMessage('assistant', result.reply));
-    return result;
+
+    if (!reply && shouldUseAssistantApi(routed)) {
+      reply = typeof routed?.data?.reply === 'string' ? routed.data.reply : '';
+      references = Array.isArray(routed?.data?.references) ? routed.data.references : [];
+    }
+
+    if (!reply) {
+      reply = 'Added to inbox for later review.';
+    }
+
+    if (assistantMessages instanceof HTMLElement) {
+      const replyNode = appendMessage(assistantMessages, reply, 'assistant-message assistant-message--reply');
+      appendReferences(replyNode, references);
+    }
+    addMessage(createStoredMessage('assistant', reply));
+    return { reply, references, routed };
   } catch (error) {
     console.error('[assistant-service] Assistant unavailable', error);
     if (assistantMessages instanceof HTMLElement) {

--- a/src/brain/queryEngine.js
+++ b/src/brain/queryEngine.js
@@ -20,28 +20,36 @@ export function detectIntent(query) {
     source: 'query_engine',
     entryPoint: 'queryEngine.detectIntent',
   });
-  const q = text.toLowerCase();
 
   if (routedIntent?.type === 'reminder') {
-    return { type: 'reminder_query' };
+    return { type: 'reminder_query', source: 'intent_router' };
   }
 
+  if (routedIntent?.type === 'query') {
+    return { type: 'memory_query', source: 'intent_router' };
+  }
+
+  if (routedIntent?.type !== 'unknown') {
+    return { type: 'mixed_query', source: 'intent_router' };
+  }
+
+  const q = text.toLowerCase();
   const hasReminderKeywords = q.includes('remind') || q.includes('today') || q.includes('due') || q.includes('reminder');
   const hasMemoryKeywords = q.includes('what did i') || q.includes('notes') || q.includes('write') || q.includes('ideas');
 
   if (hasReminderKeywords && hasMemoryKeywords) {
-    return { type: 'mixed_query' };
+    return { type: 'mixed_query', source: 'heuristic_fallback' };
   }
 
   if (hasReminderKeywords) {
-    return { type: 'reminder_query' };
+    return { type: 'reminder_query', source: 'heuristic_fallback' };
   }
 
-  if (hasMemoryKeywords || routedIntent?.type === 'query') {
-    return { type: 'memory_query' };
+  if (hasMemoryKeywords) {
+    return { type: 'memory_query', source: 'heuristic_fallback' };
   }
 
-  return { type: 'mixed_query' };
+  return { type: 'mixed_query', source: 'heuristic_fallback' };
 }
 
 function filterToday(reminders) {

--- a/src/chat/actionRouter.js
+++ b/src/chat/actionRouter.js
@@ -17,15 +17,6 @@ const createActionResult = (intent, message, status) => ({
   status,
 });
 
-const shouldProcessInbox = (text) => {
-  const normalized = typeof text === 'string' ? text.trim().toLowerCase() : '';
-  if (!normalized) {
-    return false;
-  }
-
-  return normalized.includes('process') && (normalized.includes('notes') || normalized.includes('inbox'));
-};
-
 const routeCapture = async (text) => {
   const result = await executeCommand('capture', { text, source: 'capture' });
   return createActionResult('capture', result.message, result);
@@ -85,21 +76,17 @@ const routeProcessInbox = async (dependencies = {}) => {
 };
 
 export const routeAction = async (intent, text, dependencies = {}) => {
-  if (shouldProcessInbox(text)) {
-    return routeProcessInbox(dependencies);
+  switch (intent) {
+    case 'processInbox':
+      return routeProcessInbox(dependencies);
+    case 'reminder':
+      return routeReminder(text, dependencies);
+    case 'assistant':
+      return routeAssistant(text);
+    case 'memorySearch':
+      return routeMemorySearch(text);
+    case 'capture':
+    default:
+      return routeCapture(text);
   }
-
-  if (intent === 'reminder') {
-    return routeReminder(text, dependencies);
-  }
-
-  if (intent === 'assistant') {
-    return routeAssistant(text);
-  }
-
-  if (intent === 'memorySearch') {
-    return routeMemorySearch(text);
-  }
-
-  return routeCapture(text);
 };


### PR DESCRIPTION
### Motivation
- Remove duplicated/local intent parsing and ensure all free-text user input flows through the single canonical path `captureInput(...) → intentRouter(...)` so classification is centralized. 
- Prevent direct assistant API bypasses where typed text sent straight to `/api/assistant-chat` circumvented the capture pipeline. 
- Avoid parallel heuristic classification in the query engine so router classification is authoritative and heuristics only run as a fallback. 

### Description
- Convert `src/chat/actionRouter.js` into a thin dispatcher that trusts an already-classified `intent` and only dispatches to the appropriate handler, removing local keyword-based `processInbox` detection. 
- Refactor `js/services/assistant-service.js` so assistant text is routed through `captureInput(...)` first and the assistant API is only used when `intentRouter`/capture indicates an assistant/LLM decision; added lightweight formatting helpers for local `query_memory`/`mixed_results` rendering. 
- Update `src/brain/queryEngine.js` to prefer `intentRouter(...)` results and only run existing heuristic fallback checks when the router returns `unknown`, avoiding concurrent classification paths. 
- Files changed: `src/chat/actionRouter.js`, `js/services/assistant-service.js`, and `src/brain/queryEngine.js`. 

### Testing
- Ran `npm run verify`, which completed successfully. 
- Ran `npm test -- --runInBand`; the test run exposed existing, unrelated runtime/import issues (examples: `Cannot use import statement outside a module`, `A dynamic import callback was not specified`, and `initAuth is not defined`) causing several mobile/reminder tests to fail; these failures pre-date and are unrelated to the routing changes. 
- Ran `npm run build`, which produced normal Tailwind/Browserslist warnings but completed build steps in the non-interactive check window.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba7d89d5d88324816b0c0e798c89f3)