### PR TITLE
Backfill embeddings for Firestore memories

### DIFF
--- a/js/modules/notes-sync.js
+++ b/js/modules/notes-sync.js
@@ -5,6 +5,33 @@ import {
 } from './notes-storage.js';
 import { syncNotes } from '../../src/services/firestoreSyncService.js';
 
+let backfillEmbeddingsModulePromise = null;
+
+const syncFirestoreMemoriesToLocalCache = async (notes = []) => {
+  if (!Array.isArray(notes) || !notes.length) {
+    return;
+  }
+
+  if (!backfillEmbeddingsModulePromise) {
+    backfillEmbeddingsModulePromise = import('../../src/brain/backfillEmbeddings.js').catch((error) => {
+      console.warn('[notes-sync] Failed to load memory backfill module.', error);
+      return null;
+    });
+  }
+
+  const backfillModule = await backfillEmbeddingsModulePromise;
+  const syncMemoriesFromFirestore = backfillModule?.syncMemoriesFromFirestore;
+  if (typeof syncMemoriesFromFirestore !== 'function') {
+    return;
+  }
+
+  try {
+    await syncMemoriesFromFirestore(notes);
+  } catch (error) {
+    console.warn('[notes-sync] Failed to backfill Firestore memory embeddings.', error);
+  }
+};
+
 const mapRemoteNote = (note = {}) => {
   if (!note || typeof note !== 'object' || typeof note.id !== 'string' || !note.id) {
     return null;
@@ -61,6 +88,9 @@ export const initNotesSync = (options = {}) => {
 
       isApplyingRemote = true;
       const saved = saveAllNotes(normalized, { skipRemoteSync: true });
+      if (saved) {
+        await syncFirestoreMemoriesToLocalCache(normalized);
+      }
       isApplyingRemote = false;
 
       if (!saved) {

--- a/src/brain/backfillEmbeddings.js
+++ b/src/brain/backfillEmbeddings.js
@@ -1,17 +1,70 @@
 import * as memoryService from '../services/memoryService.js';
 import { generateEmbedding } from './embeddingService.js';
 
-export async function backfillEmbeddings() {
-  const memories = memoryService.getMemories();
+const normalizeText = (value) => (typeof value === 'string' ? value.trim() : '');
 
-  for (const memory of memories) {
-    if (!memory.embedding) {
-      const embedding = await generateEmbedding(memory.text);
-      await memoryService.saveMemory({
-        ...memory,
-        embedding,
-      });
-      console.log('[backfill] updated memory', memory.id);
+const toMemoryPayload = (memory = {}) => ({
+  id: typeof memory?.id === 'string' ? memory.id : '',
+  text: normalizeText(memory?.text || memory?.bodyText || memory?.body || memory?.content || memory?.title),
+  createdAt: memory?.createdAt,
+  updatedAt: memory?.updatedAt,
+  type: memory?.type || memory?.parsedType || memory?.metadata?.type || 'note',
+  source: memory?.source || memory?.metadata?.source || 'capture',
+  entryPoint: memory?.entryPoint || 'notes-sync.firestore',
+  tags: Array.isArray(memory?.tags) ? memory.tags : memory?.keywords,
+  embedding: memory?.embedding,
+  pendingSync: memory?.pendingSync,
+});
+
+export async function backfillEmbeddings(memories = []) {
+  const normalizedMemories = Array.isArray(memories) ? memories : [];
+
+  for (const memory of normalizedMemories) {
+    if (!memory?.id || Array.isArray(memory.embedding) && memory.embedding.length) {
+      continue;
+    }
+
+    const text = normalizeText(memory.text);
+    if (!text) {
+      console.warn('[backfill] failed for:', memory.id);
+      continue;
+    }
+
+    console.log('[backfill] generating embedding for:', text);
+
+    const embedding = await generateEmbedding(text);
+
+    if (!Array.isArray(embedding) || !embedding.length) {
+      console.warn('[backfill] failed for:', memory.id);
+      continue;
+    }
+
+    await memoryService.updateMemory(memory.id, {
+      embedding,
+      pendingSync: memory.pendingSync === false ? false : true,
+    });
+
+    console.log('[backfill] stored embedding for:', memory.id);
+  }
+}
+
+export async function syncMemoriesFromFirestore(memories = []) {
+  const normalizedMemories = Array.isArray(memories) ? memories : [];
+  const syncedMemories = [];
+
+  for (const memory of normalizedMemories) {
+    const payload = toMemoryPayload(memory);
+    if (!payload.id || !payload.text) {
+      continue;
+    }
+
+    const synced = await memoryService.updateMemory(payload.id, payload);
+
+    if (synced) {
+      syncedMemories.push(synced);
     }
   }
+
+  await backfillEmbeddings(syncedMemories);
+  return syncedMemories;
 }

--- a/src/reminders/reminderController.js
+++ b/src/reminders/reminderController.js
@@ -52,6 +52,32 @@ let serviceWorkerReadyPromise = null;
 let backgroundSyncRegistrationPromise = null;
 let backgroundSyncRegistrationSucceeded = false;
 let embeddingServiceModulePromise = null;
+let firestoreMemoryBackfillModulePromise = null;
+
+async function syncFirestoreMemoriesToLocalCache(notes = []) {
+  if (!Array.isArray(notes) || !notes.length) {
+    return;
+  }
+
+  if (!firestoreMemoryBackfillModulePromise) {
+    firestoreMemoryBackfillModulePromise = import('../brain/backfillEmbeddings.js').catch((error) => {
+      console.warn('[backfill] Failed to load Firestore memory backfill module', error);
+      return null;
+    });
+  }
+
+  const backfillModule = await firestoreMemoryBackfillModulePromise;
+  const syncMemoriesFromFirestore = backfillModule?.syncMemoriesFromFirestore;
+  if (typeof syncMemoriesFromFirestore !== 'function') {
+    return;
+  }
+
+  try {
+    await syncMemoriesFromFirestore(notes);
+  } catch (error) {
+    console.warn('[backfill] Failed to sync Firestore memories', error);
+  }
+}
 const DEFAULT_CATEGORY = 'General';
 const SEEDED_CATEGORIES = Object.freeze([
   DEFAULT_CATEGORY,
@@ -3993,6 +4019,7 @@ export async function initReminders(sel = {}) {
 
     if (normalizedNotes.length) {
       saveAllNotes(normalizedNotes, { skipRemoteSync: true });
+      await syncFirestoreMemoriesToLocalCache(normalizedNotes);
       lastSyncedNoteIds = new Set(normalizedNotes.map((note) => note.id));
       return;
     }

--- a/src/services/memoryService.js
+++ b/src/services/memoryService.js
@@ -325,6 +325,39 @@ const triggerSync = async () => {
   writeCacheToStorage(memoryCache);
 };
 
+const mergeMemoryIntoCache = (memory = {}) => {
+  const normalized = normalizeMemory(memory, {
+    source: normalizeSource(memory.source, 'capture'),
+    entryPoint: normalizeText(memory.entryPoint) || 'capture',
+  });
+
+  if (!normalized.text) {
+    return null;
+  }
+
+  const existing = normalized.id
+    ? memoryCache.find((entry) => entry.id === normalized.id) || null
+    : null;
+
+  const nextMemory = {
+    ...(existing || {}),
+    ...normalized,
+    embedding: normalizeEmbedding(memory.embedding)
+      || normalizeEmbedding(normalized.embedding)
+      || normalizeEmbedding(existing?.embedding),
+    pendingSync: memory.pendingSync === false ? false : normalized.pendingSync,
+  };
+
+  memoryCache = mergeByLatest([
+    ...memoryCache,
+    nextMemory,
+  ]);
+
+  writeCacheToStorage(memoryCache);
+  void triggerSync();
+  return nextMemory;
+};
+
 const lexicalSearch = (query, limit = DEFAULT_SEARCH_LIMIT) => {
   const normalizedQuery = normalizeText(query).toLowerCase();
   if (!normalizedQuery) {
@@ -379,19 +412,17 @@ export const saveMemory = async (memory = {}) => {
     }
   }
 
-  const memoryWithEmbedding = {
+  const memoryWithEmbedding = mergeMemoryIntoCache({
     ...nextMemory,
     embedding,
     updatedAt: Date.now(),
     pendingSync: true,
-  };
+  });
 
-  memoryCache = mergeByLatest([
-    ...memoryCache,
-    memoryWithEmbedding,
-  ]);
+  if (!memoryWithEmbedding) {
+    return null;
+  }
 
-  writeCacheToStorage(memoryCache);
   learnPattern(nextMemory);
   console.info('[brain] memory_saved', {
     id: memoryWithEmbedding.id,
@@ -399,8 +430,25 @@ export const saveMemory = async (memory = {}) => {
     source: memoryWithEmbedding.source,
   });
 
-  void triggerSync();
   return memoryWithEmbedding;
+};
+
+export const updateMemory = async (id, updates = {}) => {
+  ensureCacheLoaded();
+
+  const targetId = normalizeText(id);
+  if (!targetId) {
+    return null;
+  }
+
+  const existing = memoryCache.find((memory) => memory.id === targetId) || {};
+
+  return mergeMemoryIntoCache({
+    ...existing,
+    ...updates,
+    id: targetId,
+    updatedAt: Date.now(),
+  });
 };
 
 export const getMemoryById = (id) => {


### PR DESCRIPTION
### Motivation
- Firestore-hydrated notes were not mirrored into the memory cache and many memories lacked embeddings, causing semantic search to return no results.  
- We need a focused backfill that generates embeddings only for memories that are missing them and persists them using existing embedding APIs.  
- The change must not overwrite existing embeddings or modify UI/query/reminder behaviour.

### Description
- Add `backfillEmbeddings(memories)` and `syncMemoriesFromFirestore(memories)` in `src/brain/backfillEmbeddings.js` to normalize Firestore notes, mirror them into the memory cache, generate embeddings only when missing, log progress (`[backfill] generating embedding for:` / `[backfill] stored embedding for:`), and persist via `memoryService.updateMemory(...)`.  
- Add `mergeMemoryIntoCache(...)` and `updateMemory(id, updates)` to `src/services/memoryService.js` and make `saveMemory(...)` reuse the same merge path so Firestore-hydrated records are merged without clobbering existing embeddings.  
- Trigger the Firestore->memory sync and embedding backfill immediately after remote notes are loaded in `js/modules/notes-sync.js` and in the login-time notes load in `src/reminders/reminderController.js`, calling the helper that mirrors notes into `memoryService` and then runs the missing-only backfill.  
- All writes use existing `generateEmbedding(...)` and `memoryService` storage paths so no new external endpoints or UI/query logic were introduced.

### Testing
- Ran `npm test -- --runInBand js/tests/notes-storage.folders.test.js js/tests/notes-storage.links.test.js` and both test suites passed.  
- Ran `npm run verify` and build verification passed.  
- Ran `npm test -- --runInBand js/__tests__/reminders.auth.test.js` which failed due to an existing Jest dynamic `import()` limitation in the test environment (`TypeError: A dynamic import callback was not specified.`); this failure is unrelated to the backfill logic changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb8b88df288324ba709ef6b17b5eb2)