### PR TITLE
Add embedding-aware semantic search fallback

### DIFF
--- a/docs/ENVIRONMENT_CONFIG.md
+++ b/docs/ENVIRONMENT_CONFIG.md
@@ -1,7 +1,7 @@
 # Environment Configuration
 
 ## Server variables
-- `OPENAI_API_KEY`: required for `/api/assistant-chat` to call OpenAI Responses API.
+- `OPENAI_API_KEY`: required for `/api/assistant-chat`, client-side embeddings, and semantic search to call OpenAI APIs. When it is missing, note/reminder creation and query handling keep the existing keyword-only behavior.
 - `APP_URL` (optional): historical endpoint base URL. Current assistant flow uses relative `/api/assistant-chat`.
 
 ## Client/runtime configuration

--- a/src/brain/embeddingService.js
+++ b/src/brain/embeddingService.js
@@ -1,13 +1,25 @@
-if (!window.__ENV) {
+if (typeof window !== 'undefined' && !window.__ENV) {
   window.__ENV = {};
 }
 
-const OPENAI_KEY =
-  window.__ENV?.OPENAI_API_KEY || import.meta.env?.VITE_OPENAI_API_KEY;
+const resolveOpenAiKey = () => {
+  if (typeof window !== 'undefined') {
+    const runtimeKey = typeof window.__ENV?.OPENAI_API_KEY === 'string'
+      ? window.__ENV.OPENAI_API_KEY.trim()
+      : '';
+    if (runtimeKey) {
+      return runtimeKey;
+    }
+  }
 
-if (!OPENAI_KEY) {
-  console.warn('[embedding] no OpenAI key configured');
-}
+  if (typeof process !== 'undefined' && typeof process.env?.OPENAI_API_KEY === 'string') {
+    return process.env.OPENAI_API_KEY.trim();
+  }
+
+  return '';
+};
+
+export const isEmbeddingEnabled = () => Boolean(resolveOpenAiKey());
 
 const normalizeText = (value) => (typeof value === 'string' ? value.trim() : '');
 
@@ -23,7 +35,9 @@ const normalizeEmbedding = (value) => {
 
 export async function generateEmbedding(text) {
   const normalizedText = normalizeText(text);
-  if (!normalizedText || !OPENAI_KEY) {
+  const openAiKey = resolveOpenAiKey();
+
+  if (!normalizedText || !openAiKey) {
     return [];
   }
 
@@ -31,7 +45,7 @@ export async function generateEmbedding(text) {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${OPENAI_KEY}`,
+      Authorization: `Bearer ${openAiKey}`,
     },
     body: JSON.stringify({
       model: 'text-embedding-3-small',

--- a/src/brain/queryEngine.js
+++ b/src/brain/queryEngine.js
@@ -2,7 +2,7 @@ import { intentRouter } from '../services/intentRouter.js';
 import { getMemories } from '../services/memoryService.js';
 import { getReminderList } from '../reminders/reminderService.js';
 import { loadAllNotes } from '../../js/modules/notes-storage.js';
-import { generateEmbedding } from './embeddingService.js';
+import { generateEmbedding, isEmbeddingEnabled } from './embeddingService.js';
 import { semanticSearch } from './semanticSearchService.js';
 
 const normalizeText = (value) => (typeof value === 'string' ? value.trim() : '');
@@ -161,7 +161,7 @@ function getSemanticSourceEntries() {
 
 async function searchSemanticEntries(query) {
   const normalizedQuery = normalizeText(query);
-  if (!normalizedQuery) {
+  if (!normalizedQuery || !isEmbeddingEnabled()) {
     return [];
   }
 
@@ -215,10 +215,35 @@ async function handleMemoryQuery(intent, query) {
 function mergeResults(keyword, semantic) {
   const map = new Map();
 
-  keyword.forEach((item) => map.set(item.id, item));
-  semantic.forEach((item) => map.set(item.id, item));
+  keyword.forEach((item, index) => {
+    if (!item?.id) {
+      return;
+    }
 
-  return Array.from(map.values()).slice(0, 10);
+    map.set(item.id, {
+      ...item,
+      score: Number.isFinite(item?.score) ? item.score : Math.max(0, 1 - (index * 0.01)),
+    });
+  });
+
+  semantic.forEach((item) => {
+    if (!item?.id) {
+      return;
+    }
+
+    const existing = map.get(item.id);
+    if (!existing || Number(item?.score) > Number(existing?.score)) {
+      map.set(item.id, {
+        ...existing,
+        ...item,
+        score: Number.isFinite(item?.score) ? item.score : Number(existing?.score) || 0,
+      });
+    }
+  });
+
+  return Array.from(map.values())
+    .sort((left, right) => (Number(right?.score) || 0) - (Number(left?.score) || 0))
+    .slice(0, 10);
 }
 
 async function handleMixedQuery(intent, query) {


### PR DESCRIPTION
### Motivation
- Enable client-side semantic embeddings to power memory search when `OPENAI_API_KEY` is available while preserving the existing keyword-only behavior when it is not.
- Make the existing embedding generation paths usable by ensuring the embedding client actually reads a runtime or process `OPENAI_API_KEY`.

### Description
- Read `OPENAI_API_KEY` from `window.__ENV` or `process.env` in `src/brain/embeddingService.js` and expose `isEmbeddingEnabled()` so the app can no-op cleanly when no key is present.
- Use the key-aware embedding client from `src/brain/queryEngine.js` so `searchSemanticEntries` returns early when embeddings are not configured and avoid pointless API calls.
- Merge keyword and semantic results in `queryEngine` using a combined `mergeResults` that prefers higher semantic similarity scores while still including keyword matches and returning the top results.
- Document the client-side embedding requirement and fallback behavior in `docs/ENVIRONMENT_CONFIG.md`.

### Testing
- Ran unit tests with `npx jest api.parse-entry.test.js sample.test.js --runInBand`, and the suites passed successfully.
- Attempted a production build via `npm run build`; the build started but timed out in this environment after tailwind/daisyUI warnings, so a full production artifact was not verified here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bafcebaddc8324a7cb2cbd6b2a251c)