### PR TITLE
Align canonical memory schema

### DIFF
--- a/src/reminders/reminderController.js
+++ b/src/reminders/reminderController.js
@@ -1611,18 +1611,23 @@ export async function initReminders(sel = {}) {
     });
 
     const memoryEntries = readMemoryEntries().map((entry) => {
-      const updatedTime = typeof entry?.updatedAt === 'string' ? Date.parse(entry.updatedAt) : Number.NaN;
-      const createdTime = typeof entry?.createdAt === 'string' ? Date.parse(entry.createdAt) : Number.NaN;
+      const updatedTime = Number.isFinite(entry?.updatedAt)
+        ? entry.updatedAt
+        : (typeof entry?.updatedAt === 'string' ? Date.parse(entry.updatedAt) : Number.NaN);
+      const createdTime = Number.isFinite(entry?.createdAt)
+        ? entry.createdAt
+        : (typeof entry?.createdAt === 'string' ? Date.parse(entry.createdAt) : Number.NaN);
+      const entryText = typeof entry?.text === 'string' ? entry.text : '';
       return {
         id: typeof entry?.id === 'string' ? entry.id : '',
         type: normalizeMemoryEntryType(entry?.type),
-        title: typeof entry?.title === 'string' ? entry.title : '',
-        body: typeof entry?.body === 'string' ? entry.body : '',
+        title: entryText ? extractTitle(entryText) : (typeof entry?.title === 'string' ? entry.title : ''),
+        body: entryText || (typeof entry?.body === 'string' ? entry.body : ''),
         category: typeof entry?.category === 'string' ? entry.category : '',
         tags: Array.isArray(entry?.tags) ? entry.tags : [],
         relatedIds: Array.isArray(entry?.relatedIds) ? entry.relatedIds : [],
-        createdAt: typeof entry?.createdAt === 'string' ? entry.createdAt : '',
-        updatedAt: typeof entry?.updatedAt === 'string' ? entry.updatedAt : '',
+        createdAt: Number.isFinite(createdTime) ? new Date(createdTime).toISOString() : '',
+        updatedAt: Number.isFinite(updatedTime) ? new Date(updatedTime).toISOString() : '',
         timestamp: Number.isFinite(updatedTime) ? updatedTime : (Number.isFinite(createdTime) ? createdTime : null),
         semanticEmbedding: null,
       };

--- a/src/services/firestoreSyncService.js
+++ b/src/services/firestoreSyncService.js
@@ -1,4 +1,5 @@
 import { normalizeReminder, normalizeReminderList } from '../reminders/reminderNormalizer.js';
+import { normalizeMemoryList } from './memoryService.js';
 
 const NOTES_KEY = 'memoryCueNotes';
 const INBOX_KEY = 'memoryCueInbox';
@@ -42,7 +43,7 @@ export const syncNotes = async (localItemsOverride = null) => {
   return readLocal(NOTES_KEY);
 };
 
-export const syncInbox = async () => readLocal(INBOX_KEY);
+export const syncInbox = async () => normalizeMemoryList(readLocal(INBOX_KEY), { type: 'inbox', source: 'capture' });
 export const syncReminders = async () => normalizeReminderList(readLocal(REMINDERS_KEY));
 export const syncChatHistory = async () => readLocal(CHAT_KEY);
 export const pushChanges = async () => {};
@@ -50,8 +51,9 @@ export const pullChanges = async () => {};
 
 export const upsertInboxEntry = async (entry) => {
   if (!entry?.id) return;
-  const cached = readLocal(INBOX_KEY).filter((item) => String(item?.id) !== String(entry.id));
-  cached.unshift({ ...entry, pendingSync: false, updatedAt: Date.now() });
+  const cached = normalizeMemoryList(readLocal(INBOX_KEY), { type: 'inbox', source: 'capture' })
+    .filter((item) => String(item?.id) !== String(entry.id));
+  cached.unshift({ ...entry, type: 'inbox', pendingSync: false, updatedAt: Date.now() });
   writeLocal(INBOX_KEY, cached);
 };
 

--- a/src/services/inboxService.js
+++ b/src/services/inboxService.js
@@ -1,6 +1,6 @@
 import { syncInbox, upsertInboxEntry } from './firestoreSyncService.js';
 import { indexSourceEmbedding } from './embeddingService.js';
-import { saveMemory, normalizeMemoryEntry } from './memoryService.js';
+import { saveMemory, normalizeMemory } from './memoryService.js';
 
 export const INBOX_STORAGE_KEY = 'memoryCueInbox';
 const LEGACY_INBOX_STORAGE_KEYS = ['memoryEntries'];
@@ -44,7 +44,7 @@ const normalizeTags = (tags) => {
 
 
 const normalizeInboxEntry = (entryInput = {}) => {
-  const canonical = normalizeMemoryEntry({
+  const canonical = normalizeMemory({
     ...entryInput,
     type: 'inbox',
     source: entryInput?.source,
@@ -57,13 +57,14 @@ const normalizeInboxEntry = (entryInput = {}) => {
   return {
     id: canonical.id,
     text: canonical.text,
+    type: canonical.type,
     tags: canonical.tags,
     createdAt: canonical.createdAt,
+    updatedAt: canonical.updatedAt,
     source: canonical.source,
     parsedType: normalizeParsedType(entryInput?.parsedType || 'unknown'),
     metadata: entryInput?.metadata && typeof entryInput.metadata === 'object' ? entryInput.metadata : {},
     pendingSync: canonical.pendingSync,
-    updatedAt: canonical.updatedAt,
     entryPoint: canonical.entryPoint,
   };
 };

--- a/src/services/memoryService.js
+++ b/src/services/memoryService.js
@@ -3,10 +3,14 @@ import { generateEmbedding } from '../brain/embeddingService.js';
 
 const MEMORY_CACHE_KEY = 'memoryCueCache';
 const LEGACY_KEYS = ['memoryCueNotes', 'mobileNotes', 'memory-cue-notes', 'memoryCueInbox'];
-const MEMORY_TYPES = new Set(['note', 'reminder', 'idea', 'task', 'inbox']);
+const MEMORY_TYPES = new Set(['note', 'inbox', 'memory', 'system']);
+const MEMORY_SOURCES = new Set(['capture', 'assistant', 'import']);
 const MEMORY_TYPE_ALIASES = Object.freeze({
-  lesson_idea: 'idea',
-  coaching_drill: 'idea',
+  reminder: 'memory',
+  idea: 'memory',
+  task: 'memory',
+  lesson_idea: 'memory',
+  coaching_drill: 'memory',
   question: 'note',
   unknown: 'inbox',
 });
@@ -52,12 +56,22 @@ const normalizeType = (value) => {
   return MEMORY_TYPES.has(type) ? type : 'note';
 };
 
+const normalizeSource = (value, fallback = 'capture') => {
+  const source = normalizeText(value).toLowerCase();
+  if (source === 'quick-add' || source === 'quick_add' || source === 'quick capture') {
+    return 'capture';
+  }
+  if (source === 'manual' || source === 'inbox' || source === 'reminder') {
+    return 'capture';
+  }
+  return MEMORY_SOURCES.has(source) ? source : fallback;
+};
+
 export const MEMORY_TYPE_USAGE = Object.freeze({
   note: 'General note or reference content.',
   inbox: 'Unprocessed capture awaiting triage.',
-  idea: 'Draft concept, brainstorm, or lesson/coaching idea.',
-  task: 'Actionable item that is not a scheduled reminder.',
-  reminder: 'Scheduled or time-based commitment.',
+  memory: 'Stored knowledge or captured item retained in the second brain.',
+  system: 'System-generated memory or app-created reference content.',
 });
 
 const getCurrentUserId = () => {
@@ -81,6 +95,33 @@ const normalizeEmbedding = (value) => {
   return numbers.length ? numbers : undefined;
 };
 
+const attachLegacyAccessors = (memory) => {
+  if (!memory || typeof memory !== 'object') {
+    return memory;
+  }
+
+  const accessors = {
+    content: { get: () => memory.text },
+    note: { get: () => memory.text },
+    body: { get: () => memory.text },
+    bodyText: { get: () => memory.text },
+    timestamp: { get: () => memory.createdAt },
+  };
+
+  Object.entries(accessors).forEach(([key, descriptor]) => {
+    if (Object.prototype.hasOwnProperty.call(memory, key)) {
+      return;
+    }
+    Object.defineProperty(memory, key, {
+      enumerable: false,
+      configurable: true,
+      ...descriptor,
+    });
+  });
+
+  return memory;
+};
+
 const toMemoryShape = (entry = {}, fallback = {}) => {
   const now = Date.now();
   const createdAt = normalizeNumber(entry.createdAt, now);
@@ -90,22 +131,35 @@ const toMemoryShape = (entry = {}, fallback = {}) => {
       ? crypto.randomUUID()
       : `memory-${updatedAt}`);
 
-  return {
+  const memory = {
     id: resolvedId,
     userId: normalizeText(entry.userId) || fallback.userId || getCurrentUserId(),
-    text: normalizeText(entry.text || entry.bodyText || entry.body || entry.title),
-    type: normalizeType(entry.type || entry.parsedType),
+    text: normalizeText(
+      entry.text
+      || entry.content
+      || entry.note
+      || entry.bodyText
+      || entry.body
+      || entry.title
+    ),
+    type: normalizeType(entry.type || entry.parsedType || fallback.type),
     createdAt,
     updatedAt,
-    source: normalizeText(entry.source) || fallback.source || 'capture',
+    source: normalizeSource(entry.source || entry.metadata?.source, fallback.source || 'capture'),
     entryPoint: normalizeText(entry.entryPoint) || fallback.entryPoint || 'capture',
-    tags: normalizeTags(entry.tags),
+    tags: normalizeTags(entry.tags || entry.metadata?.tags || entry.keywords),
     embedding: normalizeEmbedding(entry.embedding),
     pendingSync: entry.pendingSync === false ? false : true,
   };
+
+  return attachLegacyAccessors(memory);
 };
 
-export const normalizeMemoryEntry = (entry = {}, fallback = {}) => toMemoryShape(entry, fallback);
+export const normalizeMemory = (entry = {}, fallback = {}) => toMemoryShape(entry, fallback);
+export const normalizeMemoryEntry = normalizeMemory;
+export const normalizeMemoryList = (entries = [], fallback = {}) => (
+  Array.isArray(entries) ? entries.map((entry) => normalizeMemory(entry, fallback)).filter((entry) => entry.text) : []
+);
 
 const readCacheFromStorage = () => {
   if (typeof localStorage === 'undefined') {
@@ -123,7 +177,7 @@ const readCacheFromStorage = () => {
       return [];
     }
 
-    return parsed.map((item) => toMemoryShape(item)).filter((item) => item.text);
+    return normalizeMemoryList(parsed);
   } catch (error) {
     console.warn('[memory-service] Failed to read memory cache', error);
     return [];
@@ -307,8 +361,8 @@ void triggerSync();
 export const saveMemory = async (memory = {}) => {
   ensureCacheLoaded();
 
-  const nextMemory = toMemoryShape(memory, {
-    source: normalizeText(memory.source) || 'capture',
+  const nextMemory = normalizeMemory(memory, {
+    source: normalizeSource(memory.source, 'capture'),
     entryPoint: normalizeText(memory.entryPoint) || 'capture',
   });
 


### PR DESCRIPTION
### Motivation
- Provide a single, tolerant canonical memory shape so notes, inbox items, captured text and stored memories share a consistent model for the app’s "second brain".
- Align memory record fields with reminders for future unification while keeping the two systems separate for now.
- Preserve backward compatibility by accepting legacy shapes and exposing non-enumerable legacy accessors to avoid breaking UI and existing storage.

### Description
- Added a canonical normalizer `normalizeMemory()` and helpers (`normalizeMemoryList`, `normalizeSource`, `attachLegacyAccessors`) in `src/services/memoryService.js` that map legacy fields (`content`, `note`, `body`, `bodyText`, `title`, `keywords`, etc.) into the canonical structure (`id`, `text`, `createdAt`, `updatedAt`, `type`, `tags`, `source`, etc.).
- Standardized memory types and sources (core `type`: `note | inbox | memory | system`; core `source`: `capture | assistant | import`) while tolerating legacy aliases (`reminder`, `idea`, `task`, `lesson_idea`, `quick-add`, `manual`, etc.).
- Routed inbox creation/reads through the canonical normalizer by updating `src/services/inboxService.js` to use `normalizeMemory()` so inbox entries now carry consistent `id/text/type/createdAt/updatedAt/source/tags/entryPoint` values while still preserving `parsedType` and `metadata` for UI compatibility.
- Normalized local/sync inbox reads and upserts in `src/services/firestoreSyncService.js` to read and persist canonical memory records for inbox sync flows.
- Adjusted `src/reminders/reminderController.js` inbox-search/read path to consume canonical `text` and numeric epoch timestamps (ms) when building search/render entries so UI/search results display consistently.
- Files updated: `src/services/memoryService.js`, `src/services/inboxService.js`, `src/services/firestoreSyncService.js`, `src/reminders/reminderController.js`.

### Testing
- Ran unit tests with `npm test -- --runInBand`; the test run failed with multiple pre-existing Jest / module-loading and service-worker related failures (14 suites failed, 31 tests failed), which are unrelated to the four modified files and caused by the test environment importing/build setup rather than the normalization changes.
- Ran the build with `npm run build`; the build pipeline completed its CSS/JS steps and produced assets, but the harness run encountered environment/timeout/exit behavior (warnings from Tailwind/DaisyUI / browserslist were emitted); no build-time errors were introduced by this change.
- Manual inspection and targeted checks confirmed the changed modules now normalize legacy inputs and expose the canonical fields (`id`, `text`, `createdAt`, `updatedAt`, `type`, `tags`, `source`) and that inbox read/write and local sync flows pass through the new normalizer.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba83bb5a288324982312e02a4d9f35)