### PR TITLE
Fix embedding service export

### DIFF
--- a/src/services/embeddingService.js
+++ b/src/services/embeddingService.js
@@ -1,5 +1,8 @@
 import { getMemories, saveMemory } from './memoryService.js';
-import { generateEmbedding } from '../brain/embeddingService.js';
+import { generateEmbedding as generateBrainEmbedding } from '../brain/embeddingService.js';
+
+
+export const generateEmbedding = async (text) => generateBrainEmbedding(text);
 
 const resolveUid = async (uid) => {
   if (typeof uid === 'string' && uid.trim()) {


### PR DESCRIPTION
### Motivation
- Resolve a production build error caused by `src/services/semanticSearchService.js` importing `generateEmbedding` from `src/services/embeddingService.js` when that export was missing, restoring the expected service-layer API so existing callers keep working.

### Description
- Reintroduced the `generateEmbedding` export in `src/services/embeddingService.js` by importing `generateEmbedding` from `src/brain/embeddingService.js` as `generateBrainEmbedding` and re-exporting it as `generateEmbedding`, preserving existing import sites and minimizing changes.

### Testing
- Ran `npm run build` which completed successfully after the fix.
- Ran `npm test -- --runInBand` which exercised the test suite and produced failures unrelated to this change (Test Suites: 14 failed, 10 passed; Tests: 31 failed, 48 passed), indicating pre-existing Jest/ESM import issues in the repo rather than this export fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc62428f2c8324a970cadfc4b40971)