### PR TITLE
Add embeddings to notes, reminders, and query engine

### DIFF
--- a/js/modules/notes-storage.js
+++ b/js/modules/notes-storage.js
@@ -16,6 +16,7 @@ const normalizeSemanticEmbedding = (value) => {
 
 let remoteSyncHandler = null;
 let memoryServiceModulePromise = null;
+let embeddingServiceModulePromise = null;
 
 export const setRemoteSyncHandler = (handler) => {
   remoteSyncHandler = typeof handler === 'function' ? handler : null;
@@ -226,6 +227,50 @@ const syncNoteToMemoryService = (note, payload = {}) => {
     });
 };
 
+const ensureNoteEmbedding = (note, notes, options = {}) => {
+  if (!note || typeof note !== 'object' || normalizeSemanticEmbedding(note.semanticEmbedding)) {
+    return;
+  }
+
+  const embeddingText = [note.title, note.bodyText, note.body]
+    .filter((value) => typeof value === 'string' && value.trim())
+    .join('\n')
+    .trim();
+
+  if (!embeddingText) {
+    return;
+  }
+
+  if (!embeddingServiceModulePromise) {
+    embeddingServiceModulePromise = import('../../src/brain/embeddingService.js').catch((error) => {
+      console.warn('[notes-storage] Failed to load embedding service', error);
+      return null;
+    });
+  }
+
+  embeddingServiceModulePromise
+    .then(async (embeddingServiceModule) => {
+      const generateEmbedding = embeddingServiceModule?.generateEmbedding;
+      if (typeof generateEmbedding !== 'function') {
+        return;
+      }
+
+      const embedding = normalizeSemanticEmbedding(await generateEmbedding(embeddingText));
+      if (!embedding) {
+        return;
+      }
+
+      note.semanticEmbedding = embedding;
+      const nextNotes = Array.isArray(notes)
+        ? notes.map((entry) => (entry?.id === note.id ? { ...entry, semanticEmbedding: embedding } : entry))
+        : [note];
+      saveAllNotes(nextNotes, options);
+    })
+    .catch((error) => {
+      console.warn('[notes-storage] Failed to generate note embedding', error);
+    });
+};
+
 export const createAndSaveNote = (payload = {}, options = {}) => {
   const normalizedPayload = payload && typeof payload === 'object' ? payload : {};
   const text = typeof normalizedPayload.text === 'string' ? normalizedPayload.text.trim() : '';
@@ -263,6 +308,7 @@ export const createAndSaveNote = (payload = {}, options = {}) => {
   const saved = saveAllNotes([note, ...notes], options);
   if (saved) {
     syncNoteToMemoryService(note, normalizedPayload);
+    ensureNoteEmbedding(note, [note, ...notes], options);
   }
   return saved ? note : null;
 };

--- a/src/brain/queryEngine.js
+++ b/src/brain/queryEngine.js
@@ -1,6 +1,8 @@
 import { intentRouter } from '../services/intentRouter.js';
 import { getMemories } from '../services/memoryService.js';
 import { getReminderList } from '../reminders/reminderService.js';
+import { loadAllNotes } from '../../js/modules/notes-storage.js';
+import { generateEmbedding } from './embeddingService.js';
 import { semanticSearch } from './semanticSearchService.js';
 
 const normalizeText = (value) => (typeof value === 'string' ? value.trim() : '');
@@ -12,6 +14,37 @@ const normalizeReminderDate = (reminder) => {
   }
   const due = normalizeText(reminder?.due);
   return due;
+};
+
+const normalizeEmbedding = (value) => (
+  Array.isArray(value)
+    ? value.map((item) => Number(item)).filter((item) => Number.isFinite(item))
+    : []
+);
+
+const cosineSimilarity = (left, right) => {
+  const a = normalizeEmbedding(left);
+  const b = normalizeEmbedding(right);
+  if (!a.length || !b.length) {
+    return -1;
+  }
+
+  const dimensions = Math.min(a.length, b.length);
+  let dot = 0;
+  let magA = 0;
+  let magB = 0;
+
+  for (let index = 0; index < dimensions; index += 1) {
+    dot += a[index] * b[index];
+    magA += a[index] * a[index];
+    magB += b[index] * b[index];
+  }
+
+  if (!magA || !magB) {
+    return -1;
+  }
+
+  return dot / (Math.sqrt(magA) * Math.sqrt(magB));
 };
 
 export function detectIntent(query) {
@@ -80,10 +113,12 @@ async function handleReminderQuery(intent, query) {
   }
 
   reminders = filterRemindersByQuery(reminders, query);
+  const semanticMatches = (await searchSemanticEntries(query))
+    .filter((entry) => entry.type === 'reminder');
 
   return {
     type: 'reminder_results',
-    items: reminders,
+    items: mergeResults(reminders, semanticMatches),
     intent,
   };
 }
