### PR TITLE
Fix overflow menu focus handoff

### DIFF
--- a/src/ui/mobileShellUi.js
+++ b/src/ui/mobileShellUi.js
@@ -85,23 +85,41 @@ export const initHeaderOverflowMenu = () => {
     }
   };
 
-  const closeMenu = ({ restoreFocus = true } = {}) => {
-    if (menu.classList.contains('hidden')) return;
-    const focusTarget =
-      restoreFocus && restoreFocusTo instanceof HTMLElement
-        ? restoreFocusTo
-        : null;
+  const getSafeFocusTarget = ({ restoreFocus = true } = {}) => {
+    const candidates = [
+      restoreFocus ? restoreFocusTo : null,
+      menuBtn,
+      document.body instanceof HTMLElement ? document.body : null,
+    ];
 
-    if (
-      focusTarget &&
-      menu.contains(document.activeElement) &&
-      typeof focusTarget.focus === 'function'
-    ) {
+    return candidates.find((candidate) => isVisible(candidate)) || null;
+  };
+
+  const moveFocusSafely = (target) => {
+    if (!(target instanceof HTMLElement) || typeof target.focus !== 'function') {
+      return;
+    }
+
+    try {
+      target.focus({ preventScroll: true });
+    } catch {
       try {
-        focusTarget.focus();
+        target.focus();
       } catch {
         /* ignore */
       }
+    }
+  };
+
+  const closeMenu = ({ restoreFocus = true } = {}) => {
+    if (menu.classList.contains('hidden')) return;
+
+    const activeElement = document.activeElement;
+    const activeInsideMenu = activeElement instanceof HTMLElement && menu.contains(activeElement);
+    const focusTarget = activeInsideMenu ? getSafeFocusTarget({ restoreFocus }) : null;
+
+    if (focusTarget && focusTarget !== activeElement) {
+      moveFocusSafely(focusTarget);
     }
 
     menu.classList.add('hidden');
@@ -112,13 +130,9 @@ export const initHeaderOverflowMenu = () => {
     if (
       focusTarget &&
       document.activeElement !== focusTarget &&
-      typeof focusTarget.focus === 'function'
+      !menu.contains(document.activeElement)
     ) {
-      try {
-        focusTarget.focus();
-      } catch {
-        /* ignore */
-      }
+      moveFocusSafely(focusTarget);
     }
   };
 
@@ -155,6 +169,21 @@ export const initHeaderOverflowMenu = () => {
     return target.closest('[data-menu-action]');
   };
 
+  const closeMenuThenRun = (callback, options = {}) => {
+    closeMenu(options);
+
+    if (typeof callback !== 'function') return;
+
+    const defer =
+      typeof window !== 'undefined' && typeof window.setTimeout === 'function'
+        ? window.setTimeout
+        : setTimeout;
+
+    defer(() => {
+      callback();
+    }, 0);
+  };
+
   const handleMenuAction = (event) => {
     const button = getMenuActionTarget(event);
     if (!button) return;
@@ -179,38 +208,42 @@ export const initHeaderOverflowMenu = () => {
       }
 
       case 'settings': {
-        const settingsTrigger = document.querySelector('[data-open="settings"]');
-        if (settingsTrigger instanceof HTMLElement) {
-          settingsTrigger.click();
-        } else {
-          const settingsModal = document.getElementById('settingsModal');
-          if (settingsModal instanceof HTMLElement) {
-            settingsModal.classList.remove('hidden');
-            settingsModal.removeAttribute('aria-hidden');
+        closeMenuThenRun(() => {
+          const settingsTrigger = document.querySelector('[data-open="settings"]');
+          if (settingsTrigger instanceof HTMLElement) {
+            settingsTrigger.click();
+          } else {
+            const settingsModal = document.getElementById('settingsModal');
+            if (settingsModal instanceof HTMLElement) {
+              settingsModal.classList.remove('hidden');
+              settingsModal.removeAttribute('aria-hidden');
+            }
           }
-        }
-        break;
+        });
+        return;
       }
 
       case 'saved-notes': {
-        try {
-          if (typeof window.showSavedNotesSheet === 'function') {
-            window.showSavedNotesSheet();
-          } else {
-            const trigger =
-              document.getElementById('openSavedNotesGlobal') ||
-              document.getElementById('openSavedNotesSheetButton') ||
-              document.getElementById('openSavedNotesSheet') ||
-              document.getElementById('savedNotesShortcut') ||
-              document.querySelector('.open-saved-notes-global');
-            if (trigger instanceof HTMLElement) {
-              trigger.click();
+        closeMenuThenRun(() => {
+          try {
+            if (typeof window.showSavedNotesSheet === 'function') {
+              window.showSavedNotesSheet();
+            } else {
+              const trigger =
+                document.getElementById('openSavedNotesGlobal') ||
+                document.getElementById('openSavedNotesSheetButton') ||
+                document.getElementById('openSavedNotesSheet') ||
+                document.getElementById('savedNotesShortcut') ||
+                document.querySelector('.open-saved-notes-global');
+              if (trigger instanceof HTMLElement) {
+                trigger.click();
+              }
             }
+          } catch (error) {
+            console.warn('[overflow-menu] failed to open saved notes sheet', error);
           }
-        } catch (error) {
-          console.warn('[overflow-menu] failed to open saved notes sheet', error);
-        }
-        break;
+        });
+        return;
       }
 
       case 'sign-in': {
@@ -260,15 +293,17 @@ export const initHeaderOverflowMenu = () => {
         break;
 
       case 'about': {
-        const aboutTrigger =
-          document.querySelector('[data-open="about"]') ||
-          document.getElementById('aboutMemoryCueBtn');
-        if (aboutTrigger instanceof HTMLElement) {
-          aboutTrigger.click();
-        } else if (typeof window.showAboutMemoryCue === 'function') {
-          window.showAboutMemoryCue();
-        }
-        break;
+        closeMenuThenRun(() => {
+          const aboutTrigger =
+            document.querySelector('[data-open="about"]') ||
+            document.getElementById('aboutMemoryCueBtn');
+          if (aboutTrigger instanceof HTMLElement) {
+            aboutTrigger.click();
+          } else if (typeof window.showAboutMemoryCue === 'function') {
+            window.showAboutMemoryCue();
+          }
+        });
+        return;
       }
 
       default:


### PR DESCRIPTION
### Motivation

- Fix an accessibility bug where hiding the overflow menu with `aria-hidden="true"` was blocked because a menu descendant retained keyboard focus. 
- Keep existing overflow menu behavior unchanged except for reliably moving focus before the menu is hidden. 
- Ensure actions that open another panel/modal (settings, saved notes, about) close the menu safely first so focus is not left in a hidden subtree.

### Description

- Modified `src/ui/mobileShellUi.js` to add `getSafeFocusTarget()` and `moveFocusSafely()` and to update `closeMenu()` so focus is moved to a visible safe target before the menu is hidden. 
- Added `closeMenuThenRun()` helper and updated `settings`, `saved-notes`, and `about` menu actions to close the menu first, then open the target UI on the next tick. 
- Kept original focus-restoration behavior where possible (`restoreFocusTo` is still used) and limited changes to the existing overflow menu logic only. 
- No architecture changes or broad inert-based rewrites were introduced; the fix is small and targeted to the menu hide/open timing.

### Testing

- Ran `npm test -- --runInBand`; test run completed but many failing suites reflect pre-existing repo test issues (CommonJS/ESM module loading and dynamic import failures) unrelated to this focused UI change. The overflow-menu change did not introduce new test-suite-level regressions observable in this environment. 
- Ran `npm run build` (timed command in CI/dev environment); build output produced Tailwind/daisyUI rebuild messages and did not complete within the short timed run here, so a full build verification was not completed in this environment. 
- Committed the single-file change `src/ui/mobileShellUi.js` and verified the behavior by code inspection; please run the app in a browser or run end-to-end checks to confirm the accessibility warning is resolved in the target runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf032d912c8324bd100ceab15e95fa)