### PR TITLE
Fix compareRemindersForDisplay to place completed reminders last

### DIFF
--- a/src/reminders/reminderController.js
+++ b/src/reminders/reminderController.js
@@ -28,6 +28,11 @@ import {
 // This module wires up Firebase-backed reminder UI handlers.
 
 function compareRemindersForDisplay(a, b) {
+  // Completed reminders go last.
+  if (a?.completed && !b?.completed) return 1;
+  if (!a?.completed && b?.completed) return -1;
+
+  // Sort by due date with no-date reminders after dated reminders.
   const aTime = a?.dueAt ?? Infinity;
   const bTime = b?.dueAt ?? Infinity;
 


### PR DESCRIPTION
### Motivation
- Reminders loaded from Firestore caused a runtime crash because the display comparator used by `reminders.sort(compareRemindersForDisplay)` was not enforcing the intended ordering, so restore a minimal local comparator to prevent the UI error and preserve expected sorting.

### Description
- Restored/updated the local `function compareRemindersForDisplay(a, b)` in `src/reminders/reminderController.js` to ensure completed reminders sort last and remaining reminders sort by `dueAt` (earliest first, undated treated as last), keeping the function local and not attached to `window` or external imports.

### Testing
- Ran `npm run verify`, which completed successfully.
- Ran `timeout 60s npm run build`; the build output started normally in this environment but did not exit before the timeout (verification still passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba95e9b59c8324af706e88b975d9ba)