### PR TITLE
Add server-side /api/embed endpoint and route client to it

### DIFF
--- a/api/embed.ts
+++ b/api/embed.ts
@@ -1,0 +1,128 @@
+const LOCALHOST_ORIGINS = [
+  'http://localhost:3000',
+  'http://localhost:5173'
+];
+
+function buildAllowedOrigins() {
+  const envOrigins = [
+    process.env.CORS_ALLOWED_ORIGINS,
+    process.env.CLOUDFLARE_PAGES_URL,
+    process.env.CLOUDFLARE_APP_URL,
+    process.env.APP_URL,
+    process.env.PUBLIC_APP_URL
+  ]
+    .filter(Boolean)
+    .flatMap((value) => String(value).split(','))
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
+  return Array.from(new Set([
+    'https://dmaher42.github.io',
+    'https://memory-cue.pages.dev',
+    ...envOrigins,
+    ...LOCALHOST_ORIGINS
+  ]));
+}
+
+const ALLOWED_ORIGINS = buildAllowedOrigins();
+
+function applyCors(req, res) {
+  const origin = req.headers.origin;
+  if (origin && ALLOWED_ORIGINS.includes(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Vary', 'Origin');
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  }
+}
+
+function toText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeEmbedding(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((item) => Number(item))
+    .filter((item) => Number.isFinite(item));
+}
+
+export default async function handler(req, res) {
+  applyCors(req, res);
+
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end();
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({
+      success: false,
+      error: 'Method not allowed',
+    });
+  }
+
+  const body = req.body && typeof req.body === 'object' ? req.body : {};
+  const text = toText(body.text);
+
+  if (!text) {
+    return res.status(400).json({
+      success: false,
+      error: 'Missing text',
+    });
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    console.warn('[embed] OPENAI_API_KEY is not configured');
+    return res.status(500).json({
+      success: false,
+      error: 'Embedding service unavailable',
+    });
+  }
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/embeddings', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: 'text-embedding-3-small',
+        input: text,
+      }),
+    });
+
+    if (!response.ok) {
+      console.warn('[embed] OpenAI embeddings request failed', { status: response.status });
+      return res.status(response.status >= 400 && response.status < 500 ? 502 : 500).json({
+        success: false,
+        error: 'Failed to generate embedding',
+      });
+    }
+
+    const payload = await response.json();
+    const embedding = normalizeEmbedding(payload?.data?.[0]?.embedding);
+
+    if (!embedding.length) {
+      console.warn('[embed] OpenAI embeddings response did not include a valid vector');
+      return res.status(502).json({
+        success: false,
+        error: 'Failed to generate embedding',
+      });
+    }
+
+    return res.status(200).json({
+      success: true,
+      embedding,
+    });
+  } catch (error) {
+    console.warn('[embed] Unexpected embedding error', error instanceof Error ? error.message : error);
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to generate embedding',
+    });
+  }
+}

--- a/src/brain/embeddingService.js
+++ b/src/brain/embeddingService.js
@@ -1,25 +1,4 @@
-if (typeof window !== 'undefined' && !window.__ENV) {
-  window.__ENV = {};
-}
-
-const resolveOpenAiKey = () => {
-  if (typeof window !== 'undefined') {
-    const runtimeKey = typeof window.__ENV?.OPENAI_API_KEY === 'string'
-      ? window.__ENV.OPENAI_API_KEY.trim()
-      : '';
-    if (runtimeKey) {
-      return runtimeKey;
-    }
-  }
-
-  if (typeof process !== 'undefined' && typeof process.env?.OPENAI_API_KEY === 'string') {
-    return process.env.OPENAI_API_KEY.trim();
-  }
-
-  return '';
-};
-
-export const isEmbeddingEnabled = () => Boolean(resolveOpenAiKey());
+export const isEmbeddingEnabled = () => true;
 
 const normalizeText = (value) => (typeof value === 'string' ? value.trim() : '');
 
@@ -35,21 +14,18 @@ const normalizeEmbedding = (value) => {
 
 export async function generateEmbedding(text) {
   const normalizedText = normalizeText(text);
-  const openAiKey = resolveOpenAiKey();
 
-  if (!normalizedText || !openAiKey) {
+  if (!normalizedText) {
     return [];
   }
 
-  const res = await fetch('https://api.openai.com/v1/embeddings', {
+  const res = await fetch('/api/embed', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${openAiKey}`,
     },
     body: JSON.stringify({
-      model: 'text-embedding-3-small',
-      input: normalizedText,
+      text: normalizedText,
     }),
   });
 
@@ -58,5 +34,5 @@ export async function generateEmbedding(text) {
   }
 
   const data = await res.json();
-  return normalizeEmbedding(data?.data?.[0]?.embedding);
+  return normalizeEmbedding(data?.embedding);
 }


### PR DESCRIPTION
### Motivation
- Prevent exposing the OpenAI API key in the browser by providing a secure server-side embedding endpoint. 
- Keep existing API patterns and Cloudflare Pages Functions style consistent with `api/assistant-chat.ts` and existing CORS handling. 

### Description
- Add a new Cloudflare Pages-style handler `api/embed.ts` that validates `text`, applies the same allowed-origin/CORS logic, calls OpenAI embeddings at `https://api.openai.com/v1/embeddings` using `process.env.OPENAI_API_KEY`, and returns `{ success: true, embedding }` or a safe error payload. 
- Use the `text-embedding-3-small` model and normalize the returned vector before returning it to callers. 
- Update `src/brain/embeddingService.js` to POST `{ text }` to `/api/embed` and to consume the new `{ embedding }` response shape, and keep embedding-enabled detection returning `true` so semantic flows remain active. 

### Testing
- Ran a syntax sanity check on the new handler with `node -e "const fs=require('fs'); const ts=fs.readFileSync('api/embed.ts','utf8'); new Function(ts.replace(/export default async function handler/, 'async function handler')); console.log('embed syntax ok');"` which reported the file parsed successfully. 
- Attempted `npm run build` to exercise the project build, which started successfully in this environment but did not finish within the execution window (no full build artifacts verified). 
- No unit tests were modified or added; existing test suite was not run to completion in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb2c2b690c8324b6143ccf1bd3563f)