### PR TITLE
Add reminder clarification flow with pendingIntent and minimal date parsing

### DIFF
--- a/src/brain/queryEngine.js
+++ b/src/brain/queryEngine.js
@@ -20,16 +20,17 @@ export function detectIntent(query) {
     source: 'query_engine',
     entryPoint: 'queryEngine.detectIntent',
   });
+  const normalizedType = routedIntent?.payload?.intentType || routedIntent?.type;
 
-  if (routedIntent?.type === 'reminder') {
+  if (normalizedType === 'reminder') {
     return { type: 'reminder_query', source: 'intent_router' };
   }
 
-  if (routedIntent?.type === 'query') {
+  if (normalizedType === 'query') {
     return { type: 'memory_query', source: 'intent_router' };
   }
 
-  if (routedIntent?.type !== 'unknown') {
+  if (normalizedType !== 'unknown') {
     return { type: 'mixed_query', source: 'intent_router' };
   }
 

--- a/src/core/capturePipeline.js
+++ b/src/core/capturePipeline.js
@@ -6,6 +6,9 @@ import { handleQuery } from '../brain/queryEngine.js';
 import { saveInboxEntry } from '../services/inboxService.js';
 import { buildMemoryAssistantRequest, requestAssistantChat } from '../services/assistantOrchestrator.js';
 
+// Lightweight in-memory conversation state for one-step clarifications.
+let pendingIntent = null;
+
 const normalizeText = (value) => {
   if (typeof value !== 'string') {
     return '';
@@ -40,6 +43,56 @@ const normalizeParsedEntry = (parsed, text = '') => {
   };
 };
 
+const buildAssistantResponse = (message, extra = {}) => ({
+  type: 'assistant_response',
+  message,
+  ...extra,
+});
+
+const toIsoString = (date) => (date instanceof Date && Number.isFinite(date.getTime()) ? date.toISOString() : null);
+
+const setTimeOnDate = (date, hours, minutes = 0) => {
+  const nextDate = new Date(date.getTime());
+  nextDate.setHours(hours, minutes, 0, 0);
+  return nextDate;
+};
+
+const parseFollowUpDueAt = (text, now = new Date()) => {
+  const normalized = normalizeText(text).toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+
+  const tomorrowMatch = normalized.match(/\btomorrow(?:\s+at\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?)?\b/);
+  if (tomorrowMatch) {
+    const dueDate = new Date(now.getTime());
+    dueDate.setDate(dueDate.getDate() + 1);
+
+    if (tomorrowMatch[1]) {
+      let hours = Number.parseInt(tomorrowMatch[1], 10);
+      const minutes = tomorrowMatch[2] ? Number.parseInt(tomorrowMatch[2], 10) : 0;
+      const meridiem = tomorrowMatch[3];
+      if (meridiem === 'pm' && hours < 12) hours += 12;
+      if (meridiem === 'am' && hours === 12) hours = 0;
+      return toIsoString(setTimeOnDate(dueDate, hours, minutes));
+    }
+
+    return toIsoString(setTimeOnDate(dueDate, 9, 0));
+  }
+
+  if (/\btonight\b/.test(normalized)) {
+    return toIsoString(setTimeOnDate(now, 19, 0));
+  }
+
+  if (/\bnext week\b/.test(normalized)) {
+    const dueDate = new Date(now.getTime());
+    dueDate.setDate(dueDate.getDate() + 7);
+    return toIsoString(setTimeOnDate(dueDate, 9, 0));
+  }
+
+  return null;
+};
+
 const parseEntry = async (text) => {
   const response = await fetch('/api/parse-entry', {
     method: 'POST',
@@ -63,6 +116,7 @@ const resolveDecision = async (text, hints) => {
       parsedType: initialIntent.payload.parsedType,
       text,
       parsedEntry: initialIntent.payload.parsedEntry,
+      missing: Array.isArray(initialIntent?.payload?.missing) ? initialIntent.payload.missing : [],
       hints,
     };
   }
@@ -81,8 +135,56 @@ const resolveDecision = async (text, hints) => {
     parsedType: routedIntent?.payload?.parsedType || 'unknown',
     text,
     parsedEntry: routedIntent?.payload?.parsedEntry || parsedEntry,
+    missing: Array.isArray(routedIntent?.payload?.missing) ? routedIntent.payload.missing : [],
     hints,
   };
+};
+
+const buildPendingReminderDecision = (intent, dueAt) => {
+  const parsedEntry = intent?.parsedEntry && typeof intent.parsedEntry === 'object'
+    ? intent.parsedEntry
+    : {};
+
+  return {
+    decisionType: 'persist_reminder',
+    parsedType: intent?.parsedType || 'reminder',
+    text: intent?.text || parsedEntry?.title || '',
+    parsedEntry: {
+      ...parsedEntry,
+      type: 'reminder',
+      title: intent?.payload?.text || parsedEntry?.title || intent?.text || '',
+      reminderDate: dueAt,
+      metadata: {
+        ...(parsedEntry?.metadata && typeof parsedEntry.metadata === 'object' ? parsedEntry.metadata : {}),
+        dueAt,
+      },
+    },
+    missing: dueAt ? [] : ['dueAt'],
+    hints: intent?.hints || {},
+  };
+};
+
+const maybeResolvePendingIntent = async (text) => {
+  if (!pendingIntent) {
+    return null;
+  }
+
+  // Follow-up replies are treated as clarification answers for the pending reminder.
+  const dueAt = parseFollowUpDueAt(text);
+  const decision = buildPendingReminderDecision(pendingIntent, dueAt);
+
+  if (decision.missing.length) {
+    pendingIntent = {
+      ...pendingIntent,
+      lastFollowUpText: text,
+    };
+    return {
+      clarification: buildAssistantResponse('When should I remind you?'),
+    };
+  }
+
+  pendingIntent = null;
+  return { decision };
 };
 
 const saveNoteMemory = async (text, decision, context) => {
@@ -132,7 +234,12 @@ export async function captureInput({
     ...metadata,
   };
 
-  const decision = await resolveDecision(normalizedText, hints);
+  const pendingResolution = await maybeResolvePendingIntent(normalizedText);
+  if (pendingResolution?.clarification) {
+    return pendingResolution.clarification;
+  }
+
+  const decision = pendingResolution?.decision || await resolveDecision(normalizedText, hints);
 
   console.log('[capture]', {
     source: context.source,
@@ -150,16 +257,28 @@ export async function captureInput({
       };
     }
     case 'persist_reminder': {
+      if (Array.isArray(decision?.missing) && decision.missing.includes('dueAt')) {
+        pendingIntent = {
+          ...decision,
+          payload: {
+            text: decision?.parsedEntry?.title || normalizedText,
+            dueAt: decision?.parsedEntry?.reminderDate || null,
+          },
+        };
+        return buildAssistantResponse('When should I remind you?', {
+          decision,
+        });
+      }
+
       const reminder = await createReminder({
         text: decision?.parsedEntry?.title || normalizedText,
         dueAt: decision?.parsedEntry?.reminderDate || undefined,
         source: 'capture',
       });
-      return {
+      return buildAssistantResponse('Reminder created.', {
         decision,
         data: reminder,
-        message: 'Reminder created.',
-      };
+      });
     }
     case 'query_memory': {
       const queryResults = await handleQuery(normalizedText);

--- a/src/services/intentRouter.js
+++ b/src/services/intentRouter.js
@@ -336,6 +336,9 @@ export const intentRouter = (query, context = {}) => {
       type: 'unknown',
       payload: {
         query: text,
+        text,
+        dueAt: null,
+        missing: [],
         decisionType: 'unresolved',
         parsedType: 'unknown',
         hints,
@@ -343,13 +346,28 @@ export const intentRouter = (query, context = {}) => {
     };
   }
 
+  const reminderText = typeof decision?.parsedEntry?.title === 'string' && decision.parsedEntry.title.trim()
+    ? decision.parsedEntry.title.trim()
+    : text;
+  const reminderDueAt =
+    (typeof decision?.parsedEntry?.reminderDate === 'string' && decision.parsedEntry.reminderDate.trim())
+    || (typeof decision?.parsedEntry?.metadata?.dueAt === 'string' && decision.parsedEntry.metadata.dueAt.trim())
+    || null;
+  const missing = decision.decisionType === 'persist_reminder' && !reminderDueAt
+    ? ['dueAt']
+    : [];
+
   return {
-    type: mapDecisionTypeToIntentType(decision.decisionType),
+    type: decision.decisionType,
     payload: {
       query: text,
+      text: reminderText,
+      dueAt: reminderDueAt,
+      missing,
       decisionType: decision.decisionType,
       parsedType: decision.parsedType || 'unknown',
       parsedEntry: decision.parsedEntry || null,
+      intentType: mapDecisionTypeToIntentType(decision.decisionType),
       hints,
     },
   };


### PR DESCRIPTION
### Motivation
- The assistant behaved like a command parser and did not ask follow-ups for incomplete reminders; we need a lightweight conversational layer to detect missing fields and request them before executing.
- Implement a minimal in-memory follow-up flow so incomplete reminder intents (no date) are not executed and the assistant can complete them conversationally.

### Description
- Extended `intentRouter` payload to surface execution-ready reminder fields: `text`, `dueAt`, and a `missing` array (e.g. `['dueAt']`) for incomplete reminders, while preserving a compatibility `intentType` for downstream consumers. (edited `src/services/intentRouter.js`)
- Added a pending one-step clarification flow in `capturePipeline`: introduced `pendingIntent` state, assistant-style responses (`assistant_response`), follow-up handling that merges the next user reply into the pending intent, and finalizes execution after resolution. (edited `src/core/capturePipeline.js`)
- Implemented a minimal follow-up date parser (`parseFollowUpDueAt`) supporting `tomorrow`, `tomorrow at <h>[:mm] [am|pm]`, `tonight`, and `next week` and normalizing to an ISO timestamp for `dueAt`. (edited `src/core/capturePipeline.js`)
- Preserved existing routing compatibility by adding `intentType` to router payloads and updating `queryEngine` to consult that compatibility field so existing flows continue to work. (edited `src/brain/queryEngine.js`)
- Did not change UI structure; chat components already render assistant replies so clarification prompts and confirmations are visible without UI redesign. (inspected `src/components/ChatPanel.js` and `src/components/ChatConversation.js`)

### Testing
- Ran unit tests with `npm test -- --runInBand`; most tests passed but an existing, unrelated test `js/__tests__/mobile.new-folder.test.js` failed due to `initAuth` being undefined in `mobile.js` (failure is not related to the reminder flow). (partial failure)
- Ran build verification with `npm run verify` and the build verification passed. (passed)
- Attempted a focused runtime sanity check by invoking `captureInput` under Node to exercise a two-step reminder flow, but the repository’s CommonJS/ESM interop prevented the direct import before the flow executed; this prevented finishing that automated runtime check. (blocked by module interop)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba98bf22b08324b0727c1fad7d6a49)