### PR TITLE
Define module-scoped debounce in reminderController to fix runtime error

### DIFF
--- a/src/reminders/reminderController.js
+++ b/src/reminders/reminderController.js
@@ -60,6 +60,17 @@ const uid = () => {
   }
   return `reminder-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 };
+function debounce(fn, delay = 300) {
+  let timeoutId;
+  return (...args) => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+    timeoutId = setTimeout(() => {
+      fn(...args);
+    }, delay);
+  };
+}
 function normalizeReminderRecord(reminder = {}, options = {}) {
   return normalizeReminderRecordHelper(reminder, {
     ...options,


### PR DESCRIPTION
### Motivation
- The reminders UI used `debounce(...)` but it was neither imported nor defined in `src/reminders/reminderController.js`, causing a runtime `ReferenceError: debounce is not defined`; a minimal local definition fixes the blocking error without changing reminder logic.

### Description
- Add a small module-scoped `debounce` helper to `src/reminders/reminderController.js` so the existing `title?.addEventListener('input', debounce(updateDateFeedback,300))` call resolves to a local function and no globals are introduced.

### Testing
- Ran `rg -n "\bdebounce\b" src/reminders/reminderController.js` to confirm the only usage in the file now resolves to the new helper (success). 
- Ran `npm run build` to verify the project builds after the change (success). 
- Ran `node --check src/reminders/reminderController.js` which failed due to Node treating the file as a non-ESM module in this environment, which is an environment/tooling limitation and not indicative of the runtime fix (note only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba85127a5883248994de8ce2c6b2c0)