### PR TITLE
Fix Firebase runtime env injection

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en" data-theme="caramellatte">
 <head>
+  <script src="./js/runtime-env.js"></script>
   <base href="/memory-cue/">
 <script type="module" src="./js/init-env.js" defer></script>
   <meta charset="utf-8" />
@@ -73,7 +74,6 @@
     .dashboard-widget [aria-hidden="true"].animate-pulse { opacity: .85; }
   </style>
   <!-- END GPT FIX: compact-skeleton-style -->
-  <script src="./js/runtime-env-shim.js" defer></script>
   <script type="module" src="./js/main.js" defer></script>
   <script type="module" src="./js/daily-log-view.js" defer></script>
 </head>

--- a/README.md
+++ b/README.md
@@ -50,18 +50,21 @@ Build the static app and deploy the generated `dist/` output with your preferred
 
 ## Configuration
 
-Memory Cue expects Firebase credentials to be available at runtime via `window.__ENV`. Add the following snippet to your production `index.html` (or equivalent template) **before** loading the main JavaScript bundle so the app can read the values when it starts:
+Memory Cue expects Firebase credentials to be available at runtime via `window.__ENV`.
 
-```html
-<script>
-  window.__ENV = {
-    FIREBASE_API_KEY: "https://YOUR-PROJECT.firebaseapp.com",
-    FIREBASE_APP_ID: "YOUR_ANON_KEY"
-  };
-</script>
-```
+For Cloudflare Pages, set these build environment variables so `npm run build` can write `dist/js/runtime-env.js` during deployment:
 
-Keep your real Firebase URL and anon key out of version control—set them through deployment-specific templating or secrets management rather than committing them to the repository.
+- `FIREBASE_API_KEY`
+- `FIREBASE_AUTH_DOMAIN`
+- `FIREBASE_PROJECT_ID`
+- `FIREBASE_APP_ID`
+
+Optional Firebase runtime variables:
+
+- `FIREBASE_STORAGE_BUCKET`
+- `FIREBASE_MESSAGING_SENDER_ID`
+
+For local development, place the same values in an untracked `.env.local` file before running `npm run build`. The generated runtime env script preserves any values already present in `window.__ENV`, and `js/init-env.js` remains the single runtime initializer.
 
 
 ## AI setup

--- a/docs/ENVIRONMENT_CONFIG.md
+++ b/docs/ENVIRONMENT_CONFIG.md
@@ -5,8 +5,11 @@
 - `APP_URL` (optional): historical endpoint base URL. Current assistant flow uses relative `/api/assistant-chat`.
 
 ## Client/runtime configuration
-- Firebase settings are loaded via runtime env shims in `js/init-env.js` and `js/env.js`.
-- Firebase settings are loaded from `window.__ENV` and `js/firebase-client.js`.
+- Firebase settings are injected into `window.__ENV` by `js/runtime-env.js`.
+- `js/init-env.js` is the single runtime initializer and preserves any values already injected before app boot.
+- The Firebase runtime reads `FIREBASE_API_KEY`, `FIREBASE_AUTH_DOMAIN`, `FIREBASE_PROJECT_ID`, and `FIREBASE_APP_ID`.
+- `FIREBASE_STORAGE_BUCKET` and `FIREBASE_MESSAGING_SENDER_ID` are optional runtime values when available.
+- Cloudflare Pages should expose those variables to the build so `scripts/build.mjs` can generate `dist/js/runtime-env.js`.
 - Google Apps Script endpoint configuration is managed through `syncUrl` in localStorage and notes sync modules.
 
 ## Notes

--- a/js/init-env.js
+++ b/js/init-env.js
@@ -19,7 +19,9 @@ if (typeof window !== 'undefined') {
     env.FIREBASE_API_KEY && env.FIREBASE_AUTH_DOMAIN && env.FIREBASE_PROJECT_ID && env.FIREBASE_APP_ID
   );
 
-  if (!hasFirebaseConfig) {
+  if (hasFirebaseConfig) {
+    console.info('[ENV INIT] Firebase env loaded.');
+  } else {
     console.warn('[ENV INIT] Missing Firebase env values; auth and Firestore are disabled.');
   }
 }

--- a/js/runtime-env.js
+++ b/js/runtime-env.js
@@ -1,0 +1,14 @@
+window.__ENV =
+  window.__ENV && typeof window.__ENV === 'object' && !Array.isArray(window.__ENV)
+    ? window.__ENV
+    : {};
+
+window.textureUrl =
+  window.textureUrl ||
+  ((filename) => {
+    if (typeof filename !== 'string') {
+      return '';
+    }
+
+    return filename;
+  });

--- a/mobile.html
+++ b/mobile.html
@@ -11,6 +11,7 @@ Legacy shells remain for reference only.
 <html lang="en" data-theme="light" class="h-full">
 <head>
     <script src="./js/storage.js"></script>
+  <script src="./js/runtime-env.js"></script>
   <script type="module" src="./js/init-env.js" defer></script>
   <script type="module" src="./js/services/capture-service.js"></script>
   <script type="module" src="./js/services/assistant-service.js"></script>

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -7,6 +7,16 @@ import crypto from 'node:crypto';
 const rootDir = process.cwd();
 const distDir = path.join(rootDir, 'dist');
 const assetsDir = path.join(distDir, 'assets');
