### PR TITLE
Remove client-side OpenAI usage; route embeddings via /api/embed

### DIFF
--- a/src/brain/embeddingService.js
+++ b/src/brain/embeddingService.js
@@ -13,21 +13,14 @@ const normalizeEmbedding = (value) => {
 };
 
 export async function generateEmbedding(text) {
-  const normalizedText = normalizeText(text);
-
-  if (!normalizedText) {
-    return null;
-  }
-
   console.log('[embedding] using API route');
+
   const res = await fetch('/api/embed', {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/json'
     },
-    body: JSON.stringify({
-      text: normalizedText,
-    }),
+    body: JSON.stringify({ text })
   });
 
   if (!res.ok) {
@@ -36,5 +29,5 @@ export async function generateEmbedding(text) {
   }
 
   const data = await res.json();
-  return normalizeEmbedding(data?.embedding);
+  return data.embedding;
 }

--- a/src/services/brainQueryService.js
+++ b/src/services/brainQueryService.js
@@ -1,13 +1,11 @@
 import { classifyIntentLocally } from './intentRouter.js';
+import { requestAssistantChat, buildMemoryAssistantRequest } from './assistantOrchestrator.js';
 import { generateEmbedding, similaritySearch } from './embeddingService.js';
 import { getRecentMemories, searchMemories } from './memoryService.js';
 
-const OPENAI_MODEL = 'gpt-5-nano';
 const MAX_CONTEXT_MEMORIES = 5;
 const MAX_MEMORY_TEXT_LENGTH = 220;
 const MAX_QUESTION_LENGTH = 320;
