### PR TITLE
docs: update AI_HANDOVER.md for extracted mobileNotesShellUi

### DIFF
--- a/AI_HANDOVER.md
+++ b/AI_HANDOVER.md
@@ -136,6 +136,7 @@ Do not treat those wrappers as the real implementation owner when the underlying
 Recent cleanup has created dedicated homes for parts of the mobile shell UI:
 - `src/ui/mobileShellUi.js` → shell-level UI controls that used to live in `mobile.js`
 - `src/ui/mobileSyncControls.js` → sync status and manual sync controls that used to live in `mobile.js`
+- `src/ui/mobileNotesShellUi.js` → notebook shell UI that used to live in `mobile.js`
 
 When extending shell-level mobile UI, prefer these extracted `src/ui/*` modules over putting more code back into `mobile.js`.
 
@@ -194,10 +195,11 @@ Live-code reality currently looks like this:
 - entries UI is mostly canonical through `js/entries.js` → `src/ui/*`
 - shell-level mobile UI now has an extracted home in `src/ui/mobileShellUi.js`
 - mobile sync controls now have an extracted home in `src/ui/mobileSyncControls.js`
+- notebook shell UI now has an extracted home in `src/ui/mobileNotesShellUi.js`
 - notes remain mixed, with storage centered in `js/modules/notes-storage.js` and heavy UI/orchestration still in `mobile.js`
 - assistant backend/orchestration is still one of the most duplicated areas
 - navigation still overlaps across multiple mechanisms
-- `mobile.js` is still the biggest structural hotspot, but smaller than before
+- `mobile.js` is still the biggest structural hotspot, but notebook shell UI has been reduced further
 - Cloudflare Pages is the canonical hosting target
 
 This means:
@@ -312,7 +314,7 @@ Navigation currently overlaps across hash routes, events, and local togglers.
 Do not create another routing mechanism.
 
 ### Mobile shell UI
-For low-risk shell controls and sync/status UI, prefer the extracted `src/ui/mobileShellUi.js` and `src/ui/mobileSyncControls.js` modules instead of growing `mobile.js` again.
+For low-risk shell controls and sync/status UI, prefer the extracted `src/ui/mobileShellUi.js`, `src/ui/mobileSyncControls.js`, and `src/ui/mobileNotesShellUi.js` modules instead of putting more shell-level notebook UI back into `mobile.js`.
 
 ### Hosting
 Cloudflare Pages is the canonical deploy target.


### PR DESCRIPTION
### Motivation
- Reflect the recent notebook-shell extraction so handover docs point editors to the new UI module instead of re-embedding notebook shell UI into `mobile.js`.
- Keep repository guidance aligned with the live codebase after the mobile notebook UI extraction while preserving existing non-negotiable directions (hosting, auth, storage, and avoidance of duplicate systems).

### Description
- Added `src/ui/mobileNotesShellUi.js` to the "Extracted mobile UI modules now in use" list to document the new home for notebook shell UI that used to live in `mobile.js`.
- Updated the "Current Repo Reality" section to note that the notebook shell UI now has an extracted home at `src/ui/mobileNotesShellUi.js` and to clarify that `mobile.js` remains the primary structural hotspot but that the notebook shell UI has been reduced further.
- Revised the "Mobile shell UI" guidance to prefer `src/ui/mobileShellUi.js`, `src/ui/mobileSyncControls.js`, and `src/ui/mobileNotesShellUi.js` for future shell-level notebook UI work instead of putting more shell-level notebook UI back into `mobile.js`.
- No changes were made to product priorities, storage direction, assistant direction, hosting direction, or any code files; this is a minimal documentation-only update.

### Testing
- Documentation-only change; no unit or integration tests required or run.
- Performed repository checks: `git diff --check HEAD~1 HEAD` (no conflicts) and `git status --short` to verify the modified file was staged and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be94b8523883248308e9aa07341284)