+const runtimeEnvPath = path.join(distDir, 'js', 'runtime-env.js');
+
+const CLIENT_RUNTIME_ENV_KEYS = [
+  'FIREBASE_API_KEY',
+  'FIREBASE_AUTH_DOMAIN',
+  'FIREBASE_PROJECT_ID',
+  'FIREBASE_STORAGE_BUCKET',
+  'FIREBASE_MESSAGING_SENDER_ID',
+  'FIREBASE_APP_ID',
+];
 
 function run(command, args, options = {}) {
   return new Promise((resolve, reject) => {
@@ -30,6 +40,86 @@ async function cleanDist() {
   await fs.rm(distDir, { recursive: true, force: true });
   await fs.mkdir(distDir, { recursive: true });
   await fs.mkdir(assetsDir, { recursive: true });
+}
+
+async function readDotEnvFile(filePath) {
+  try {
+    const contents = await fs.readFile(filePath, 'utf8');
+    return contents
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith('#'))
+      .reduce((env, line) => {
+        const separatorIndex = line.indexOf('=');
+        if (separatorIndex === -1) {
+          return env;
+        }
+
+        const key = line.slice(0, separatorIndex).trim();
+        let value = line.slice(separatorIndex + 1).trim();
+
+        if (
+          (value.startsWith('"') && value.endsWith('"')) ||
+          (value.startsWith("'") && value.endsWith("'"))
+        ) {
+          value = value.slice(1, -1);
+        }
+
+        if (key && typeof env[key] === 'undefined') {
+          env[key] = value;
+        }
+
+        return env;
+      }, {});
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return {};
+    }
+
+    throw error;
+  }
+}
+
+async function resolveRuntimeEnv() {
+  const [dotEnv, dotEnvLocal] = await Promise.all([
+    readDotEnvFile(path.join(rootDir, '.env')),
+    readDotEnvFile(path.join(rootDir, '.env.local')),
+  ]);
+
+  return CLIENT_RUNTIME_ENV_KEYS.reduce((env, key) => {
+    const value = process.env[key] ?? dotEnvLocal[key] ?? dotEnv[key] ?? '';
+    if (typeof value === 'string' && value.trim()) {
+      env[key] = value.trim();
+    }
+    return env;
+  }, {});
+}
+
+async function writeRuntimeEnvScript() {
+  const runtimeEnv = await resolveRuntimeEnv();
+  const script = `window.__ENV = {
+  ...(window.__ENV && typeof window.__ENV === 'object' && !Array.isArray(window.__ENV) ? window.__ENV : {}),
+  ${CLIENT_RUNTIME_ENV_KEYS.map((key) => {
+    const value = runtimeEnv[key];
+    return value ? `${JSON.stringify(key)}: ${JSON.stringify(value)},` : '';
+  })
+    .filter(Boolean)
+    .join('\n  ')}
+};
+
+window.textureUrl =
+  window.textureUrl ||
+  ((filename) => {
+    if (typeof filename !== 'string') {
+      return '';
+    }
+
+    return filename;
+  });
+`;
+
+  await fs.mkdir(path.dirname(runtimeEnvPath), { recursive: true });
+  await fs.writeFile(runtimeEnvPath, script);
 }
 
 async function buildCss() {
@@ -186,6 +276,7 @@ async function main() {
   const cssPath = await buildCss();
   const assetMap = await buildScripts();
   await copyStatic();
+  await writeRuntimeEnvScript();
   await ensureRootHtml();
   await rewriteHtml(assetMap, cssPath);
   await validateBuildOutput();


### PR DESCRIPTION
### Motivation
- The app was logging "[ENV INIT] Missing Firebase env values; auth and Firestore are disabled." because required Firebase keys were not present on `window.__ENV` at runtime.  
- The runtime expects Firebase client keys (`FIREBASE_API_KEY`, `FIREBASE_AUTH_DOMAIN`, `FIREBASE_PROJECT_ID`, `FIREBASE_APP_ID`) in `window.__ENV` and must not have a second competing bootstrap path.  
- Provide a single, reliable injection path compatible with Cloudflare Pages builds while preserving the existing `js/init-env.js` initializer and already-injected values.  

### Description
- Add `js/runtime-env.js` as a minimal pre-init shim that ensures `window.__ENV` exists, and load it before `js/init-env.js` in `mobile.html` and `404.html`.  
- Extend `scripts/build.mjs` to generate `dist/js/runtime-env.js` during `npm run build` by reading Cloudflare build env vars and falling back to `.env.local`/`.env`; only the Firebase client keys (plus optional storage/messaging keys) are written and existing `window.__ENV` values are preserved.  
- Update `js/init-env.js` to log a positive confirmation ` [ENV INIT] Firebase env loaded.` when the required keys are present while keeping the existing missing-config warning.  
- Update documentation (`README.md`, `docs/ENVIRONMENT_CONFIG.md`) to describe the new build-time injection, required and optional Firebase keys, and the local `.env.local` fallback.  

### Testing
- Ran `npm run build` and the build completed successfully and produced `dist/js/runtime-env.js`.  
- Ran `npm run verify` and the repository's build verification passed.  
- Ran the repository Jest test for reminders `npx jest js/__tests__/reminders.auth.test.js --runInBand`, which failed due to an existing dynamic-import limitation in the test environment and is unrelated to the Firebase env changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba89134ce08324ad0ded5499403a1d)