-const MAX_OUTPUT_TOKENS = 220;
-
 const normalizeText = (value) => (typeof value === 'string' ? value.trim() : '');
 
 const truncateText = (text, maxLength) => {
@@ -18,82 +16,16 @@ const truncateText = (text, maxLength) => {
   return `${normalized.slice(0, maxLength - 1)}…`;
 };
 
-const buildMemoryContext = (memories) => memories
-  .slice(0, MAX_CONTEXT_MEMORIES)
-  .map((memory, index) => {
-    const notebook = truncateText(memory?.notebook, 60);
-    const text = truncateText(memory?.text, MAX_MEMORY_TEXT_LENGTH);
-    const tags = Array.isArray(memory?.tags) ? memory.tags.slice(0, 4).join(', ') : '';
-
-    return [
-      `${index + 1}. ${text}`,
-      notebook ? `Notebook: ${notebook}` : '',
-      tags ? `Tags: ${tags}` : '',
-    ]
-      .filter(Boolean)
-      .join(' | ');
-  })
-  .filter(Boolean)
-  .join('\n');
-
-const buildPrompt = (question, memories) => {
-  const snippets = buildMemoryContext(memories) || 'No relevant memories found.';
-  return [
-    'System:',
-    'You are the Memory Cue assistant.',
-    '',
-    'Relevant memories:',
-    snippets,
-    '',
-    'User question:',
-    question,
-    '',
-    'Return answer grounded in the memories.',
-  ].join('\n');
-};
-
 const callAiSummary = async (question, memories) => {
-  const openAiApiKey = typeof process !== 'undefined' ? process.env?.OPENAI_API_KEY : '';
-  if (!openAiApiKey) {
-    console.warn('[brain] AI fallback triggered', {
-      stage: 'generateAnswer',
-      reason: 'missing_openai_api_key',
-    });
-    return 'I found relevant memories, but AI summarization is unavailable because OPENAI_API_KEY is not configured.';
-  }
+  const requestBody = buildMemoryAssistantRequest(
+    question,
+    memories.map((memory) => truncateText(memory?.text, MAX_MEMORY_TEXT_LENGTH)).filter(Boolean),
+  );
 
-  const prompt = [
-    buildPrompt(question, memories),
-  ].join('\n');
-
-  const response = await fetch('https://api.openai.com/v1/responses', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${openAiApiKey}`,
-    },
-    body: JSON.stringify({
-      model: OPENAI_MODEL,
-      store: false,
-      max_output_tokens: MAX_OUTPUT_TOKENS,
-      input: [
-        {
-          role: 'user',
-          content: [{ type: 'input_text', text: prompt }],
-        },
-      ],
-    }),
+  return requestAssistantChat(requestBody, {
+    errorMessage: 'Brain query failed',
+    fallbackReply: 'I could not generate a summary answer.',
   });
-
-  if (!response.ok) {
-    const details = await response.text();
-    throw new Error(`Brain query failed: ${details}`);
-  }
-
-  const payload = await response.json();
-  return payload.output_text
-    || payload?.output?.[0]?.content?.[0]?.text
-    || 'I could not generate a summary answer.';
 };
 
 export const retrieveRelevantMemories = async (question) => {

--- a/src/services/embeddingService.js
+++ b/src/services/embeddingService.js
@@ -59,25 +59,23 @@ const cosineSimilarity = (left, right) => {
 };
 
 export async function generateEmbedding(text) {
-  const normalizedText = normalizeText(text);
-  if (!normalizedText) {
-    return null;
-  }
-
   console.log('[embedding] using API route');
-  const response = await fetch('/api/embed', {
+
+  const res = await fetch('/api/embed', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ text: normalizedText }),
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ text })
   });
 
-  if (!response.ok) {
-    console.error('[embedding] API error', response.status);
+  if (!res.ok) {
+    console.error('[embedding] API error', res.status);
     return null;
   }
 
-  const data = await response.json();
-  return normalizeEmbedding(data?.embedding);
+  const data = await res.json();
+  return data.embedding;
 }
 
 export const getEmbeddingsForUser = async (uid) => {


### PR DESCRIPTION
### Motivation
- Remove remaining client-side attempts to read OpenAI keys or call OpenAI directly so the app no longer logs "[embedding] no OpenAI key configured" and so embeddings are always produced via the server API route `/api/embed`.

### Description
- Replaced client embedding implementations so `generateEmbedding` always calls the API route `/api/embed` and logs `"[embedding] using API route"`; this change was applied to `src/services/embeddingService.js` and `src/brain/embeddingService.js`.
- Removed frontend OpenAI environment checks and direct OpenAI Responses API calls from `src/services/brainQueryService.js`, and routed summary generation through the existing assistant orchestrator (`requestAssistantChat` / `/api/assistant-chat`) so frontend code no longer depends on `OPENAI_API_KEY`.
- Modified files: `src/services/embeddingService.js`, `src/brain/embeddingService.js`, and `src/services/brainQueryService.js`.

Updated embedding function (now used in both embedding files):

```
export async function generateEmbedding(text) {
  console.log('[embedding] using API route');

  const res = await fetch('/api/embed', {
    method: 'POST',
    headers: {
      'Content-Type': 'application/json'
    },
    body: JSON.stringify({ text })
  });

  if (!res.ok) {
    console.error('[embedding] API error', res.status);
    return null;
  }

  const data = await res.json();
  return data.embedding;
}
```

### Testing
- Searched for remaining frontend OpenAI usage with `rg -n "process\.env\.OPENAI_API_KEY|import\.meta\.env\.VITE_OPENAI_API_KEY|no OpenAI key configured|new OpenAI|https://api.openai.com/v1/(embeddings|responses|chat/completions)|from 'openai'|require\(['\"]openai['\"]\)" src js` and confirmed there are no remaining frontend matches for direct OpenAI usage.
- Ran `npm run build` and the build completed successfully.
- Ran `npm test -- --runInBand`; test run shows pre-existing Jest/environment failures unrelated to these changes (multiple UI/mobile test suites that depend on the test VM/import setup and service-worker expectations), so test suite is not fully green after this change but failures appear to be unrelated to the client-side OpenAI removal.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb652139c48324b9be4755ff2f0ec0)