### PR TITLE
Restore compareRemindersForDisplay to fix reminder sorting crash

### DIFF
--- a/src/reminders/reminderController.js
+++ b/src/reminders/reminderController.js
@@ -27,6 +27,13 @@ import {
 // Shared reminder logic used by both the mobile and desktop pages.
 // This module wires up Firebase-backed reminder UI handlers.
 
+function compareRemindersForDisplay(a, b) {
+  const aTime = a?.dueAt ?? Infinity;
+  const bTime = b?.dueAt ?? Infinity;
+
+  return aTime - bTime;
+}
+
 const ACTIVITY_EVENT_NAME = 'memoryCue:activity';
 const activeNotifications = new Map();
 let notificationCleanupBound = false;


### PR DESCRIPTION
### Motivation
- Reminders rendered by `reminderController.js` were causing a runtime crash with `ReferenceError: compareRemindersForDisplay is not defined` during sorting, so a minimal localized restore of the missing helper is needed without changing schema or Firebase logic.

### Description
- Add the small comparator `compareRemindersForDisplay(a, b)` to the top of `src/reminders/reminderController.js` which returns `a?.dueAt ?? Infinity` minus `b?.dueAt ?? Infinity`, preserving existing sorting behavior and keeping the fix minimal and local.

### Testing
- Ran `npm test -- --runInBand` and verified the `ReferenceError: compareRemindersForDisplay` no longer appears, although the repository test suite still shows unrelated pre-existing failures; attempted `npm run build` which produced build warnings and long-running steps in this environment and timed out on one attempt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba9315e1488324bd486cd11c354127)