### PR TITLE
Fix settings overflow menu focus handoff

### DIFF
--- a/src/ui/mobileShellUi.js
+++ b/src/ui/mobileShellUi.js
@@ -316,21 +316,30 @@ export const initHeaderOverflowMenu = () => {
       case 'settings': {
         const settingsTrigger = document.querySelector('[data-open="settings"]');
         const settingsModal = document.getElementById('settingsModal');
-        runMenuAction(() => {
-          if (settingsTrigger instanceof HTMLElement) {
-            settingsTrigger.click();
-          } else if (settingsModal instanceof HTMLElement) {
-            settingsModal.classList.remove('hidden');
-            settingsModal.removeAttribute('aria-hidden');
-          }
 
-          const primaryFocusTarget =
-            document.getElementById('settingsCloseBtn') ||
-            document.getElementById('closeSettings') ||
-            settingsModal;
+        // Settings needs an explicit focus handoff before the menu becomes aria-hidden.
+        moveFocusSafely(menuBtn);
+        closeMenu({ restoreFocus: false, focusTarget: menuBtn });
 
-          if (!focusElement(primaryFocusTarget)) {
-            focusFirstDescendant(settingsModal);
+        requestAnimationFrame(() => {
+          try {
+            if (settingsTrigger instanceof HTMLElement) {
+              settingsTrigger.click();
+            } else if (settingsModal instanceof HTMLElement) {
+              settingsModal.classList.remove('hidden');
+              settingsModal.removeAttribute('aria-hidden');
+            }
+
+            const primaryFocusTarget =
+              document.getElementById('settingsCloseBtn') ||
+              document.getElementById('closeSettings') ||
+              settingsModal;
+
+            if (!focusElement(primaryFocusTarget)) {
+              focusFirstDescendant(settingsModal);
+            }
+          } catch (error) {
+            console.warn('[overflow-menu] action failed', error);
           }
         });
         break;


### PR DESCRIPTION
### Motivation
- Resolve an accessibility warning where the overflow menu was set to `aria-hidden="true"` while the Settings trigger (or a menu item) still retained focus inside the menu.

### Description
- Modify the `settings` case in `initHeaderOverflowMenu` (in `src/ui/mobileShellUi.js`) to explicitly move focus to the menu trigger, close the menu, then open the Settings modal on the next animation frame and focus the settings close button or the first focusable element, reusing existing focus helpers and leaving other menu actions unchanged.

### Testing
- Bundled the updated file with `npx esbuild src/ui/mobileShellUi.js --bundle --format=esm --platform=browser --outfile=/tmp/mobileShellUi.bundle.js`, which completed successfully.
- Ran the automated test suite with `npm test -- --runInBand`, which reported pre-existing failing tests in unrelated suites (multiple `reminders.*`, `mobile.auth`, `service-worker.test.js`, etc.), and did not show new failures attributable to this targeted Settings change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf1fbce0908324997278dffe32373d)