@@ -100,15 +135,74 @@ function searchMemories(memories, query) {
   });
 }
 
+function getSemanticSourceEntries() {
+  const notes = loadAllNotes().map((note) => ({
+    id: note?.id,
+    type: 'note',
+    title: note?.title || '',
+    text: note?.bodyText || note?.body || '',
+    embedding: note?.semanticEmbedding,
+    source: 'note',
+  }));
+
+  const reminders = getReminderList().map((reminder) => ({
+    id: reminder?.id,
+    type: 'reminder',
+    title: reminder?.title || reminder?.text || '',
+    text: reminder?.notes || reminder?.text || reminder?.title || '',
+    embedding: reminder?.semanticEmbedding,
+    due: normalizeReminderDate(reminder),
+    source: 'reminder',
+  }));
+
+  return [...notes, ...reminders];
+}
+
+async function searchSemanticEntries(query) {
+  const normalizedQuery = normalizeText(query);
+  if (!normalizedQuery) {
+    return [];
+  }
+
+  const sourceEntries = getSemanticSourceEntries();
+  if (!sourceEntries.length) {
+    return [];
+  }
+
+  let queryEmbedding = [];
+  try {
+    queryEmbedding = normalizeEmbedding(await generateEmbedding(normalizedQuery));
+  } catch (error) {
+    console.warn('[queryEngine] Failed to generate query embedding', error);
+    return [];
+  }
+
+  if (!queryEmbedding.length) {
+    return [];
+  }
+
+  return sourceEntries
+    .map((entry) => ({
+      ...entry,
+      score: cosineSimilarity(queryEmbedding, entry?.embedding),
+    }))
+    .filter((entry) => Number.isFinite(entry.score) && entry.score > -1)
+    .sort((left, right) => right.score - left.score)
+    .slice(0, 10);
+}
+
 async function handleMemoryQuery(intent, query) {
   console.log('[semantic] query:', query);
 
   const memories = getMemories();
   const keywordResults = searchMemories(memories, query);
-  const semanticResults = await semanticSearch(query);
+  const [semanticResults, semanticEntries] = await Promise.all([
+    semanticSearch(query),
+    searchSemanticEntries(query),
+  ]);
   console.log('[semantic] results:', semanticResults.length);
 
-  const merged = mergeResults(keywordResults, semanticResults);
+  const merged = mergeResults(keywordResults, [...semanticResults, ...semanticEntries]);
 
   return {
     type: 'memory_results',
@@ -127,15 +221,16 @@ function mergeResults(keyword, semantic) {
 }
 
 async function handleMixedQuery(intent, query) {
-  const [memories, reminders] = await Promise.all([
+  const [memories, reminders, semanticEntries] = await Promise.all([
     handleMemoryQuery({ type: 'memory_query' }, query),
     handleReminderQuery({ type: 'reminder_query' }, query),
+    searchSemanticEntries(query),
   ]);
 
   return {
     type: 'mixed_results',
     memories: memories.items,
-    reminders: reminders.items,
+    reminders: mergeResults(reminders.items, semanticEntries.filter((entry) => entry.type === 'reminder')),
     intent,
   };
 }

--- a/src/reminders/reminderController.js
+++ b/src/reminders/reminderController.js
@@ -51,6 +51,7 @@ const SERVICE_WORKER_MESSAGE_TYPES = Object.freeze({
 let serviceWorkerReadyPromise = null;
 let backgroundSyncRegistrationPromise = null;
 let backgroundSyncRegistrationSucceeded = false;
+let embeddingServiceModulePromise = null;
 const DEFAULT_CATEGORY = 'General';
 const SEEDED_CATEGORIES = Object.freeze([
   DEFAULT_CATEGORY,
@@ -103,8 +104,27 @@ async function generateEmbedding(text) {
   if (!normalized) {
     return null;
   }
-  // TODO: Replace this stub with a real embeddings API integration.
-  return null;
+
+  if (!embeddingServiceModulePromise) {
+    embeddingServiceModulePromise = import('../brain/embeddingService.js').catch((error) => {
+      console.warn('[embedding] Failed to load embedding service', error);
+      return null;
+    });
+  }
+
+  const embeddingServiceModule = await embeddingServiceModulePromise;
+  const generateEmbeddingViaService = embeddingServiceModule?.generateEmbedding;
+  if (typeof generateEmbeddingViaService !== 'function') {
+    return null;
+  }
+
+  try {
+    const embedding = await generateEmbeddingViaService(normalized);
+    return normalizeSemanticEmbedding(embedding);
+  } catch (error) {
+    console.warn('[embedding] Failed to generate embedding', error);
+    return null;
+  }
 }
 
 async function ensureEmbeddingForItem(item) {
@@ -4254,6 +4274,18 @@ export async function initReminders(sel = {}) {
         rescheduleAllReminders();
         emitReminderUpdates();
         dispatchCueEvent('memoryCue:remindersUpdated', { items });
+
+        ensureEmbeddingForItem(createdReminder)
+          .then((embeddedReminder) => {
+            if (!normalizeSemanticEmbedding(embeddedReminder?.semanticEmbedding)) {
+              return;
+            }
+            persistItems();
+            dispatchCueEvent('memoryCue:remindersUpdated', { items });
+          })
+          .catch((error) => {
+            console.warn('Failed to generate reminder embedding', error);
+          });
       },
     });
 


### PR DESCRIPTION
### Motivation
- Enable real AI memory features by wiring the existing embedding service into note and reminder creation flows and into the query/search path so semantic matching can be used alongside keyword search.
- Preserve current behavior when embedding generation is unavailable (e.g., missing `OPENAI_API_KEY`) by making embedding generation best-effort and non-blocking.

### Description
- Notes: add `ensureNoteEmbedding` to `js/modules/notes-storage.js` that dynamically imports `src/brain/embeddingService.js`, generates a `semanticEmbedding` for newly saved notes in the background, and persists it via `saveAllNotes` when available without blocking the immediate save path.
- Reminders: replace the placeholder stub in `src/reminders/reminderController.js` with a dynamic import of `../brain/embeddingService.js` and route embedding generation through that service; call `ensureEmbeddingForItem` after reminder creation and persist when embedding becomes available.
- Query engine: update `src/brain/queryEngine.js` to load notes (`loadAllNotes`), generate an embedding for the incoming query via `generateEmbedding`, compute cosine similarity against stored `semanticEmbedding` vectors from notes and reminders, and merge semantic matches into memory/reminder/mixed query results.
- Compatibility: all embedding generation is best-effort; when no embedding is produced (e.g., missing API key) the original keyword-only fallbacks remain active.

### Testing
- Ran `git diff --check` (no issues found).
- Ran unit tests with `npm test -- --runInBand`; the test run failed in this environment due to pre-existing test harness limitations (dynamic-import runtime constraints in `js/reminders.js` tests and VM/import issues in `mobile.js` tests) and not directly because of the added embedding logic.
- Attempted `npm run build`; the build produced Tailwind/Browserslist warnings and did not produce a clean completion signal in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bafb162cf883249a594e9877d6aad2)